### PR TITLE
[codex] 完善 context 上下文裁剪与系统态感知

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ go run ./cmd/neocode
 核心模块职责：
 
 - **`internal/config`** — 配置管理、环境变量、YAML 加载
-- **`internal/context`** — system prompt、消息裁剪与上下文构建
+- **`internal/context`** — system prompt、消息裁剪、环境感知与上下文构建
 - **`internal/provider`** — Provider 契约、驱动注册与通用领域类型
 - **`internal/provider/catalog`** — 模型发现、catalog 缓存与后台刷新
 - **`internal/provider/selection`** — provider/model 选择与配置同步

--- a/docs/runtime-provider-event-flow.md
+++ b/docs/runtime-provider-event-flow.md
@@ -33,9 +33,10 @@
 - `context.Builder` 负责统一组装：
   - 固定核心 system prompt sections
   - 从 `workdir` 向上发现的 `AGENTS.md`
-  - 系统状态摘要（`workdir` / `shell` / `provider` / `model` / git branch / git dirty）
+  - 系统状态摘要（`workdir` / `shell` / `os` / `arch` / `provider` / `model` / git branch / git dirty）
   - 裁剪后的历史消息
 - `runtime` 不直接读取规则文件，也不直接查询 git 状态。
+- `context` 在本地直接采集当前进程运行环境的 `os` 与 `arch`，不依赖 `runtime` 额外传入。
 - `provider` 只消费最终生成的 `SystemPrompt`、消息列表和工具 schema，不感知上下文来源。
 
 ### System Prompt 注入顺序
@@ -51,6 +52,7 @@
 - 规则文件只支持大写文件名 `AGENTS.md`
 - 多份命中结果按“从全局到局部”的顺序注入
 - git 只注入摘要，不注入完整 `git status`
+- `System State` 当前会稳定注入 `workdir`、`shell`、`os`、`arch`、`provider`、`model` 与 git 摘要
 - 各 section 统一由 `internal/context` 内部的 `renderPromptSection` 和 `composeSystemPrompt` 渲染，`runtime` 仍只消费最终字符串
 
 ## 流式桥接

--- a/internal/context/builder.go
+++ b/internal/context/builder.go
@@ -20,22 +20,39 @@ func (b *DefaultBuilder) Build(ctx context.Context, input BuildInput) (BuildResu
 		return BuildResult{}, err
 	}
 
-	rules, err := loadProjectRules(ctx, input.Metadata.Workdir)
+	rules, systemState, err := b.collectPromptState(ctx, input.Metadata)
 	if err != nil {
 		return BuildResult{}, err
 	}
-
-	systemState, err := collectSystemState(ctx, input.Metadata, b.gitRunner)
-	if err != nil {
-		return BuildResult{}, err
-	}
-
-	sections := append([]promptSection{}, defaultSystemPromptSections()...)
-	sections = append(sections, renderProjectRulesSection(rules))
-	sections = append(sections, renderSystemStateSection(systemState))
 
 	return BuildResult{
-		SystemPrompt: composeSystemPrompt(sections...),
+		SystemPrompt: composeSystemPrompt(buildPromptSections(input, rules, systemState)...),
 		Messages:     trimMessages(input.Messages),
 	}, nil
+}
+
+func (b *DefaultBuilder) collectPromptState(ctx context.Context, metadata Metadata) ([]ruleDocument, SystemState, error) {
+	rules, err := loadProjectRules(ctx, metadata.Workdir)
+	if err != nil {
+		return nil, SystemState{}, err
+	}
+
+	systemState, err := collectSystemState(ctx, metadata, b.gitRunner)
+	if err != nil {
+		return nil, SystemState{}, err
+	}
+
+	return rules, systemState, nil
+}
+
+func buildPromptSections(input BuildInput, rules []ruleDocument, systemState SystemState) []promptSection {
+	sections := append([]promptSection{}, defaultSystemPromptSections()...)
+	sections = append(sections, buildDynamicPromptSections(input)...)
+	sections = append(sections, renderProjectRulesSection(rules))
+	sections = append(sections, renderSystemStateSection(systemState))
+	return sections
+}
+
+func buildDynamicPromptSections(BuildInput) []promptSection {
+	return nil
 }

--- a/internal/context/builder_test.go
+++ b/internal/context/builder_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"strings"
 	"testing"
 
@@ -43,6 +44,12 @@ func TestDefaultBuilderBuild(t *testing.T) {
 	}
 	if !strings.Contains(got.SystemPrompt, input.Metadata.Workdir) {
 		t.Fatalf("expected workdir in system state section")
+	}
+	if !strings.Contains(got.SystemPrompt, "- os: `"+goruntime.GOOS+"`") {
+		t.Fatalf("expected os in system state section, got %q", got.SystemPrompt)
+	}
+	if !strings.Contains(got.SystemPrompt, "- arch: `"+goruntime.GOARCH+"`") {
+		t.Fatalf("expected arch in system state section, got %q", got.SystemPrompt)
 	}
 	if len(got.Messages) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(got.Messages))

--- a/internal/context/metadata.go
+++ b/internal/context/metadata.go
@@ -19,6 +19,8 @@ type GitState struct {
 type SystemState struct {
 	Workdir  string
 	Shell    string
+	OS       string
+	Arch     string
 	Provider string
 	Model    string
 	Git      GitState

--- a/internal/context/source_system.go
+++ b/internal/context/source_system.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	goruntime "runtime"
 	"strings"
 )
 
@@ -14,6 +15,8 @@ func collectSystemState(ctx context.Context, metadata Metadata, runner gitComman
 	state := SystemState{
 		Workdir:  strings.TrimSpace(metadata.Workdir),
 		Shell:    strings.TrimSpace(metadata.Shell),
+		OS:       strings.TrimSpace(goruntime.GOOS),
+		Arch:     strings.TrimSpace(goruntime.GOARCH),
 		Provider: strings.TrimSpace(metadata.Provider),
 		Model:    strings.TrimSpace(metadata.Model),
 	}
@@ -52,6 +55,8 @@ func renderSystemStateSection(state SystemState) promptSection {
 	lines := []string{
 		fmt.Sprintf("- workdir: `%s`", promptValue(state.Workdir)),
 		fmt.Sprintf("- shell: `%s`", promptValue(state.Shell)),
+		fmt.Sprintf("- os: `%s`", promptValue(state.OS)),
+		fmt.Sprintf("- arch: `%s`", promptValue(state.Arch)),
 		fmt.Sprintf("- provider: `%s`", promptValue(state.Provider)),
 		fmt.Sprintf("- model: `%s`", promptValue(state.Model)),
 	}

--- a/internal/context/source_system_test.go
+++ b/internal/context/source_system_test.go
@@ -3,6 +3,7 @@ package context
 import (
 	"context"
 	"errors"
+	goruntime "runtime"
 	"strings"
 	"testing"
 )
@@ -20,8 +21,20 @@ func TestCollectSystemStateHandlesGitUnavailable(t *testing.T) {
 	if state.Git.Available {
 		t.Fatalf("expected git to be unavailable")
 	}
+	if state.OS != goruntime.GOOS {
+		t.Fatalf("expected os %q, got %q", goruntime.GOOS, state.OS)
+	}
+	if state.Arch != goruntime.GOARCH {
+		t.Fatalf("expected arch %q, got %q", goruntime.GOARCH, state.Arch)
+	}
 
 	section := renderPromptSection(renderSystemStateSection(state))
+	if !strings.Contains(section, "- os: `"+goruntime.GOOS+"`") {
+		t.Fatalf("expected os in system section, got %q", section)
+	}
+	if !strings.Contains(section, "- arch: `"+goruntime.GOARCH+"`") {
+		t.Fatalf("expected arch in system section, got %q", section)
+	}
 	if !strings.Contains(section, "- git: unavailable") {
 		t.Fatalf("expected unavailable git section, got %q", section)
 	}
@@ -55,8 +68,20 @@ func TestCollectSystemStateIncludesGitSummary(t *testing.T) {
 	if !state.Git.Dirty {
 		t.Fatalf("expected dirty git state")
 	}
+	if state.OS != goruntime.GOOS {
+		t.Fatalf("expected os %q, got %q", goruntime.GOOS, state.OS)
+	}
+	if state.Arch != goruntime.GOARCH {
+		t.Fatalf("expected arch %q, got %q", goruntime.GOARCH, state.Arch)
+	}
 
 	section := renderPromptSection(renderSystemStateSection(state))
+	if !strings.Contains(section, "- os: `"+goruntime.GOOS+"`") {
+		t.Fatalf("expected os in system section, got %q", section)
+	}
+	if !strings.Contains(section, "- arch: `"+goruntime.GOARCH+"`") {
+		t.Fatalf("expected arch in system section, got %q", section)
+	}
 	if !strings.Contains(section, "branch=`feature/context`") {
 		t.Fatalf("expected branch in system section, got %q", section)
 	}

--- a/internal/context/trim.go
+++ b/internal/context/trim.go
@@ -1,37 +1,233 @@
 package context
 
-import "neo-code/internal/provider"
+import (
+	"strings"
+
+	"neo-code/internal/provider"
+)
 
 const maxContextTurns = 10
 
+type trimStrategyInput struct {
+	messages []provider.Message
+	index    messageRelationIndex
+	limit    int
+}
+
+type messageRelationIndex struct {
+	assistantByToolCallID map[string]int
+	toolsByToolCallID     map[string][]int
+	rootIndexes           []int
+}
+
 func trimMessages(messages []provider.Message) []provider.Message {
-	if len(messages) <= maxContextTurns {
-		return append([]provider.Message(nil), messages...)
+	return trimMessagesWithStrategy(messages, selectRecentRootIndexes)
+}
+
+func trimMessagesWithStrategy(
+	messages []provider.Message,
+	selectRoots func(input trimStrategyInput) []int,
+) []provider.Message {
+	if len(messages) == 0 {
+		return nil
 	}
 
-	type span struct {
-		start int
-		end   int
+	index := buildMessageRelationIndex(messages)
+	roots := selectRoots(trimStrategyInput{
+		messages: messages,
+		index:    index,
+		limit:    maxContextTurns,
+	})
+	if len(roots) == 0 {
+		return nil
 	}
 
-	spans := make([]span, 0, len(messages))
-	for i := 0; i < len(messages); {
-		start := i
-		i++
+	return retainMessageClosure(messages, index, roots)
+}
 
-		if messages[start].Role == provider.RoleAssistant && len(messages[start].ToolCalls) > 0 {
-			for i < len(messages) && messages[i].Role == provider.RoleTool {
-				i++
+func buildMessageRelationIndex(messages []provider.Message) messageRelationIndex {
+	index := messageRelationIndex{
+		assistantByToolCallID: make(map[string]int),
+		toolsByToolCallID:     make(map[string][]int),
+	}
+
+	for messageIndex, message := range messages {
+		if message.Role != provider.RoleAssistant || len(message.ToolCalls) == 0 {
+			continue
+		}
+		for _, call := range message.ToolCalls {
+			toolCallID := strings.TrimSpace(call.ID)
+			if toolCallID == "" {
+				continue
 			}
+			index.assistantByToolCallID[toolCallID] = messageIndex
+		}
+	}
+
+	for messageIndex, message := range messages {
+		if message.Role != provider.RoleTool {
+			continue
+		}
+		toolCallID := strings.TrimSpace(message.ToolCallID)
+		if toolCallID == "" {
+			continue
+		}
+		index.toolsByToolCallID[toolCallID] = append(index.toolsByToolCallID[toolCallID], messageIndex)
+	}
+
+	index.rootIndexes = buildRootIndexes(messages, index)
+	return index
+}
+
+func buildRootIndexes(messages []provider.Message, index messageRelationIndex) []int {
+	roots := make([]int, 0, len(messages))
+	for messageIndex := range messages {
+		if index.isAssociatedToolMessage(messageIndex, messages) {
+			continue
+		}
+		roots = append(roots, messageIndex)
+	}
+	return roots
+}
+
+func selectRecentRootIndexes(input trimStrategyInput) []int {
+	if input.limit <= 0 || len(input.index.rootIndexes) == 0 {
+		return nil
+	}
+	if len(input.index.rootIndexes) <= input.limit {
+		return append([]int(nil), input.index.rootIndexes...)
+	}
+	return append([]int(nil), input.index.rootIndexes[len(input.index.rootIndexes)-input.limit:]...)
+}
+
+func retainMessageClosure(
+	messages []provider.Message,
+	index messageRelationIndex,
+	initialIndexes []int,
+) []provider.Message {
+	if len(messages) == 0 || len(initialIndexes) == 0 {
+		return nil
+	}
+
+	keep := make(map[int]struct{}, len(initialIndexes))
+	queue := append([]int(nil), initialIndexes...)
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		if current < 0 || current >= len(messages) {
+			continue
+		}
+		if _, exists := keep[current]; exists {
+			continue
 		}
 
-		spans = append(spans, span{start: start, end: i})
+		keep[current] = struct{}{}
+		for _, linked := range index.linkedIndexes(current, messages) {
+			if _, exists := keep[linked]; exists {
+				continue
+			}
+			queue = append(queue, linked)
+		}
 	}
 
-	if len(spans) <= maxContextTurns {
-		return append([]provider.Message(nil), messages...)
+	if len(keep) == len(messages) {
+		return cloneMessages(messages)
 	}
 
-	start := spans[len(spans)-maxContextTurns].start
-	return append([]provider.Message(nil), messages[start:]...)
+	trimmed := make([]provider.Message, 0, len(keep))
+	for messageIndex, message := range messages {
+		if _, exists := keep[messageIndex]; !exists {
+			continue
+		}
+		trimmed = append(trimmed, cloneMessage(message))
+	}
+	return trimmed
+}
+
+func (index messageRelationIndex) isAssociatedToolMessage(messageIndex int, messages []provider.Message) bool {
+	if messageIndex < 0 || messageIndex >= len(messages) {
+		return false
+	}
+
+	message := messages[messageIndex]
+	if message.Role != provider.RoleTool {
+		return false
+	}
+
+	toolCallID := strings.TrimSpace(message.ToolCallID)
+	if toolCallID == "" {
+		return false
+	}
+
+	_, exists := index.assistantByToolCallID[toolCallID]
+	return exists
+}
+
+func (index messageRelationIndex) linkedIndexes(messageIndex int, messages []provider.Message) []int {
+	if messageIndex < 0 || messageIndex >= len(messages) {
+		return nil
+	}
+
+	message := messages[messageIndex]
+	switch message.Role {
+	case provider.RoleAssistant:
+		return index.toolIndexesForAssistant(message)
+	case provider.RoleTool:
+		toolCallID := strings.TrimSpace(message.ToolCallID)
+		if toolCallID == "" {
+			return nil
+		}
+		assistantIndex, exists := index.assistantByToolCallID[toolCallID]
+		if !exists {
+			return nil
+		}
+		return []int{assistantIndex}
+	default:
+		return nil
+	}
+}
+
+func (index messageRelationIndex) toolIndexesForAssistant(message provider.Message) []int {
+	if len(message.ToolCalls) == 0 {
+		return nil
+	}
+
+	seen := make(map[int]struct{}, len(message.ToolCalls))
+	linked := make([]int, 0, len(message.ToolCalls))
+	for _, call := range message.ToolCalls {
+		toolCallID := strings.TrimSpace(call.ID)
+		if toolCallID == "" {
+			continue
+		}
+		for _, toolIndex := range index.toolsByToolCallID[toolCallID] {
+			if _, exists := seen[toolIndex]; exists {
+				continue
+			}
+			seen[toolIndex] = struct{}{}
+			linked = append(linked, toolIndex)
+		}
+	}
+	return linked
+}
+
+func cloneMessages(messages []provider.Message) []provider.Message {
+	if len(messages) == 0 {
+		return nil
+	}
+
+	cloned := make([]provider.Message, len(messages))
+	for i, message := range messages {
+		cloned[i] = cloneMessage(message)
+	}
+	return cloned
+}
+
+func cloneMessage(message provider.Message) provider.Message {
+	cloned := message
+	if len(message.ToolCalls) > 0 {
+		cloned.ToolCalls = append([]provider.ToolCall(nil), message.ToolCalls...)
+	}
+	return cloned
 }

--- a/internal/context/trim_test.go
+++ b/internal/context/trim_test.go
@@ -1,0 +1,209 @@
+package context
+
+import (
+	stdcontext "context"
+	"fmt"
+	"testing"
+
+	"neo-code/internal/provider"
+)
+
+func TestDefaultBuilderBuildDeepClonesToolCalls(t *testing.T) {
+	t.Parallel()
+
+	builder := NewBuilder()
+	input := BuildInput{
+		Messages: []provider.Message{
+			{
+				Role:    provider.RoleAssistant,
+				Content: "call tool",
+				ToolCalls: []provider.ToolCall{
+					{ID: "call-1", Name: "filesystem_edit", Arguments: `{"path":"main.go"}`},
+				},
+			},
+		},
+		Metadata: testMetadata(t.TempDir()),
+	}
+
+	got, err := builder.Build(stdcontext.Background(), input)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(got.Messages) != 1 || len(got.Messages[0].ToolCalls) != 1 {
+		t.Fatalf("expected cloned assistant tool call message, got %+v", got.Messages)
+	}
+
+	got.Messages[0].Content = "mutated"
+	got.Messages[0].ToolCalls[0].Arguments = `{"path":"mutated.go"}`
+
+	if input.Messages[0].Content != "call tool" {
+		t.Fatalf("expected input content to stay unchanged, got %q", input.Messages[0].Content)
+	}
+	if input.Messages[0].ToolCalls[0].Arguments != `{"path":"main.go"}` {
+		t.Fatalf("expected input tool calls to stay unchanged, got %+v", input.Messages[0].ToolCalls)
+	}
+}
+
+func TestTrimMessagesPreservesMultipleToolResults(t *testing.T) {
+	t.Parallel()
+
+	messages := make([]provider.Message, 0, maxContextTurns+6)
+	for i := 0; i < maxContextTurns-1; i++ {
+		messages = append(messages, provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("u-%d", i)})
+	}
+	messages = append(messages,
+		provider.Message{
+			Role: provider.RoleAssistant,
+			ToolCalls: []provider.ToolCall{
+				{ID: "call-1", Name: "filesystem_read_file", Arguments: `{"path":"a.go"}`},
+				{ID: "call-2", Name: "filesystem_read_file", Arguments: `{"path":"b.go"}`},
+			},
+		},
+		provider.Message{Role: provider.RoleUser, Content: "interleaved"},
+		provider.Message{Role: provider.RoleTool, ToolCallID: "call-1", Content: "tool-1"},
+		provider.Message{Role: provider.RoleAssistant, Content: "thinking"},
+		provider.Message{Role: provider.RoleTool, ToolCallID: "call-2", Content: "tool-2"},
+	)
+
+	trimmed := trimMessages(messages)
+
+	var foundAssistant bool
+	foundTools := map[string]bool{}
+	for _, message := range trimmed {
+		if message.Role == provider.RoleAssistant && len(message.ToolCalls) == 2 {
+			foundAssistant = true
+		}
+		if message.Role == provider.RoleTool {
+			foundTools[message.ToolCallID] = true
+		}
+	}
+
+	if !foundAssistant {
+		t.Fatalf("expected assistant tool call message to remain, got %+v", trimmed)
+	}
+	if !foundTools["call-1"] || !foundTools["call-2"] {
+		t.Fatalf("expected both tool results to remain, got %+v", trimmed)
+	}
+}
+
+func TestTrimMessagesDropsDanglingToolResultsWhenToolCallFallsOutOfWindow(t *testing.T) {
+	t.Parallel()
+
+	messages := make([]provider.Message, 0, maxContextTurns+6)
+	for i := 0; i < 4; i++ {
+		messages = append(messages, provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("old-%d", i)})
+	}
+	messages = append(messages, provider.Message{
+		Role: provider.RoleAssistant,
+		ToolCalls: []provider.ToolCall{
+			{ID: "call-1", Name: "filesystem_edit", Arguments: `{"path":"main.go"}`},
+		},
+	})
+	for i := 0; i < 6; i++ {
+		messages = append(messages, provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("mid-%d", i)})
+	}
+	messages = append(messages, provider.Message{Role: provider.RoleTool, ToolCallID: "call-1", Content: "tool-result"})
+	for i := 0; i < 4; i++ {
+		messages = append(messages, provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("tail-%d", i)})
+	}
+
+	trimmed := trimMessages(messages)
+
+	for _, message := range trimmed {
+		if message.Role == provider.RoleTool && message.ToolCallID == "call-1" {
+			t.Fatalf("expected dangling tool result to be removed, got %+v", trimmed)
+		}
+		if message.Role == provider.RoleAssistant && len(message.ToolCalls) > 0 {
+			t.Fatalf("expected matching assistant tool call to be removed with the tool result, got %+v", trimmed)
+		}
+	}
+}
+
+func TestRetainMessageClosureBackfillsAssistantAndSiblingToolResults(t *testing.T) {
+	t.Parallel()
+
+	messages := []provider.Message{
+		{
+			Role: provider.RoleAssistant,
+			ToolCalls: []provider.ToolCall{
+				{ID: "call-1", Name: "filesystem_read_file", Arguments: `{"path":"a.go"}`},
+				{ID: "call-2", Name: "filesystem_read_file", Arguments: `{"path":"b.go"}`},
+			},
+		},
+		{Role: provider.RoleTool, ToolCallID: "call-1", Content: "tool-1"},
+		{Role: provider.RoleTool, ToolCallID: "call-2", Content: "tool-2"},
+	}
+
+	index := buildMessageRelationIndex(messages)
+	retained := retainMessageClosure(messages, index, []int{1})
+
+	if len(retained) != 3 {
+		t.Fatalf("expected closure to retain assistant and sibling tools, got %+v", retained)
+	}
+	if retained[0].Role != provider.RoleAssistant {
+		t.Fatalf("expected assistant to be restored first, got %+v", retained)
+	}
+	if retained[1].ToolCallID != "call-1" || retained[2].ToolCallID != "call-2" {
+		t.Fatalf("expected both tool results to remain, got %+v", retained)
+	}
+}
+
+func TestTrimMessagesHandlesSparseAndOrphanInputs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    []provider.Message
+		wantLen  int
+		wantRole string
+	}{
+		{
+			name:    "nil input stays nil",
+			input:   nil,
+			wantLen: 0,
+		},
+		{
+			name: "single user message survives",
+			input: []provider.Message{
+				{Role: provider.RoleUser, Content: "hello"},
+			},
+			wantLen:  1,
+			wantRole: provider.RoleUser,
+		},
+		{
+			name: "orphan tool message stays stable",
+			input: []provider.Message{
+				{Role: provider.RoleTool, ToolCallID: "missing", Content: "tool-result"},
+			},
+			wantLen:  1,
+			wantRole: provider.RoleTool,
+		},
+		{
+			name: "tool before assistant does not panic",
+			input: []provider.Message{
+				{Role: provider.RoleTool, ToolCallID: "call-1", Content: "tool-result"},
+				{
+					Role: provider.RoleAssistant,
+					ToolCalls: []provider.ToolCall{
+						{ID: "call-1", Name: "filesystem_edit", Arguments: `{"path":"main.go"}`},
+					},
+				},
+			},
+			wantLen:  2,
+			wantRole: provider.RoleTool,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			trimmed := trimMessages(tt.input)
+			if len(trimmed) != tt.wantLen {
+				t.Fatalf("expected len %d, got %d (%+v)", tt.wantLen, len(trimmed), trimmed)
+			}
+			if tt.wantLen > 0 && trimmed[0].Role != tt.wantRole {
+				t.Fatalf("expected first role %q, got %+v", tt.wantRole, trimmed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
﻿## 变更说明

本 PR 聚焦 `internal/context` 的两类改进：

1. 重构上下文构建流程，拆清 `Build()` 内部的 prompt 状态收集、section 组装与消息快照生成逻辑。
2. 将历史消息裁剪从“相邻 span 截断”升级为“基于 `ToolCallID` 关系索引的闭包保留”，避免 tool call / tool result 断裂，并补充系统态中的 `os` / `arch` 环境感知。

## 主要改动

- 重构 `context.DefaultBuilder` 的内部装配流程，预留动态 prompt section 的挂点。
- 重写 `trimMessages()`，基于 assistant/tool 关联关系做闭包保留，保证工具调用链在裁剪后仍然完整。
- 为消息裁剪补充深拷贝逻辑，避免返回结果反向污染输入消息。
- 在 `System State` 中稳定注入 `os` 与 `arch`，增强模型对运行环境的感知能力。
- 同步更新 `context` 相关测试与文档说明。

## 影响与收益

- 降低 provider 因消息断链导致请求失败的风险。
- 为后续接入 repair state、token 预算裁剪等能力预留更清晰的 `context` 扩展点。
- 让模型在生成命令或路径相关建议时，能直接感知当前运行平台。

## 验证

- `go test ./internal/context`
- `go test ./...`
