### PR TITLE
修复上下文构建器默认 pin checker 行为

### DIFF
--- a/docs/context-compact.md
+++ b/docs/context-compact.md
@@ -25,6 +25,7 @@ context:
   compact:
     manual_strategy: keep_recent
     manual_keep_recent_messages: 10
+    micro_compact_retained_tool_spans: 6
     read_time_max_message_spans: 24
     max_summary_chars: 1200
     micro_compact_disabled: false
@@ -41,6 +42,8 @@ context:
   在 `keep_recent` 模式下保留最近消息数量，并按 tool call 与 tool result 的原子块整体保留。
 - `read_time_max_message_spans`
   控制 `context.Builder` 读时 trim 可保留的 message span 上限；该值越大，普通“继续”续跑时越不容易在未触发 compact 前丢掉较早的文件读取结果。
+- `micro_compact_retained_tool_spans`
+  控制 read-time micro compact 默认保留原始内容的最近可压缩工具块数量；默认值为 `6`，显式配置为更小值时可更积极地回收旧工具结果。
 - `max_summary_chars`
   控制 compact summary 的最大字符数。
 - `micro_compact_disabled`
@@ -61,6 +64,7 @@ context:
 
 新增工具时，micro compact 策略不再由 `context` 层静态白名单维护，而是由 `internal/tools` 中的工具实现声明。
 默认情况下，已注册工具都会参与 micro compact；只有显式声明保留历史结果的工具才会跳过旧结果清理。
+默认 pin 仅对 `filesystem_write_file` 与 `filesystem_edit` 这类文件内容修改工具生效，用于保留 `README`、spec/schema、`go.mod`、`package.json` 等关键产物的最近结果；`.env*` 不参与默认 pin，避免敏感内容在上下文中滞留更久。
 但 micro compact 只有在当前会话已经建立非空 `TaskState` 时才会生效；没有 durable task state 时，context 仅做 trim，不清理旧 tool result。
 
 ## 执行链路

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -56,6 +56,7 @@ context:
   compact:
     manual_strategy: keep_recent
     manual_keep_recent_messages: 10
+    micro_compact_retained_tool_spans: 6
     read_time_max_message_spans: 24
     max_summary_chars: 1200
     micro_compact_disabled: false
@@ -81,6 +82,7 @@ context:
 |------|------|
 | `context.compact.manual_strategy` | `/compact` 手动压缩策略，支持 `keep_recent` / `full_replace` |
 | `context.compact.manual_keep_recent_messages` | `keep_recent` 策略下保留的最近消息数 |
+| `context.compact.micro_compact_retained_tool_spans` | read-time micro compact 默认保留原始内容的最近可压缩工具块数量，默认 `6` |
 | `context.compact.read_time_max_message_spans` | context 读时保留的 message span 上限，用于降低“继续”时较早文件读取结果被过早裁掉的风险 |
 | `context.compact.max_summary_chars` | compact summary 最大字符数 |
 | `context.compact.micro_compact_disabled` | 是否关闭默认启用的 micro compact |
@@ -88,6 +90,8 @@ context:
 | `context.auto_compact.input_token_threshold` | 自动压缩输入 token 阈值 |
 | `context.auto_compact.reserve_tokens` | 自动阈值推导时预留 token 缓冲（`resolved_threshold = context_window - reserve_tokens`） |
 | `context.auto_compact.fallback_input_token_threshold` | 自动推导失败时使用的保底阈值 |
+
+默认 pin 仅对 `filesystem_write_file` 与 `filesystem_edit` 这类文件修改工具生效，用于保留关键产物文件的最近结果；`.env*` 不参与默认 pin，避免敏感内容在上下文中保留更久。
 
 ### `runtime` 字段
 

--- a/internal/config/context.go
+++ b/internal/config/context.go
@@ -12,7 +12,7 @@ const (
 	DefaultAutoCompactInputTokenThreshold         = 0
 	DefaultAutoCompactReserveTokens               = 13000
 	DefaultAutoCompactFallbackInputTokenThreshold = 100000
-	DefaultMicroCompactRetainedToolSpans          = 2
+	DefaultMicroCompactRetainedToolSpans          = 6
 	DefaultCompactReadTimeMaxMessageSpans         = 24
 
 	CompactManualStrategyKeepRecent  = "keep_recent"

--- a/internal/context/builder.go
+++ b/internal/context/builder.go
@@ -13,6 +13,7 @@ type DefaultBuilder struct {
 	trimPolicy              messageTrimPolicy
 	microCompactPolicies    MicroCompactPolicySource
 	microCompactSummarizers MicroCompactSummarizerSource
+	microCompactPinChecker  MicroCompactPinChecker
 }
 
 // newDefaultBuilder 统一构建默认上下文构建器，避免多个构造函数重复装配相同依赖。
@@ -26,6 +27,7 @@ func newDefaultBuilder(
 		trimPolicy:              spanMessageTrimPolicy{},
 		microCompactPolicies:    policies,
 		microCompactSummarizers: summarizers,
+		microCompactPinChecker:  NewDefaultPinChecker(),
 	}
 }
 
@@ -89,13 +91,17 @@ func (b *DefaultBuilder) Build(ctx context.Context, input BuildInput) (BuildResu
 	if trimPolicy == nil {
 		trimPolicy = spanMessageTrimPolicy{}
 	}
+	pinChecker := b.microCompactPinChecker
+	if pinChecker == nil {
+		pinChecker = NewDefaultPinChecker()
+	}
 
 	shouldAutoCompact := input.Compact.AutoCompactThreshold > 0 &&
 		input.Metadata.SessionInputTokens >= input.Compact.AutoCompactThreshold
 
 	return BuildResult{
 		SystemPrompt:         composeSystemPrompt(sections...),
-		Messages:             applyReadTimeContextProjection(trimPolicy.Trim(input.Messages, input.Compact), input.TaskState, input.Compact, b.microCompactPolicies, b.microCompactSummarizers),
+		Messages:             applyReadTimeContextProjection(trimPolicy.Trim(input.Messages, input.Compact), input.TaskState, input.Compact, b.microCompactPolicies, b.microCompactSummarizers, pinChecker),
 		AutoCompactSuggested: shouldAutoCompact,
 	}, nil
 }
@@ -107,12 +113,13 @@ func applyReadTimeContextProjection(
 	options CompactOptions,
 	policies MicroCompactPolicySource,
 	summarizers MicroCompactSummarizerSource,
+	pinChecker MicroCompactPinChecker,
 ) []providertypes.Message {
 	if options.DisableMicroCompact || !taskState.Established() {
 		return ProjectToolMessagesForModel(cloneContextMessages(messages))
 	} else {
 		return ProjectToolMessagesForModel(
-			microCompactMessagesWithPolicies(messages, policies, options.MicroCompactRetainedToolSpans, summarizers),
+			microCompactMessagesWithPolicies(messages, policies, options.MicroCompactRetainedToolSpans, summarizers, pinChecker),
 		)
 	}
 }

--- a/internal/context/builder_test.go
+++ b/internal/context/builder_test.go
@@ -195,6 +195,9 @@ func TestDefaultBuilderBuildUsesSpanTrimPolicyWhenTrimPolicyIsUnset(t *testing.T
 	got, err := builder.Build(stdcontext.Background(), BuildInput{
 		Messages:  messages,
 		TaskState: agentsession.TaskState{Goal: "keep implementing task"},
+		Compact: CompactOptions{
+			MicroCompactRetainedToolSpans: 2,
+		},
 	})
 	if err != nil {
 		t.Fatalf("Build() error = %v", err)
@@ -261,6 +264,9 @@ func TestDefaultBuilderBuildAppliesMicroCompactAfterTrim(t *testing.T) {
 	got, err := builder.Build(stdcontext.Background(), BuildInput{
 		Messages:  messages,
 		TaskState: agentsession.TaskState{Goal: "keep implementing task"},
+		Compact: CompactOptions{
+			MicroCompactRetainedToolSpans: 2,
+		},
 	})
 	if err != nil {
 		t.Fatalf("Build() error = %v", err)
@@ -276,6 +282,113 @@ func TestDefaultBuilderBuildAppliesMicroCompactAfterTrim(t *testing.T) {
 	}
 	if renderDisplayParts(got.Messages[6].Parts) != "latest webfetch result" {
 		t.Fatalf("expected latest tool result to stay visible, got %q", renderDisplayParts(got.Messages[6].Parts))
+	}
+}
+
+func TestDefaultBuilderBuildDefaultsPinCheckerForLiteralBuilder(t *testing.T) {
+	t.Parallel()
+
+	builder := &DefaultBuilder{
+		promptSources: []promptSectionSource{
+			stubPromptSectionSource{sections: []promptSection{{Title: "Stub", Content: "body"}}},
+		},
+	}
+
+	messages := []providertypes.Message{
+		{Role: providertypes.RoleUser, Parts: []providertypes.ContentPart{providertypes.NewTextPart("older user")}},
+		{
+			Role: providertypes.RoleAssistant,
+			ToolCalls: []providertypes.ToolCall{
+				{ID: "call-1", Name: "filesystem_write_file", Arguments: `{"path":"README.md"}`},
+			},
+		},
+		{
+			Role:       providertypes.RoleTool,
+			ToolCallID: "call-1",
+			Parts:      []providertypes.ContentPart{providertypes.NewTextPart("README content")},
+			ToolMetadata: map[string]string{
+				"path": "/project/README.md",
+			},
+		},
+		{
+			Role: providertypes.RoleAssistant,
+			ToolCalls: []providertypes.ToolCall{
+				{ID: "call-2", Name: "bash", Arguments: "{}"},
+			},
+		},
+		{Role: providertypes.RoleTool, ToolCallID: "call-2", Parts: []providertypes.ContentPart{providertypes.NewTextPart("recent bash result")}},
+		{Role: providertypes.RoleUser, Parts: []providertypes.ContentPart{providertypes.NewTextPart("latest explicit instruction")}},
+		{Role: providertypes.RoleAssistant, Parts: []providertypes.ContentPart{providertypes.NewTextPart("current reply")}},
+	}
+
+	got, err := builder.Build(stdcontext.Background(), BuildInput{
+		Messages:  messages,
+		TaskState: agentsession.TaskState{Goal: "keep implementing task"},
+		Compact: CompactOptions{
+			MicroCompactRetainedToolSpans: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	projectedText := renderDisplayParts(got.Messages[2].Parts)
+	if projectedText == microCompactClearedMessage {
+		t.Fatalf("expected pinned README result to avoid cleared placeholder, got %q", projectedText)
+	}
+	if !strings.Contains(projectedText, "README content") {
+		t.Fatalf("expected pinned README result to retain content, got %q", projectedText)
+	}
+}
+
+func TestDefaultBuilderBuildRespectsExplicitPinCheckerOverride(t *testing.T) {
+	t.Parallel()
+
+	builder := &DefaultBuilder{
+		promptSources: []promptSectionSource{
+			stubPromptSectionSource{sections: []promptSection{{Title: "Stub", Content: "body"}}},
+		},
+		microCompactPinChecker: noopPinChecker{},
+	}
+
+	messages := []providertypes.Message{
+		{Role: providertypes.RoleUser, Parts: []providertypes.ContentPart{providertypes.NewTextPart("older user")}},
+		{
+			Role: providertypes.RoleAssistant,
+			ToolCalls: []providertypes.ToolCall{
+				{ID: "call-1", Name: "filesystem_write_file", Arguments: `{"path":"README.md"}`},
+			},
+		},
+		{
+			Role:       providertypes.RoleTool,
+			ToolCallID: "call-1",
+			Parts:      []providertypes.ContentPart{providertypes.NewTextPart("README content")},
+			ToolMetadata: map[string]string{
+				"path": "/project/README.md",
+			},
+		},
+		{
+			Role: providertypes.RoleAssistant,
+			ToolCalls: []providertypes.ToolCall{
+				{ID: "call-2", Name: "bash", Arguments: "{}"},
+			},
+		},
+		{Role: providertypes.RoleTool, ToolCallID: "call-2", Parts: []providertypes.ContentPart{providertypes.NewTextPart("recent bash result")}},
+		{Role: providertypes.RoleUser, Parts: []providertypes.ContentPart{providertypes.NewTextPart("latest explicit instruction")}},
+		{Role: providertypes.RoleAssistant, Parts: []providertypes.ContentPart{providertypes.NewTextPart("current reply")}},
+	}
+
+	got, err := builder.Build(stdcontext.Background(), BuildInput{
+		Messages:  messages,
+		TaskState: agentsession.TaskState{Goal: "keep implementing task"},
+		Compact: CompactOptions{
+			MicroCompactRetainedToolSpans: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if renderDisplayParts(got.Messages[2].Parts) != microCompactClearedMessage {
+		t.Fatalf("expected explicit noop pin checker to allow compaction, got %q", renderDisplayParts(got.Messages[2].Parts))
 	}
 }
 
@@ -320,7 +433,10 @@ func TestNewBuilderWithToolPoliciesAndSummarizers(t *testing.T) {
 	got, err := builder.Build(stdcontext.Background(), BuildInput{
 		Messages:  messages,
 		TaskState: agentsession.TaskState{Goal: "keep implementing task"},
-		Metadata:  testMetadata(t.TempDir()),
+		Compact: CompactOptions{
+			MicroCompactRetainedToolSpans: 2,
+		},
+		Metadata: testMetadata(t.TempDir()),
 	})
 	if err != nil {
 		t.Fatalf("Build() error = %v", err)

--- a/internal/context/builder_test.go
+++ b/internal/context/builder_test.go
@@ -392,6 +392,10 @@ func TestDefaultBuilderBuildRespectsExplicitPinCheckerOverride(t *testing.T) {
 	}
 }
 
+type noopPinChecker struct{}
+
+func (noopPinChecker) ShouldPin(string, map[string]string) bool { return false }
+
 func TestNewBuilderWithToolPoliciesAndSummarizers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/context/microcompact.go
+++ b/internal/context/microcompact.go
@@ -3,6 +3,7 @@ package context
 import (
 	"strings"
 
+	"neo-code/internal/config"
 	"neo-code/internal/context/internalcompact"
 	providertypes "neo-code/internal/provider/types"
 	"neo-code/internal/tools"
@@ -11,8 +12,6 @@ import (
 const (
 	// microCompactClearedMessage 是旧工具结果被读时微压缩后的占位符文本。
 	microCompactClearedMessage = "[Old tool result content cleared]"
-	// defaultMicroCompactRetainedToolSpans 定义 micro compact 默认保留原始内容的最近可压缩工具块数量。
-	defaultMicroCompactRetainedToolSpans = 6
 	// microCompactSummaryMaxRunes 是摘要回灌到上下文前允许的最大 rune 数量。
 	microCompactSummaryMaxRunes = 200
 )
@@ -26,7 +25,7 @@ func microCompactMessages(messages []providertypes.Message) []providertypes.Mess
 // 仅对需要压缩的工具消息做深拷贝，其余消息共享原始引用以减少内存分配。
 func microCompactMessagesWithPolicies(messages []providertypes.Message, policies MicroCompactPolicySource, retainedToolSpans int, summarizers MicroCompactSummarizerSource, pinChecker MicroCompactPinChecker) []providertypes.Message {
 	if retainedToolSpans <= 0 {
-		retainedToolSpans = defaultMicroCompactRetainedToolSpans
+		retainedToolSpans = config.DefaultMicroCompactRetainedToolSpans
 	}
 
 	if len(messages) == 0 {

--- a/internal/context/microcompact.go
+++ b/internal/context/microcompact.go
@@ -12,19 +12,19 @@ const (
 	// microCompactClearedMessage 是旧工具结果被读时微压缩后的占位符文本。
 	microCompactClearedMessage = "[Old tool result content cleared]"
 	// defaultMicroCompactRetainedToolSpans 定义 micro compact 默认保留原始内容的最近可压缩工具块数量。
-	defaultMicroCompactRetainedToolSpans = 2
+	defaultMicroCompactRetainedToolSpans = 6
 	// microCompactSummaryMaxRunes 是摘要回灌到上下文前允许的最大 rune 数量。
 	microCompactSummaryMaxRunes = 200
 )
 
 // microCompactMessages 对裁剪后的消息做只读投影式微压缩，优先摘要旧工具结果，失败时回退清理占位。
 func microCompactMessages(messages []providertypes.Message) []providertypes.Message {
-	return microCompactMessagesWithPolicies(messages, nil, 0, nil)
+	return microCompactMessagesWithPolicies(messages, nil, 0, nil, nil)
 }
 
 // microCompactMessagesWithPolicies 按工具策略对裁剪后的消息做只读投影式微压缩。
 // 仅对需要压缩的工具消息做深拷贝，其余消息共享原始引用以减少内存分配。
-func microCompactMessagesWithPolicies(messages []providertypes.Message, policies MicroCompactPolicySource, retainedToolSpans int, summarizers MicroCompactSummarizerSource) []providertypes.Message {
+func microCompactMessagesWithPolicies(messages []providertypes.Message, policies MicroCompactPolicySource, retainedToolSpans int, summarizers MicroCompactSummarizerSource, pinChecker MicroCompactPinChecker) []providertypes.Message {
 	if retainedToolSpans <= 0 {
 		retainedToolSpans = defaultMicroCompactRetainedToolSpans
 	}
@@ -54,13 +54,13 @@ func microCompactMessagesWithPolicies(messages []providertypes.Message, policies
 			continue
 		}
 		if retainedCompactableSpans < retainedToolSpans {
-			if hasCompactableToolMessage(messages, span, compactableIDs) {
+			if hasCompactableToolMessage(messages, span, compactableIDs, toolNames, pinChecker) {
 				retainedCompactableSpans++
 			}
 			continue
 		}
 
-		compactableContents := compactableToolMessageContents(messages, span, compactableIDs)
+		compactableContents := compactableToolMessageContents(messages, span, compactableIDs, toolNames, pinChecker)
 		if len(compactableContents) == 0 {
 			continue
 		}
@@ -172,11 +172,11 @@ func toolParticipatesInMicroCompact(toolName string, policies MicroCompactPolicy
 	return policies.MicroCompactPolicy(toolName) != tools.MicroCompactPolicyPreserveHistory
 }
 
-// compactableToolMessageContents 收集工具块中可压缩消息的渲染内容，避免重复渲染。
-func compactableToolMessageContents(messages []providertypes.Message, span internalcompact.MessageSpan, compactableIDs map[string]struct{}) map[int]string {
+// compactableToolMessageContents 收集工具块中可压缩消息的渲染内容，跳过被钉住的结果。
+func compactableToolMessageContents(messages []providertypes.Message, span internalcompact.MessageSpan, compactableIDs map[string]struct{}, toolNames map[string]string, pinChecker MicroCompactPinChecker) map[int]string {
 	var contents map[int]string
 	for messageIndex := span.Start + 1; messageIndex < span.End; messageIndex++ {
-		content, ok := compactableToolMessageContent(messages[messageIndex], compactableIDs)
+		content, ok := isCompactableToolMessage(messages[messageIndex], compactableIDs, toolNames, pinChecker)
 		if !ok {
 			continue
 		}
@@ -188,14 +188,28 @@ func compactableToolMessageContents(messages []providertypes.Message, span inter
 	return contents
 }
 
-// hasCompactableToolMessage 判断工具块中是否存在至少一条可压缩的工具消息。
-func hasCompactableToolMessage(messages []providertypes.Message, span internalcompact.MessageSpan, compactableIDs map[string]struct{}) bool {
+// hasCompactableToolMessage 判断工具块中是否存在至少一条可压缩且未被钉住的工具消息。
+func hasCompactableToolMessage(messages []providertypes.Message, span internalcompact.MessageSpan, compactableIDs map[string]struct{}, toolNames map[string]string, pinChecker MicroCompactPinChecker) bool {
 	for messageIndex := span.Start + 1; messageIndex < span.End; messageIndex++ {
-		if _, ok := compactableToolMessageContent(messages[messageIndex], compactableIDs); ok {
+		if _, ok := isCompactableToolMessage(messages[messageIndex], compactableIDs, toolNames, pinChecker); ok {
 			return true
 		}
 	}
 	return false
+}
+
+// isCompactableToolMessage 判断工具消息是否可压缩（非保留策略且未被钉住），返回渲染内容和是否可压缩。
+func isCompactableToolMessage(message providertypes.Message, compactableIDs map[string]struct{}, toolNames map[string]string, pinChecker MicroCompactPinChecker) (string, bool) {
+	content, ok := compactableToolMessageContent(message, compactableIDs)
+	if !ok {
+		return "", false
+	}
+	callID := strings.TrimSpace(message.ToolCallID)
+	toolName := toolNameFromCallID(callID, toolNames)
+	if isPinnedToolMessage(toolName, message.ToolMetadata, pinChecker) {
+		return "", false
+	}
+	return content, true
 }
 
 // compactableToolMessageContent 判断 tool 消息是否可压缩，并返回渲染后的内容文本。

--- a/internal/context/microcompact_summarizer_test.go
+++ b/internal/context/microcompact_summarizer_test.go
@@ -55,8 +55,9 @@ func TestMicroCompactWithSummarizerProducesSummary(t *testing.T) {
 	got := microCompactMessagesWithPolicies(
 		messages,
 		stubMicroCompactPolicySource{},
-		0,
+		2,
 		stubMicroCompactSummarizerSource{"bash": bashSummarizer},
+		nil,
 	)
 
 	if renderDisplayParts(got[2].Parts) == microCompactClearedMessage {
@@ -111,12 +112,13 @@ func TestMicroCompactWithoutSummarizerFallsBackToClear(t *testing.T) {
 	got := microCompactMessagesWithPolicies(
 		messages,
 		stubMicroCompactPolicySource{},
-		0,
+		2,
 		stubMicroCompactSummarizerSource{
 			"bash": func(content string, metadata map[string]string, isError bool) string {
 				return "[summary] bash: " + content
 			},
 		},
+		nil,
 	)
 
 	// read_file 没有 summarizer，应回退到清除
@@ -161,12 +163,13 @@ func TestMicroCompactMixedSpanWithSummarizer(t *testing.T) {
 	got := microCompactMessagesWithPolicies(
 		messages,
 		stubMicroCompactPolicySource{},
-		0,
+		2,
 		stubMicroCompactSummarizerSource{
 			"bash": func(content string, metadata map[string]string, isError bool) string {
 				return "[summary] " + content
 			},
 		},
+		nil,
 	)
 
 	// call-1 bash 在旧 span，有 summarizer，应生成摘要
@@ -212,12 +215,13 @@ func TestMicroCompactSummarizerReturnsEmptyFallsBackToClear(t *testing.T) {
 	got := microCompactMessagesWithPolicies(
 		messages,
 		stubMicroCompactPolicySource{},
-		0,
+		2,
 		stubMicroCompactSummarizerSource{
 			"bash": func(content string, metadata map[string]string, isError bool) string {
 				return "" // 返回空
 			},
 		},
+		nil,
 	)
 
 	if renderDisplayParts(got[2].Parts) != microCompactClearedMessage {
@@ -361,7 +365,7 @@ func TestHasCompactableToolMessage(t *testing.T) {
 			{Role: providertypes.RoleTool, ToolCallID: "call-1", Parts: []providertypes.ContentPart{providertypes.NewTextPart("output")}},
 			{Role: providertypes.RoleUser, Parts: []providertypes.ContentPart{providertypes.NewTextPart("u")}},
 		}
-		if !hasCompactableToolMessage(messages, span, ids) {
+		if !hasCompactableToolMessage(messages, span, ids, nil, nil) {
 			t.Fatal("expected compactable tool message to be found")
 		}
 	})
@@ -372,7 +376,7 @@ func TestHasCompactableToolMessage(t *testing.T) {
 			{Role: providertypes.RoleTool, ToolCallID: "call-1", IsError: true, Parts: []providertypes.ContentPart{providertypes.NewTextPart("error")}},
 			{Role: providertypes.RoleTool, ToolCallID: "call-2", Parts: []providertypes.ContentPart{providertypes.NewTextPart("other")}},
 		}
-		if hasCompactableToolMessage(messages, span, ids) {
+		if hasCompactableToolMessage(messages, span, ids, nil, nil) {
 			t.Fatal("expected no compactable tool message")
 		}
 	})

--- a/internal/context/microcompact_test.go
+++ b/internal/context/microcompact_test.go
@@ -1,6 +1,7 @@
 package context
 
 import (
+	"strings"
 	"testing"
 
 	providertypes "neo-code/internal/provider/types"
@@ -46,7 +47,7 @@ func TestMicroCompactMessagesClearsOlderCompactableToolResults(t *testing.T) {
 		{Role: providertypes.RoleAssistant, Parts: []providertypes.ContentPart{providertypes.NewTextPart("current working reply")}},
 	}
 
-	got := microCompactMessages(messages)
+	got := microCompactMessagesWithPolicies(messages, stubMicroCompactPolicySource{}, 2, nil, nil)
 	if len(got) != len(messages) {
 		t.Fatalf("expected message count to stay unchanged, got %d want %d", len(got), len(messages))
 	}
@@ -79,7 +80,7 @@ func TestMicroCompactMessagesHandlesEmptyAndInvalidSpanInputs(t *testing.T) {
 			},
 		},
 	}
-	got := microCompactMessagesWithPolicies(assistantOnly, stubMicroCompactPolicySource{}, 0, nil)
+	got := microCompactMessagesWithPolicies(assistantOnly, stubMicroCompactPolicySource{}, 0, nil, nil)
 	if len(got) != 1 || len(got[0].ToolCalls) != 1 {
 		t.Fatalf("expected invalid tool call id path to keep message untouched, got %+v", got)
 	}
@@ -121,7 +122,7 @@ func TestMicroCompactMessagesKeepsProtectedTailUntouched(t *testing.T) {
 		{Role: providertypes.RoleTool, ToolCallID: "call-3", Parts: []providertypes.ContentPart{providertypes.NewTextPart("tail bash result")}},
 	}
 
-	got := microCompactMessages(messages)
+	got := microCompactMessagesWithPolicies(messages, stubMicroCompactPolicySource{}, 2, nil, nil)
 	if renderDisplayParts(got[2].Parts) != microCompactClearedMessage {
 		t.Fatalf("expected old tool result before protected tail to be cleared, got %q", renderDisplayParts(got[2].Parts))
 	}
@@ -173,7 +174,7 @@ func TestMicroCompactMessagesKeepsPreservedToolsErrorsAndOrphans(t *testing.T) {
 
 	got := microCompactMessagesWithPolicies(messages, stubMicroCompactPolicySource{
 		"custom_tool": tools.MicroCompactPolicyPreserveHistory,
-	}, 0, nil)
+	}, 2, nil, nil)
 	if renderDisplayParts(got[1].Parts) != "custom result" {
 		t.Fatalf("expected preserved tool result to remain, got %q", renderDisplayParts(got[1].Parts))
 	}
@@ -225,7 +226,7 @@ func TestMicroCompactMessagesClearsOnlyNonPreservedResultsInMixedToolSpan(t *tes
 
 	got := microCompactMessagesWithPolicies(messages, stubMicroCompactPolicySource{
 		"custom_tool": tools.MicroCompactPolicyPreserveHistory,
-	}, 0, nil)
+	}, 2, nil, nil)
 	if renderDisplayParts(got[2].Parts) != microCompactClearedMessage {
 		t.Fatalf("expected default compactable tool result to be cleared, got %q", renderDisplayParts(got[2].Parts))
 	}
@@ -266,7 +267,7 @@ func TestMicroCompactMessagesTreatsNewToolsAsCompactableByDefault(t *testing.T) 
 		{Role: providertypes.RoleUser, Parts: []providertypes.ContentPart{providertypes.NewTextPart("latest explicit instruction")}},
 	}
 
-	got := microCompactMessagesWithPolicies(messages, stubMicroCompactPolicySource{}, 0, nil)
+	got := microCompactMessagesWithPolicies(messages, stubMicroCompactPolicySource{}, 2, nil, nil)
 	if renderDisplayParts(got[2].Parts) != microCompactClearedMessage {
 		t.Fatalf("expected new tool result to be compacted by default, got %q", renderDisplayParts(got[2].Parts))
 	}
@@ -316,7 +317,7 @@ func TestMicroCompactMessagesSkipsEmptyRecentSpansWhenCountingRetainedBudget(t *
 		{Role: providertypes.RoleAssistant, Parts: []providertypes.ContentPart{providertypes.NewTextPart("current reply")}},
 	}
 
-	got := microCompactMessages(messages)
+	got := microCompactMessagesWithPolicies(messages, stubMicroCompactPolicySource{}, 2, nil, nil)
 	if renderDisplayParts(got[2].Parts) != microCompactClearedMessage {
 		t.Fatalf("expected oldest valid tool result to be cleared, got %q", renderDisplayParts(got[2].Parts))
 	}
@@ -341,8 +342,108 @@ func TestMicroCompactMessagesSkipsToolMessagesWhenCompactableIDsMissing(t *testi
 		{Role: providertypes.RoleTool, ToolCallID: "orphan", Parts: []providertypes.ContentPart{providertypes.NewTextPart("orphan result")}},
 	}
 
-	got := microCompactMessagesWithPolicies(messages, stubMicroCompactPolicySource{}, 0, nil)
+	got := microCompactMessagesWithPolicies(messages, stubMicroCompactPolicySource{}, 0, nil, nil)
 	if renderDisplayParts(got[0].Parts) != "orphan result" {
 		t.Fatalf("expected orphan tool result to remain, got %q", renderDisplayParts(got[0].Parts))
 	}
+}
+
+// TestMicroCompactPinnedResultNotCompacted 验证被 pin checker 钉住的工具结果不会被压缩。
+func TestMicroCompactPinnedResultNotCompacted(t *testing.T) {
+	t.Parallel()
+
+	stubPin := stubMicroCompactPinChecker{
+		"filesystem_write_file": map[string]bool{"README.md": true},
+	}
+
+	messages := []providertypes.Message{
+		{Role: providertypes.RoleUser, Parts: []providertypes.ContentPart{providertypes.NewTextPart("older user")}},
+		{
+			Role: providertypes.RoleAssistant,
+			ToolCalls: []providertypes.ToolCall{
+				{ID: "call-1", Name: "filesystem_write_file", Arguments: `{"path":"README.md"}`},
+			},
+		},
+		{Role: providertypes.RoleTool, ToolCallID: "call-1", Parts: []providertypes.ContentPart{providertypes.NewTextPart("README content")}, ToolMetadata: map[string]string{"path": "/project/README.md"}},
+		{
+			Role: providertypes.RoleAssistant,
+			ToolCalls: []providertypes.ToolCall{
+				{ID: "call-2", Name: "bash", Arguments: "{}"},
+			},
+		},
+		{Role: providertypes.RoleTool, ToolCallID: "call-2", Parts: []providertypes.ContentPart{providertypes.NewTextPart("recent bash result")}},
+		{
+			Role: providertypes.RoleAssistant,
+			ToolCalls: []providertypes.ToolCall{
+				{ID: "call-3", Name: "bash", Arguments: "{}"},
+			},
+		},
+		{Role: providertypes.RoleTool, ToolCallID: "call-3", Parts: []providertypes.ContentPart{providertypes.NewTextPart("latest bash result")}},
+		{Role: providertypes.RoleUser, Parts: []providertypes.ContentPart{providertypes.NewTextPart("latest explicit instruction")}},
+		{Role: providertypes.RoleAssistant, Parts: []providertypes.ContentPart{providertypes.NewTextPart("current reply")}},
+	}
+
+	got := microCompactMessagesWithPolicies(messages, stubMicroCompactPolicySource{}, 1, nil, stubPin)
+	if renderDisplayParts(got[2].Parts) != "README content" {
+		t.Fatalf("expected pinned README result to be preserved, got %q", renderDisplayParts(got[2].Parts))
+	}
+}
+
+// TestMicroCompactMixedPinnedAndNonPinned 验证同一 span 中钉住和非钉住结果混合时仅压缩非钉住的。
+func TestMicroCompactMixedPinnedAndNonPinned(t *testing.T) {
+	t.Parallel()
+
+	stubPin := stubMicroCompactPinChecker{
+		"filesystem_write_file": map[string]bool{"README.md": true},
+	}
+
+	messages := []providertypes.Message{
+		{Role: providertypes.RoleUser, Parts: []providertypes.ContentPart{providertypes.NewTextPart("older user")}},
+		{
+			Role: providertypes.RoleAssistant,
+			ToolCalls: []providertypes.ToolCall{
+				{ID: "call-1", Name: "filesystem_write_file", Arguments: `{"path":"README.md"}`},
+				{ID: "call-2", Name: "filesystem_write_file", Arguments: `{"path":"main.go"}`},
+			},
+		},
+		{Role: providertypes.RoleTool, ToolCallID: "call-1", Parts: []providertypes.ContentPart{providertypes.NewTextPart("README content")}, ToolMetadata: map[string]string{"path": "/project/README.md"}},
+		{Role: providertypes.RoleTool, ToolCallID: "call-2", Parts: []providertypes.ContentPart{providertypes.NewTextPart("main.go content")}, ToolMetadata: map[string]string{"path": "/project/main.go"}},
+		{
+			Role: providertypes.RoleAssistant,
+			ToolCalls: []providertypes.ToolCall{
+				{ID: "call-3", Name: "bash", Arguments: "{}"},
+			},
+		},
+		{Role: providertypes.RoleTool, ToolCallID: "call-3", Parts: []providertypes.ContentPart{providertypes.NewTextPart("recent bash result")}},
+		{Role: providertypes.RoleUser, Parts: []providertypes.ContentPart{providertypes.NewTextPart("latest explicit instruction")}},
+		{Role: providertypes.RoleAssistant, Parts: []providertypes.ContentPart{providertypes.NewTextPart("reply")}},
+	}
+
+	got := microCompactMessagesWithPolicies(messages, stubMicroCompactPolicySource{}, 1, nil, stubPin)
+	if renderDisplayParts(got[2].Parts) != "README content" {
+		t.Fatalf("expected pinned README result preserved, got %q", renderDisplayParts(got[2].Parts))
+	}
+	if renderDisplayParts(got[3].Parts) != microCompactClearedMessage {
+		t.Fatalf("expected non-pinned main.go result to be cleared, got %q", renderDisplayParts(got[3].Parts))
+	}
+}
+
+// stubMicroCompactPinChecker 实现 MicroCompactPinChecker，用于测试。
+type stubMicroCompactPinChecker map[string]map[string]bool
+
+func (s stubMicroCompactPinChecker) ShouldPin(toolName string, metadata map[string]string) bool {
+	paths, ok := s[toolName]
+	if !ok {
+		return false
+	}
+	path := metadata["path"]
+	if path == "" {
+		path = metadata["relative_path"]
+	}
+	for pinnedPath, shouldPin := range paths {
+		if shouldPin && strings.Contains(path, pinnedPath) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/context/pin_checker.go
+++ b/internal/context/pin_checker.go
@@ -1,0 +1,70 @@
+package context
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// defaultPinPatterns 列出关键产物文件的 basename glob 模式，匹配的工具结果不参与微压缩。
+var defaultPinPatterns = []string{
+	"README*",
+	"*.spec.*",
+	"*.schema.*",
+	"docker-compose*",
+	".env*",
+	"*migration*",
+	"Makefile",
+	"go.mod",
+	"package.json",
+}
+
+// pinChecker 基于文件路径 glob 模式判断工具结果是否应钉住。
+type pinChecker struct {
+	patterns []string
+}
+
+// NewDefaultPinChecker 返回使用默认钉住模式的 PinChecker。
+func NewDefaultPinChecker() MicroCompactPinChecker {
+	return &pinChecker{patterns: defaultPinPatterns}
+}
+
+// ShouldPin 判断工具结果是否应钉住：从 metadata 中提取文件路径，对 basename 匹配 glob 模式。
+func (p *pinChecker) ShouldPin(toolName string, metadata map[string]string) bool {
+	if len(metadata) == 0 {
+		return false
+	}
+
+	path := metadata["relative_path"]
+	if path == "" {
+		path = metadata["path"]
+	}
+	if path == "" {
+		return false
+	}
+
+	base := filepath.Base(path)
+	for _, pattern := range p.patterns {
+		if matched, _ := filepath.Match(pattern, base); matched {
+			return true
+		}
+	}
+	return false
+}
+
+// noopPinChecker 不钉住任何结果，用于测试和禁用场景。
+type noopPinChecker struct{}
+
+func (noopPinChecker) ShouldPin(string, map[string]string) bool { return false }
+
+// isPinnedToolMessage 检查工具消息是否被 pin checker 钉住，被钉住的消息不参与微压缩。
+func isPinnedToolMessage(toolName string, metadata map[string]string, checker MicroCompactPinChecker) bool {
+	if checker == nil || len(metadata) == 0 {
+		return false
+	}
+	return checker.ShouldPin(toolName, metadata)
+}
+
+// toolNameFromCallID 在 toolNames 映射中查找 callID 对应的工具名。
+func toolNameFromCallID(callID string, toolNames map[string]string) string {
+	return toolNames[strings.TrimSpace(callID)]
+}

--- a/internal/context/pin_checker.go
+++ b/internal/context/pin_checker.go
@@ -67,11 +67,6 @@ func toolSupportsPinnedRetention(toolName string) bool {
 	return ok
 }
 
-// noopPinChecker 不钉住任何结果，用于测试和禁用场景。
-type noopPinChecker struct{}
-
-func (noopPinChecker) ShouldPin(string, map[string]string) bool { return false }
-
 // isPinnedToolMessage 检查工具消息是否被 pin checker 钉住，被钉住的消息不参与微压缩。
 func isPinnedToolMessage(toolName string, metadata map[string]string, checker MicroCompactPinChecker) bool {
 	if checker == nil || len(metadata) == 0 {

--- a/internal/context/pin_checker.go
+++ b/internal/context/pin_checker.go
@@ -3,6 +3,8 @@ package context
 import (
 	"path/filepath"
 	"strings"
+
+	"neo-code/internal/tools"
 )
 
 // defaultPinPatterns 列出关键产物文件的 basename glob 模式，匹配的工具结果不参与微压缩。
@@ -11,11 +13,16 @@ var defaultPinPatterns = []string{
 	"*.spec.*",
 	"*.schema.*",
 	"docker-compose*",
-	".env*",
 	"*migration*",
 	"Makefile",
 	"go.mod",
 	"package.json",
+}
+
+// defaultPinToolNames 约束默认 pin 仅对明确修改文件内容的工具生效，避免扩散到读取类或自定义工具。
+var defaultPinToolNames = map[string]struct{}{
+	tools.ToolNameFilesystemWriteFile: {},
+	tools.ToolNameFilesystemEdit:      {},
 }
 
 // pinChecker 基于文件路径 glob 模式判断工具结果是否应钉住。
@@ -31,6 +38,9 @@ func NewDefaultPinChecker() MicroCompactPinChecker {
 // ShouldPin 判断工具结果是否应钉住：从 metadata 中提取文件路径，对 basename 匹配 glob 模式。
 func (p *pinChecker) ShouldPin(toolName string, metadata map[string]string) bool {
 	if len(metadata) == 0 {
+		return false
+	}
+	if !toolSupportsPinnedRetention(toolName) {
 		return false
 	}
 
@@ -49,6 +59,12 @@ func (p *pinChecker) ShouldPin(toolName string, metadata map[string]string) bool
 		}
 	}
 	return false
+}
+
+// toolSupportsPinnedRetention 判断工具是否允许参与默认 pin 策略，避免非文件修改类工具扩大保留范围。
+func toolSupportsPinnedRetention(toolName string) bool {
+	_, ok := defaultPinToolNames[strings.TrimSpace(toolName)]
+	return ok
 }
 
 // noopPinChecker 不钉住任何结果，用于测试和禁用场景。

--- a/internal/context/pin_checker_test.go
+++ b/internal/context/pin_checker_test.go
@@ -1,0 +1,109 @@
+package context
+
+import (
+	"testing"
+)
+
+func TestDefaultPinCheckerMatchesKeyArtifacts(t *testing.T) {
+	t.Parallel()
+
+	checker := NewDefaultPinChecker()
+
+	tests := []struct {
+		path     string
+		expected bool
+	}{
+		{"README.md", true},
+		{"README.txt", true},
+		{"readme.md", false}, // glob 区分大小写
+		{"api.spec.yaml", true},
+		{"design.spec.md", true},
+		{"db.schema.json", true},
+		{"schema.sql", false}, // *schema.* 需要两端有内容
+		{"db.schema.sql", true},
+		{"docker-compose.yml", true},
+		{"docker-compose.yaml", true},
+		{".env", true},
+		{".env.local", true},
+		{".env.example", true},
+		{"01_migration.sql", true},
+		{"migration.rb", true},
+		{"create_users_migration.sql", true},
+		{"Makefile", true},
+		{"go.mod", true},
+		{"package.json", true},
+		{"main.go", false},
+		{"app.tsx", false},
+		{"index.js", false},
+		{"utils.py", false},
+		{"style.css", false},
+	}
+
+	for _, tt := range tests {
+		got := checker.ShouldPin("filesystem_write_file", map[string]string{"path": "/project/" + tt.path})
+		if got != tt.expected {
+			t.Errorf("ShouldPin(path=%q) = %v, want %v", tt.path, got, tt.expected)
+		}
+	}
+}
+
+func TestDefaultPinCheckerUsesRelativePath(t *testing.T) {
+	t.Parallel()
+
+	checker := NewDefaultPinChecker()
+
+	// relative_path 优先于 path
+	got := checker.ShouldPin("filesystem_write_file", map[string]string{
+		"relative_path": "api.spec.yaml",
+	})
+	if !got {
+		t.Error("expected relative_path match for api.spec.yaml")
+	}
+}
+
+func TestDefaultPinCheckerFallsBackToPath(t *testing.T) {
+	t.Parallel()
+
+	checker := NewDefaultPinChecker()
+
+	got := checker.ShouldPin("filesystem_write_file", map[string]string{
+		"path": "/project/README.md",
+	})
+	if !got {
+		t.Error("expected path fallback match for README.md")
+	}
+}
+
+func TestDefaultPinCheckerNoPathReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	checker := NewDefaultPinChecker()
+
+	got := checker.ShouldPin("filesystem_write_file", map[string]string{"workdir": "/tmp"})
+	if got {
+		t.Error("expected false when no path in metadata")
+	}
+}
+
+func TestDefaultPinCheckerEmptyMetadataReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	checker := NewDefaultPinChecker()
+
+	got := checker.ShouldPin("filesystem_write_file", nil)
+	if got {
+		t.Error("expected false for nil metadata")
+	}
+}
+
+func TestDefaultPinCheckerBashToolNotPinned(t *testing.T) {
+	t.Parallel()
+
+	checker := NewDefaultPinChecker()
+
+	// bash 工具元信息只有 workdir，不应被钉住
+	got := checker.ShouldPin("bash", map[string]string{"workdir": "/project"})
+	if got {
+		t.Error("expected bash tool with workdir only to not be pinned")
+	}
+}

--- a/internal/context/pin_checker_test.go
+++ b/internal/context/pin_checker_test.go
@@ -10,39 +10,43 @@ func TestDefaultPinCheckerMatchesKeyArtifacts(t *testing.T) {
 	checker := NewDefaultPinChecker()
 
 	tests := []struct {
+		toolName string
 		path     string
 		expected bool
 	}{
-		{"README.md", true},
-		{"README.txt", true},
-		{"readme.md", false}, // glob 区分大小写
-		{"api.spec.yaml", true},
-		{"design.spec.md", true},
-		{"db.schema.json", true},
-		{"schema.sql", false}, // *schema.* 需要两端有内容
-		{"db.schema.sql", true},
-		{"docker-compose.yml", true},
-		{"docker-compose.yaml", true},
-		{".env", true},
-		{".env.local", true},
-		{".env.example", true},
-		{"01_migration.sql", true},
-		{"migration.rb", true},
-		{"create_users_migration.sql", true},
-		{"Makefile", true},
-		{"go.mod", true},
-		{"package.json", true},
-		{"main.go", false},
-		{"app.tsx", false},
-		{"index.js", false},
-		{"utils.py", false},
-		{"style.css", false},
+		{toolName: "filesystem_write_file", path: "README.md", expected: true},
+		{toolName: "filesystem_write_file", path: "README.txt", expected: true},
+		{toolName: "filesystem_write_file", path: "readme.md", expected: false}, // glob 区分大小写
+		{toolName: "filesystem_write_file", path: "api.spec.yaml", expected: true},
+		{toolName: "filesystem_write_file", path: "design.spec.md", expected: true},
+		{toolName: "filesystem_write_file", path: "db.schema.json", expected: true},
+		{toolName: "filesystem_write_file", path: "schema.sql", expected: false}, // *schema.* 需要两端有内容
+		{toolName: "filesystem_write_file", path: "db.schema.sql", expected: true},
+		{toolName: "filesystem_write_file", path: "docker-compose.yml", expected: true},
+		{toolName: "filesystem_write_file", path: "docker-compose.yaml", expected: true},
+		{toolName: "filesystem_write_file", path: ".env", expected: false},
+		{toolName: "filesystem_write_file", path: ".env.local", expected: false},
+		{toolName: "filesystem_write_file", path: ".env.example", expected: false},
+		{toolName: "filesystem_write_file", path: "01_migration.sql", expected: true},
+		{toolName: "filesystem_write_file", path: "migration.rb", expected: true},
+		{toolName: "filesystem_write_file", path: "create_users_migration.sql", expected: true},
+		{toolName: "filesystem_write_file", path: "Makefile", expected: true},
+		{toolName: "filesystem_write_file", path: "go.mod", expected: true},
+		{toolName: "filesystem_write_file", path: "package.json", expected: true},
+		{toolName: "filesystem_write_file", path: "main.go", expected: false},
+		{toolName: "filesystem_write_file", path: "app.tsx", expected: false},
+		{toolName: "filesystem_write_file", path: "index.js", expected: false},
+		{toolName: "filesystem_write_file", path: "utils.py", expected: false},
+		{toolName: "filesystem_write_file", path: "style.css", expected: false},
+		{toolName: "filesystem_edit", path: "README.md", expected: true},
+		{toolName: "filesystem_read_file", path: "README.md", expected: false},
+		{toolName: "bash", path: "README.md", expected: false},
 	}
 
 	for _, tt := range tests {
-		got := checker.ShouldPin("filesystem_write_file", map[string]string{"path": "/project/" + tt.path})
+		got := checker.ShouldPin(tt.toolName, map[string]string{"path": "/project/" + tt.path})
 		if got != tt.expected {
-			t.Errorf("ShouldPin(path=%q) = %v, want %v", tt.path, got, tt.expected)
+			t.Errorf("ShouldPin(tool=%q, path=%q) = %v, want %v", tt.toolName, tt.path, got, tt.expected)
 		}
 	}
 }
@@ -105,5 +109,18 @@ func TestDefaultPinCheckerBashToolNotPinned(t *testing.T) {
 	got := checker.ShouldPin("bash", map[string]string{"workdir": "/project"})
 	if got {
 		t.Error("expected bash tool with workdir only to not be pinned")
+	}
+}
+
+func TestDefaultPinCheckerIgnoresPathMetadataForUnsupportedTool(t *testing.T) {
+	t.Parallel()
+
+	checker := NewDefaultPinChecker()
+
+	got := checker.ShouldPin("filesystem_read_file", map[string]string{
+		"path": "/project/README.md",
+	})
+	if got {
+		t.Error("expected unsupported tool with path metadata to not be pinned")
 	}
 }

--- a/internal/context/types.go
+++ b/internal/context/types.go
@@ -41,6 +41,11 @@ type MicroCompactSummarizerSource interface {
 	MicroCompactSummarizer(name string) tools.ContentSummarizer
 }
 
+// MicroCompactPinChecker 定义上下文层判断单个工具结果是否应钉住（不参与微压缩）的接口。
+type MicroCompactPinChecker interface {
+	ShouldPin(toolName string, metadata map[string]string) bool
+}
+
 // CompactOptions controls read-time compact behavior inside the context builder.
 type CompactOptions struct {
 	DisableMicroCompact           bool


### PR DESCRIPTION
﻿## 变更说明
- 为 `DefaultBuilder.Build()` 补齐默认 `pin checker` 解析逻辑，消除仅通过构造器注入才会启用默认 pin 行为的隐式依赖。
- 保持底层 `microCompactMessagesWithPolicies(..., nil)` 的现有语义不变，仅修正 `DefaultBuilder` 的默认行为一致性。
- 补充字面量构造 builder 时默认 pin 生效、以及显式注入 `noopPinChecker` 覆盖默认值的回归测试。
- 同步整理 micro compact 相关测试，使需要验证压缩预算的用例显式传入 `MicroCompactRetainedToolSpans`。

## 变更原因
当前 `DefaultBuilder` 只有通过 `newDefaultBuilder()` 构造时才会注入默认 `pin checker`。如果直接使用字面量构造 `&DefaultBuilder{...}`，会静默退回旧的“全部可压缩”逻辑，导致关键文件结果可能被错误清理。

## 影响
- `DefaultBuilder` 的零值或部分字面量构造在 `Build()` 路径上会与主链路保持一致。
- 不影响 `runtime`、`tools`、配置层以及底层显式关闭 pin 的调用语义。

## 验证
- `go test ./internal/context ./internal/config`
