### PR TITLE
fix(tools): route low-risk external writes through approval ask

### DIFF
--- a/internal/tools/manager.go
+++ b/internal/tools/manager.go
@@ -593,8 +593,15 @@ func splitPathSegments(path string) []string {
 
 // sandboxErrorDetails 生成可回灌给模型的沙箱拒绝详情，便于模型正确感知失败原因。
 func sandboxErrorDetails(action security.Action, sandboxErr error) string {
+	securityMessage := strings.TrimSpace(errorMessage(sandboxErr))
+	if securityMessage == "" {
+		securityMessage = "sandbox rejected action"
+	}
+	if !strings.HasPrefix(strings.ToLower(securityMessage), "security:") {
+		securityMessage = "security: " + securityMessage
+	}
 	parts := []string{
-		"security: " + strings.TrimSpace(errorMessage(sandboxErr)),
+		securityMessage,
 	}
 	if workdir := strings.TrimSpace(action.Payload.Workdir); workdir != "" {
 		parts = append(parts, "workdir: "+workdir)

--- a/internal/tools/manager.go
+++ b/internal/tools/manager.go
@@ -338,11 +338,10 @@ func (m *DefaultManager) Execute(ctx context.Context, input ToolCallInput) (Tool
 				result := blockedToolResult(input, decision)
 				return result, permissionErrorFromDecision(decision)
 			}
-		} else {
-			result := NewErrorResult(input.Name, "workspace sandbox rejected action", sandboxErrorDetails(action, err), actionMetadata(action))
-			result.ToolCallID = input.ID
-			return result, err
 		}
+		result := NewErrorResult(input.Name, "workspace sandbox rejected action", sandboxErrorDetails(action, err), actionMetadata(action))
+		result.ToolCallID = input.ID
+		return result, err
 	}
 	m.auditCapabilityDecision(action, string(security.DecisionAllow), "")
 
@@ -399,6 +398,9 @@ func resolveSandboxOutsideWriteDecision(
 
 // isSandboxOutsideWriteApprovalCandidate 判断当前沙箱错误是否可升级为“工作区外低风险写入审批”。
 func isSandboxOutsideWriteApprovalCandidate(action security.Action, sandboxErr error) bool {
+	if isWorkspaceSymlinkViolationError(sandboxErr) {
+		return false
+	}
 	if !isWorkspaceBoundaryViolationError(sandboxErr) {
 		return false
 	}
@@ -428,6 +430,15 @@ func isWorkspaceBoundaryViolationError(err error) bool {
 		strings.Contains(message, "different volume than workspace root")
 }
 
+// isWorkspaceSymlinkViolationError 判断沙箱拒绝是否来自符号链接越界逃逸。
+func isWorkspaceSymlinkViolationError(err error) bool {
+	message := strings.ToLower(strings.TrimSpace(errorMessage(err)))
+	if message == "" {
+		return false
+	}
+	return strings.Contains(message, "escapes workspace root via symlink")
+}
+
 // resolveActionSandboxTargetPath 将 action 的 sandbox target 解析为可判定风险的绝对路径。
 func resolveActionSandboxTargetPath(action security.Action) string {
 	target := strings.TrimSpace(action.Payload.SandboxTarget)
@@ -455,10 +466,53 @@ func isLowRiskExternalWritePath(targetPath string) bool {
 	if isSystemProtectedPath(cleaned) {
 		return false
 	}
+	if isUserStartupProfilePath(cleaned) {
+		return false
+	}
 	if isHighRiskExecutableExtension(filepath.Ext(cleaned)) {
 		return false
 	}
 	return true
+}
+
+// isUserStartupProfilePath 判断路径是否命中用户级 shell/profile 启动文件，命中后必须保持硬拒绝。
+func isUserStartupProfilePath(path string) bool {
+	cleaned := strings.ToLower(strings.TrimSpace(filepath.Clean(path)))
+	if cleaned == "" || cleaned == "." {
+		return false
+	}
+
+	base := filepath.Base(cleaned)
+	switch base {
+	case ".bashrc", ".bash_profile", ".bash_login", ".profile",
+		".zshrc", ".zprofile", ".zlogin", ".zshenv",
+		".cshrc", ".tcshrc", "config.fish",
+		"profile.ps1", "microsoft.powershell_profile.ps1",
+		"microsoft.vscode_profile.ps1", "profile":
+		return true
+	}
+
+	segments := splitPathSegments(cleaned)
+	if len(segments) == 0 {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		for i := 0; i+2 < len(segments); i++ {
+			if segments[i] == "documents" && segments[i+1] == "windowspowershell" && strings.HasSuffix(base, ".ps1") {
+				return true
+			}
+			if segments[i] == "documents" && segments[i+1] == "powershell" && strings.HasSuffix(base, ".ps1") {
+				return true
+			}
+		}
+		return false
+	}
+	for i := 0; i+2 < len(segments); i++ {
+		if segments[i] == ".config" && segments[i+1] == "fish" && base == "config.fish" {
+			return true
+		}
+	}
+	return false
 }
 
 // isSystemProtectedPath 判定路径是否命中系统受保护目录，命中后必须保持硬拒绝。

--- a/internal/tools/manager.go
+++ b/internal/tools/manager.go
@@ -338,16 +338,15 @@ func (m *DefaultManager) Execute(ctx context.Context, input ToolCallInput) (Tool
 				result := blockedToolResult(input, decision)
 				return result, permissionErrorFromDecision(decision)
 			}
+		} else {
+			result := NewErrorResult(input.Name, "workspace sandbox rejected action", sandboxErrorDetails(action, err), actionMetadata(action))
+			result.ToolCallID = input.ID
+			return result, err
 		}
-		result := NewErrorResult(input.Name, "workspace sandbox rejected action", sandboxErrorDetails(action, err), actionMetadata(action))
-		result.ToolCallID = input.ID
-		return result, err
-	}
-	m.auditCapabilityDecision(action, string(security.DecisionAllow), "")
-
-	if plan != nil {
+	} else if plan != nil {
 		input.WorkspacePlan = plan
 	}
+	m.auditCapabilityDecision(action, string(security.DecisionAllow), "")
 
 	return m.executor.Execute(ctx, input)
 }

--- a/internal/tools/manager.go
+++ b/internal/tools/manager.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -66,6 +68,13 @@ var (
 	ErrPermissionApprovalRequired = errors.New("tools: permission approval required")
 	// ErrCapabilityDenied 标记拒绝由 capability token 触发。
 	ErrCapabilityDenied = errors.New("tools: capability denied")
+)
+
+const (
+	// sandboxExternalWriteApprovalRuleID 是工作区外低风险写入的审批规则标识。
+	sandboxExternalWriteApprovalRuleID = "workspace-sandbox:external-write-ask"
+	// sandboxExternalWriteApprovalReason 是工作区外低风险写入需要审批时的统一提示。
+	sandboxExternalWriteApprovalReason = "workspace write outside workdir requires approval"
 )
 
 // PermissionDecisionError reports a non-allow permission decision.
@@ -324,9 +333,16 @@ func (m *DefaultManager) Execute(ctx context.Context, input ToolCallInput) (Tool
 
 	plan, err := m.sandbox.Check(ctx, action)
 	if err != nil {
-		result := NewErrorResult(input.Name, "workspace sandbox rejected action", err.Error(), actionMetadata(action))
-		result.ToolCallID = input.ID
-		return result, err
+		if decision, decisionMatched := resolveSandboxOutsideWriteDecision(input, action, err, m.sessionDecisions); decisionMatched {
+			if decision.Decision != security.DecisionAllow {
+				result := blockedToolResult(input, decision)
+				return result, permissionErrorFromDecision(decision)
+			}
+		} else {
+			result := NewErrorResult(input.Name, "workspace sandbox rejected action", sandboxErrorDetails(action, err), actionMetadata(action))
+			result.ToolCallID = input.ID
+			return result, err
+		}
 	}
 	m.auditCapabilityDecision(action, string(security.DecisionAllow), "")
 
@@ -335,6 +351,206 @@ func (m *DefaultManager) Execute(ctx context.Context, input ToolCallInput) (Tool
 	}
 
 	return m.executor.Execute(ctx, input)
+}
+
+// resolveSandboxOutsideWriteDecision 将“工作区外低风险写入”沙箱拒绝收敛为 ask/remembered allow/remembered deny。
+func resolveSandboxOutsideWriteDecision(
+	input ToolCallInput,
+	action security.Action,
+	sandboxErr error,
+	sessionMemory *sessionPermissionMemory,
+) (security.CheckResult, bool) {
+	if !isSandboxOutsideWriteApprovalCandidate(action, sandboxErr) {
+		return security.CheckResult{}, false
+	}
+
+	decision := security.CheckResult{
+		Decision: security.DecisionAsk,
+		Action:   action,
+		Rule: &security.Rule{
+			ID:       sandboxExternalWriteApprovalRuleID,
+			Type:     action.Type,
+			Resource: action.Payload.Resource,
+			Decision: security.DecisionAsk,
+			Reason:   sandboxExternalWriteApprovalReason,
+		},
+		Reason: sandboxExternalWriteApprovalReason,
+	}
+
+	if sessionMemory != nil {
+		if rememberedDecision, rememberedScope, ok := sessionMemory.resolve(input.SessionID, action); ok {
+			decision = security.CheckResult{
+				Decision: rememberedDecision,
+				Action:   action,
+				Rule: &security.Rule{
+					ID:       "session-memory:" + string(rememberedScope),
+					Type:     action.Type,
+					Resource: action.Payload.Resource,
+					Decision: rememberedDecision,
+					Reason:   sessionDecisionReason(rememberedScope),
+				},
+				Reason: sessionDecisionReason(rememberedScope),
+			}
+		}
+	}
+
+	return decision, true
+}
+
+// isSandboxOutsideWriteApprovalCandidate 判断当前沙箱错误是否可升级为“工作区外低风险写入审批”。
+func isSandboxOutsideWriteApprovalCandidate(action security.Action, sandboxErr error) bool {
+	if !isWorkspaceBoundaryViolationError(sandboxErr) {
+		return false
+	}
+	if action.Type != security.ActionTypeWrite {
+		return false
+	}
+	resource := strings.TrimSpace(strings.ToLower(action.Payload.Resource))
+	toolName := strings.TrimSpace(strings.ToLower(action.Payload.ToolName))
+	if resource != ToolNameFilesystemWriteFile && toolName != ToolNameFilesystemWriteFile {
+		return false
+	}
+
+	targetPath := resolveActionSandboxTargetPath(action)
+	if targetPath == "" {
+		return false
+	}
+	return isLowRiskExternalWritePath(targetPath)
+}
+
+// isWorkspaceBoundaryViolationError 判断错误是否由工作区边界校验触发。
+func isWorkspaceBoundaryViolationError(err error) bool {
+	message := strings.ToLower(strings.TrimSpace(errorMessage(err)))
+	if message == "" {
+		return false
+	}
+	return strings.Contains(message, "escapes workspace root") ||
+		strings.Contains(message, "different volume than workspace root")
+}
+
+// resolveActionSandboxTargetPath 将 action 的 sandbox target 解析为可判定风险的绝对路径。
+func resolveActionSandboxTargetPath(action security.Action) string {
+	target := strings.TrimSpace(action.Payload.SandboxTarget)
+	if target == "" {
+		target = strings.TrimSpace(action.Payload.Target)
+	}
+	if target == "" {
+		return ""
+	}
+	if !filepath.IsAbs(target) && strings.TrimSpace(action.Payload.Workdir) != "" {
+		target = filepath.Join(strings.TrimSpace(action.Payload.Workdir), target)
+	}
+	if absoluteTarget, err := filepath.Abs(target); err == nil {
+		target = absoluteTarget
+	}
+	return filepath.Clean(target)
+}
+
+// isLowRiskExternalWritePath 判断工作区外写入目标是否属于可审批放行的低风险路径。
+func isLowRiskExternalWritePath(targetPath string) bool {
+	cleaned := strings.TrimSpace(filepath.Clean(targetPath))
+	if cleaned == "" || cleaned == "." {
+		return false
+	}
+	if isSystemProtectedPath(cleaned) {
+		return false
+	}
+	if isHighRiskExecutableExtension(filepath.Ext(cleaned)) {
+		return false
+	}
+	return true
+}
+
+// isSystemProtectedPath 判定路径是否命中系统受保护目录，命中后必须保持硬拒绝。
+func isSystemProtectedPath(path string) bool {
+	normalized := strings.ToLower(filepath.Clean(path))
+	if runtime.GOOS == "windows" {
+		volume := strings.ToLower(filepath.VolumeName(normalized))
+		rest := strings.TrimPrefix(normalized, volume)
+		rest = strings.TrimLeft(rest, `\/`)
+		if rest == "" {
+			return true
+		}
+		segments := splitPathSegments(rest)
+		if len(segments) == 0 {
+			return true
+		}
+		switch segments[0] {
+		case "windows", "program files", "program files (x86)", "programdata",
+			"$recycle.bin", "system volume information", "recovery", "boot":
+			return true
+		}
+		if len(segments) >= 3 && segments[0] == "users" && segments[2] == "appdata" {
+			return true
+		}
+	} else {
+		trimmed := strings.TrimLeft(normalized, "/")
+		segments := splitPathSegments(trimmed)
+		if len(segments) == 0 {
+			return true
+		}
+		switch segments[0] {
+		case "etc", "bin", "sbin", "usr", "var", "lib", "lib64", "boot", "proc", "sys", "dev", "run", "root":
+			return true
+		}
+	}
+
+	for _, segment := range splitPathSegments(normalized) {
+		if segment == ".ssh" {
+			return true
+		}
+	}
+	return false
+}
+
+// isHighRiskExecutableExtension 识别高风险可执行文件后缀，命中后不走审批放行链路。
+func isHighRiskExecutableExtension(extension string) bool {
+	switch strings.ToLower(strings.TrimSpace(extension)) {
+	case ".exe", ".dll", ".sys", ".bat", ".cmd", ".com", ".scr", ".msi", ".reg":
+		return true
+	default:
+		return false
+	}
+}
+
+// splitPathSegments 把路径按目录分隔符拆成稳定片段，忽略空片段。
+func splitPathSegments(path string) []string {
+	normalized := strings.ReplaceAll(path, "\\", "/")
+	rawSegments := strings.Split(normalized, "/")
+	segments := make([]string, 0, len(rawSegments))
+	for _, segment := range rawSegments {
+		trimmed := strings.TrimSpace(segment)
+		if trimmed == "" {
+			continue
+		}
+		segments = append(segments, trimmed)
+	}
+	return segments
+}
+
+// sandboxErrorDetails 生成可回灌给模型的沙箱拒绝详情，便于模型正确感知失败原因。
+func sandboxErrorDetails(action security.Action, sandboxErr error) string {
+	parts := []string{
+		"security: " + strings.TrimSpace(errorMessage(sandboxErr)),
+	}
+	if workdir := strings.TrimSpace(action.Payload.Workdir); workdir != "" {
+		parts = append(parts, "workdir: "+workdir)
+	}
+	if target := strings.TrimSpace(action.Payload.Target); target != "" {
+		parts = append(parts, "target: "+target)
+	}
+	if sandboxTarget := strings.TrimSpace(action.Payload.SandboxTarget); sandboxTarget != "" {
+		parts = append(parts, "sandbox_target: "+sandboxTarget)
+	}
+	return strings.Join(parts, "\n")
+}
+
+// errorMessage 提取错误文本，统一处理 nil 输入避免重复分支。
+func errorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }
 
 // verifyCapabilityToken 校验 capability token 的签名、绑定关系与时效性。

--- a/internal/tools/manager.go
+++ b/internal/tools/manager.go
@@ -477,6 +477,11 @@ func isLowRiskExternalWritePath(targetPath string) bool {
 
 // isUserStartupProfilePath 判断路径是否命中用户级 shell/profile 启动文件，命中后必须保持硬拒绝。
 func isUserStartupProfilePath(path string) bool {
+	return isUserStartupProfilePathForOS(path, runtime.GOOS)
+}
+
+// isUserStartupProfilePathForOS 按指定操作系统判定路径是否命中用户级 shell/profile 启动文件。
+func isUserStartupProfilePathForOS(path string, goos string) bool {
 	cleaned := strings.ToLower(strings.TrimSpace(filepath.Clean(path)))
 	if cleaned == "" || cleaned == "." {
 		return false
@@ -485,8 +490,7 @@ func isUserStartupProfilePath(path string) bool {
 	base := filepath.Base(cleaned)
 	switch base {
 	case ".bashrc", ".bash_profile", ".bash_login", ".profile",
-		".zshrc", ".zprofile", ".zlogin", ".zshenv",
-		".cshrc", ".tcshrc", "config.fish",
+		".zshrc", ".zprofile", ".zlogin", ".zshenv", ".cshrc", ".tcshrc",
 		"profile.ps1", "microsoft.powershell_profile.ps1",
 		"microsoft.vscode_profile.ps1", "profile":
 		return true
@@ -496,7 +500,7 @@ func isUserStartupProfilePath(path string) bool {
 	if len(segments) == 0 {
 		return false
 	}
-	if runtime.GOOS == "windows" {
+	if strings.EqualFold(strings.TrimSpace(goos), "windows") {
 		for i := 0; i+2 < len(segments); i++ {
 			if segments[i] == "documents" && segments[i+1] == "windowspowershell" && strings.HasSuffix(base, ".ps1") {
 				return true
@@ -517,18 +521,23 @@ func isUserStartupProfilePath(path string) bool {
 
 // isSystemProtectedPath 判定路径是否命中系统受保护目录，命中后必须保持硬拒绝。
 func isSystemProtectedPath(path string) bool {
+	return isSystemProtectedPathForOS(path, runtime.GOOS)
+}
+
+// isSystemProtectedPathForOS 按指定操作系统判定路径是否命中系统受保护目录。
+func isSystemProtectedPathForOS(path string, goos string) bool {
 	normalized := strings.ToLower(filepath.Clean(path))
-	if runtime.GOOS == "windows" {
+	if strings.EqualFold(strings.TrimSpace(goos), "windows") {
 		volume := strings.ToLower(filepath.VolumeName(normalized))
+		if volume == "" && len(normalized) >= 2 && normalized[1] == ':' {
+			volume = normalized[:2]
+		}
 		rest := strings.TrimPrefix(normalized, volume)
 		rest = strings.TrimLeft(rest, `\/`)
 		if rest == "" {
 			return true
 		}
 		segments := splitPathSegments(rest)
-		if len(segments) == 0 {
-			return true
-		}
 		switch segments[0] {
 		case "windows", "program files", "program files (x86)", "programdata",
 			"$recycle.bin", "system volume information", "recovery", "boot":

--- a/internal/tools/manager.go
+++ b/internal/tools/manager.go
@@ -338,6 +338,8 @@ func (m *DefaultManager) Execute(ctx context.Context, input ToolCallInput) (Tool
 				result := blockedToolResult(input, decision)
 				return result, permissionErrorFromDecision(decision)
 			}
+			m.auditCapabilityDecision(action, string(security.DecisionAllow), decision.Reason)
+			return m.executor.Execute(ctx, input)
 		}
 		result := NewErrorResult(input.Name, "workspace sandbox rejected action", sandboxErrorDetails(action, err), actionMetadata(action))
 		result.ToolCallID = input.ID

--- a/internal/tools/manager_test.go
+++ b/internal/tools/manager_test.go
@@ -452,11 +452,11 @@ func TestDefaultManagerSandboxOutsideWriteSessionMemory(t *testing.T) {
 	}
 
 	_, err = manager.Execute(context.Background(), input)
-	if err == nil || !strings.Contains(err.Error(), "escapes workspace root") {
-		t.Fatalf("expected sandbox rejection after remembered allow, got %v", err)
+	if err != nil {
+		t.Fatalf("expected remembered allow retry to pass, got %v", err)
 	}
-	if writeTool.callCount != 0 {
-		t.Fatalf("expected write tool not to execute after remembered allow, got %d", writeTool.callCount)
+	if writeTool.callCount != 1 {
+		t.Fatalf("expected write tool to execute after remembered allow, got %d", writeTool.callCount)
 	}
 }
 

--- a/internal/tools/manager_test.go
+++ b/internal/tools/manager_test.go
@@ -3,8 +3,10 @@ package tools
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -69,6 +71,10 @@ func (s *stubSandbox) Check(ctx context.Context, action security.Action) (*secur
 		return nil, err
 	}
 	return s.plan, s.err
+}
+
+func isWindowsRuntime() bool {
+	return runtime.GOOS == "windows"
 }
 
 func mustAllowEngine(t *testing.T) security.PermissionEngine {
@@ -234,6 +240,15 @@ func TestDefaultManagerListAvailableSpecsBoundaries(t *testing.T) {
 func TestDefaultManagerExecute(t *testing.T) {
 	t.Parallel()
 
+	lowRiskOutsidePath := filepath.Join(string(filepath.Separator), "tmp", "snake_game.py")
+	workspaceRoot := filepath.Join(string(filepath.Separator), "workspace", "project")
+	protectedOutsidePath := filepath.Join(string(filepath.Separator), "etc", "hosts")
+	if isWindowsRuntime() {
+		lowRiskOutsidePath = `C:\Users\tester\Desktop\SnakeGame\snake_game.py`
+		workspaceRoot = `C:\workspace\project`
+		protectedOutsidePath = `C:\Windows\System32\drivers\etc\hosts`
+	}
+
 	tests := []struct {
 		name              string
 		rules             []security.Rule
@@ -302,6 +317,36 @@ func TestDefaultManagerExecute(t *testing.T) {
 			expectSandboxRuns: 1,
 		},
 		{
+			name: "low risk outside workspace write becomes ask",
+			input: ToolCallInput{
+				ID:        "call-6",
+				Name:      "filesystem_write_file",
+				Arguments: []byte(fmt.Sprintf(`{"path":%q,"content":"hi"}`, lowRiskOutsidePath)),
+				Workdir:   workspaceRoot,
+				SessionID: "session-low-risk-outside",
+			},
+			sandboxErr:        fmt.Errorf("security: path %q escapes workspace root", lowRiskOutsidePath),
+			expectErr:         sandboxExternalWriteApprovalReason,
+			expectContent:     []string{"tool error", "reason: " + sandboxExternalWriteApprovalReason},
+			expectDecision:    "ask",
+			expectCalls:       0,
+			expectSandboxRuns: 1,
+		},
+		{
+			name: "protected outside path keeps hard sandbox reject",
+			input: ToolCallInput{
+				ID:        "call-7",
+				Name:      "filesystem_write_file",
+				Arguments: []byte(fmt.Sprintf(`{"path":%q,"content":"hi"}`, protectedOutsidePath)),
+				Workdir:   workspaceRoot,
+			},
+			sandboxErr:        fmt.Errorf("security: path %q escapes workspace root", protectedOutsidePath),
+			expectErr:         "escapes workspace root",
+			expectContent:     []string{"tool error", "reason: workspace sandbox rejected action", "target: " + protectedOutsidePath},
+			expectCalls:       0,
+			expectSandboxRuns: 1,
+		},
+		{
 			name: "unknown tool uses executor error",
 			input: ToolCallInput{
 				ID:   "call-4",
@@ -364,6 +409,164 @@ func TestDefaultManagerExecute(t *testing.T) {
 				t.Fatalf("expected sandbox runs %d, got %d", tt.expectSandboxRuns, sandbox.callCount)
 			}
 		})
+	}
+}
+
+func TestDefaultManagerSandboxOutsideWriteSessionMemory(t *testing.T) {
+	t.Parallel()
+
+	outsidePath := filepath.Join(string(filepath.Separator), "tmp", "snake_game.py")
+	workspaceRoot := filepath.Join(string(filepath.Separator), "workspace", "project")
+	if isWindowsRuntime() {
+		outsidePath = `C:\Users\tester\Desktop\SnakeGame\snake_game.py`
+		workspaceRoot = `C:\workspace\project`
+	}
+
+	registry := NewRegistry()
+	writeTool := &managerStubTool{name: "filesystem_write_file", content: "ok"}
+	registry.Register(writeTool)
+
+	manager, err := NewManager(registry, mustAllowEngine(t), &stubSandbox{
+		err: fmt.Errorf("security: path %q escapes workspace root", outsidePath),
+	})
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	input := ToolCallInput{
+		ID:        "call-outside-ask",
+		Name:      "filesystem_write_file",
+		Arguments: []byte(fmt.Sprintf(`{"path":%q,"content":"hi"}`, outsidePath)),
+		Workdir:   workspaceRoot,
+		SessionID: "session-outside-ask",
+	}
+
+	_, execErr := manager.Execute(context.Background(), input)
+	var permissionErr *PermissionDecisionError
+	if !errors.As(execErr, &permissionErr) || permissionErr.Decision() != "ask" {
+		t.Fatalf("expected initial ask decision, got %v", execErr)
+	}
+
+	if rememberErr := manager.RememberSessionDecision(input.SessionID, permissionErr.Action(), SessionPermissionScopeAlways); rememberErr != nil {
+		t.Fatalf("remember outside write allow: %v", rememberErr)
+	}
+
+	if _, err := manager.Execute(context.Background(), input); err != nil {
+		t.Fatalf("expected remembered allow to bypass sandbox block, got %v", err)
+	}
+	if writeTool.callCount != 1 {
+		t.Fatalf("expected write tool to execute once after remember, got %d", writeTool.callCount)
+	}
+}
+
+func TestSandboxOutsideWriteApprovalCandidate(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := filepath.Join(string(filepath.Separator), "workspace", "project")
+	lowRiskPath := filepath.Join(string(filepath.Separator), "tmp", "sample.py")
+	protectedPath := filepath.Join(string(filepath.Separator), "etc", "hosts")
+	highRiskExecutable := filepath.Join(string(filepath.Separator), "tmp", "sample.exe")
+	if isWindowsRuntime() {
+		workspaceRoot = `C:\workspace\project`
+		lowRiskPath = `C:\Users\tester\Desktop\sample.py`
+		protectedPath = `C:\Windows\System32\drivers\etc\hosts`
+		highRiskExecutable = `C:\Users\tester\Desktop\sample.exe`
+	}
+
+	buildAction := func(target string, toolName string) security.Action {
+		return security.Action{
+			Type: security.ActionTypeWrite,
+			Payload: security.ActionPayload{
+				ToolName:      toolName,
+				Resource:      toolName,
+				Operation:     "write_file",
+				Workdir:       workspaceRoot,
+				TargetType:    security.TargetTypePath,
+				Target:        target,
+				SandboxTarget: target,
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		action     security.Action
+		sandboxErr error
+		want       bool
+	}{
+		{
+			name:       "boundary violation low risk file asks approval",
+			action:     buildAction(lowRiskPath, "filesystem_write_file"),
+			sandboxErr: fmt.Errorf("security: path %q escapes workspace root", lowRiskPath),
+			want:       true,
+		},
+		{
+			name:       "non-boundary sandbox error keeps hard reject",
+			action:     buildAction(lowRiskPath, "filesystem_write_file"),
+			sandboxErr: errors.New("workspace denied"),
+			want:       false,
+		},
+		{
+			name:       "protected system path keeps hard reject",
+			action:     buildAction(protectedPath, "filesystem_write_file"),
+			sandboxErr: fmt.Errorf("security: path %q escapes workspace root", protectedPath),
+			want:       false,
+		},
+		{
+			name:       "high risk executable extension keeps hard reject",
+			action:     buildAction(highRiskExecutable, "filesystem_write_file"),
+			sandboxErr: fmt.Errorf("security: path %q escapes workspace root", highRiskExecutable),
+			want:       false,
+		},
+		{
+			name:       "write tool not in allowlist keeps hard reject",
+			action:     buildAction(lowRiskPath, "filesystem_edit"),
+			sandboxErr: fmt.Errorf("security: path %q escapes workspace root", lowRiskPath),
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isSandboxOutsideWriteApprovalCandidate(tt.action, tt.sandboxErr)
+			if got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestSandboxErrorDetailsIncludesWorkspaceContext(t *testing.T) {
+	t.Parallel()
+
+	action := security.Action{
+		Type: security.ActionTypeWrite,
+		Payload: security.ActionPayload{
+			ToolName:      "filesystem_write_file",
+			Resource:      "filesystem_write_file",
+			Workdir:       `C:\workspace\project`,
+			Target:        `C:\Users\tester\Desktop\SnakeGame\snake_game.py`,
+			SandboxTarget: `C:\Users\tester\Desktop\SnakeGame\snake_game.py`,
+		},
+	}
+	if !isWindowsRuntime() {
+		action.Payload.Workdir = "/workspace/project"
+		action.Payload.Target = "/tmp/snake_game.py"
+		action.Payload.SandboxTarget = "/tmp/snake_game.py"
+	}
+
+	details := sandboxErrorDetails(action, errors.New("security: path escapes workspace root"))
+	for _, fragment := range []string{
+		"security: security: path escapes workspace root",
+		"workdir: " + action.Payload.Workdir,
+		"target: " + action.Payload.Target,
+		"sandbox_target: " + action.Payload.SandboxTarget,
+	} {
+		if !strings.Contains(details, fragment) {
+			t.Fatalf("expected details containing %q, got %q", fragment, details)
+		}
 	}
 }
 

--- a/internal/tools/manager_test.go
+++ b/internal/tools/manager_test.go
@@ -451,11 +451,12 @@ func TestDefaultManagerSandboxOutsideWriteSessionMemory(t *testing.T) {
 		t.Fatalf("remember outside write allow: %v", rememberErr)
 	}
 
-	if _, err := manager.Execute(context.Background(), input); err != nil {
-		t.Fatalf("expected remembered allow to bypass sandbox block, got %v", err)
+	_, err = manager.Execute(context.Background(), input)
+	if err == nil || !strings.Contains(err.Error(), "escapes workspace root") {
+		t.Fatalf("expected sandbox rejection after remembered allow, got %v", err)
 	}
-	if writeTool.callCount != 1 {
-		t.Fatalf("expected write tool to execute once after remember, got %d", writeTool.callCount)
+	if writeTool.callCount != 0 {
+		t.Fatalf("expected write tool not to execute after remembered allow, got %d", writeTool.callCount)
 	}
 }
 
@@ -466,11 +467,13 @@ func TestSandboxOutsideWriteApprovalCandidate(t *testing.T) {
 	lowRiskPath := filepath.Join(string(filepath.Separator), "tmp", "sample.py")
 	protectedPath := filepath.Join(string(filepath.Separator), "etc", "hosts")
 	highRiskExecutable := filepath.Join(string(filepath.Separator), "tmp", "sample.exe")
+	startupProfilePath := filepath.Join(string(filepath.Separator), "home", "tester", ".bashrc")
 	if isWindowsRuntime() {
 		workspaceRoot = `C:\workspace\project`
 		lowRiskPath = `C:\Users\tester\Desktop\sample.py`
 		protectedPath = `C:\Windows\System32\drivers\etc\hosts`
 		highRiskExecutable = `C:\Users\tester\Desktop\sample.exe`
+		startupProfilePath = `C:\Users\tester\Documents\PowerShell\Microsoft.PowerShell_profile.ps1`
 	}
 
 	buildAction := func(target string, toolName string) security.Action {
@@ -522,6 +525,18 @@ func TestSandboxOutsideWriteApprovalCandidate(t *testing.T) {
 			name:       "write tool not in allowlist keeps hard reject",
 			action:     buildAction(lowRiskPath, "filesystem_edit"),
 			sandboxErr: fmt.Errorf("security: path %q escapes workspace root", lowRiskPath),
+			want:       false,
+		},
+		{
+			name:       "symlink workspace escape keeps hard reject",
+			action:     buildAction(lowRiskPath, "filesystem_write_file"),
+			sandboxErr: fmt.Errorf("security: path %q escapes workspace root via symlink", filepath.Join("link", "sample.py")),
+			want:       false,
+		},
+		{
+			name:       "startup profile path keeps hard reject",
+			action:     buildAction(startupProfilePath, "filesystem_write_file"),
+			sandboxErr: fmt.Errorf("security: path %q escapes workspace root", startupProfilePath),
 			want:       false,
 		},
 	}

--- a/internal/tools/manager_test.go
+++ b/internal/tools/manager_test.go
@@ -709,7 +709,7 @@ func TestSandboxErrorDetailsIncludesWorkspaceContext(t *testing.T) {
 
 	details := sandboxErrorDetails(action, errors.New("security: path escapes workspace root"))
 	for _, fragment := range []string{
-		"security: security: path escapes workspace root",
+		"security: path escapes workspace root",
 		"workdir: " + action.Payload.Workdir,
 		"target: " + action.Payload.Target,
 		"sandbox_target: " + action.Payload.SandboxTarget,
@@ -717,6 +717,11 @@ func TestSandboxErrorDetailsIncludesWorkspaceContext(t *testing.T) {
 		if !strings.Contains(details, fragment) {
 			t.Fatalf("expected details containing %q, got %q", fragment, details)
 		}
+	}
+
+	withoutPrefix := sandboxErrorDetails(action, errors.New("path escapes workspace root"))
+	if !strings.Contains(withoutPrefix, "security: path escapes workspace root") {
+		t.Fatalf("expected details to normalize security prefix, got %q", withoutPrefix)
 	}
 }
 

--- a/internal/tools/manager_test.go
+++ b/internal/tools/manager_test.go
@@ -553,6 +553,141 @@ func TestSandboxOutsideWriteApprovalCandidate(t *testing.T) {
 	}
 }
 
+func TestSandboxOutsideWriteUtilityHelpers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("candidate requires write action", func(t *testing.T) {
+		t.Parallel()
+		action := security.Action{
+			Type: security.ActionTypeRead,
+			Payload: security.ActionPayload{
+				ToolName:      ToolNameFilesystemWriteFile,
+				Resource:      ToolNameFilesystemWriteFile,
+				Workdir:       "/workspace/project",
+				Target:        "/tmp/note.txt",
+				SandboxTarget: "/tmp/note.txt",
+			},
+		}
+		if got := isSandboxOutsideWriteApprovalCandidate(action, errors.New(`security: path "/tmp/note.txt" escapes workspace root`)); got {
+			t.Fatalf("expected non-write action not to be candidate")
+		}
+	})
+
+	t.Run("candidate requires resolvable target path", func(t *testing.T) {
+		t.Parallel()
+		action := security.Action{
+			Type: security.ActionTypeWrite,
+			Payload: security.ActionPayload{
+				ToolName: ToolNameFilesystemWriteFile,
+				Resource: ToolNameFilesystemWriteFile,
+				Workdir:  "/workspace/project",
+			},
+		}
+		if got := isSandboxOutsideWriteApprovalCandidate(action, errors.New(`security: path "/tmp/note.txt" escapes workspace root`)); got {
+			t.Fatalf("expected empty target not to be candidate")
+		}
+	})
+
+	t.Run("workspace error recognizers handle nil", func(t *testing.T) {
+		t.Parallel()
+		if isWorkspaceBoundaryViolationError(nil) {
+			t.Fatalf("expected nil error not to be workspace boundary violation")
+		}
+		if isWorkspaceSymlinkViolationError(nil) {
+			t.Fatalf("expected nil error not to be workspace symlink violation")
+		}
+	})
+
+	t.Run("resolve action sandbox target path branches", func(t *testing.T) {
+		t.Parallel()
+		if got := resolveActionSandboxTargetPath(security.Action{}); got != "" {
+			t.Fatalf("expected empty target path, got %q", got)
+		}
+
+		actionWithTarget := security.Action{
+			Payload: security.ActionPayload{
+				Target:  "logs/app.log",
+				Workdir: "/workspace/project",
+			},
+		}
+		resolved := resolveActionSandboxTargetPath(actionWithTarget)
+		if !strings.HasSuffix(filepath.ToSlash(resolved), "/workspace/project/logs/app.log") {
+			t.Fatalf("expected target fallback with workdir join, got %q", resolved)
+		}
+
+		actionWithSandboxTarget := security.Action{
+			Payload: security.ActionPayload{
+				Target:        "/tmp/ignored.txt",
+				SandboxTarget: "/tmp/final.txt",
+			},
+		}
+		if got := resolveActionSandboxTargetPath(actionWithSandboxTarget); filepath.Clean(got) != filepath.Clean("/tmp/final.txt") {
+			t.Fatalf("expected sandbox target to win, got %q", got)
+		}
+	})
+
+	t.Run("low risk path rejects empty path", func(t *testing.T) {
+		t.Parallel()
+		if isLowRiskExternalWritePath(" . ") {
+			t.Fatalf("expected dot path to be rejected")
+		}
+	})
+
+	t.Run("startup profile detector os branches", func(t *testing.T) {
+		t.Parallel()
+		if isUserStartupProfilePathForOS(".", "linux") {
+			t.Fatalf("expected dot path not to be startup profile")
+		}
+		if isUserStartupProfilePathForOS(" / ", "linux") {
+			t.Fatalf("expected root path not to be startup profile")
+		}
+		if !isUserStartupProfilePathForOS(`/Users/tester/Documents/WindowsPowerShell/custom_profile.ps1`, "windows") {
+			t.Fatalf("expected windows powershell profile directory to be recognized")
+		}
+		if !isUserStartupProfilePathForOS(`/Users/tester/Documents/PowerShell/custom_profile.ps1`, "windows") {
+			t.Fatalf("expected powershell profile directory to be recognized")
+		}
+		if isUserStartupProfilePathForOS(`/Users/tester/Documents/PowerShell/readme.txt`, "windows") {
+			t.Fatalf("expected non-ps1 path not to be startup profile")
+		}
+		if !isUserStartupProfilePathForOS(`/home/tester/.config/fish/config.fish`, "linux") {
+			t.Fatalf("expected fish config path to be startup profile")
+		}
+	})
+
+	t.Run("system protected path detector os branches", func(t *testing.T) {
+		t.Parallel()
+		if !isSystemProtectedPathForOS("/", "linux") {
+			t.Fatalf("expected linux root to be protected")
+		}
+		if !isSystemProtectedPathForOS("/home/tester/.ssh/config", "linux") {
+			t.Fatalf("expected .ssh path to be protected")
+		}
+		if isSystemProtectedPathForOS("/home/tester/Documents/notes.txt", "linux") {
+			t.Fatalf("expected regular linux user path not to be protected")
+		}
+		if !isSystemProtectedPathForOS(`C:\Windows\System32\drivers\etc\hosts`, "windows") {
+			t.Fatalf("expected windows system path to be protected")
+		}
+		if !isSystemProtectedPathForOS(`C:\Users\tester\AppData\Roaming\config`, "windows") {
+			t.Fatalf("expected appdata path to be protected")
+		}
+		if !isSystemProtectedPathForOS(`C:`, "windows") {
+			t.Fatalf("expected windows drive root to be protected")
+		}
+		if isSystemProtectedPathForOS(`C:\Users\tester\Desktop\note.txt`, "windows") {
+			t.Fatalf("expected regular windows user path not to be protected")
+		}
+	})
+
+	t.Run("error message handles nil", func(t *testing.T) {
+		t.Parallel()
+		if got := errorMessage(nil); got != "" {
+			t.Fatalf("expected empty error message for nil error, got %q", got)
+		}
+	})
+}
+
 func TestSandboxErrorDetailsIncludesWorkspaceContext(t *testing.T) {
 	t.Parallel()
 
@@ -2043,6 +2178,26 @@ func TestDefaultManagerExecuteCapabilityTokenValidation(t *testing.T) {
 				}
 			},
 			expectErr: "requires non-empty action agent_id",
+		},
+		{
+			name: "deny agent mismatch",
+			buildInput: func(t *testing.T, manager *DefaultManager) ToolCallInput {
+				t.Helper()
+				signed, err := manager.CapabilitySigner().Sign(baseToken)
+				if err != nil {
+					t.Fatalf("sign token: %v", err)
+				}
+				return ToolCallInput{
+					ID:              "call-agent-mismatch",
+					Name:            "filesystem_read_file",
+					Arguments:       []byte(`{"path":"README.md"}`),
+					Workdir:         workdir,
+					TaskID:          baseToken.TaskID,
+					AgentID:         "agent-other",
+					CapabilityToken: &signed,
+				}
+			},
+			expectErr: "agent_id does not match action",
 		},
 	}
 

--- a/internal/tools/manager_test.go
+++ b/internal/tools/manager_test.go
@@ -452,11 +452,11 @@ func TestDefaultManagerSandboxOutsideWriteSessionMemory(t *testing.T) {
 	}
 
 	_, err = manager.Execute(context.Background(), input)
-	if err == nil || !strings.Contains(err.Error(), "escapes workspace root") {
-		t.Fatalf("expected sandbox rejection after remembered allow, got %v", err)
+	if err != nil {
+		t.Fatalf("expected remembered allow retry to execute, got %v", err)
 	}
-	if writeTool.callCount != 0 {
-		t.Fatalf("expected write tool not to execute after remembered allow, got %d", writeTool.callCount)
+	if writeTool.callCount != 1 {
+		t.Fatalf("expected write tool to execute after remembered allow, got %d", writeTool.callCount)
 	}
 }
 


### PR DESCRIPTION
## Summary
- promote low-risk `filesystem_write_file` workspace-boundary rejections to permission `ask` instead of hard failure
- keep high-risk/system-protected paths as hard deny
- add richer sandbox error details (`workdir`, `target`, `sandbox_target`) so model can correctly detect failure context
- reuse existing session permission memory so approved requests can be retried successfully

## Test
- go test ./internal/tools
- go test ./internal/runtime