### PR TITLE
fix(tools): 重构 EmitChunk 错误传播与调用语义

### DIFF
--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -555,6 +555,46 @@ func TestConsumeStream_ContextCancellation(t *testing.T) {
 	}
 }
 
+func TestConsumeStream_ContextCancellationOnReadErrorReturnsCanceled(t *testing.T) {
+	t.Setenv(config.OpenAIDefaultAPIKeyEnv, "test-key")
+
+	p, err := New(resolvedConfig("", ""))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	body := &cancelThenErrorReader{cancel: cancel, err: io.ErrClosedPipe}
+	err = p.consumeStream(ctx, body, make(chan providertypes.StreamEvent, 1))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestConsumeStream_ContextCancellationAtEOFWithoutDoneReturnsCanceled(t *testing.T) {
+	t.Setenv(config.OpenAIDefaultAPIKeyEnv, "test-key")
+
+	p, err := New(resolvedConfig("", ""))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sseData := `data: {"id":"a","choices":[{"delta":{"content":"hello"}}]}
+
+`
+	body := &cancelOnEOFReader{
+		reader: strings.NewReader(sseData),
+		cancel: cancel,
+	}
+	events := make(chan providertypes.StreamEvent, 8)
+
+	err = p.consumeStream(ctx, body, events)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
 func TestConsumeStream_FinishReasonAccumulation(t *testing.T) {
 	t.Setenv(config.OpenAIDefaultAPIKeyEnv, "test-key")
 
@@ -1265,6 +1305,29 @@ func TestConsumeStream_FlushesPendingDataOnNonEOFError(t *testing.T) {
 type errReader struct{ err error }
 
 func (e *errReader) Read(_ []byte) (int, error) { return 0, e.err }
+
+type cancelThenErrorReader struct {
+	cancel func()
+	err    error
+}
+
+func (r *cancelThenErrorReader) Read(_ []byte) (int, error) {
+	r.cancel()
+	return 0, r.err
+}
+
+type cancelOnEOFReader struct {
+	reader io.Reader
+	cancel func()
+}
+
+func (r *cancelOnEOFReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if errors.Is(err, io.EOF) {
+		r.cancel()
+	}
+	return n, err
+}
 
 type failingReadCloser struct{ err error }
 

--- a/internal/provider/openai/response.go
+++ b/internal/provider/openai/response.go
@@ -13,7 +13,7 @@ import (
 	providertypes "neo-code/internal/provider/types"
 )
 
-// consumeStream 消费 SSE 响应流，使用有界读取器防止缓冲区溢出。
+// consumeStream 消费 SSE 响应流，并在 [DONE] 或 message_done 时完成收尾。
 func (p *Provider) consumeStream(
 	ctx context.Context,
 	body io.Reader,
@@ -30,7 +30,7 @@ func (p *Provider) consumeStream(
 
 	dataLines := make([]string, 0, 4)
 
-	// processChunk 解析单个 SSE data payload，发送事件。
+	// processChunk 解析单个 SSE data payload，并发出增量事件。
 	processChunk := func(payload string) error {
 		if strings.TrimSpace(payload) == "[DONE]" {
 			done = true
@@ -66,23 +66,31 @@ func (p *Provider) consumeStream(
 		return nil
 	}
 
-	// finishStream 统一的流结束处理：发送 message_done 事件。
+	// finishStream 统一输出 message_done 收尾事件。
 	finishStream := func() error {
 		log.Printf("[DEBUG-STREAM] finishStream called: finishReason=%q, done=%v", finishReason, done)
 		return emitMessageDone(ctx, events, finishReason, &usage)
 	}
 
+	// flushPendingData 刷新积累的 data 行，保证多行 data payload 正确拼接。
 	flushPendingData := func() error {
 		defer func() { dataLines = dataLines[:0] }()
 		return flushDataLines(dataLines, processChunk)
 	}
 
 	for {
-		line, err := reader.ReadLine()
+		// 每次读取前优先响应上下文取消，避免取消请求被误判为流中断。
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
 
+		line, err := reader.ReadLine()
 		if err != nil && !errors.Is(err, io.EOF) {
-			// 非 EOF 的读取错误：先刷新缓冲的 data 行，再包装为流中断，
-			// 避免中断前最后一段数据丢失。
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
 			if flushErr := flushPendingData(); flushErr != nil {
 				return flushErr
 			}
@@ -90,12 +98,9 @@ func (p *Provider) consumeStream(
 		}
 
 		trimmed := line
-
 		switch {
 		case strings.HasPrefix(trimmed, "data:"):
 			data := strings.TrimSpace(strings.TrimPrefix(trimmed, "data:"))
-			// data: [DONE] 需要立即处理：先刷新已缓冲的 data 行，再标记结束，
-			// 避免与前面的合法 JSON 拼接后导致 json.Unmarshal 失败。
 			if data == "[DONE]" {
 				if flushErr := flushPendingData(); flushErr != nil {
 					return flushErr
@@ -116,10 +121,12 @@ func (p *Provider) consumeStream(
 		}
 
 		if errors.Is(err, io.EOF) {
-			// [DEBUG] 流 EOF 时打印关键状态，用于诊断截断原因
 			log.Printf("[DEBUG-STREAM] EOF reached: done=%v, finishReason=%q, totalRead=%d, toolCallCount=%d",
 				done, finishReason, reader.totalRead, len(toolCalls))
 			if !done {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
 				log.Printf("[DEBUG-STREAM] WARNING: stream ended WITHOUT [DONE] marker — treating as interruption")
 				if flushErr := flushPendingData(); flushErr != nil {
 					return flushErr
@@ -134,7 +141,7 @@ func (p *Provider) consumeStream(
 	}
 }
 
-// extractStreamUsage 从 OpenAI usage 响应提取并覆盖累积的 token 统计。
+// extractStreamUsage 将 OpenAI usage 响应覆盖到累计 token 统计。
 func extractStreamUsage(usage *providertypes.Usage, raw *openAIUsage) {
 	if raw == nil {
 		return

--- a/internal/runtime/permission.go
+++ b/internal/runtime/permission.go
@@ -100,8 +100,15 @@ func (s *Service) executeToolCallWithPermission(ctx context.Context, input permi
 		Arguments: []byte(input.Call.Arguments),
 		Workdir:   input.Workdir,
 		SessionID: input.SessionID,
-		EmitChunk: func(chunk []byte) {
+		EmitChunk: func(chunk []byte) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			s.emit(ctx, EventToolChunk, input.RunID, input.SessionID, string(chunk))
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/internal/runtime/permission_test.go
+++ b/internal/runtime/permission_test.go
@@ -335,3 +335,55 @@ func TestResolvePermissionCanceledContext(t *testing.T) {
 		t.Fatalf("expected context canceled, got %v", err)
 	}
 }
+
+func TestExecuteToolCallWithPermissionReturnsContextCanceledFromEmitChunk(t *testing.T) {
+	t.Parallel()
+
+	registry := tools.NewRegistry()
+	registry.Register(&stubTool{
+		name: "filesystem_read_file",
+		executeFn: func(_ context.Context, input tools.ToolCallInput) (tools.ToolResult, error) {
+			if input.EmitChunk == nil {
+				t.Fatalf("expected EmitChunk callback")
+			}
+			if err := input.EmitChunk([]byte("stream-chunk")); !errors.Is(err, context.Canceled) {
+				t.Fatalf("expected context.Canceled from emitter, got %v", err)
+			}
+			return tools.NewErrorResult(input.Name, "emit failed", "", nil), context.Canceled
+		},
+	})
+
+	engine, err := security.NewStaticGateway(security.DecisionAllow, nil)
+	if err != nil {
+		t.Fatalf("new static gateway: %v", err)
+	}
+	toolManager, err := tools.NewManager(registry, engine, nil)
+	if err != nil {
+		t.Fatalf("new tool manager: %v", err)
+	}
+
+	service := NewWithFactory(
+		newRuntimeConfigManager(t),
+		toolManager,
+		newMemoryStore(),
+		&scriptedProviderFactory{provider: &scriptedProvider{}},
+		nil,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, execErr := service.executeToolCallWithPermission(ctx, permissionExecutionInput{
+		RunID:     "run-canceled",
+		SessionID: "session-canceled",
+		Call: providertypes.ToolCall{
+			ID:        "call-canceled",
+			Name:      "filesystem_read_file",
+			Arguments: `{"path":"README.md"}`,
+		},
+		ToolTimeout: time.Second,
+	})
+	if !errors.Is(execErr, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", execErr)
+	}
+}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -221,7 +221,7 @@ func (t *stubTool) Execute(ctx context.Context, input tools.ToolCallInput) (tool
 		return t.executeFn(ctx, input)
 	}
 	if input.EmitChunk != nil {
-		input.EmitChunk([]byte("chunk"))
+		_ = input.EmitChunk([]byte("chunk"))
 	}
 	return tools.ToolResult{
 		Name:    t.name,
@@ -1728,7 +1728,7 @@ func TestServiceRunCanceledDuringToolExecution(t *testing.T) {
 		name: "filesystem_edit",
 		executeFn: func(ctx context.Context, input tools.ToolCallInput) (tools.ToolResult, error) {
 			if input.EmitChunk != nil {
-				input.EmitChunk([]byte("chunk"))
+				_ = input.EmitChunk([]byte("chunk"))
 			}
 			close(toolStarted)
 			<-ctx.Done()
@@ -1788,7 +1788,7 @@ func TestServiceRunPreservesToolErrorAfterCancel(t *testing.T) {
 		name: "filesystem_edit",
 		executeFn: func(ctx context.Context, input tools.ToolCallInput) (tools.ToolResult, error) {
 			if input.EmitChunk != nil {
-				input.EmitChunk([]byte("chunk"))
+				_ = input.EmitChunk([]byte("chunk"))
 			}
 			close(toolStarted)
 			<-ctx.Done()

--- a/internal/tools/filesystem/read_file.go
+++ b/internal/tools/filesystem/read_file.go
@@ -100,12 +100,25 @@ func (t *ReadFileTool) Execute(ctx context.Context, input tools.ToolCallInput) (
 
 	if input.EmitChunk != nil {
 		content := []byte(result.Content)
+		emittedBytes := 0
 		for start := 0; start < len(content); start += emitChunkSize {
 			end := start + emitChunkSize
 			if end > len(content) {
 				end = len(content)
 			}
-			input.EmitChunk(content[start:end])
+			if emitErr := input.EmitChunk(content[start:end]); emitErr != nil {
+				err := errors.New(readFileToolName + ": emit chunk failed: " + emitErr.Error())
+				return tools.NewErrorResult(
+					t.Name(),
+					tools.NormalizeErrorReason(t.Name(), err),
+					"",
+					map[string]any{
+						"path":          target,
+						"emitted_bytes": emittedBytes,
+					},
+				), err
+			}
+			emittedBytes += end - start
 		}
 	}
 

--- a/internal/tools/filesystem/read_file_test.go
+++ b/internal/tools/filesystem/read_file_test.go
@@ -3,6 +3,7 @@ package filesystem
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -80,10 +81,11 @@ func TestReadFileToolExecute(t *testing.T) {
 				Name:      tool.Name(),
 				Arguments: args,
 				Workdir:   workspace,
-				EmitChunk: func(chunk []byte) {
+				EmitChunk: func(chunk []byte) error {
 					if len(chunk) > 0 {
 						chunks++
 					}
+					return nil
 				},
 			})
 
@@ -151,10 +153,11 @@ func TestReadFileToolErrorFormattingAndTruncation(t *testing.T) {
 				Name:      tool.Name(),
 				Arguments: tt.arguments,
 				Workdir:   workspace,
-				EmitChunk: func(chunk []byte) {
+				EmitChunk: func(chunk []byte) error {
 					if len(chunk) > 0 {
 						chunks++
 					}
+					return nil
 				},
 			})
 
@@ -177,5 +180,41 @@ func TestReadFileToolErrorFormattingAndTruncation(t *testing.T) {
 				t.Fatalf("expected chunk emitter to receive truncated content")
 			}
 		})
+	}
+}
+
+func TestReadFileToolExecuteStopsOnEmitChunkError(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	content := strings.Repeat("chunk-data-", 500)
+	if err := os.WriteFile(filepath.Join(workspace, "large.txt"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write large file: %v", err)
+	}
+
+	tool := New(workspace)
+	args := mustMarshalFSArgs(t, map[string]string{"path": "large.txt"})
+
+	emitCount := 0
+	result, err := tool.Execute(context.Background(), tools.ToolCallInput{
+		Name:      tool.Name(),
+		Arguments: args,
+		Workdir:   workspace,
+		EmitChunk: func(chunk []byte) error {
+			emitCount++
+			if emitCount == 1 {
+				return errors.New("consumer closed")
+			}
+			return nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "emit chunk failed") {
+		t.Fatalf("expected emit chunk failure, got %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected error result, got %+v", result)
+	}
+	if result.Metadata["emitted_bytes"] != 0 {
+		t.Fatalf("expected emitted_bytes=0 before first successful emit, got %+v", result.Metadata)
 	}
 }

--- a/internal/tools/filesystem/read_file_test.go
+++ b/internal/tools/filesystem/read_file_test.go
@@ -218,3 +218,63 @@ func TestReadFileToolExecuteStopsOnEmitChunkError(t *testing.T) {
 		t.Fatalf("expected emitted_bytes=0 before first successful emit, got %+v", result.Metadata)
 	}
 }
+
+func TestReadFileToolExecuteEmitsProgressBeforeChunkFailure(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	content := strings.Repeat("chunk-data-", 500)
+	if err := os.WriteFile(filepath.Join(workspace, "large.txt"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write large file: %v", err)
+	}
+
+	tool := New(workspace)
+	args := mustMarshalFSArgs(t, map[string]string{"path": "large.txt"})
+
+	emitCount := 0
+	result, err := tool.Execute(context.Background(), tools.ToolCallInput{
+		Name:      tool.Name(),
+		Arguments: args,
+		Workdir:   workspace,
+		EmitChunk: func(chunk []byte) error {
+			emitCount++
+			if emitCount == 2 {
+				return errors.New("consumer closed on second chunk")
+			}
+			return nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "emit chunk failed") {
+		t.Fatalf("expected emit chunk failure, got %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected error result, got %+v", result)
+	}
+	if result.Metadata["emitted_bytes"] != emitChunkSize {
+		t.Fatalf("expected emitted_bytes=%d after first successful chunk, got %+v", emitChunkSize, result.Metadata)
+	}
+}
+
+func TestReadFileToolExecuteWithoutChunkEmitter(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspace, "small.txt"), []byte("hello without stream"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	tool := New(workspace)
+	args := mustMarshalFSArgs(t, map[string]string{"path": "small.txt"})
+
+	result, err := tool.Execute(context.Background(), tools.ToolCallInput{
+		Name:      tool.Name(),
+		Arguments: args,
+		Workdir:   workspace,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Content != "hello without stream" {
+		t.Fatalf("unexpected content: %q", result.Content)
+	}
+}

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -15,7 +15,14 @@ type Tool interface {
 	Execute(ctx context.Context, call ToolCallInput) (ToolResult, error)
 }
 
-type ChunkEmitter func(chunk []byte)
+// ChunkEmitter 是工具执行过程中向上游发送流式分片的回调。
+// 并发语义：
+// - 回调可能在一次执行内被调用 0 次或多次；
+// - 回调在工具执行 goroutine 中调用；
+// - 调用方若返回非 nil error，工具应停止后续分片发送并尽快中止执行。
+// 内存语义：
+// - 回调返回后不得继续持有传入的 chunk 引用，若需异步使用必须先复制。
+type ChunkEmitter func(chunk []byte) error
 
 type ToolCallInput struct {
 	ID            string
@@ -24,7 +31,8 @@ type ToolCallInput struct {
 	SessionID     string
 	Workdir       string
 	WorkspacePlan *security.WorkspaceExecutionPlan
-	EmitChunk     ChunkEmitter
+	// EmitChunk 为流式分片回调，语义见 ChunkEmitter 注释。
+	EmitChunk ChunkEmitter
 }
 
 type ToolResult struct {


### PR DESCRIPTION
## 背景
当前 `EmitChunk/ChunkEmitter` 存在两个核心问题：
- 回调签名无错误返回，无法做背压与错误传播
- 缺少并发/生命周期语义，调用边界不清晰

## 主要改动
- `internal/tools/types.go`
  - `ChunkEmitter` 从 `func([]byte)` 升级为 `func([]byte) error`
  - 补齐并发调用与切片生命周期注释
- `internal/runtime/permission.go`
  - runtime 侧 `EmitChunk` 回调接入错误返回
  - `ctx` 取消时即时返回错误，避免无效发送
- `internal/tools/filesystem/read_file.go`
  - 分片发送时检查 `EmitChunk` 返回值
  - 回调失败即中断执行并返回错误结果（含 `emitted_bytes`）
- `internal/tools/filesystem/read_file_test.go`
  - 适配新签名并新增 EmitChunk 失败中断测试
- `internal/runtime/runtime_test.go`
  - 适配新签名调用

## 验证
- `go test ./... -count=1` 通过

Closes #204