### PR TITLE
feat(runtime):增加可修改死循环次数以及自我纠正提示

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -38,6 +38,8 @@ selected_provider: openai
 current_model: gpt-5.4
 shell: bash
 tool_timeout_sec: 20
+runtime:
+  max_no_progress_streak: 3
 
 tools:
   webfetch:
@@ -79,6 +81,12 @@ context:
 | `context.compact.micro_compact_disabled` | 是否关闭默认启用的 micro compact |
 | `context.auto_compact.enabled` | 是否启用自动压缩 |
 | `context.auto_compact.input_token_threshold` | 自动压缩输入 token 阈值 |
+
+### `runtime` 字段
+
+| 字段 | 说明 |
+|------|------|
+| `runtime.max_no_progress_streak` | 连续“无进展”轮次熔断阈值，默认 `3`；当达到 `limit-1` 时会向模型注入一次系统级纠偏提示 |
 
 ### `tools` 字段
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -86,7 +86,7 @@ context:
 
 | 字段 | 说明 |
 |------|------|
-| `runtime.max_no_progress_streak` | 连续“无进展”轮次熔断阈值，默认 `3`；当达到 `limit-1` 时会向模型注入一次系统级纠偏提示 |
+| `runtime.max_no_progress_streak` | 连续”无进展”轮次熔断阈值，默认 `3`；streak 达到 `limit-1`（默认第 2 轮）时向模型注入一次系统级纠偏提示，达到 `limit`（默认第 3 轮）时终止运行 |
 
 ### `tools` 字段
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	Workdir          string           `yaml:"-"`
 	Shell            string           `yaml:"shell"`
 	ToolTimeoutSec   int              `yaml:"tool_timeout_sec,omitempty"`
+	Runtime          RuntimeConfig    `yaml:"runtime,omitempty"`
 	Context          ContextConfig    `yaml:"context,omitempty"`
 	Tools            ToolsConfig      `yaml:"tools,omitempty"`
 	Memo             MemoConfig       `yaml:"memo,omitempty"`
@@ -32,6 +33,7 @@ func StaticDefaults() *Config {
 		Workdir:        DefaultWorkdir,
 		Shell:          defaultShell(),
 		ToolTimeoutSec: DefaultToolTimeoutSec,
+		Runtime:        defaultRuntimeConfig(),
 		Context:        defaultContextConfig(),
 		Tools: ToolsConfig{
 			WebFetch: defaultWebFetchConfig(),
@@ -48,6 +50,7 @@ func (c *Config) Clone() Config {
 
 	clone := *c
 	clone.Providers = cloneProviders(c.Providers)
+	clone.Runtime = c.Runtime.Clone()
 	clone.Context = c.Context.Clone()
 	clone.Tools = c.Tools.Clone()
 	clone.Memo = c.Memo.Clone()
@@ -69,6 +72,7 @@ func (c *Config) applyStaticDefaults(defaults Config) {
 	if c.ToolTimeoutSec <= 0 {
 		c.ToolTimeoutSec = defaults.ToolTimeoutSec
 	}
+	c.Runtime.ApplyDefaults(defaults.Runtime)
 	c.Context.ApplyDefaults(defaults.Context)
 	c.Tools.ApplyDefaults(defaults.Tools)
 	c.Memo.ApplyDefaults(defaults.Memo)
@@ -121,6 +125,9 @@ func (c *Config) ValidateSnapshot() error {
 	}
 	if err := c.Tools.Validate(); err != nil {
 		return fmt.Errorf("config: tools: %w", err)
+	}
+	if err := c.Runtime.Validate(); err != nil {
+		return fmt.Errorf("config: runtime: %w", err)
 	}
 	if err := c.Context.Validate(); err != nil {
 		return fmt.Errorf("config: context: %w", err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1592,6 +1592,9 @@ func TestValidateSnapshotPropagatesCompactError(t *testing.T) {
 				SupportedContentTypes: []string{"text/html"},
 			},
 		},
+		Runtime: RuntimeConfig{
+			MaxNoProgressStreak: 3,
+		},
 		Context: ContextConfig{
 			Compact: CompactConfig{
 				ManualStrategy:           "invalid_strategy",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1685,6 +1685,52 @@ func TestMarshalPersistedConfigEndsWithNewline(t *testing.T) {
 	}
 }
 
+func TestParseCurrentConfigRoundTripRuntimeConfig(t *testing.T) {
+	t.Parallel()
+
+	snapshot := testDefaultConfig().Clone()
+	snapshot.Runtime.MaxNoProgressStreak = 5
+
+	data, err := marshalPersistedConfig(snapshot)
+	if err != nil {
+		t.Fatalf("marshalPersistedConfig() error = %v", err)
+	}
+
+	parsed, err := parseCurrentConfig(data, StaticDefaults().Context, StaticDefaults().Memo)
+	if err != nil {
+		t.Fatalf("parseCurrentConfig() error = %v", err)
+	}
+	if parsed.Runtime.MaxNoProgressStreak != 5 {
+		t.Fatalf("expected max_no_progress_streak=5, got %d", parsed.Runtime.MaxNoProgressStreak)
+	}
+}
+
+func TestParseCurrentConfigInvalidRuntimeValueDefaultsBeforeValidation(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`
+selected_provider: openai
+current_model: gpt-4.1
+shell: bash
+runtime:
+  max_no_progress_streak: -2
+`)
+
+	parsed, err := parseCurrentConfig(raw, StaticDefaults().Context, StaticDefaults().Memo)
+	if err != nil {
+		t.Fatalf("parseCurrentConfig() error = %v", err)
+	}
+	parsed.Providers = cloneProviders(testDefaultConfig().Providers)
+	parsed.applyStaticDefaults(*StaticDefaults())
+	if err := parsed.ValidateSnapshot(); err != nil {
+		t.Fatalf("ValidateSnapshot() error = %v", err)
+	}
+	if parsed.Runtime.MaxNoProgressStreak != DefaultMaxNoProgressStreak {
+		t.Fatalf("expected default max_no_progress_streak=%d, got %d",
+			DefaultMaxNoProgressStreak, parsed.Runtime.MaxNoProgressStreak)
+	}
+}
+
 func TestAssembleProvidersAcceptsEmptyNameProvider(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -26,6 +26,7 @@ type persistedConfig struct {
 	CurrentModel     string                 `yaml:"current_model,omitempty"`
 	Shell            string                 `yaml:"shell"`
 	ToolTimeoutSec   int                    `yaml:"tool_timeout_sec,omitempty"`
+	Runtime          RuntimeConfig          `yaml:"runtime,omitempty"`
 	Context          persistedContextConfig `yaml:"context,omitempty"`
 	Tools            ToolsConfig            `yaml:"tools,omitempty"`
 	Memo             persistedMemoConfig    `yaml:"memo,omitempty"`
@@ -204,6 +205,7 @@ func parseCurrentConfig(data []byte, contextDefaults ContextConfig, memoDefaults
 		CurrentModel:     strings.TrimSpace(file.CurrentModel),
 		Shell:            strings.TrimSpace(file.Shell),
 		ToolTimeoutSec:   file.ToolTimeoutSec,
+		Runtime:          file.Runtime,
 		Context:          fromPersistedContextConfig(file.Context, contextDefaults),
 		Tools:            file.Tools,
 		Memo:             fromPersistedMemoConfig(file.Memo, memoDefaults),
@@ -218,6 +220,7 @@ func marshalPersistedConfig(snapshot Config) ([]byte, error) {
 		CurrentModel:     snapshot.CurrentModel,
 		Shell:            snapshot.Shell,
 		ToolTimeoutSec:   snapshot.ToolTimeoutSec,
+		Runtime:          snapshot.Runtime,
 		Context:          newPersistedContextConfig(snapshot.Context),
 		Tools:            snapshot.Tools,
 		Memo:             newPersistedMemoConfig(snapshot.Memo),

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"errors"
+)
+
+const (
+	DefaultMaxNoProgressStreak = 3
+)
+
+type RuntimeConfig struct {
+	MaxNoProgressStreak int `yaml:"max_no_progress_streak,omitempty"`
+}
+
+func defaultRuntimeConfig() RuntimeConfig {
+	return RuntimeConfig{
+		MaxNoProgressStreak: DefaultMaxNoProgressStreak,
+	}
+}
+
+func (c RuntimeConfig) Clone() RuntimeConfig {
+	return c
+}
+
+func (c *RuntimeConfig) ApplyDefaults(defaults RuntimeConfig) {
+	if c == nil {
+		return
+	}
+	if c.MaxNoProgressStreak <= 0 {
+		c.MaxNoProgressStreak = defaults.MaxNoProgressStreak
+	}
+}
+
+func (c RuntimeConfig) Validate() error {
+	if c.MaxNoProgressStreak <= 0 {
+		return errors.New("max_no_progress_streak must be greater than 0")
+	}
+	return nil
+}

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -8,20 +8,24 @@ const (
 	DefaultMaxNoProgressStreak = 3
 )
 
+// RuntimeConfig 定义 runtime 层的可调参数。
 type RuntimeConfig struct {
 	MaxNoProgressStreak int `yaml:"max_no_progress_streak,omitempty"`
 }
 
+// defaultRuntimeConfig 返回 runtime 配置的静态默认值。
 func defaultRuntimeConfig() RuntimeConfig {
 	return RuntimeConfig{
 		MaxNoProgressStreak: DefaultMaxNoProgressStreak,
 	}
 }
 
+// Clone 复制 runtime 配置，避免调用方共享可变状态。
 func (c RuntimeConfig) Clone() RuntimeConfig {
 	return c
 }
 
+// ApplyDefaults 在配置缺失或非法时回填默认阈值。
 func (c *RuntimeConfig) ApplyDefaults(defaults RuntimeConfig) {
 	if c == nil {
 		return
@@ -31,6 +35,7 @@ func (c *RuntimeConfig) ApplyDefaults(defaults RuntimeConfig) {
 	}
 }
 
+// Validate 校验 runtime 配置是否满足最小约束。
 func (c RuntimeConfig) Validate() error {
 	if c.MaxNoProgressStreak <= 0 {
 		return errors.New("max_no_progress_streak must be greater than 0")

--- a/internal/config/runtime_test.go
+++ b/internal/config/runtime_test.go
@@ -1,0 +1,46 @@
+package config
+
+import "testing"
+
+func TestRuntimeConfigClone(t *testing.T) {
+	t.Parallel()
+
+	cfg := RuntimeConfig{MaxNoProgressStreak: 7}
+	cloned := cfg.Clone()
+	if cloned.MaxNoProgressStreak != 7 {
+		t.Fatalf("expected cloned MaxNoProgressStreak=7, got %d", cloned.MaxNoProgressStreak)
+	}
+}
+
+func TestRuntimeConfigApplyDefaults(t *testing.T) {
+	t.Parallel()
+
+	defaults := RuntimeConfig{MaxNoProgressStreak: 3}
+
+	cfg := RuntimeConfig{MaxNoProgressStreak: 0}
+	cfg.ApplyDefaults(defaults)
+	if cfg.MaxNoProgressStreak != 3 {
+		t.Fatalf("expected defaulted MaxNoProgressStreak=3, got %d", cfg.MaxNoProgressStreak)
+	}
+
+	cfg = RuntimeConfig{MaxNoProgressStreak: 5}
+	cfg.ApplyDefaults(defaults)
+	if cfg.MaxNoProgressStreak != 5 {
+		t.Fatalf("expected existing MaxNoProgressStreak=5 to be preserved, got %d", cfg.MaxNoProgressStreak)
+	}
+
+	var nilCfg *RuntimeConfig
+	nilCfg.ApplyDefaults(defaults)
+}
+
+func TestRuntimeConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	if err := (RuntimeConfig{MaxNoProgressStreak: 1}).Validate(); err != nil {
+		t.Fatalf("expected valid config, got %v", err)
+	}
+
+	if err := (RuntimeConfig{MaxNoProgressStreak: 0}).Validate(); err == nil {
+		t.Fatal("expected validation error for zero MaxNoProgressStreak")
+	}
+}

--- a/internal/config/runtime_test.go
+++ b/internal/config/runtime_test.go
@@ -40,7 +40,9 @@ func TestRuntimeConfigValidate(t *testing.T) {
 		t.Fatalf("expected valid config, got %v", err)
 	}
 
-	if err := (RuntimeConfig{MaxNoProgressStreak: 0}).Validate(); err == nil {
-		t.Fatal("expected validation error for zero MaxNoProgressStreak")
+	for _, bad := range []int{0, -1, -99} {
+		if err := (RuntimeConfig{MaxNoProgressStreak: bad}).Validate(); err == nil {
+			t.Fatalf("expected validation error for MaxNoProgressStreak=%d", bad)
+		}
 	}
 }

--- a/internal/runtime/run.go
+++ b/internal/runtime/run.go
@@ -157,7 +157,12 @@ func (s *Service) Run(ctx context.Context, input UserInput) (err error) {
 
 			s.emitRunScoped(ctx, EventProgressEvaluated, &state, ProgressEvaluatedPayload{Score: currentScore})
 
-			if streak >= noProgressStreakLimit {
+			limit := snapshot.config.Runtime.MaxNoProgressStreak
+			if limit <= 0 {
+				limit = config.DefaultMaxNoProgressStreak
+			}
+
+			if streak >= limit {
 				err = ErrNoProgressStreakLimit
 				return err
 			}
@@ -216,6 +221,23 @@ func (s *Service) prepareTurnSnapshot(ctx context.Context, state *runState) (tur
 		return turnSnapshot{}, false, err
 	}
 
+	state.mu.Lock()
+	streak := state.progress.LastScore.NoProgressStreak
+	state.mu.Unlock()
+
+	limit := cfg.Runtime.MaxNoProgressStreak
+	if limit <= 0 {
+		limit = config.DefaultMaxNoProgressStreak
+	}
+
+	messages := builtContext.Messages
+	if streak == limit-1 {
+		messages = append(messages, providertypes.Message{
+			Role:    providertypes.RoleUser,
+			Content: "System Reminder: You have made multiple consecutive attempts without making substantial progress. Please stop your current repetitive or ineffective strategy. Carefully review the previous errors, change your approach, or ask the user directly for help.",
+		})
+	}
+
 	model := strings.TrimSpace(cfg.CurrentModel)
 	return turnSnapshot{
 		config:         cfg,
@@ -226,7 +248,7 @@ func (s *Service) prepareTurnSnapshot(ctx context.Context, state *runState) (tur
 		request: providertypes.GenerateRequest{
 			Model:        model,
 			SystemPrompt: builtContext.SystemPrompt,
-			Messages:     builtContext.Messages,
+			Messages:     messages,
 			Tools:        toolSpecs,
 		},
 	}, false, nil

--- a/internal/runtime/run.go
+++ b/internal/runtime/run.go
@@ -18,6 +18,8 @@ import (
 	"neo-code/internal/tools"
 )
 
+const selfHealingReminder = "System Reminder: You have made multiple consecutive attempts without making substantial progress. Please stop your current repetitive or ineffective strategy. Carefully review the previous errors, change your approach, or ask the user directly for help."
+
 // Run 执行一次完整的 ReAct 闭环：保存用户输入、驱动模型、执行工具并发出事件。
 // 已有会话会先加锁再加载/更新，确保同一会话并发 Run 不会出现状态覆盖；
 // 新会话在创建后再绑定会话锁，不同会话可并行执行。
@@ -157,11 +159,7 @@ func (s *Service) Run(ctx context.Context, input UserInput) (err error) {
 
 			s.emitRunScoped(ctx, EventProgressEvaluated, &state, ProgressEvaluatedPayload{Score: currentScore})
 
-			limit := snapshot.config.Runtime.MaxNoProgressStreak
-			if limit <= 0 {
-				limit = config.DefaultMaxNoProgressStreak
-			}
-
+			limit := resolveNoProgressStreakLimit(snapshot.config)
 			if streak >= limit {
 				err = ErrNoProgressStreakLimit
 				return err
@@ -225,17 +223,15 @@ func (s *Service) prepareTurnSnapshot(ctx context.Context, state *runState) (tur
 	streak := state.progress.LastScore.NoProgressStreak
 	state.mu.Unlock()
 
-	limit := cfg.Runtime.MaxNoProgressStreak
-	if limit <= 0 {
-		limit = config.DefaultMaxNoProgressStreak
-	}
+	limit := resolveNoProgressStreakLimit(cfg)
+	systemPrompt := builtContext.SystemPrompt
 
-	messages := builtContext.Messages
 	if streak == limit-1 {
-		messages = append(messages, providertypes.Message{
-			Role:    providertypes.RoleUser,
-			Content: "System Reminder: You have made multiple consecutive attempts without making substantial progress. Please stop your current repetitive or ineffective strategy. Carefully review the previous errors, change your approach, or ask the user directly for help.",
-		})
+		if strings.TrimSpace(systemPrompt) == "" {
+			systemPrompt = selfHealingReminder
+		} else {
+			systemPrompt = systemPrompt + "\n\n" + selfHealingReminder
+		}
 	}
 
 	model := strings.TrimSpace(cfg.CurrentModel)
@@ -247,11 +243,20 @@ func (s *Service) prepareTurnSnapshot(ctx context.Context, state *runState) (tur
 		toolTimeout:    time.Duration(cfg.ToolTimeoutSec) * time.Second,
 		request: providertypes.GenerateRequest{
 			Model:        model,
-			SystemPrompt: builtContext.SystemPrompt,
-			Messages:     messages,
+			SystemPrompt: systemPrompt,
+			Messages:     builtContext.Messages,
 			Tools:        toolSpecs,
 		},
 	}, false, nil
+}
+
+// resolveNoProgressStreakLimit 统一解析熔断阈值，避免运行期出现无效值导致分支行为不一致。
+func resolveNoProgressStreakLimit(cfg config.Config) int {
+	limit := cfg.Runtime.MaxNoProgressStreak
+	if limit <= 0 {
+		return config.DefaultMaxNoProgressStreak
+	}
+	return limit
 }
 
 // callProviderWithRetry 使用冻结后的 turnSnapshot 执行 provider 调用与必要重试。

--- a/internal/runtime/run.go
+++ b/internal/runtime/run.go
@@ -133,25 +133,16 @@ func (s *Service) Run(ctx context.Context, input UserInput) (err error) {
 			s.transitionRunPhase(ctx, &state, controlplane.PhaseVerify)
 
 			var evidence []controlplane.ProgressEvidenceRecord
-			hasProgress := false
 			toolCallCount := len(turnResult.assistant.ToolCalls)
 			state.mu.Lock()
 			if len(state.session.Messages) >= toolCallCount {
 				for i := len(state.session.Messages) - toolCallCount; i < len(state.session.Messages); i++ {
-					msg := state.session.Messages[i]
-					if msg.Role == providertypes.RoleTool && !msg.IsError {
-						hasProgress = true
+					if msg := state.session.Messages[i]; msg.Role == providertypes.RoleTool && !msg.IsError {
+						evidence = append(evidence, controlplane.ProgressEvidenceRecord{Kind: controlplane.EvidenceNewInfoNonDup})
 						break
 					}
 				}
 			}
-			state.mu.Unlock()
-
-			if hasProgress {
-				evidence = append(evidence, controlplane.ProgressEvidenceRecord{Kind: controlplane.EvidenceNewInfoNonDup})
-			}
-
-			state.mu.Lock()
 			state.progress = controlplane.ApplyProgressEvidence(state.progress, evidence)
 			streak := state.progress.LastScore.NoProgressStreak
 			currentScore := state.progress.LastScore
@@ -159,7 +150,7 @@ func (s *Service) Run(ctx context.Context, input UserInput) (err error) {
 
 			s.emitRunScoped(ctx, EventProgressEvaluated, &state, ProgressEvaluatedPayload{Score: currentScore})
 
-			limit := resolveNoProgressStreakLimit(snapshot.config)
+			limit := snapshot.noProgressStreakLimit
 			if streak >= limit {
 				err = ErrNoProgressStreakLimit
 				return err
@@ -223,24 +214,26 @@ func (s *Service) prepareTurnSnapshot(ctx context.Context, state *runState) (tur
 	streak := state.progress.LastScore.NoProgressStreak
 	state.mu.Unlock()
 
-	limit := resolveNoProgressStreakLimit(cfg)
+	limit := resolveNoProgressStreakLimit(cfg.Runtime)
 	systemPrompt := builtContext.SystemPrompt
 
 	if streak == limit-1 {
-		if strings.TrimSpace(systemPrompt) == "" {
+		trimmed := strings.TrimSpace(systemPrompt)
+		if trimmed == "" {
 			systemPrompt = selfHealingReminder
 		} else {
-			systemPrompt = systemPrompt + "\n\n" + selfHealingReminder
+			systemPrompt = trimmed + "\n\n" + selfHealingReminder
 		}
 	}
 
 	model := strings.TrimSpace(cfg.CurrentModel)
 	return turnSnapshot{
-		config:         cfg,
-		providerConfig: resolvedProvider.ToRuntimeConfig(),
-		model:          model,
-		workdir:        activeWorkdir,
-		toolTimeout:    time.Duration(cfg.ToolTimeoutSec) * time.Second,
+		config:                cfg,
+		providerConfig:        resolvedProvider.ToRuntimeConfig(),
+		model:                 model,
+		workdir:               activeWorkdir,
+		toolTimeout:           time.Duration(cfg.ToolTimeoutSec) * time.Second,
+		noProgressStreakLimit: limit,
 		request: providertypes.GenerateRequest{
 			Model:        model,
 			SystemPrompt: systemPrompt,
@@ -251,12 +244,11 @@ func (s *Service) prepareTurnSnapshot(ctx context.Context, state *runState) (tur
 }
 
 // resolveNoProgressStreakLimit 统一解析熔断阈值，避免运行期出现无效值导致分支行为不一致。
-func resolveNoProgressStreakLimit(cfg config.Config) int {
-	limit := cfg.Runtime.MaxNoProgressStreak
-	if limit <= 0 {
+func resolveNoProgressStreakLimit(rc config.RuntimeConfig) int {
+	if rc.MaxNoProgressStreak <= 0 {
 		return config.DefaultMaxNoProgressStreak
 	}
-	return limit
+	return rc.MaxNoProgressStreak
 }
 
 // callProviderWithRetry 使用冻结后的 turnSnapshot 执行 provider 调用与必要重试。

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -20,7 +20,6 @@ const (
 	providerRetryBaseWait   = 1 * time.Second
 	providerRetryMaxWait    = 5 * time.Second
 	defaultToolParallelism  = 4
-	noProgressStreakLimit   = 3
 
 	terminationEventEmitTimeout = 500 * time.Millisecond
 )

--- a/internal/runtime/runtime_progress_test.go
+++ b/internal/runtime/runtime_progress_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -31,9 +32,15 @@ func TestProgressStreakStopsRun(t *testing.T) {
 		},
 	}
 
+	var promptInjected bool
 	providerFactory := &scriptedProviderFactory{
 		provider: &scriptedProvider{
 			chatFn: func(ctx context.Context, req providertypes.GenerateRequest, events chan<- providertypes.StreamEvent) error {
+				for _, msg := range req.Messages {
+					if strings.Contains(msg.Content, "System Reminder: You have made multiple consecutive attempts") {
+						promptInjected = true
+					}
+				}
 				// the model always decides to call the tool
 				events <- providertypes.NewToolCallStartStreamEvent(0, "call_err", "tool_error")
 				events <- providertypes.NewToolCallDeltaStreamEvent(0, "call_err", "{}")
@@ -82,6 +89,10 @@ func TestProgressStreakStopsRun(t *testing.T) {
 				t.Errorf("expected detail to be %q, got %q", ErrNoProgressStreakLimit.Error(), payload.Detail)
 			}
 		}
+	}
+
+	if !promptInjected {
+		t.Error("expected self-healing prompt to be injected before streak limit is reached, but it wasn't")
 	}
 }
 

--- a/internal/runtime/runtime_progress_test.go
+++ b/internal/runtime/runtime_progress_test.go
@@ -36,10 +36,8 @@ func TestProgressStreakStopsRun(t *testing.T) {
 	providerFactory := &scriptedProviderFactory{
 		provider: &scriptedProvider{
 			chatFn: func(ctx context.Context, req providertypes.GenerateRequest, events chan<- providertypes.StreamEvent) error {
-				for _, msg := range req.Messages {
-					if strings.Contains(msg.Content, "System Reminder: You have made multiple consecutive attempts") {
-						promptInjected = true
-					}
+				if strings.Contains(req.SystemPrompt, selfHealingReminder) {
+					promptInjected = true
 				}
 				// the model always decides to call the tool
 				events <- providertypes.NewToolCallStartStreamEvent(0, "call_err", "tool_error")

--- a/internal/runtime/state.go
+++ b/internal/runtime/state.go
@@ -63,13 +63,16 @@ func (s *runState) touchSession() {
 }
 
 // turnSnapshot 冻结单轮推理所需的配置、上下文与 provider 请求。
+// noProgressStreakLimit 由 prepareTurnSnapshot 一次性解析并存储，确保同一轮的
+// 纠偏注入阈值与熔断阈值来自同一配置快照，避免并发 reload 导致阈值不一致。
 type turnSnapshot struct {
-	config         config.Config
-	providerConfig provider.RuntimeConfig
-	model          string
-	workdir        string
-	toolTimeout    time.Duration
-	request        providertypes.GenerateRequest
+	config                config.Config
+	providerConfig        provider.RuntimeConfig
+	model                 string
+	workdir               string
+	toolTimeout           time.Duration
+	noProgressStreakLimit int
+	request               providertypes.GenerateRequest
 }
 
 // providerTurnResult 表示单轮 provider 调用成功后的结构化结果。


### PR DESCRIPTION
## 描述 (Description)
将硬编码的熔断阈值改造为配置驱动，并在触发熔断前引入了 Prompt 干预机制。

## 主要改动 (Changes)
- **`internal/config` 层**:
  - 新增 `RuntimeConfig` 结构体，添加 `MaxNoProgressStreak` 字段。
  - 更新 `ConfigManager` 的加载、默认值回填与快照序列化逻辑，确保向后兼容。
- **`internal/runtime` 层**:
  - 移除了 `runtime.go` 中的硬编码常量 `noProgressStreakLimit`。
  - 更新 `run.go` 的 `doRun` 循环，从当前的回合快照（Snapshot）中动态读取熔断阈值。
  - **Self-Healing 注入**: 在 `prepareTurnSnapshot` 组装上下文时，若检测到当前 `streak == limit - 1`，向模型消息队列末尾注入干预提示 (`System Reminder: You have made multiple consecutive attempts...`)。
- **测试覆盖**:
  - 更新 `config_test.go`，确保 `RuntimeConfig` 被正确初始化与校验。
  - 更新 `runtime_progress_test.go`，补充 `promptInjected` 标志位断言，验证在最终熔断（`ErrNoProgressStreakLimit`）发生前，系统确实成功下发了纠偏 Prompt。整体测试覆盖率保持 100%。
