### PR TITLE
fix: 修复 GitHub Actions Release 流水线配置隐患

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22' # 替换为 NeoCode 实际使用的 Go 版本
+          go-version-file: 'go.mod' # 💡 修复点 1：让 Action 自动跟随项目真实的 Go 版本
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
@@ -34,4 +34,5 @@ jobs:
           version: '~> v2'
           args: release --clean
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}       # 💡 修复点 2：补回本仓库的内置鉴权令牌
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
## 目的 / Purpose
本 PR 旨在修复自动化发版流水线（GitHub Actions + GoReleaser）中存在的鉴权丢失与环境版本硬编码问题，确保官方在触发打 Tag 发版时能够顺利、无误地创建 Release 产物。

## 变更内容 / Changes
-  **补全鉴权令牌**: 在 `release.yml` 的 GoReleaser 步骤中显式注入了 `${{ secrets.GITHUB_TOKEN }}`。修复了因缺乏该内置权限，导致 GoReleaser 无法在当前仓库创建 Release 及挂载产物的致命问题 (Error 403 / exit code 1)。
-  **统一 Go 环境版本**: 移除了 `release.yml` 中硬编码的 `go-version: '1.22'`，改为官方推荐的 `go-version-file: 'go.mod'` 配置。这使得 CI 编译环境能够始终与代码底座 (Go 1.25.0) 保持严格的动态一致，彻底杜绝了因跨版本编译可能引发的语法报错或隐患。
