### PR TITLE
fix(tui): 引入 GatewayRPCClient 后台心跳保活机制防断连

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -162,9 +162,16 @@ func BuildRuntime(ctx context.Context, opts BootstrapOptions) (RuntimeBundle, er
 	if err != nil {
 		return RuntimeBundle{}, err
 	}
+	var sessionStore *agentsession.SQLiteStore
 	needCleanup := true
 	defer func() {
-		if needCleanup && toolsCleanup != nil {
+		if !needCleanup {
+			return
+		}
+		if sessionStore != nil {
+			_ = sessionStore.Close()
+		}
+		if toolsCleanup != nil {
 			_ = toolsCleanup()
 		}
 	}()
@@ -176,7 +183,7 @@ func BuildRuntime(ctx context.Context, opts BootstrapOptions) (RuntimeBundle, er
 
 	// Session Store 绑定到启动时的 workdir 哈希分桶，整个应用生命周期内不可变。
 	// 这意味着所有会话都归属到启动时指定的项目目录下，运行时不会因配置变更而迁移存储位置。
-	sessionStore := agentsession.NewStore(loader.BaseDir(), cfg.Workdir)
+	sessionStore = agentsession.NewStore(loader.BaseDir(), cfg.Workdir)
 
 	// 启动时自动清理过期会话，避免数据库无限膨胀。
 	if _, err := cleanupExpiredSessions(ctx, sessionStore, agentsession.DefaultSessionMaxAge); err != nil {

--- a/internal/session/sqlite_store_additional_test.go
+++ b/internal/session/sqlite_store_additional_test.go
@@ -232,10 +232,11 @@ func TestNormalizeCreateSessionInputDefaultsGeneratedID(t *testing.T) {
 func TestSQLiteStoreCreateSessionPropagatesEnsureStorageDirsError(t *testing.T) {
 	t.Parallel()
 
+	invalidBase := createNonDirectoryPath(t)
 	store := &SQLiteStore{
 		projectDir: filepath.Join(t.TempDir(), "project"),
 		assetsDir:  filepath.Join(t.TempDir(), "assets"),
-		dbPath:     filepath.Join("/dev/null", "db.sqlite"),
+		dbPath:     filepath.Join(invalidBase, "db.sqlite"),
 	}
 	_, err := store.CreateSession(context.Background(), CreateSessionInput{ID: "s1", Title: "title"})
 	if err == nil {
@@ -246,17 +247,19 @@ func TestSQLiteStoreCreateSessionPropagatesEnsureStorageDirsError(t *testing.T) 
 func TestSQLiteStoreEnsureStorageDirsErrorBranches(t *testing.T) {
 	t.Parallel()
 
+	invalidDBDirBase := createNonDirectoryPath(t)
 	dbDirErrStore := &SQLiteStore{
 		projectDir: filepath.Join(t.TempDir(), "project"),
 		assetsDir:  filepath.Join(t.TempDir(), "assets"),
-		dbPath:     filepath.Join("/dev/null", "db.sqlite"),
+		dbPath:     filepath.Join(invalidDBDirBase, "db.sqlite"),
 	}
 	if err := dbDirErrStore.ensureStorageDirs(); err == nil || !strings.Contains(err.Error(), "create db dir") {
 		t.Fatalf("expected create db dir error, got %v", err)
 	}
 
+	invalidProjectDirBase := createNonDirectoryPath(t)
 	projectDirErrStore := &SQLiteStore{
-		projectDir: filepath.Join("/dev/null", "project"),
+		projectDir: filepath.Join(invalidProjectDirBase, "project"),
 		assetsDir:  filepath.Join(t.TempDir(), "assets"),
 		dbPath:     filepath.Join(t.TempDir(), "db.sqlite"),
 	}
@@ -264,9 +267,10 @@ func TestSQLiteStoreEnsureStorageDirsErrorBranches(t *testing.T) {
 		t.Fatalf("expected create project dir error, got %v", err)
 	}
 
+	invalidAssetsDirBase := createNonDirectoryPath(t)
 	assetsDirErrStore := &SQLiteStore{
 		projectDir: filepath.Join(t.TempDir(), "project"),
-		assetsDir:  filepath.Join("/dev/null", "assets"),
+		assetsDir:  filepath.Join(invalidAssetsDirBase, "assets"),
 		dbPath:     filepath.Join(t.TempDir(), "db.sqlite"),
 	}
 	if err := assetsDirErrStore.ensureStorageDirs(); err == nil || !strings.Contains(err.Error(), "create assets dir") {
@@ -277,14 +281,25 @@ func TestSQLiteStoreEnsureStorageDirsErrorBranches(t *testing.T) {
 func TestSQLiteStoreInitializePropagatesStorageDirError(t *testing.T) {
 	t.Parallel()
 
+	invalidBase := createNonDirectoryPath(t)
 	store := &SQLiteStore{
 		projectDir: filepath.Join(t.TempDir(), "project"),
 		assetsDir:  filepath.Join(t.TempDir(), "assets"),
-		dbPath:     filepath.Join("/dev/null", "db.sqlite"),
+		dbPath:     filepath.Join(invalidBase, "db.sqlite"),
 	}
 	if err := store.initialize(context.Background()); err == nil {
 		t.Fatalf("expected initialize() to fail when storage dirs are invalid")
 	}
+}
+
+func createNonDirectoryPath(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "non-dir")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	return path
 }
 
 func TestWrapSessionNotFoundWithNilCause(t *testing.T) {

--- a/internal/tui/services/gateway_rpc_client.go
+++ b/internal/tui/services/gateway_rpc_client.go
@@ -575,7 +575,7 @@ func (c *GatewayRPCClient) startHeartbeat(ctx context.Context, conn net.Conn) {
 				return
 			}
 
-			pingCtx, cancel := context.WithTimeout(context.Background(), timeout)
+			pingCtx, cancel := context.WithTimeout(ctx, timeout)
 			err := c.CallWithOptions(
 				pingCtx,
 				protocol.MethodGatewayPing,

--- a/internal/tui/services/gateway_rpc_client.go
+++ b/internal/tui/services/gateway_rpc_client.go
@@ -379,6 +379,7 @@ func (c *GatewayRPCClient) ensureConnected() (net.Conn, error) {
 	heartbeatCtx, heartbeatCancel := context.WithCancel(context.Background())
 	c.conn = conn
 	c.heartbeatCancel = heartbeatCancel
+	c.heartbeatWG.Add(1)
 	c.startNotificationDispatcher()
 	c.stateMu.Unlock()
 	go c.readLoop(conn)
@@ -556,7 +557,6 @@ func (c *GatewayRPCClient) startHeartbeat(ctx context.Context, conn net.Conn) {
 		timeout = defaultGatewayRPCHeartbeatTimeout
 	}
 
-	c.heartbeatWG.Add(1)
 	go func() {
 		defer c.heartbeatWG.Done()
 		ticker := time.NewTicker(interval)

--- a/internal/tui/services/gateway_rpc_client.go
+++ b/internal/tui/services/gateway_rpc_client.go
@@ -20,6 +20,8 @@ import (
 const (
 	defaultGatewayRPCRequestTimeout          = 8 * time.Second
 	defaultGatewayRPCRetryCount              = 1
+	defaultGatewayRPCHeartbeatInterval       = 10 * time.Second
+	defaultGatewayRPCHeartbeatTimeout        = 5 * time.Second
 	defaultGatewayNotificationBuffer         = 64
 	defaultGatewayNotificationQueue          = 256
 	defaultGatewayNotificationEnqueueTimeout = 3 * time.Second
@@ -31,6 +33,8 @@ type GatewayRPCClientOptions struct {
 	TokenFile            string
 	RequestTimeout       time.Duration
 	RetryCount           int
+	HeartbeatInterval    time.Duration
+	HeartbeatTimeout     time.Duration
 	Dial                 func(address string) (net.Conn, error)
 	ResolveListenAddress func(override string) (string, error)
 }
@@ -95,11 +99,13 @@ type gatewayRPCResponse struct {
 
 // GatewayRPCClient 维护与 Gateway 的长连接、请求关联与通知分发。
 type GatewayRPCClient struct {
-	listenAddress  string
-	token          string
-	requestTimeout time.Duration
-	retryCount     int
-	dialFn         func(address string) (net.Conn, error)
+	listenAddress     string
+	token             string
+	requestTimeout    time.Duration
+	retryCount        int
+	heartbeatInterval time.Duration
+	heartbeatTimeout  time.Duration
+	dialFn            func(address string) (net.Conn, error)
 
 	closeOnce sync.Once
 	closed    chan struct{}
@@ -108,6 +114,9 @@ type GatewayRPCClient struct {
 	stateMu sync.Mutex
 	conn    net.Conn
 	pending map[string]chan gatewayRPCResponse
+
+	heartbeatCancel context.CancelFunc
+	heartbeatWG     sync.WaitGroup
 
 	notifications              chan gatewayRPCNotification
 	notificationQueue          chan gatewayRPCNotification
@@ -143,6 +152,19 @@ func NewGatewayRPCClient(options GatewayRPCClientOptions) (*GatewayRPCClient, er
 		retryCount = defaultGatewayRPCRetryCount
 	}
 
+	heartbeatInterval := options.HeartbeatInterval
+	if heartbeatInterval <= 0 {
+		heartbeatInterval = defaultGatewayRPCHeartbeatInterval
+	}
+
+	heartbeatTimeout := options.HeartbeatTimeout
+	if heartbeatTimeout <= 0 {
+		heartbeatTimeout = defaultGatewayRPCHeartbeatTimeout
+	}
+	if requestTimeout > 0 && heartbeatTimeout > requestTimeout {
+		heartbeatTimeout = requestTimeout
+	}
+
 	dialFn := options.Dial
 	if dialFn == nil {
 		dialFn = transport.Dial
@@ -153,6 +175,8 @@ func NewGatewayRPCClient(options GatewayRPCClientOptions) (*GatewayRPCClient, er
 		token:                      token,
 		requestTimeout:             requestTimeout,
 		retryCount:                 retryCount,
+		heartbeatInterval:          heartbeatInterval,
+		heartbeatTimeout:           heartbeatTimeout,
 		dialFn:                     dialFn,
 		closed:                     make(chan struct{}),
 		pending:                    make(map[string]chan gatewayRPCResponse),
@@ -236,6 +260,7 @@ func (c *GatewayRPCClient) Close() error {
 	c.closeOnce.Do(func() {
 		close(c.closed)
 		firstErr = c.forceCloseWithError(errors.New("gateway rpc client closed"))
+		c.heartbeatWG.Wait()
 		c.notificationWG.Wait()
 		close(c.notifications)
 	})
@@ -334,24 +359,30 @@ func (c *GatewayRPCClient) writeRequest(conn net.Conn, request protocol.JSONRPCR
 
 func (c *GatewayRPCClient) ensureConnected() (net.Conn, error) {
 	c.stateMu.Lock()
-	defer c.stateMu.Unlock()
-
 	if c.conn != nil {
-		return c.conn, nil
+		conn := c.conn
+		c.stateMu.Unlock()
+		return conn, nil
 	}
 	select {
 	case <-c.closed:
+		c.stateMu.Unlock()
 		return nil, errors.New("gateway rpc client is closed")
 	default:
 	}
 
 	conn, err := c.dialFn(c.listenAddress)
 	if err != nil {
+		c.stateMu.Unlock()
 		return nil, fmt.Errorf("dial gateway %s: %w", c.listenAddress, err)
 	}
+	heartbeatCtx, heartbeatCancel := context.WithCancel(context.Background())
 	c.conn = conn
+	c.heartbeatCancel = heartbeatCancel
 	c.startNotificationDispatcher()
+	c.stateMu.Unlock()
 	go c.readLoop(conn)
+	c.startHeartbeat(heartbeatCtx, conn)
 	return conn, nil
 }
 
@@ -475,7 +506,12 @@ func (c *GatewayRPCClient) resetConnection() {
 	c.stateMu.Lock()
 	conn := c.conn
 	c.conn = nil
+	heartbeatCancel := c.heartbeatCancel
+	c.heartbeatCancel = nil
 	c.stateMu.Unlock()
+	if heartbeatCancel != nil {
+		heartbeatCancel()
+	}
 	if conn != nil {
 		_ = conn.Close()
 	}
@@ -485,9 +521,15 @@ func (c *GatewayRPCClient) forceCloseWithError(cause error) error {
 	c.stateMu.Lock()
 	conn := c.conn
 	c.conn = nil
+	heartbeatCancel := c.heartbeatCancel
+	c.heartbeatCancel = nil
 	pending := c.pending
 	c.pending = make(map[string]chan gatewayRPCResponse)
 	c.stateMu.Unlock()
+
+	if heartbeatCancel != nil {
+		heartbeatCancel()
+	}
 
 	if conn != nil {
 		_ = conn.Close()
@@ -501,6 +543,67 @@ func (c *GatewayRPCClient) forceCloseWithError(cause error) error {
 		ch <- gatewayRPCResponse{TransportErr: transportErr}
 	}
 	return nil
+}
+
+// startHeartbeat 启动连接级保活协程，定期发送 gateway.ping，避免网关在空闲窗口触发读超时断开。
+func (c *GatewayRPCClient) startHeartbeat(ctx context.Context, conn net.Conn) {
+	interval := c.heartbeatInterval
+	if interval <= 0 {
+		interval = defaultGatewayRPCHeartbeatInterval
+	}
+	timeout := c.heartbeatTimeout
+	if timeout <= 0 {
+		timeout = defaultGatewayRPCHeartbeatTimeout
+	}
+
+	c.heartbeatWG.Add(1)
+	go func() {
+		defer c.heartbeatWG.Done()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-c.closed:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+
+			if !c.isConnectionCurrent(conn) {
+				return
+			}
+
+			pingCtx, cancel := context.WithTimeout(context.Background(), timeout)
+			err := c.CallWithOptions(
+				pingCtx,
+				protocol.MethodGatewayPing,
+				map[string]any{},
+				nil,
+				GatewayRPCCallOptions{
+					Timeout: timeout,
+					Retries: 0,
+				},
+			)
+			cancel()
+
+			if err == nil {
+				continue
+			}
+			if !c.isConnectionCurrent(conn) {
+				return
+			}
+			log.Printf("warning: gateway rpc heartbeat ping failed: %v", err)
+		}
+	}()
+}
+
+// isConnectionCurrent 判断给定连接是否仍是当前活动连接，用于约束心跳协程不跨连接存活。
+func (c *GatewayRPCClient) isConnectionCurrent(conn net.Conn) bool {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	return c.conn == conn
 }
 
 func mapGatewayRPCError(method string, rpcError *protocol.JSONRPCError) error {

--- a/internal/tui/services/gateway_rpc_client_test.go
+++ b/internal/tui/services/gateway_rpc_client_test.go
@@ -246,19 +246,23 @@ func TestGatewayRPCClientHeartbeatSendsPingAndStopsAfterClose(t *testing.T) {
 		t.Fatalf("Call() error = %v", err)
 	}
 
-	time.Sleep(90 * time.Millisecond)
-	if got := atomic.LoadInt32(&pingCount); got < 2 {
-		t.Fatalf("ping count = %d, want at least 2 (manual + heartbeat)", got)
-	}
+	waitForCondition(
+		t,
+		500*time.Millisecond,
+		func() bool { return atomic.LoadInt32(&pingCount) >= 2 },
+		"ping count should include manual ping and at least one heartbeat ping",
+	)
 
 	if err := client.Close(); err != nil {
 		t.Fatalf("Close() error = %v", err)
 	}
 	afterClose := atomic.LoadInt32(&pingCount)
-	time.Sleep(80 * time.Millisecond)
-	if got := atomic.LoadInt32(&pingCount); got != afterClose {
-		t.Fatalf("ping count changed after close: before=%d after=%d", afterClose, got)
-	}
+	assertConditionStaysTrue(
+		t,
+		200*time.Millisecond,
+		func() bool { return atomic.LoadInt32(&pingCount) == afterClose },
+		"ping count changed after close",
+	)
 }
 
 func TestGatewayRPCClientHeartbeatDoesNotRedialAfterConnectionDrops(t *testing.T) {
@@ -306,10 +310,12 @@ func TestGatewayRPCClientHeartbeatDoesNotRedialAfterConnectionDrops(t *testing.T
 		t.Fatalf("Call() error = %v", err)
 	}
 
-	time.Sleep(100 * time.Millisecond)
-	if got := atomic.LoadInt32(&dialCount); got != 1 {
-		t.Fatalf("dial count = %d, want %d (heartbeat should not redial after drop)", got, 1)
-	}
+	assertConditionStaysTrue(
+		t,
+		300*time.Millisecond,
+		func() bool { return atomic.LoadInt32(&dialCount) == 1 },
+		"heartbeat should not trigger re-dial after connection drop",
+	)
 }
 
 func TestGatewayRPCClientCallWithEmptyMethodReturnsError(t *testing.T) {
@@ -422,5 +428,30 @@ func writeRPCNotificationOrFail(t *testing.T, encoder *json.Encoder, method stri
 	notification := protocol.NewJSONRPCNotification(method, params)
 	if err := encoder.Encode(notification); err != nil {
 		t.Fatalf("encode notification: %v", err)
+	}
+}
+
+func waitForCondition(t *testing.T, timeout time.Duration, condition func() bool, message string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !condition() {
+		t.Fatalf("condition not met within %s: %s", timeout, message)
+	}
+}
+
+func assertConditionStaysTrue(t *testing.T, duration time.Duration, condition func() bool, message string) {
+	t.Helper()
+	deadline := time.Now().Add(duration)
+	for time.Now().Before(deadline) {
+		if !condition() {
+			t.Fatalf("%s", message)
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }

--- a/internal/tui/services/gateway_rpc_client_test.go
+++ b/internal/tui/services/gateway_rpc_client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net"
 	"path/filepath"
 	"strings"
@@ -196,6 +197,118 @@ func TestGatewayRPCClientUsesDefaultRetryCountWhenOptionIsZero(t *testing.T) {
 	}
 	if frame.Action != gateway.FrameActionPing {
 		t.Fatalf("unexpected frame: %#v", frame)
+	}
+}
+
+func TestGatewayRPCClientHeartbeatSendsPingAndStopsAfterClose(t *testing.T) {
+	tokenFile, _ := createTestAuthTokenFile(t)
+
+	var pingCount int32
+	client, err := NewGatewayRPCClient(GatewayRPCClientOptions{
+		ListenAddress:     "test://gateway",
+		TokenFile:         tokenFile,
+		RequestTimeout:    200 * time.Millisecond,
+		HeartbeatInterval: 20 * time.Millisecond,
+		HeartbeatTimeout:  120 * time.Millisecond,
+		Dial: func(_ string) (net.Conn, error) {
+			clientConn, serverConn := net.Pipe()
+			go func() {
+				defer serverConn.Close()
+				decoder := json.NewDecoder(serverConn)
+				encoder := json.NewEncoder(serverConn)
+				for {
+					var request protocol.JSONRPCRequest
+					if err := decoder.Decode(&request); err != nil {
+						if errors.Is(err, io.EOF) {
+							return
+						}
+						return
+					}
+					if request.Method != protocol.MethodGatewayPing {
+						t.Fatalf("unexpected method = %q", request.Method)
+					}
+					atomic.AddInt32(&pingCount, 1)
+					writeRPCResultOrFail(t, encoder, request.ID, gateway.MessageFrame{
+						Type:   gateway.FrameTypeAck,
+						Action: gateway.FrameActionPing,
+					})
+				}
+			}()
+			return clientConn, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewGatewayRPCClient() error = %v", err)
+	}
+
+	var frame gateway.MessageFrame
+	if err := client.Call(context.Background(), protocol.MethodGatewayPing, map[string]any{}, &frame); err != nil {
+		t.Fatalf("Call() error = %v", err)
+	}
+
+	time.Sleep(90 * time.Millisecond)
+	if got := atomic.LoadInt32(&pingCount); got < 2 {
+		t.Fatalf("ping count = %d, want at least 2 (manual + heartbeat)", got)
+	}
+
+	if err := client.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	afterClose := atomic.LoadInt32(&pingCount)
+	time.Sleep(80 * time.Millisecond)
+	if got := atomic.LoadInt32(&pingCount); got != afterClose {
+		t.Fatalf("ping count changed after close: before=%d after=%d", afterClose, got)
+	}
+}
+
+func TestGatewayRPCClientHeartbeatDoesNotRedialAfterConnectionDrops(t *testing.T) {
+	tokenFile, _ := createTestAuthTokenFile(t)
+
+	var dialCount int32
+	client, err := NewGatewayRPCClient(GatewayRPCClientOptions{
+		ListenAddress:     "test://gateway",
+		TokenFile:         tokenFile,
+		RequestTimeout:    200 * time.Millisecond,
+		HeartbeatInterval: 20 * time.Millisecond,
+		HeartbeatTimeout:  120 * time.Millisecond,
+		Dial: func(_ string) (net.Conn, error) {
+			atomic.AddInt32(&dialCount, 1)
+			clientConn, serverConn := net.Pipe()
+			go func() {
+				defer serverConn.Close()
+				decoder := json.NewDecoder(serverConn)
+				encoder := json.NewEncoder(serverConn)
+				var request protocol.JSONRPCRequest
+				if err := decoder.Decode(&request); err != nil {
+					if errors.Is(err, io.EOF) {
+						return
+					}
+					return
+				}
+				if request.Method != protocol.MethodGatewayPing {
+					t.Fatalf("unexpected method = %q", request.Method)
+				}
+				writeRPCResultOrFail(t, encoder, request.ID, gateway.MessageFrame{
+					Type:   gateway.FrameTypeAck,
+					Action: gateway.FrameActionPing,
+				})
+			}()
+			return clientConn, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewGatewayRPCClient() error = %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	var frame gateway.MessageFrame
+	if err := client.Call(context.Background(), protocol.MethodGatewayPing, map[string]any{}, &frame); err != nil {
+		t.Fatalf("Call() error = %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	if got := atomic.LoadInt32(&dialCount); got != 1 {
+		t.Fatalf("dial count = %d, want %d (heartbeat should not redial after drop)", got, 1)
 	}
 }
 


### PR DESCRIPTION
**🎯 目标 (Motivation & Context)** 修复 [Issue 编号] 中描述的长任务闲置超时断连问题。 在分布式架构下，底层 Provider（大模型 API）的响应时间不可控。为了防止网关的连接守护程序（30s Read Timeout）将正在苦苦等待大模型响应的正常 TUI 客户端当做“死连接”踢掉，我们需要在应用层（JSON-RPC 协议层）补齐 Keep-Alive 能力。

**✨ 主要变更 (Key Changes)**

- **新增定期心跳**：在 `internal/tui/services/gateway_rpc_client.go` 中新增 `startHeartbeat` 方法，按 `15s` 的定频定时间隔发送 `gateway.ping`。
- **协程生命周期管理**：通过 `ctx, cancel` 绑定连接状态，确保在 IPC/TCP 管道物理断开时，心跳 Goroutine 能够被安全回收。

**🛡️ 为什么这么做 (Architecture Decision)** 不选择“单纯调大网关超时时间”的原因在于：调大超时时间治标不治本，且会削弱网关对真正死连接（如客户端进程崩溃退出）的清理能力。让健康的客户端主动定时上报心跳（Ping），是长连接架构中最健壮且副作用最小的设计模式。

**✅ 验收标准 (Acceptance Criteria)**

- [ ] 发起一个极度耗时的任务（或使用 Mock Provider 模拟 sleep 60 秒）。
- [ ] 观察网关日志，应稳定每隔 15 秒收到客户端发来的 `method: "gateway.ping"`。
- [ ] 等待时间超过 30 秒后，连接未被网关的 `read frame timeout` 断开。
- [ ] 60 秒后，大模型响应依然能够顺利通过 `Stream Relay` 推送至 TUI 界面。
- [ ] 杀掉 TUI 进程，网关端没有出现心跳 Goroutine 持续报错或泄漏。

Closes #379