### PR TITLE
refactor(tui): 收敛启动链中的重复安全初始化逻辑

### DIFF
--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -7,13 +7,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"go-llm-demo/configs"
-	"go-llm-demo/internal/server/infra/repository"
-	"go-llm-demo/internal/server/infra/tools"
-	"go-llm-demo/internal/server/service"
 	"go-llm-demo/internal/tui/bootstrap"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -90,11 +86,7 @@ func runWithDeps(workspaceFlag string, deps runDeps) error {
 
 	workspaceRoot, err := deps.prepareWorkspace(workspaceFlag)
 	if err != nil {
-		return fmt.Errorf("解析工作区失败: %w", err)
-	}
-
-	if err := initializeSecurity(filepath.Join(workspaceRoot, "configs", "security")); err != nil {
-		return fmt.Errorf("安全策略初始化失败：%w", err)
+		return fmt.Errorf("工作区初始化失败: %w", err)
 	}
 
 	scanner := bufio.NewScanner(deps.stdin)
@@ -127,16 +119,6 @@ func runWithDeps(workspaceFlag string, deps runDeps) error {
 		return fmt.Errorf("运行失败: %w", err)
 	}
 
-	return nil
-}
-
-func initializeSecurity(configDir string) error {
-	securityRepo := repository.NewSecurityConfigRepository()
-	securitySvc := service.NewSecurityService(securityRepo)
-	if err := securitySvc.Initialize(configDir); err != nil {
-		return err
-	}
-	tools.SetSecurityChecker(securitySvc)
 	return nil
 }
 

--- a/internal/tui/bootstrap/setup.go
+++ b/internal/tui/bootstrap/setup.go
@@ -32,13 +32,13 @@ var (
 func PrepareWorkspace(workspaceFlag string) (string, error) {
 	workspaceRoot, err := resolveWorkspaceRoot(workspaceFlag)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("解析工作区失败: %w", err)
 	}
 	if err := setWorkspaceRoot(workspaceRoot); err != nil {
-		return "", err
+		return "", fmt.Errorf("设置工作区失败: %w", err)
 	}
 	if err := initializeSecurity(filepath.Join(workspaceRoot, "configs", "security")); err != nil {
-		return "", err
+		return "", fmt.Errorf("初始化安全策略失败: %w", err)
 	}
 	return workspaceRoot, nil
 }


### PR DESCRIPTION
## 概要

收敛 TUI 启动链中的重复安全初始化逻辑。

## 本次修改

- 保留 `PrepareWorkspace(...)` 中的安全初始化
- 删除 `cmd/tui/main.go` 中重复的 `initializeSecurity(...)` 调用
- 补充 workspace 准备阶段的错误包装，使错误来源更清晰

## 修改原因

之前的启动流程中，安全模块会被初始化两次：

1. `PrepareWorkspace(...)` 内部已经完成一次初始化
2. `cmd/tui/main.go` 中又重复初始化了一次

虽然这不会立即导致功能错误，但会让启动生命周期职责不够清晰，也会增加后续维护成本。

## 验证

已通过以下测试：

- `go test ./cmd/tui ./internal/tui/bootstrap`
- `go test ./...`


---
Closes #54 