### PR TITLE
feat(skills): 完成Skills边界收口与用户入口落地

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ go run ./cmd/neocode --runtime-mode gateway
 - `/memo`：查看记忆索引
 - `/remember <text>`：保存记忆
 - `/forget <keyword>`：按关键词删除记忆
+- `/skills`：查看当前可用 skills（含当前会话激活标记）
+- `/skill use <id>`：在当前会话启用 skill
+- `/skill off <id>`：在当前会话停用 skill
+- `/skill active`：查看当前会话已激活 skills
 - `& <command>`：在当前工作区执行本地命令
 
 示例输入：
@@ -159,6 +163,7 @@ go run ./cmd/neocode --runtime-mode gateway
 - [Session 持久化设计](docs/session-persistence-design.md)
 - [Context Compact 说明](docs/context-compact.md)
 - [Tools 与 TUI 集成](docs/tools-and-tui-integration.md)
+- [Skills 设计与使用](docs/skills-system-design.md)
 - [MCP 配置指南](docs/guides/mcp-configuration.md)
 - [更新与升级](docs/guides/update.md)
 

--- a/docs/runtime-provider-event-flow.md
+++ b/docs/runtime-provider-event-flow.md
@@ -18,6 +18,9 @@
 - `permission_requested`
 - `permission_resolved`
 - `token_usage`
+- `skill_activated`
+- `skill_deactivated`
+- `skill_missing`
 - `compact_start`
 - `compact_applied`
 - `compact_error`

--- a/docs/skills-system-design.md
+++ b/docs/skills-system-design.md
@@ -1,0 +1,116 @@
+# Skills 设计与使用说明
+
+## 1. 目标与定位
+Skills 是 NeoCode 的“能力提示层”，用于给模型提供任务约束、参考资料和工具偏好，不是新的执行层。
+
+主链路保持不变：
+
+`TUI -> Runtime -> Provider / Tool Manager -> Security -> Executor`
+
+Skills 只影响：
+- Context 注入内容
+- 工具暴露顺序（提示优先级）
+
+Skills 不影响：
+- 工具是否真正可执行
+- 权限 ask/deny/allow 决策
+- MCP 注册与权限链路
+
+## 2. 发现机制（Discovery）
+当前本地发现路径：
+- `~/.neocode/skills/`
+
+加载规则：
+- 扫描 root 下的子目录（忽略隐藏目录）
+- 每个 skill 目录要求存在 `SKILL.md`
+- 也支持 root 目录直接放置一个 `SKILL.md`
+- 缺失文件、无效 metadata、空内容会记录为 `LoadIssue`，不阻塞其它 skill 加载
+
+## 3. 加载机制（Loader + Registry）
+核心模块：
+- `internal/skills/loader.go`：本地扫描与解析
+- `internal/skills/registry.go`：内存索引、查询与刷新
+- `internal/skills/filter.go`：按 source/scope/workspace 过滤
+
+关键约束：
+- `SKILL.md` 单文件读取有大小上限（默认 1 MiB）
+- 前置 metadata 和正文解析后统一归一化
+- skill id 去重冲突时 fail-closed（冲突项不进入可用列表）
+
+## 4. skill 文件结构（建议）
+`SKILL.md` 支持 frontmatter + 正文 section：
+
+```md
+---
+id: go-review
+name: Go Review
+description: Go 代码审查助手
+version: v1
+scope: session
+source: local
+tool_hints:
+  - filesystem_read_file
+  - filesystem_grep
+---
+
+## Instruction
+优先做静态阅读，再给出可执行修改建议。
+
+## References
+- [代码规范](./guides/go-style.md)
+
+## Examples
+- 先总结问题，再给补丁
+
+## ToolHints
+- filesystem_read_file
+- filesystem_grep
+```
+
+## 5. 激活与会话模型
+Runtime 提供会话级接口：
+- `ActivateSessionSkill(session_id, skill_id)`
+- `DeactivateSessionSkill(session_id, skill_id)`
+- `ListSessionSkills(session_id)`
+- `ListAvailableSkills(session_id)`
+
+TUI 入口：
+- `/skills`
+- `/skill use <id>`
+- `/skill off <id>`
+- `/skill active`
+
+说明：
+- `use/off/active` 需要当前有 active session
+- session 重载后会恢复 `activated_skills` 状态
+- skill 在 registry 中缺失时，会标记为 missing 并发出事件
+
+## 6. 模型如何使用 skill
+Runtime 在每轮 context 构建时把激活 skills 注入 `Skills` section，内容包含：
+- instruction
+- tool_hints（裁剪）
+- references（裁剪）
+- examples（裁剪）
+
+模型预期行为：
+- 把 skill 当成策略与工作流提示
+- 只调用当前真实暴露的工具 schema
+- 通过正常工具调用链路执行，不跳过权限层
+
+## 7. Tools / Security / MCP 边界
+Skills 与安全边界的约束：
+- skill 不能注入未注册工具
+- skill 不能变成权限 allowlist
+- skill 不能绕过 `PermissionEngine` 的 ask/deny/allow
+- MCP 工具仍经过统一 registry + exposure filter + permission 检查
+
+当前实现中，`tool_hints` 仅用于对已暴露工具做排序优先级调整，不会新增工具，也不会改变权限决策。
+
+## 8. 可观测事件
+Runtime 会发出以下 skills 事件（供 TUI/日志调试）：
+- `skill_activated`
+- `skill_deactivated`
+- `skill_missing`
+
+## 9. 兼容与扩展
+当前 focus 是本地 skills；后续如需引入 remote source / marketplace，可在 `Loader` 与 `Registry` 层扩展，不需要改动 runtime 主执行链路。

--- a/docs/tools-and-tui-integration.md
+++ b/docs/tools-and-tui-integration.md
@@ -30,6 +30,12 @@
 - TUI 的 `/memo`、`/remember`、`/forget` 等 Slash Command 不再直接依赖 memo service，而是通过 `Runtime.ExecuteSystemTool` 统一入口触发系统工具执行，保证 UI 与 memo 逻辑解耦。
 - TUI 不会展示后台自动提取的中间状态。
 
+## Skills 能力集成
+- Skills 由 `internal/skills` 统一发现、加载和注册；TUI 不直接读取 `SKILL.md` 文件。
+- TUI 通过 runtime 接口管理会话激活状态：`/skills`、`/skill use <id>`、`/skill off <id>`、`/skill active`。
+- Skills 只影响提示注入与工具排序优先级，不改变工具执行入口；真实调用仍走 `Runtime -> Tool Manager -> Security -> Executor`。
+- Skills 不提供权限豁免；命中 ask/deny 规则时行为与未启用 skill 保持一致。
+
 ## TUI 集成方式
 - 本地配置操作统一通过 Slash Command 完成，例如 Base URL、API Key 和模型选择
 - runtime 事件以内联形式渲染到 transcript 中，而不是单独拆出控制台面板

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -1649,6 +1649,13 @@ func (s *stubRemoteRuntimeForBootstrap) ListSessionSkills(context.Context, strin
 	return nil, nil
 }
 
+func (s *stubRemoteRuntimeForBootstrap) ListAvailableSkills(
+	context.Context,
+	string,
+) ([]agentruntime.AvailableSkillState, error) {
+	return nil, nil
+}
+
 func (s *stubRemoteRuntimeForBootstrap) Close() error {
 	s.closed = true
 	return nil

--- a/internal/cli/gateway_runtime_bridge_test.go
+++ b/internal/cli/gateway_runtime_bridge_test.go
@@ -101,6 +101,10 @@ func (s *runtimeStub) ListSessionSkills(context.Context, string) ([]agentruntime
 	return nil, nil
 }
 
+func (s *runtimeStub) ListAvailableSkills(context.Context, string) ([]agentruntime.AvailableSkillState, error) {
+	return nil, nil
+}
+
 type runtimeWithoutCreator struct {
 	base *runtimeStub
 }
@@ -143,6 +147,13 @@ func (r *runtimeWithoutCreator) DeactivateSessionSkill(ctx context.Context, sess
 }
 func (r *runtimeWithoutCreator) ListSessionSkills(ctx context.Context, sessionID string) ([]agentruntime.SessionSkillState, error) {
 	return r.base.ListSessionSkills(ctx, sessionID)
+}
+
+func (r *runtimeWithoutCreator) ListAvailableSkills(
+	ctx context.Context,
+	sessionID string,
+) ([]agentruntime.AvailableSkillState, error) {
+	return r.base.ListAvailableSkills(ctx, sessionID)
 }
 
 func TestNewGatewayRuntimePortBridgeRuntimeUnavailable(t *testing.T) {

--- a/internal/runtime/run.go
+++ b/internal/runtime/run.go
@@ -255,6 +255,7 @@ func (s *Service) prepareTurnSnapshot(ctx context.Context, state *runState) (tur
 	if err != nil {
 		return turnSnapshot{}, false, err
 	}
+	toolSpecs = prioritizeToolSpecsBySkillHints(toolSpecs, activeSkills)
 
 	resolvedProvider, err := config.ResolveSelectedProvider(cfg)
 	if err != nil {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -3,8 +3,8 @@ package runtime
 import (
 	"context"
 	"errors"
-	"os"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -46,6 +46,7 @@ type Runtime interface {
 	ActivateSessionSkill(ctx context.Context, sessionID string, skillID string) error
 	DeactivateSessionSkill(ctx context.Context, sessionID string, skillID string) error
 	ListSessionSkills(ctx context.Context, sessionID string) ([]SessionSkillState, error)
+	ListAvailableSkills(ctx context.Context, sessionID string) ([]AvailableSkillState, error)
 }
 
 // UserInput 描述一次用户输入请求的最小运行参数。

--- a/internal/runtime/skills.go
+++ b/internal/runtime/skills.go
@@ -144,6 +144,8 @@ func (s *Service) ListAvailableSkills(ctx context.Context, sessionID string) ([]
 		} else {
 			workspace = strings.TrimSpace(session.Workdir)
 		}
+	} else if s.configManager != nil {
+		workspace = strings.TrimSpace(s.configManager.Get().Workdir)
 	}
 
 	descriptors, err := s.skillsRegistry.List(ctx, skills.ListInput{Workspace: workspace})
@@ -236,7 +238,8 @@ func prioritizeToolSpecsBySkillHints(
 		case rightHit:
 			return false
 		default:
-			return strings.ToLower(prioritized[i].Name) < strings.ToLower(prioritized[j].Name)
+			// 未命中的工具保持原有相对顺序，避免 hint 影响无关工具排序。
+			return false
 		}
 	})
 	return prioritized

--- a/internal/runtime/skills.go
+++ b/internal/runtime/skills.go
@@ -3,9 +3,11 @@ package runtime
 import (
 	"context"
 	"errors"
+	"sort"
 	"strings"
 	"time"
 
+	providertypes "neo-code/internal/provider/types"
 	agentsession "neo-code/internal/session"
 	"neo-code/internal/skills"
 )
@@ -17,6 +19,12 @@ type SessionSkillState struct {
 	SkillID    string
 	Missing    bool
 	Descriptor *skills.Descriptor
+}
+
+// AvailableSkillState 描述当前可见 skill 的元信息及其在会话中的激活状态。
+type AvailableSkillState struct {
+	Descriptor skills.Descriptor
+	Active     bool
 }
 
 // ActivateSessionSkill 在 session 级激活一个已注册的 skill。
@@ -113,6 +121,54 @@ func (s *Service) ListSessionSkills(ctx context.Context, sessionID string) ([]Se
 	return states, nil
 }
 
+// ListAvailableSkills 返回当前 registry 中对会话可见的技能列表，并标记激活状态。
+func (s *Service) ListAvailableSkills(ctx context.Context, sessionID string) ([]AvailableSkillState, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if s.skillsRegistry == nil {
+		return nil, errSkillsRegistryUnavailable
+	}
+
+	normalizedSessionID := strings.TrimSpace(sessionID)
+	workspace := ""
+	activeSet := map[string]struct{}{}
+	if normalizedSessionID != "" {
+		session, err := s.sessionStore.LoadSession(ctx, normalizedSessionID)
+		if err != nil {
+			return nil, err
+		}
+		activeSet = skillSetFromIDs(session.ActiveSkillIDs())
+		if s.configManager != nil {
+			workspace = agentsession.EffectiveWorkdir(session.Workdir, s.configManager.Get().Workdir)
+		} else {
+			workspace = strings.TrimSpace(session.Workdir)
+		}
+	}
+
+	descriptors, err := s.skillsRegistry.List(ctx, skills.ListInput{Workspace: workspace})
+	if err != nil {
+		return nil, err
+	}
+	if len(descriptors) == 0 {
+		return nil, nil
+	}
+
+	states := make([]AvailableSkillState, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		key := normalizeRuntimeSkillID(descriptor.ID)
+		_, active := activeSet[key]
+		states = append(states, AvailableSkillState{
+			Descriptor: descriptor,
+			Active:     active,
+		})
+	}
+	sort.Slice(states, func(i, j int) bool {
+		return normalizeRuntimeSkillID(states[i].Descriptor.ID) < normalizeRuntimeSkillID(states[j].Descriptor.ID)
+	})
+	return states, nil
+}
+
 // resolveActiveSkills 解析当前 session 激活的 skills，并对缺失项做事件降级。
 func (s *Service) resolveActiveSkills(ctx context.Context, state *runState) ([]skills.Skill, error) {
 	if err := ctx.Err(); err != nil {
@@ -151,6 +207,41 @@ func (s *Service) resolveActiveSkills(ctx context.Context, state *runState) ([]s
 	return resolved, nil
 }
 
+// prioritizeToolSpecsBySkillHints 按激活 skill 的 tool_hints 调整工具顺序，仅影响提示优先级。
+func prioritizeToolSpecsBySkillHints(
+	specs []providertypes.ToolSpec,
+	activeSkills []skills.Skill,
+) []providertypes.ToolSpec {
+	if len(specs) == 0 {
+		return nil
+	}
+	hints := collectSkillToolHints(activeSkills)
+	if len(hints) == 0 {
+		return append([]providertypes.ToolSpec(nil), specs...)
+	}
+
+	rank := make(map[string]int, len(hints))
+	for idx, hint := range hints {
+		rank[hint] = idx
+	}
+	prioritized := append([]providertypes.ToolSpec(nil), specs...)
+	sort.SliceStable(prioritized, func(i, j int) bool {
+		leftRank, leftHit := rank[normalizeRuntimeSkillID(prioritized[i].Name)]
+		rightRank, rightHit := rank[normalizeRuntimeSkillID(prioritized[j].Name)]
+		switch {
+		case leftHit && rightHit:
+			return leftRank < rightRank
+		case leftHit:
+			return true
+		case rightHit:
+			return false
+		default:
+			return strings.ToLower(prioritized[i].Name) < strings.ToLower(prioritized[j].Name)
+		}
+	})
+	return prioritized
+}
+
 // emitSkillMissingOnce 在同一次 run 内只上报一次指定 skill 的缺失事件，避免重复噪音。
 func (s *Service) emitSkillMissingOnce(ctx context.Context, state *runState, skillID string) {
 	if state == nil {
@@ -161,6 +252,45 @@ func (s *Service) emitSkillMissingOnce(ctx context.Context, state *runState, ski
 		return
 	}
 	_ = s.emitRunScoped(ctx, EventSkillMissing, state, SessionSkillEventPayload{SkillID: skillID})
+}
+
+// collectSkillToolHints 收集并规范化激活 skills 中的 tool_hints，用于工具排序提示。
+func collectSkillToolHints(activeSkills []skills.Skill) []string {
+	if len(activeSkills) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(activeSkills))
+	seen := make(map[string]struct{}, len(activeSkills))
+	for _, skill := range activeSkills {
+		for _, hint := range skill.Content.ToolHints {
+			normalized := normalizeRuntimeSkillID(hint)
+			if normalized == "" {
+				continue
+			}
+			if _, ok := seen[normalized]; ok {
+				continue
+			}
+			seen[normalized] = struct{}{}
+			out = append(out, normalized)
+		}
+	}
+	return out
+}
+
+// skillSetFromIDs 将技能 ID 列表转换为规范化集合，便于快速判断激活状态。
+func skillSetFromIDs(ids []string) map[string]struct{} {
+	if len(ids) == 0 {
+		return map[string]struct{}{}
+	}
+	set := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		normalized := normalizeRuntimeSkillID(id)
+		if normalized == "" {
+			continue
+		}
+		set[normalized] = struct{}{}
+	}
+	return set
 }
 
 // mutateSessionSkills 串行修改 session 的激活 skills，并在发生变化时立即持久化。

--- a/internal/runtime/skills_test.go
+++ b/internal/runtime/skills_test.go
@@ -634,6 +634,125 @@ func TestNormalizeRuntimeSkillID(t *testing.T) {
 	}
 }
 
+func TestResolveActiveSkillsBranchCoverage(t *testing.T) {
+	t.Parallel()
+
+	manager := newRuntimeConfigManager(t)
+	store := newMemoryStore()
+	session := newRuntimeSession("session-resolve-active-skills")
+	session.ActivateSkill("missing-a")
+	session.ActivateSkill("missing-b")
+	store.sessions[session.ID] = cloneSession(session)
+	service := NewWithFactory(manager, &stubToolManager{}, store, &scriptedProviderFactory{provider: &scriptedProvider{}}, &stubContextBuilder{})
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := service.resolveActiveSkills(canceledCtx, nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled context to fail early, got %v", err)
+	}
+	if skillsResolved, err := service.resolveActiveSkills(context.Background(), nil); err != nil || skillsResolved != nil {
+		t.Fatalf("expected nil state to return nil,nil; got %+v err=%v", skillsResolved, err)
+	}
+
+	state := newRunState("run-resolve-active-skills", session)
+	skillsResolved, err := service.resolveActiveSkills(context.Background(), &state)
+	if err != nil {
+		t.Fatalf("resolveActiveSkills() error = %v", err)
+	}
+	if len(skillsResolved) != 0 {
+		t.Fatalf("expected unresolved skills with nil registry, got %+v", skillsResolved)
+	}
+
+	events := collectRuntimeEvents(service.Events())
+	if len(events) != 2 {
+		t.Fatalf("expected two skill_missing events, got %+v", events)
+	}
+}
+
+func TestListSessionSkillsHandlesSkillNotFoundFromRegistry(t *testing.T) {
+	t.Parallel()
+
+	manager := newRuntimeConfigManager(t)
+	store := newMemoryStore()
+	session := newRuntimeSession("session-list-session-skills-missing")
+	session.ActivateSkill("missing-skill")
+	store.sessions[session.ID] = cloneSession(session)
+
+	service := NewWithFactory(manager, &stubToolManager{}, store, &scriptedProviderFactory{provider: &scriptedProvider{}}, &stubContextBuilder{})
+	service.SetSkillsRegistry(&stubSkillsRegistry{skills: map[string]skills.Skill{}})
+
+	states, err := service.ListSessionSkills(context.Background(), session.ID)
+	if err != nil {
+		t.Fatalf("ListSessionSkills() error = %v", err)
+	}
+	if len(states) != 1 || !states[0].Missing || states[0].Descriptor != nil {
+		t.Fatalf("expected skill-not-found to map to missing state, got %+v", states)
+	}
+}
+
+func TestListAvailableSkillsAdditionalBranches(t *testing.T) {
+	t.Parallel()
+
+	manager := newRuntimeConfigManager(t)
+	store := newMemoryStore()
+	session := newRuntimeSession("session-list-available-branches")
+	session.Workdir = "/tmp/project"
+	store.sessions[session.ID] = cloneSession(session)
+
+	service := NewWithFactory(manager, &stubToolManager{}, store, &scriptedProviderFactory{provider: &scriptedProvider{}}, &stubContextBuilder{})
+	registry := &stubSkillsRegistry{skills: map[string]skills.Skill{}}
+	service.SetSkillsRegistry(registry)
+
+	states, err := service.ListAvailableSkills(context.Background(), session.ID)
+	if err != nil {
+		t.Fatalf("ListAvailableSkills() error = %v", err)
+	}
+	if states != nil {
+		t.Fatalf("expected nil states for empty descriptor list, got %+v", states)
+	}
+	if strings.TrimSpace(registry.lastListInput.Workspace) == "" {
+		t.Fatalf("expected workspace from session/config, got %+v", registry.lastListInput)
+	}
+
+	service.configManager = nil
+	if _, err := service.ListAvailableSkills(context.Background(), session.ID); err != nil {
+		t.Fatalf("expected config-manager-nil branch to still succeed, got %v", err)
+	}
+	if strings.TrimSpace(registry.lastListInput.Workspace) != "/tmp/project" {
+		t.Fatalf("expected workspace from session workdir when config manager nil, got %+v", registry.lastListInput)
+	}
+}
+
+func TestSkillHelperFunctionsBranches(t *testing.T) {
+	t.Parallel()
+
+	if set := skillSetFromIDs(nil); len(set) != 0 {
+		t.Fatalf("expected empty set for nil input, got %+v", set)
+	}
+	set := skillSetFromIDs([]string{"  ", "Go_Review", "go-review"})
+	if len(set) != 1 {
+		t.Fatalf("expected deduped set size 1, got %+v", set)
+	}
+	if _, ok := set["go-review"]; !ok {
+		t.Fatalf("expected normalized key in set, got %+v", set)
+	}
+
+	hints := collectSkillToolHints([]skills.Skill{
+		{
+			Content: skills.Content{ToolHints: []string{"", "bash", " Bash ", "web_fetch"}},
+		},
+		{
+			Content: skills.Content{ToolHints: []string{"web-fetch"}},
+		},
+	})
+	if !reflect.DeepEqual(hints, []string{"bash", "web-fetch"}) {
+		t.Fatalf("unexpected normalized hints: %+v", hints)
+	}
+	if collectSkillToolHints(nil) != nil {
+		t.Fatalf("expected nil for empty active skills")
+	}
+}
+
 func TestServiceRunReinjectsSkillsAfterAutoCompact(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/skills_test.go
+++ b/internal/runtime/skills_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"neo-code/internal/config"
@@ -18,16 +19,22 @@ import (
 )
 
 type stubSkillsRegistry struct {
-	skills map[string]skills.Skill
-	getErr error
+	skills         map[string]skills.Skill
+	getErr         error
+	lastListInput  skills.ListInput
+	listFilterByWS bool
 }
 
 func (r *stubSkillsRegistry) List(ctx context.Context, input skills.ListInput) ([]skills.Descriptor, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	r.lastListInput = input
 	result := make([]skills.Descriptor, 0, len(r.skills))
 	for _, skill := range r.skills {
+		if r.listFilterByWS && skill.Descriptor.Scope == skills.ScopeWorkspace && strings.TrimSpace(input.Workspace) == "" {
+			continue
+		}
 		result = append(result, skill.Descriptor)
 	}
 	return result, nil
@@ -422,6 +429,39 @@ func TestListAvailableSkillsReportsActiveStateAndSorts(t *testing.T) {
 	}
 }
 
+func TestListAvailableSkillsUsesConfigWorkdirWhenSessionIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	manager := newRuntimeConfigManager(t)
+	store := newMemoryStore()
+	service := NewWithFactory(manager, &stubToolManager{}, store, &scriptedProviderFactory{provider: &scriptedProvider{}}, &stubContextBuilder{})
+	registry := &stubSkillsRegistry{
+		listFilterByWS: true,
+		skills: map[string]skills.Skill{
+			"workspace-only": {
+				Descriptor: skills.Descriptor{
+					ID:    "workspace-only",
+					Name:  "Workspace Only",
+					Scope: skills.ScopeWorkspace,
+				},
+				Content: skills.Content{Instruction: "workspace"},
+			},
+		},
+	}
+	service.SetSkillsRegistry(registry)
+
+	states, err := service.ListAvailableSkills(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListAvailableSkills() error = %v", err)
+	}
+	if len(states) != 1 || states[0].Descriptor.ID != "workspace-only" {
+		t.Fatalf("expected workspace skill visible with config workdir fallback, got %+v", states)
+	}
+	if strings.TrimSpace(registry.lastListInput.Workspace) == "" {
+		t.Fatalf("expected non-empty workspace fallback, got %+v", registry.lastListInput)
+	}
+}
+
 func TestListAvailableSkillsHandlesValidationAndRegistryErrors(t *testing.T) {
 	t.Parallel()
 
@@ -467,6 +507,33 @@ func TestPrioritizeToolSpecsBySkillHintsOnlyReordersVisibleTools(t *testing.T) {
 	prioritized := prioritizeToolSpecsBySkillHints(specs, activeSkills)
 	got := []string{prioritized[0].Name, prioritized[1].Name, prioritized[2].Name}
 	want := []string{"webfetch", "bash", "filesystem_read_file"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("prioritized tool order = %v, want %v", got, want)
+	}
+}
+
+func TestPrioritizeToolSpecsBySkillHintsKeepsNonHintedRelativeOrder(t *testing.T) {
+	t.Parallel()
+
+	specs := []providertypes.ToolSpec{
+		{Name: "filesystem_read_file"},
+		{Name: "webfetch"},
+		{Name: "bash"},
+		{Name: "mcp_tool"},
+	}
+	activeSkills := []skills.Skill{
+		{
+			Descriptor: skills.Descriptor{ID: "go-review", Name: "Go Review"},
+			Content: skills.Content{
+				Instruction: "review",
+				ToolHints:   []string{"bash"},
+			},
+		},
+	}
+
+	prioritized := prioritizeToolSpecsBySkillHints(specs, activeSkills)
+	got := []string{prioritized[0].Name, prioritized[1].Name, prioritized[2].Name, prioritized[3].Name}
+	want := []string{"bash", "filesystem_read_file", "webfetch", "mcp_tool"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("prioritized tool order = %v, want %v", got, want)
 	}

--- a/internal/runtime/skills_test.go
+++ b/internal/runtime/skills_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"testing"
 
 	"neo-code/internal/config"
@@ -380,6 +381,138 @@ func TestListSessionSkillsValidatesInput(t *testing.T) {
 	}
 	if _, err := service.ListSessionSkills(context.Background(), " "); err == nil {
 		t.Fatalf("expected empty session id to fail")
+	}
+}
+
+func TestListAvailableSkillsReportsActiveStateAndSorts(t *testing.T) {
+	t.Parallel()
+
+	manager := newRuntimeConfigManager(t)
+	store := newMemoryStore()
+	session := newRuntimeSession("session-list-available-skills")
+	session.ActivateSkill("go-review")
+	store.sessions[session.ID] = cloneSession(session)
+
+	service := NewWithFactory(manager, &stubToolManager{}, store, &scriptedProviderFactory{provider: &scriptedProvider{}}, &stubContextBuilder{})
+	service.SetSkillsRegistry(&stubSkillsRegistry{
+		skills: map[string]skills.Skill{
+			"zeta": {
+				Descriptor: skills.Descriptor{ID: "zeta", Name: "Zeta"},
+				Content:    skills.Content{Instruction: "z"},
+			},
+			"go-review": {
+				Descriptor: skills.Descriptor{ID: "go-review", Name: "Go Review"},
+				Content:    skills.Content{Instruction: "go"},
+			},
+		},
+	})
+
+	states, err := service.ListAvailableSkills(context.Background(), session.ID)
+	if err != nil {
+		t.Fatalf("ListAvailableSkills() error = %v", err)
+	}
+	if len(states) != 2 {
+		t.Fatalf("ListAvailableSkills() len = %d, want 2", len(states))
+	}
+	if states[0].Descriptor.ID != "go-review" || !states[0].Active {
+		t.Fatalf("expected go-review active first, got %+v", states[0])
+	}
+	if states[1].Descriptor.ID != "zeta" || states[1].Active {
+		t.Fatalf("expected zeta inactive second, got %+v", states[1])
+	}
+}
+
+func TestListAvailableSkillsHandlesValidationAndRegistryErrors(t *testing.T) {
+	t.Parallel()
+
+	manager := newRuntimeConfigManager(t)
+	store := newMemoryStore()
+	session := newRuntimeSession("session-list-available-errors")
+	store.sessions[session.ID] = cloneSession(session)
+	service := NewWithFactory(manager, &stubToolManager{}, store, &scriptedProviderFactory{provider: &scriptedProvider{}}, &stubContextBuilder{})
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := service.ListAvailableSkills(canceledCtx, session.ID); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled context error, got %v", err)
+	}
+	if _, err := service.ListAvailableSkills(context.Background(), session.ID); !errors.Is(err, errSkillsRegistryUnavailable) {
+		t.Fatalf("expected registry unavailable error, got %v", err)
+	}
+
+	service.SetSkillsRegistry(&stubSkillsRegistry{getErr: os.ErrPermission})
+	if _, err := service.ListAvailableSkills(context.Background(), "missing-session"); err == nil {
+		t.Fatalf("expected missing session error")
+	}
+}
+
+func TestPrioritizeToolSpecsBySkillHintsOnlyReordersVisibleTools(t *testing.T) {
+	t.Parallel()
+
+	specs := []providertypes.ToolSpec{
+		{Name: "filesystem_read_file"},
+		{Name: "bash"},
+		{Name: "webfetch"},
+	}
+	activeSkills := []skills.Skill{
+		{
+			Descriptor: skills.Descriptor{ID: "go-review", Name: "Go Review"},
+			Content: skills.Content{
+				Instruction: "review",
+				ToolHints:   []string{"webfetch", "unknown_tool", "bash"},
+			},
+		},
+	}
+
+	prioritized := prioritizeToolSpecsBySkillHints(specs, activeSkills)
+	got := []string{prioritized[0].Name, prioritized[1].Name, prioritized[2].Name}
+	want := []string{"webfetch", "bash", "filesystem_read_file"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("prioritized tool order = %v, want %v", got, want)
+	}
+}
+
+func TestPrepareTurnSnapshotPrioritizesToolsByActiveSkillHints(t *testing.T) {
+	t.Parallel()
+
+	manager := newRuntimeConfigManager(t)
+	store := newMemoryStore()
+	session := newRuntimeSession("session-skill-tool-priority")
+	session.ActivateSkill("go-review")
+	store.sessions[session.ID] = cloneSession(session)
+
+	toolManager := &stubToolManager{
+		specs: []providertypes.ToolSpec{
+			{Name: "filesystem_read_file"},
+			{Name: "bash"},
+		},
+	}
+	service := NewWithFactory(manager, toolManager, store, &scriptedProviderFactory{provider: &scriptedProvider{}}, &stubContextBuilder{})
+	service.SetSkillsRegistry(&stubSkillsRegistry{
+		skills: map[string]skills.Skill{
+			"go-review": {
+				Descriptor: skills.Descriptor{ID: "go-review", Name: "Go Review"},
+				Content: skills.Content{
+					Instruction: "review",
+					ToolHints:   []string{"bash"},
+				},
+			},
+		},
+	})
+
+	state := newRunState("run-skill-tool-priority", session)
+	snapshot, rebuilt, err := service.prepareTurnSnapshot(context.Background(), &state)
+	if err != nil {
+		t.Fatalf("prepareTurnSnapshot() error = %v", err)
+	}
+	if rebuilt {
+		t.Fatalf("did not expect snapshot rebuild")
+	}
+	if len(snapshot.request.Tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(snapshot.request.Tools))
+	}
+	if snapshot.request.Tools[0].Name != "bash" {
+		t.Fatalf("expected hinted tool first, got %q", snapshot.request.Tools[0].Name)
 	}
 }
 

--- a/internal/runtime/subagent_tool_executor_test.go
+++ b/internal/runtime/subagent_tool_executor_test.go
@@ -517,10 +517,12 @@ func TestSubAgentRuntimeToolExecutorExecuteToolEvents(t *testing.T) {
 		workdir := t.TempDir()
 		allowed := filepath.Join(workdir, "safe")
 		allowedFile := filepath.Join(allowed, "note.txt")
+		taskID := "task-subagent-cap-path-allow"
+		agentID := "subagent:cap-path-allow"
 		parent := security.CapabilityToken{
 			ID:              "parent-path-allow",
-			TaskID:          "task-parent-path-allow",
-			AgentID:         "agent-parent-path-allow",
+			TaskID:          taskID,
+			AgentID:         agentID,
 			IssuedAt:        time.Now().UTC().Add(-time.Minute),
 			ExpiresAt:       time.Now().UTC().Add(10 * time.Minute),
 			AllowedTools:    []string{tools.ToolNameFilesystemReadFile},
@@ -535,9 +537,9 @@ func TestSubAgentRuntimeToolExecutorExecuteToolEvents(t *testing.T) {
 		result, execErr := executor.ExecuteTool(context.Background(), subagent.ToolExecutionInput{
 			RunID:           "run-subagent-cap-path-allow",
 			SessionID:       "session-subagent-cap-path-allow",
-			TaskID:          "task-subagent-cap-path-allow",
+			TaskID:          taskID,
 			Role:            subagent.RoleCoder,
-			AgentID:         "subagent:cap-path-allow",
+			AgentID:         agentID,
 			Workdir:         workdir,
 			Timeout:         2 * time.Second,
 			CapabilityToken: &signedParent,

--- a/internal/security/workspace_test.go
+++ b/internal/security/workspace_test.go
@@ -570,7 +570,7 @@ func TestAbsoluteWorkspaceTarget(t *testing.T) {
 			if err != nil {
 				t.Fatalf("filepath.Abs(%q): %v", tt.want, err)
 			}
-			if got != filepath.Clean(wantAbs) {
+			if !samePathKey(got, wantAbs) {
 				t.Fatalf("absoluteWorkspaceTarget() = %q, want %q", got, filepath.Clean(wantAbs))
 			}
 		})

--- a/internal/tui/bootstrap/builder_test.go
+++ b/internal/tui/bootstrap/builder_test.go
@@ -82,6 +82,15 @@ func (r *testRuntime) ListSessionSkills(ctx context.Context, sessionID string) (
 	return []agentruntime.SessionSkillState{{SkillID: "test", Descriptor: &skills.Descriptor{ID: "test"}}}, nil
 }
 
+func (r *testRuntime) ListAvailableSkills(ctx context.Context, sessionID string) ([]agentruntime.AvailableSkillState, error) {
+	return []agentruntime.AvailableSkillState{
+		{
+			Descriptor: skills.Descriptor{ID: "test", Name: "Test"},
+			Active:     true,
+		},
+	}, nil
+}
+
 type testProviderService struct{}
 
 func (s *testProviderService) ListProviderOptions(ctx context.Context) ([]configstate.ProviderOption, error) {
@@ -301,6 +310,10 @@ func (r noopRuntime) DeactivateSessionSkill(ctx context.Context, sessionID strin
 }
 
 func (r noopRuntime) ListSessionSkills(ctx context.Context, sessionID string) ([]agentruntime.SessionSkillState, error) {
+	return nil, nil
+}
+
+func (r noopRuntime) ListAvailableSkills(ctx context.Context, sessionID string) ([]agentruntime.AvailableSkillState, error) {
 	return nil, nil
 }
 

--- a/internal/tui/core/app/commands.go
+++ b/internal/tui/core/app/commands.go
@@ -31,6 +31,8 @@ const (
 	slashCommandMemo        = "/memo"
 	slashCommandRemember    = "/remember"
 	slashCommandForget      = "/forget"
+	slashCommandSkills      = "/skills"
+	slashCommandSkill       = "/skill"
 
 	slashUsageHelp        = "/help"
 	slashUsageExit        = "/exit"
@@ -45,6 +47,10 @@ const (
 	slashUsageMemo        = "/memo"
 	slashUsageRemember    = "/remember <text>"
 	slashUsageForget      = "/forget <keyword>"
+	slashUsageSkills      = "/skills"
+	slashUsageSkillUse    = "/skill use <id>"
+	slashUsageSkillOff    = "/skill off <id>"
+	slashUsageSkillActive = "/skill active"
 
 	commandMenuTitle       = "Suggestions"
 	providerPickerTitle    = "Select Provider"
@@ -127,6 +133,10 @@ var builtinSlashCommands = []slashCommand{
 	{Usage: slashUsageMemo, Description: "Show persistent memo index"},
 	{Usage: slashUsageRemember, Description: "Save a persistent memo (/remember <text>)"},
 	{Usage: slashUsageForget, Description: "Remove memos matching keyword (/forget <keyword>)"},
+	{Usage: slashUsageSkills, Description: "List available skills for current workspace/session"},
+	{Usage: slashUsageSkillUse, Description: "Activate one skill in current session"},
+	{Usage: slashUsageSkillOff, Description: "Deactivate one skill in current session"},
+	{Usage: slashUsageSkillActive, Description: "Show active skills in current session"},
 	{Usage: slashUsageProvider, Description: "Open the interactive provider picker"},
 	{Usage: slashUsageProviderAdd, Description: "Add a new custom provider"},
 	{Usage: slashUsageModel, Description: "Open the interactive model picker"},

--- a/internal/tui/core/app/commands_test.go
+++ b/internal/tui/core/app/commands_test.go
@@ -20,6 +20,8 @@ func TestBuiltinSlashCommands(t *testing.T) {
 
 	found := false
 	foundTodo := false
+	foundSkills := false
+	foundSkillUse := false
 	for _, cmd := range builtinSlashCommands {
 		if cmd.Usage == slashUsageHelp {
 			found = true
@@ -27,12 +29,24 @@ func TestBuiltinSlashCommands(t *testing.T) {
 		if strings.HasPrefix(cmd.Usage, "/todo") {
 			foundTodo = true
 		}
+		if cmd.Usage == slashUsageSkills {
+			foundSkills = true
+		}
+		if cmd.Usage == slashUsageSkillUse {
+			foundSkillUse = true
+		}
 	}
 	if !found {
 		t.Error("expected to find /help command")
 	}
 	if foundTodo {
 		t.Error("did not expect /todo command in builtin slash commands")
+	}
+	if !foundSkills {
+		t.Error("expected to find /skills command")
+	}
+	if !foundSkillUse {
+		t.Error("expected to find /skill use command")
 	}
 }
 

--- a/internal/tui/core/app/skills_commands.go
+++ b/internal/tui/core/app/skills_commands.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -13,27 +14,30 @@ import (
 	tuiservices "neo-code/internal/tui/services"
 )
 
-const unsupportedSkillActionReason = "unsupported_action_in_gateway_mode"
+const (
+	maxRenderedSkillsCount = 50
+	maxSkillFieldLength    = 120
+)
+
+var ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
 
 // skillCommandResultMsg 承载 skills 相关 slash 命令的异步执行结果。
 type skillCommandResultMsg struct {
-	Notice string
-	Err    error
+	Notice           string
+	Err              error
+	RequestSessionID string
 }
 
 // handleSkillsCommand 处理 `/skills`，输出当前可用技能列表与会话激活状态。
 func (a *App) handleSkillsCommand() tea.Cmd {
 	sessionID := strings.TrimSpace(a.state.ActiveSessionID)
-	return tuiservices.RunLocalCommandCmd(
+	return a.runSkillCommand(sessionID,
 		func(ctx context.Context) (string, error) {
 			states, err := a.runtime.ListAvailableSkills(ctx, sessionID)
 			if err != nil {
 				return "", normalizeSkillCommandError(err)
 			}
 			return formatAvailableSkills(states, sessionID), nil
-		},
-		func(notice string, err error) tea.Msg {
-			return skillCommandResultMsg{Notice: notice, Err: err}
 		},
 	)
 }
@@ -48,20 +52,12 @@ func (a *App) handleSkillCommand(rest string) tea.Cmd {
 		return a.handleSkillOffCommand(argument)
 	case "active":
 		if strings.TrimSpace(argument) != "" {
-			errText := fmt.Sprintf("usage: %s", slashUsageSkillActive)
-			a.state.ExecutionError = errText
-			a.state.StatusText = errText
-			a.appendInlineMessage(roleError, errText)
-			a.rebuildTranscript()
+			a.applyInlineCommandError(fmt.Sprintf("usage: %s", slashUsageSkillActive))
 			return nil
 		}
 		return a.handleSkillActiveCommand()
 	default:
-		errText := "usage: /skill use <id> | /skill off <id> | /skill active"
-		a.state.ExecutionError = errText
-		a.state.StatusText = errText
-		a.appendInlineMessage(roleError, errText)
-		a.rebuildTranscript()
+		a.applyInlineCommandError("usage: /skill use <id> | /skill off <id> | /skill active")
 		return nil
 	}
 }
@@ -74,23 +70,16 @@ func (a *App) handleSkillUseCommand(skillID string) tea.Cmd {
 	}
 	normalizedSkillID := strings.TrimSpace(skillID)
 	if normalizedSkillID == "" || isSkillUsagePlaceholder(normalizedSkillID) {
-		errText := fmt.Sprintf("usage: %s", slashUsageSkillUse)
-		a.state.ExecutionError = errText
-		a.state.StatusText = errText
-		a.appendInlineMessage(roleError, errText)
-		a.rebuildTranscript()
+		a.applyInlineCommandError(fmt.Sprintf("usage: %s", slashUsageSkillUse))
 		return nil
 	}
 
-	return tuiservices.RunLocalCommandCmd(
+	return a.runSkillCommand(sessionID,
 		func(ctx context.Context) (string, error) {
 			if err := a.runtime.ActivateSessionSkill(ctx, sessionID, normalizedSkillID); err != nil {
 				return "", normalizeSkillCommandError(err)
 			}
-			return fmt.Sprintf("Skill activated: %s", normalizedSkillID), nil
-		},
-		func(notice string, err error) tea.Msg {
-			return skillCommandResultMsg{Notice: notice, Err: err}
+			return fmt.Sprintf("Skill activated: %s", sanitizeSkillDisplayText(normalizedSkillID, "(unknown)")), nil
 		},
 	)
 }
@@ -103,23 +92,16 @@ func (a *App) handleSkillOffCommand(skillID string) tea.Cmd {
 	}
 	normalizedSkillID := strings.TrimSpace(skillID)
 	if normalizedSkillID == "" || isSkillUsagePlaceholder(normalizedSkillID) {
-		errText := fmt.Sprintf("usage: %s", slashUsageSkillOff)
-		a.state.ExecutionError = errText
-		a.state.StatusText = errText
-		a.appendInlineMessage(roleError, errText)
-		a.rebuildTranscript()
+		a.applyInlineCommandError(fmt.Sprintf("usage: %s", slashUsageSkillOff))
 		return nil
 	}
 
-	return tuiservices.RunLocalCommandCmd(
+	return a.runSkillCommand(sessionID,
 		func(ctx context.Context) (string, error) {
 			if err := a.runtime.DeactivateSessionSkill(ctx, sessionID, normalizedSkillID); err != nil {
 				return "", normalizeSkillCommandError(err)
 			}
-			return fmt.Sprintf("Skill deactivated: %s", normalizedSkillID), nil
-		},
-		func(notice string, err error) tea.Msg {
-			return skillCommandResultMsg{Notice: notice, Err: err}
+			return fmt.Sprintf("Skill deactivated: %s", sanitizeSkillDisplayText(normalizedSkillID, "(unknown)")), nil
 		},
 	)
 }
@@ -136,16 +118,13 @@ func (a *App) handleSkillActiveCommand() tea.Cmd {
 	if !ok {
 		return nil
 	}
-	return tuiservices.RunLocalCommandCmd(
+	return a.runSkillCommand(sessionID,
 		func(ctx context.Context) (string, error) {
 			states, err := a.runtime.ListSessionSkills(ctx, sessionID)
 			if err != nil {
 				return "", normalizeSkillCommandError(err)
 			}
 			return formatSessionSkills(states), nil
-		},
-		func(notice string, err error) tea.Msg {
-			return skillCommandResultMsg{Notice: notice, Err: err}
 		},
 	)
 }
@@ -156,12 +135,18 @@ func (a *App) requireActiveSessionForSkillCommand() (string, bool) {
 	if sessionID != "" {
 		return sessionID, true
 	}
-	errText := "skill command requires an active session; send one message first or switch session via /session"
-	a.state.ExecutionError = errText
-	a.state.StatusText = errText
-	a.appendInlineMessage(roleError, errText)
-	a.rebuildTranscript()
+	a.applyInlineCommandError("skill command requires an active session; send one message first or switch session via /session")
 	return "", false
+}
+
+// runSkillCommand 统一封装 skills 相关本地命令的异步执行与结果消息封装。
+func (a *App) runSkillCommand(sessionID string, run func(context.Context) (string, error)) tea.Cmd {
+	return tuiservices.RunLocalCommandCmd(
+		run,
+		func(notice string, err error) tea.Msg {
+			return skillCommandResultMsg{Notice: notice, Err: err, RequestSessionID: sessionID}
+		},
+	)
 }
 
 // normalizeSkillCommandError 将 gateway 不支持等底层错误映射为可读的命令反馈。
@@ -169,7 +154,7 @@ func normalizeSkillCommandError(err error) error {
 	if err == nil {
 		return nil
 	}
-	if strings.Contains(strings.ToLower(err.Error()), unsupportedSkillActionReason) {
+	if errors.Is(err, tuiservices.ErrUnsupportedActionInGatewayMode) {
 		return errors.New("gateway 模式暂不支持 skills 管理，请切换到 local runtime")
 	}
 	return err
@@ -180,13 +165,14 @@ func formatAvailableSkills(states []agentruntime.AvailableSkillState, sessionID 
 	if len(states) == 0 {
 		return "No skills found in local registry."
 	}
-	rows := make([]string, 0, len(states)+2)
+	rows := make([]string, 0, min(len(states), maxRenderedSkillsCount)+3)
 	header := "Available skills:"
 	if strings.TrimSpace(sessionID) != "" {
 		header += " (active marks from current session)"
 	}
 	rows = append(rows, header)
-	for _, state := range states {
+	visibleCount := min(len(states), maxRenderedSkillsCount)
+	for _, state := range states[:visibleCount] {
 		scope := strings.TrimSpace(string(state.Descriptor.Scope))
 		if scope == "" {
 			scope = "explicit"
@@ -195,19 +181,23 @@ func formatAvailableSkills(states []agentruntime.AvailableSkillState, sessionID 
 		if state.Active {
 			status = "active"
 		}
-		description := strings.TrimSpace(state.Descriptor.Description)
-		if description == "" {
-			description = "-"
-		}
+		description := sanitizeSkillDisplayText(state.Descriptor.Description, "-")
+		id := sanitizeSkillDisplayText(state.Descriptor.ID, "(unknown)")
+		source := sanitizeSkillDisplayText(string(state.Descriptor.Source.Kind), "unknown")
+		version := sanitizeSkillDisplayText(state.Descriptor.Version, "-")
+		scope = sanitizeSkillDisplayText(scope, "explicit")
 		rows = append(rows, fmt.Sprintf(
 			"- %s [%s] scope=%s source=%s version=%s | %s",
-			state.Descriptor.ID,
+			id,
 			status,
 			scope,
-			state.Descriptor.Source.Kind,
-			strings.TrimSpace(state.Descriptor.Version),
+			source,
+			version,
 			description,
 		))
+	}
+	if len(states) > visibleCount {
+		rows = append(rows, fmt.Sprintf("... and %d more skills", len(states)-visibleCount))
 	}
 	return strings.Join(rows, "\n")
 }
@@ -227,18 +217,31 @@ func formatSessionSkills(states []agentruntime.SessionSkillState) string {
 	rows = append(rows, "Active skills:")
 	for _, state := range normalized {
 		if state.Missing {
-			rows = append(rows, fmt.Sprintf("- %s [missing]", state.SkillID))
+			rows = append(rows, fmt.Sprintf("- %s [missing]", sanitizeSkillDisplayText(state.SkillID, "(unknown)")))
 			continue
 		}
 		if state.Descriptor == nil {
-			rows = append(rows, fmt.Sprintf("- %s [active]", state.SkillID))
+			rows = append(rows, fmt.Sprintf("- %s [active]", sanitizeSkillDisplayText(state.SkillID, "(unknown)")))
 			continue
 		}
-		description := strings.TrimSpace(state.Descriptor.Description)
-		if description == "" {
-			description = "-"
-		}
-		rows = append(rows, fmt.Sprintf("- %s [active] %s", state.Descriptor.ID, description))
+		description := sanitizeSkillDisplayText(state.Descriptor.Description, "-")
+		id := sanitizeSkillDisplayText(state.Descriptor.ID, "(unknown)")
+		rows = append(rows, fmt.Sprintf("- %s [active] %s", id, description))
 	}
 	return strings.Join(rows, "\n")
+}
+
+// sanitizeSkillDisplayText 清理并截断技能展示文本，避免控制字符污染和超长输出影响渲染。
+func sanitizeSkillDisplayText(value string, fallback string) string {
+	cleaned := sanitizePermissionDisplayText(ansiEscapePattern.ReplaceAllString(value, ""))
+	if strings.TrimSpace(cleaned) == "" {
+		cleaned = strings.TrimSpace(fallback)
+	}
+	if strings.TrimSpace(cleaned) == "" {
+		return ""
+	}
+	if len([]rune(cleaned)) <= maxSkillFieldLength {
+		return cleaned
+	}
+	return string([]rune(cleaned)[:maxSkillFieldLength-3]) + "..."
 }

--- a/internal/tui/core/app/skills_commands.go
+++ b/internal/tui/core/app/skills_commands.go
@@ -1,0 +1,244 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	agentruntime "neo-code/internal/runtime"
+	tuiservices "neo-code/internal/tui/services"
+)
+
+const unsupportedSkillActionReason = "unsupported_action_in_gateway_mode"
+
+// skillCommandResultMsg 承载 skills 相关 slash 命令的异步执行结果。
+type skillCommandResultMsg struct {
+	Notice string
+	Err    error
+}
+
+// handleSkillsCommand 处理 `/skills`，输出当前可用技能列表与会话激活状态。
+func (a *App) handleSkillsCommand() tea.Cmd {
+	sessionID := strings.TrimSpace(a.state.ActiveSessionID)
+	return tuiservices.RunLocalCommandCmd(
+		func(ctx context.Context) (string, error) {
+			states, err := a.runtime.ListAvailableSkills(ctx, sessionID)
+			if err != nil {
+				return "", normalizeSkillCommandError(err)
+			}
+			return formatAvailableSkills(states, sessionID), nil
+		},
+		func(notice string, err error) tea.Msg {
+			return skillCommandResultMsg{Notice: notice, Err: err}
+		},
+	)
+}
+
+// handleSkillCommand 解析 `/skill ...` 子命令，并分发到 use/off/active。
+func (a *App) handleSkillCommand(rest string) tea.Cmd {
+	action, argument := splitFirstWord(strings.TrimSpace(rest))
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case "use":
+		return a.handleSkillUseCommand(argument)
+	case "off":
+		return a.handleSkillOffCommand(argument)
+	case "active":
+		if strings.TrimSpace(argument) != "" {
+			errText := fmt.Sprintf("usage: %s", slashUsageSkillActive)
+			a.state.ExecutionError = errText
+			a.state.StatusText = errText
+			a.appendInlineMessage(roleError, errText)
+			a.rebuildTranscript()
+			return nil
+		}
+		return a.handleSkillActiveCommand()
+	default:
+		errText := "usage: /skill use <id> | /skill off <id> | /skill active"
+		a.state.ExecutionError = errText
+		a.state.StatusText = errText
+		a.appendInlineMessage(roleError, errText)
+		a.rebuildTranscript()
+		return nil
+	}
+}
+
+// handleSkillUseCommand 在当前会话激活指定 skill。
+func (a *App) handleSkillUseCommand(skillID string) tea.Cmd {
+	sessionID, ok := a.requireActiveSessionForSkillCommand()
+	if !ok {
+		return nil
+	}
+	normalizedSkillID := strings.TrimSpace(skillID)
+	if normalizedSkillID == "" || isSkillUsagePlaceholder(normalizedSkillID) {
+		errText := fmt.Sprintf("usage: %s", slashUsageSkillUse)
+		a.state.ExecutionError = errText
+		a.state.StatusText = errText
+		a.appendInlineMessage(roleError, errText)
+		a.rebuildTranscript()
+		return nil
+	}
+
+	return tuiservices.RunLocalCommandCmd(
+		func(ctx context.Context) (string, error) {
+			if err := a.runtime.ActivateSessionSkill(ctx, sessionID, normalizedSkillID); err != nil {
+				return "", normalizeSkillCommandError(err)
+			}
+			return fmt.Sprintf("Skill activated: %s", normalizedSkillID), nil
+		},
+		func(notice string, err error) tea.Msg {
+			return skillCommandResultMsg{Notice: notice, Err: err}
+		},
+	)
+}
+
+// handleSkillOffCommand 在当前会话停用指定 skill。
+func (a *App) handleSkillOffCommand(skillID string) tea.Cmd {
+	sessionID, ok := a.requireActiveSessionForSkillCommand()
+	if !ok {
+		return nil
+	}
+	normalizedSkillID := strings.TrimSpace(skillID)
+	if normalizedSkillID == "" || isSkillUsagePlaceholder(normalizedSkillID) {
+		errText := fmt.Sprintf("usage: %s", slashUsageSkillOff)
+		a.state.ExecutionError = errText
+		a.state.StatusText = errText
+		a.appendInlineMessage(roleError, errText)
+		a.rebuildTranscript()
+		return nil
+	}
+
+	return tuiservices.RunLocalCommandCmd(
+		func(ctx context.Context) (string, error) {
+			if err := a.runtime.DeactivateSessionSkill(ctx, sessionID, normalizedSkillID); err != nil {
+				return "", normalizeSkillCommandError(err)
+			}
+			return fmt.Sprintf("Skill deactivated: %s", normalizedSkillID), nil
+		},
+		func(notice string, err error) tea.Msg {
+			return skillCommandResultMsg{Notice: notice, Err: err}
+		},
+	)
+}
+
+// isSkillUsagePlaceholder 判断入参是否还是 help 文案中的占位符（例如 <id>）。
+func isSkillUsagePlaceholder(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	return strings.HasPrefix(trimmed, "<") && strings.HasSuffix(trimmed, ">")
+}
+
+// handleSkillActiveCommand 输出当前会话激活技能状态（含缺失项标记）。
+func (a *App) handleSkillActiveCommand() tea.Cmd {
+	sessionID, ok := a.requireActiveSessionForSkillCommand()
+	if !ok {
+		return nil
+	}
+	return tuiservices.RunLocalCommandCmd(
+		func(ctx context.Context) (string, error) {
+			states, err := a.runtime.ListSessionSkills(ctx, sessionID)
+			if err != nil {
+				return "", normalizeSkillCommandError(err)
+			}
+			return formatSessionSkills(states), nil
+		},
+		func(notice string, err error) tea.Msg {
+			return skillCommandResultMsg{Notice: notice, Err: err}
+		},
+	)
+}
+
+// requireActiveSessionForSkillCommand 校验 skills 会话命令所需的 session 上下文是否存在。
+func (a *App) requireActiveSessionForSkillCommand() (string, bool) {
+	sessionID := strings.TrimSpace(a.state.ActiveSessionID)
+	if sessionID != "" {
+		return sessionID, true
+	}
+	errText := "skill command requires an active session; send one message first or switch session via /session"
+	a.state.ExecutionError = errText
+	a.state.StatusText = errText
+	a.appendInlineMessage(roleError, errText)
+	a.rebuildTranscript()
+	return "", false
+}
+
+// normalizeSkillCommandError 将 gateway 不支持等底层错误映射为可读的命令反馈。
+func normalizeSkillCommandError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(strings.ToLower(err.Error()), unsupportedSkillActionReason) {
+		return errors.New("gateway 模式暂不支持 skills 管理，请切换到 local runtime")
+	}
+	return err
+}
+
+// formatAvailableSkills 渲染 `/skills` 输出，包含可见技能清单与当前激活标记。
+func formatAvailableSkills(states []agentruntime.AvailableSkillState, sessionID string) string {
+	if len(states) == 0 {
+		return "No skills found in local registry."
+	}
+	rows := make([]string, 0, len(states)+2)
+	header := "Available skills:"
+	if strings.TrimSpace(sessionID) != "" {
+		header += " (active marks from current session)"
+	}
+	rows = append(rows, header)
+	for _, state := range states {
+		scope := strings.TrimSpace(string(state.Descriptor.Scope))
+		if scope == "" {
+			scope = "explicit"
+		}
+		status := "inactive"
+		if state.Active {
+			status = "active"
+		}
+		description := strings.TrimSpace(state.Descriptor.Description)
+		if description == "" {
+			description = "-"
+		}
+		rows = append(rows, fmt.Sprintf(
+			"- %s [%s] scope=%s source=%s version=%s | %s",
+			state.Descriptor.ID,
+			status,
+			scope,
+			state.Descriptor.Source.Kind,
+			strings.TrimSpace(state.Descriptor.Version),
+			description,
+		))
+	}
+	return strings.Join(rows, "\n")
+}
+
+// formatSessionSkills 渲染 `/skill active` 输出，并明确缺失技能状态。
+func formatSessionSkills(states []agentruntime.SessionSkillState) string {
+	if len(states) == 0 {
+		return "No active skills in current session."
+	}
+	normalized := append([]agentruntime.SessionSkillState(nil), states...)
+	sort.Slice(normalized, func(i, j int) bool {
+		return strings.ToLower(strings.TrimSpace(normalized[i].SkillID)) <
+			strings.ToLower(strings.TrimSpace(normalized[j].SkillID))
+	})
+
+	rows := make([]string, 0, len(normalized)+1)
+	rows = append(rows, "Active skills:")
+	for _, state := range normalized {
+		if state.Missing {
+			rows = append(rows, fmt.Sprintf("- %s [missing]", state.SkillID))
+			continue
+		}
+		if state.Descriptor == nil {
+			rows = append(rows, fmt.Sprintf("- %s [active]", state.SkillID))
+			continue
+		}
+		description := strings.TrimSpace(state.Descriptor.Description)
+		if description == "" {
+			description = "-"
+		}
+		rows = append(rows, fmt.Sprintf("- %s [active] %s", state.Descriptor.ID, description))
+	}
+	return strings.Join(rows, "\n")
+}

--- a/internal/tui/core/app/skills_commands_test.go
+++ b/internal/tui/core/app/skills_commands_test.go
@@ -2,11 +2,13 @@ package tui
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	agentruntime "neo-code/internal/runtime"
 	"neo-code/internal/skills"
+	tuiservices "neo-code/internal/tui/services"
 )
 
 func TestFormatAvailableSkills(t *testing.T) {
@@ -62,9 +64,13 @@ func TestSkillCommandErrorAndPlaceholderHelpers(t *testing.T) {
 		t.Fatalf("did not expect normal id as placeholder")
 	}
 
-	unsupported := normalizeSkillCommandError(errors.New("unsupported_action_in_gateway_mode"))
+	unsupported := normalizeSkillCommandError(tuiservices.ErrUnsupportedActionInGatewayMode)
 	if unsupported == nil || !strings.Contains(strings.ToLower(unsupported.Error()), "gateway") {
 		t.Fatalf("expected gateway hint, got %v", unsupported)
+	}
+	containsButNotSentinel := errors.New("skill id unsupported_action_in_gateway_mode is invalid")
+	if normalizeSkillCommandError(containsButNotSentinel) != containsButNotSentinel {
+		t.Fatalf("expected plain error passthrough when only message contains gateway marker")
 	}
 	plain := errors.New("plain")
 	if normalizeSkillCommandError(plain) != plain {
@@ -128,7 +134,7 @@ func TestHandleSkillsAndActiveCommandErrorBranches(t *testing.T) {
 	t.Parallel()
 
 	app, runtime := newTestApp(t)
-	runtime.availableSkillsErr = errors.New(unsupportedSkillActionReason)
+	runtime.availableSkillsErr = tuiservices.ErrUnsupportedActionInGatewayMode
 	runtime.sessionSkillsErr = errors.New("list failed")
 
 	skillsCmd := app.handleSkillsCommand()
@@ -203,5 +209,50 @@ func TestFormatHelpersCoverFallbackBranches(t *testing.T) {
 	}
 	if !strings.Contains(sessionText, "- Alpha [active] -") {
 		t.Fatalf("expected empty-description fallback, got %q", sessionText)
+	}
+}
+
+func TestFormatSkillHelpersSanitizeAndLimitOutput(t *testing.T) {
+	t.Parallel()
+
+	evil := "go\x1b[31m-review"
+	longDescription := strings.Repeat("x", maxSkillFieldLength+20)
+	text := formatAvailableSkills([]agentruntime.AvailableSkillState{
+		{
+			Descriptor: skills.Descriptor{
+				ID:          evil,
+				Description: longDescription,
+				Scope:       skills.ScopeSession,
+				Version:     "v1",
+				Source:      skills.Source{Kind: skills.SourceKindLocal},
+			},
+			Active: true,
+		},
+	}, "session-1")
+	if strings.Contains(text, "\x1b") {
+		t.Fatalf("expected ansi control chars to be stripped, got %q", text)
+	}
+	if !strings.Contains(text, "go-review [active]") {
+		t.Fatalf("expected sanitized skill id, got %q", text)
+	}
+	if !strings.Contains(text, "...") {
+		t.Fatalf("expected long description to be truncated, got %q", text)
+	}
+
+	states := make([]agentruntime.AvailableSkillState, 0, maxRenderedSkillsCount+1)
+	for i := 0; i < maxRenderedSkillsCount+1; i++ {
+		states = append(states, agentruntime.AvailableSkillState{
+			Descriptor: skills.Descriptor{
+				ID:          fmt.Sprintf("skill-%02d", i),
+				Description: "desc",
+				Scope:       skills.ScopeSession,
+				Version:     "v1",
+				Source:      skills.Source{Kind: skills.SourceKindLocal},
+			},
+		})
+	}
+	limited := formatAvailableSkills(states, "")
+	if !strings.Contains(limited, "... and 1 more skills") {
+		t.Fatalf("expected overflow summary, got %q", limited)
 	}
 }

--- a/internal/tui/core/app/skills_commands_test.go
+++ b/internal/tui/core/app/skills_commands_test.go
@@ -70,4 +70,138 @@ func TestSkillCommandErrorAndPlaceholderHelpers(t *testing.T) {
 	if normalizeSkillCommandError(plain) != plain {
 		t.Fatalf("expected non-gateway error passthrough")
 	}
+	if normalizeSkillCommandError(nil) != nil {
+		t.Fatalf("expected nil error passthrough")
+	}
+}
+
+func TestHandleSkillCommandUsageBranches(t *testing.T) {
+	t.Parallel()
+
+	app, _ := newTestApp(t)
+
+	if cmd := app.handleSkillCommand("active unexpected"); cmd != nil {
+		t.Fatalf("expected nil cmd for invalid active usage")
+	}
+	if !strings.Contains(app.state.StatusText, slashUsageSkillActive) {
+		t.Fatalf("expected /skill active usage text, got %q", app.state.StatusText)
+	}
+
+	if cmd := app.handleSkillCommand("unknown go-review"); cmd != nil {
+		t.Fatalf("expected nil cmd for unknown action")
+	}
+	if !strings.Contains(app.state.StatusText, "usage: /skill use <id> | /skill off <id> | /skill active") {
+		t.Fatalf("expected generic skill usage text, got %q", app.state.StatusText)
+	}
+}
+
+func TestHandleSkillUseAndOffValidationBranches(t *testing.T) {
+	t.Parallel()
+
+	app, _ := newTestApp(t)
+	app.state.ActiveSessionID = "session-skills"
+
+	if cmd := app.handleSkillUseCommand("<id>"); cmd != nil {
+		t.Fatalf("expected nil cmd for placeholder id")
+	}
+	if !strings.Contains(app.state.StatusText, slashUsageSkillUse) {
+		t.Fatalf("expected /skill use usage text, got %q", app.state.StatusText)
+	}
+
+	if cmd := app.handleSkillOffCommand(" "); cmd != nil {
+		t.Fatalf("expected nil cmd for blank id")
+	}
+	if !strings.Contains(app.state.StatusText, slashUsageSkillOff) {
+		t.Fatalf("expected /skill off usage text, got %q", app.state.StatusText)
+	}
+
+	app.state.ActiveSessionID = ""
+	if cmd := app.handleSkillOffCommand("go-review"); cmd != nil {
+		t.Fatalf("expected nil cmd when /skill off has no active session")
+	}
+	if !strings.Contains(app.state.StatusText, "requires an active session") {
+		t.Fatalf("expected active session requirement hint, got %q", app.state.StatusText)
+	}
+}
+
+func TestHandleSkillsAndActiveCommandErrorBranches(t *testing.T) {
+	t.Parallel()
+
+	app, runtime := newTestApp(t)
+	runtime.availableSkillsErr = errors.New(unsupportedSkillActionReason)
+	runtime.sessionSkillsErr = errors.New("list failed")
+
+	skillsCmd := app.handleSkillsCommand()
+	if skillsCmd == nil {
+		t.Fatalf("expected /skills cmd")
+	}
+	model, _ := app.Update(skillsCmd())
+	app = model.(App)
+	if !strings.Contains(strings.ToLower(app.state.StatusText), "gateway") {
+		t.Fatalf("expected gateway hint for /skills error, got %q", app.state.StatusText)
+	}
+
+	app.state.ActiveSessionID = ""
+	if cmd := app.handleSkillActiveCommand(); cmd != nil {
+		t.Fatalf("expected nil cmd when /skill active has no active session")
+	}
+	if !strings.Contains(app.state.StatusText, "requires an active session") {
+		t.Fatalf("expected active session requirement hint, got %q", app.state.StatusText)
+	}
+
+	app.state.ActiveSessionID = "session-skills"
+	activeCmd := app.handleSkillActiveCommand()
+	if activeCmd == nil {
+		t.Fatalf("expected /skill active cmd")
+	}
+	model, _ = app.Update(activeCmd())
+	app = model.(App)
+	if !strings.Contains(app.state.StatusText, "list failed") {
+		t.Fatalf("expected runtime error passthrough for /skill active, got %q", app.state.StatusText)
+	}
+
+	runtime.deactivateSkillErr = errors.New("deactivate failed")
+	offCmd := app.handleSkillOffCommand("go-review")
+	if offCmd == nil {
+		t.Fatalf("expected /skill off cmd")
+	}
+	model, _ = app.Update(offCmd())
+	app = model.(App)
+	if !strings.Contains(app.state.StatusText, "deactivate failed") {
+		t.Fatalf("expected /skill off error passthrough, got %q", app.state.StatusText)
+	}
+}
+
+func TestFormatHelpersCoverFallbackBranches(t *testing.T) {
+	t.Parallel()
+
+	text := formatAvailableSkills([]agentruntime.AvailableSkillState{
+		{
+			Descriptor: skills.Descriptor{
+				ID:          "plain",
+				Description: "",
+				Scope:       "",
+				Version:     " ",
+				Source:      skills.Source{Kind: ""},
+			},
+			Active: false,
+		},
+	}, "")
+	if !strings.Contains(text, "scope=explicit") {
+		t.Fatalf("expected explicit scope fallback, got %q", text)
+	}
+	if !strings.Contains(text, "| -") {
+		t.Fatalf("expected empty description fallback, got %q", text)
+	}
+
+	sessionText := formatSessionSkills([]agentruntime.SessionSkillState{
+		{SkillID: "zeta", Descriptor: nil},
+		{SkillID: "Alpha", Descriptor: &skills.Descriptor{ID: "Alpha", Description: ""}},
+	})
+	if !strings.Contains(sessionText, "- zeta [active]") {
+		t.Fatalf("expected descriptor-nil fallback line, got %q", sessionText)
+	}
+	if !strings.Contains(sessionText, "- Alpha [active] -") {
+		t.Fatalf("expected empty-description fallback, got %q", sessionText)
+	}
 }

--- a/internal/tui/core/app/skills_commands_test.go
+++ b/internal/tui/core/app/skills_commands_test.go
@@ -1,0 +1,73 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	agentruntime "neo-code/internal/runtime"
+	"neo-code/internal/skills"
+)
+
+func TestFormatAvailableSkills(t *testing.T) {
+	t.Parallel()
+
+	if got := formatAvailableSkills(nil, ""); !strings.Contains(got, "No skills found") {
+		t.Fatalf("expected empty message, got %q", got)
+	}
+
+	text := formatAvailableSkills([]agentruntime.AvailableSkillState{
+		{
+			Descriptor: skills.Descriptor{
+				ID:          "go-review",
+				Description: "review go code",
+				Scope:       skills.ScopeSession,
+				Version:     "v1",
+				Source:      skills.Source{Kind: skills.SourceKindLocal},
+			},
+			Active: true,
+		},
+	}, "session-1")
+	if !strings.Contains(text, "go-review [active]") {
+		t.Fatalf("expected active entry, got %q", text)
+	}
+}
+
+func TestFormatSessionSkills(t *testing.T) {
+	t.Parallel()
+
+	if got := formatSessionSkills(nil); !strings.Contains(got, "No active skills") {
+		t.Fatalf("expected empty active message, got %q", got)
+	}
+
+	text := formatSessionSkills([]agentruntime.SessionSkillState{
+		{SkillID: "missing", Missing: true},
+		{SkillID: "go-review", Descriptor: &skills.Descriptor{ID: "go-review", Description: "review"}},
+	})
+	if !strings.Contains(text, "missing [missing]") {
+		t.Fatalf("expected missing entry, got %q", text)
+	}
+	if !strings.Contains(text, "go-review [active]") {
+		t.Fatalf("expected active entry, got %q", text)
+	}
+}
+
+func TestSkillCommandErrorAndPlaceholderHelpers(t *testing.T) {
+	t.Parallel()
+
+	if !isSkillUsagePlaceholder("<id>") {
+		t.Fatalf("expected placeholder marker")
+	}
+	if isSkillUsagePlaceholder("go-review") {
+		t.Fatalf("did not expect normal id as placeholder")
+	}
+
+	unsupported := normalizeSkillCommandError(errors.New("unsupported_action_in_gateway_mode"))
+	if unsupported == nil || !strings.Contains(strings.ToLower(unsupported.Error()), "gateway") {
+		t.Fatalf("expected gateway hint, got %v", unsupported)
+	}
+	plain := errors.New("plain")
+	if normalizeSkillCommandError(plain) != plain {
+		t.Fatalf("expected non-gateway error passthrough")
+	}
+}

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -222,6 +222,11 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return a, tea.Batch(cmds...)
 	case skillCommandResultMsg:
+		requestSessionID := strings.TrimSpace(typed.RequestSessionID)
+		activeSessionID := strings.TrimSpace(a.state.ActiveSessionID)
+		if requestSessionID != "" && !strings.EqualFold(requestSessionID, activeSessionID) {
+			return a, tea.Batch(cmds...)
+		}
 		if typed.Err != nil {
 			a.state.ExecutionError = typed.Err.Error()
 			a.state.StatusText = typed.Err.Error()
@@ -1187,10 +1192,7 @@ func runtimeEventSkillActivatedHandler(a *App, event agentruntime.RuntimeEvent) 
 	if !ok {
 		return false
 	}
-	skillID := strings.TrimSpace(payload.SkillID)
-	if skillID == "" {
-		skillID = "(unknown)"
-	}
+	skillID := sanitizeSkillDisplayText(payload.SkillID, "(unknown)")
 	a.appendActivity("skills", "Skill activated", skillID, false)
 	return false
 }
@@ -1201,10 +1203,7 @@ func runtimeEventSkillDeactivatedHandler(a *App, event agentruntime.RuntimeEvent
 	if !ok {
 		return false
 	}
-	skillID := strings.TrimSpace(payload.SkillID)
-	if skillID == "" {
-		skillID = "(unknown)"
-	}
+	skillID := sanitizeSkillDisplayText(payload.SkillID, "(unknown)")
 	a.appendActivity("skills", "Skill deactivated", skillID, false)
 	return false
 }
@@ -1215,10 +1214,7 @@ func runtimeEventSkillMissingHandler(a *App, event agentruntime.RuntimeEvent) bo
 	if !ok {
 		return false
 	}
-	skillID := strings.TrimSpace(payload.SkillID)
-	if skillID == "" {
-		skillID = "(unknown)"
-	}
+	skillID := sanitizeSkillDisplayText(payload.SkillID, "(unknown)")
 	a.appendActivity("skills", "Skill missing in registry", skillID, true)
 	return false
 }
@@ -1691,6 +1687,18 @@ func (a *App) appendInlineMessage(role string, message string) {
 	}
 
 	a.activeMessages = append(a.activeMessages, providertypes.Message{Role: role, Parts: []providertypes.ContentPart{providertypes.NewTextPart(content)}})
+}
+
+// applyInlineCommandError 统一写入命令错误并刷新转录区，确保错误提示立即可见。
+func (a *App) applyInlineCommandError(message string) {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return
+	}
+	a.state.ExecutionError = message
+	a.state.StatusText = message
+	a.appendInlineMessage(roleError, message)
+	a.rebuildTranscript()
 }
 
 func (a *App) appendActivity(kind string, title string, detail string, isError bool) {
@@ -2476,27 +2484,15 @@ func (a *App) handleImmediateSlashCommand(input string) (bool, tea.Cmd) {
 		return true, nil
 	case slashCommandCompact:
 		if strings.TrimSpace(rest) != "" {
-			errText := fmt.Sprintf("usage: %s", slashUsageCompact)
-			a.state.ExecutionError = errText
-			a.state.StatusText = errText
-			a.appendInlineMessage(roleError, errText)
-			a.rebuildTranscript()
+			a.applyInlineCommandError(fmt.Sprintf("usage: %s", slashUsageCompact))
 			return true, nil
 		}
 		if strings.TrimSpace(a.state.ActiveSessionID) == "" {
-			errText := "compact requires an existing session"
-			a.state.ExecutionError = errText
-			a.state.StatusText = errText
-			a.appendInlineMessage(roleError, errText)
-			a.rebuildTranscript()
+			a.applyInlineCommandError("compact requires an existing session")
 			return true, nil
 		}
 		if a.isBusy() {
-			errText := "compact is already running, please wait"
-			a.state.ExecutionError = errText
-			a.state.StatusText = errText
-			a.appendInlineMessage(roleError, errText)
-			a.rebuildTranscript()
+			a.applyInlineCommandError("compact is already running, please wait")
 			return true, nil
 		}
 		a.state.IsCompacting = true
@@ -2513,11 +2509,7 @@ func (a *App) handleImmediateSlashCommand(input string) (bool, tea.Cmd) {
 		return true, a.handleForgetCommand(rest)
 	case slashCommandSkills:
 		if strings.TrimSpace(rest) != "" {
-			errText := fmt.Sprintf("usage: %s", slashUsageSkills)
-			a.state.ExecutionError = errText
-			a.state.StatusText = errText
-			a.appendInlineMessage(roleError, errText)
-			a.rebuildTranscript()
+			a.applyInlineCommandError(fmt.Sprintf("usage: %s", slashUsageSkills))
 			return true, nil
 		}
 		return true, a.handleSkillsCommand()

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -225,6 +225,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		requestSessionID := strings.TrimSpace(typed.RequestSessionID)
 		activeSessionID := strings.TrimSpace(a.state.ActiveSessionID)
 		if requestSessionID != "" && !strings.EqualFold(requestSessionID, activeSessionID) {
+			a.recordStaleSkillCommandResult(requestSessionID, activeSessionID, typed.Err)
 			return a, tea.Batch(cmds...)
 		}
 		if typed.Err != nil {
@@ -1699,6 +1700,15 @@ func (a *App) applyInlineCommandError(message string) {
 	a.state.StatusText = message
 	a.appendInlineMessage(roleError, message)
 	a.rebuildTranscript()
+}
+
+// recordStaleSkillCommandResult 记录来自旧会话的技能命令结果，避免在会话切换后错误被静默丢弃。
+func (a *App) recordStaleSkillCommandResult(requestSessionID, activeSessionID string, runErr error) {
+	detail := fmt.Sprintf("result from session %q ignored after switching to %q", requestSessionID, activeSessionID)
+	if runErr != nil {
+		detail = fmt.Sprintf("%s; original error: %s", detail, runErr.Error())
+	}
+	a.appendActivity("skills", "Ignored stale skill command result", detail, runErr != nil)
 }
 
 func (a *App) appendActivity(kind string, title string, detail string, isError bool) {

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -221,6 +221,23 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.appendActivity("command", typed.Notice, "", false)
 		}
 		return a, tea.Batch(cmds...)
+	case skillCommandResultMsg:
+		if typed.Err != nil {
+			a.state.ExecutionError = typed.Err.Error()
+			a.state.StatusText = typed.Err.Error()
+			a.appendActivity("skills", "Skill command failed", typed.Err.Error(), true)
+		} else {
+			notice := strings.TrimSpace(typed.Notice)
+			if notice == "" {
+				notice = "Skill command completed."
+			}
+			a.state.ExecutionError = ""
+			a.state.StatusText = notice
+			a.appendInlineMessage(roleSystem, notice)
+			a.appendActivity("skills", "Skill command completed", notice, false)
+		}
+		a.rebuildTranscript()
+		return a, tea.Batch(cmds...)
 	case workspaceCommandResultMsg:
 		if typed.Command == "" && typed.Err != nil {
 			a.state.ExecutionError = typed.Err.Error()
@@ -1062,6 +1079,9 @@ var runtimeEventHandlerRegistry = map[agentruntime.EventType]func(*App, agentrun
 	agentruntime.EventStopReasonDecided:                        runtimeEventStopReasonDecidedHandler,
 	agentruntime.EventTodoUpdated:                              runtimeEventTodoUpdatedHandler,
 	agentruntime.EventTodoConflict:                             runtimeEventTodoConflictHandler,
+	agentruntime.EventSkillActivated:                           runtimeEventSkillActivatedHandler,
+	agentruntime.EventSkillDeactivated:                         runtimeEventSkillDeactivatedHandler,
+	agentruntime.EventSkillMissing:                             runtimeEventSkillMissingHandler,
 }
 
 func runtimeEventPhaseChangedHandler(a *App, event agentruntime.RuntimeEvent) bool {
@@ -1159,6 +1179,71 @@ func runtimeEventTodoConflictHandler(a *App, event agentruntime.RuntimeEvent) bo
 	}
 	a.appendActivity("todo", "Todo conflict", reason, true)
 	return false
+}
+
+// runtimeEventSkillActivatedHandler 在 runtime 激活 skill 后同步活动日志。
+func runtimeEventSkillActivatedHandler(a *App, event agentruntime.RuntimeEvent) bool {
+	payload, ok := parseSessionSkillEventPayload(event.Payload)
+	if !ok {
+		return false
+	}
+	skillID := strings.TrimSpace(payload.SkillID)
+	if skillID == "" {
+		skillID = "(unknown)"
+	}
+	a.appendActivity("skills", "Skill activated", skillID, false)
+	return false
+}
+
+// runtimeEventSkillDeactivatedHandler 在 runtime 停用 skill 后同步活动日志。
+func runtimeEventSkillDeactivatedHandler(a *App, event agentruntime.RuntimeEvent) bool {
+	payload, ok := parseSessionSkillEventPayload(event.Payload)
+	if !ok {
+		return false
+	}
+	skillID := strings.TrimSpace(payload.SkillID)
+	if skillID == "" {
+		skillID = "(unknown)"
+	}
+	a.appendActivity("skills", "Skill deactivated", skillID, false)
+	return false
+}
+
+// runtimeEventSkillMissingHandler 在会话 skill 丢失时输出显式错误反馈，便于排查恢复问题。
+func runtimeEventSkillMissingHandler(a *App, event agentruntime.RuntimeEvent) bool {
+	payload, ok := parseSessionSkillEventPayload(event.Payload)
+	if !ok {
+		return false
+	}
+	skillID := strings.TrimSpace(payload.SkillID)
+	if skillID == "" {
+		skillID = "(unknown)"
+	}
+	a.appendActivity("skills", "Skill missing in registry", skillID, true)
+	return false
+}
+
+// parseSessionSkillEventPayload 解析 runtime skill 事件负载并兼容 map 结构。
+func parseSessionSkillEventPayload(payload any) (agentruntime.SessionSkillEventPayload, bool) {
+	switch typed := payload.(type) {
+	case agentruntime.SessionSkillEventPayload:
+		return typed, true
+	case *agentruntime.SessionSkillEventPayload:
+		if typed == nil {
+			return agentruntime.SessionSkillEventPayload{}, false
+		}
+		return *typed, true
+	case map[string]any:
+		if raw, ok := typed["skill_id"]; ok && raw != nil {
+			return agentruntime.SessionSkillEventPayload{SkillID: strings.TrimSpace(fmt.Sprintf("%v", raw))}, true
+		}
+		if raw, ok := typed["SkillID"]; ok && raw != nil {
+			return agentruntime.SessionSkillEventPayload{SkillID: strings.TrimSpace(fmt.Sprintf("%v", raw))}, true
+		}
+		return agentruntime.SessionSkillEventPayload{}, false
+	default:
+		return agentruntime.SessionSkillEventPayload{}, false
+	}
 }
 
 func parseTodoEventPayload(payload any) (agentruntime.TodoEventPayload, bool) {
@@ -2426,6 +2511,18 @@ func (a *App) handleImmediateSlashCommand(input string) (bool, tea.Cmd) {
 		return true, a.handleRememberCommand(rest)
 	case slashCommandForget:
 		return true, a.handleForgetCommand(rest)
+	case slashCommandSkills:
+		if strings.TrimSpace(rest) != "" {
+			errText := fmt.Sprintf("usage: %s", slashUsageSkills)
+			a.state.ExecutionError = errText
+			a.state.StatusText = errText
+			a.appendInlineMessage(roleError, errText)
+			a.rebuildTranscript()
+			return true, nil
+		}
+		return true, a.handleSkillsCommand()
+	case slashCommandSkill:
+		return true, a.handleSkillCommand(rest)
 	case slashCommandSession:
 		if err := a.ensureSessionSwitchAllowed(""); err != nil {
 			a.state.ExecutionError = err.Error()

--- a/internal/tui/core/app/update_permission_test.go
+++ b/internal/tui/core/app/update_permission_test.go
@@ -85,6 +85,10 @@ func (r *permissionTestRuntime) ListSessionSkills(ctx context.Context, sessionID
 	return nil, nil
 }
 
+func (r *permissionTestRuntime) ListAvailableSkills(ctx context.Context, sessionID string) ([]agentruntime.AvailableSkillState, error) {
+	return nil, nil
+}
+
 func newPermissionTestApp(runtime agentruntime.Runtime) *App {
 	input := textarea.New()
 	spin := spinner.New()

--- a/internal/tui/core/app/update_runtime_events_test.go
+++ b/internal/tui/core/app/update_runtime_events_test.go
@@ -355,6 +355,14 @@ func TestRuntimeSkillEventHandlers(t *testing.T) {
 	if !last.IsError || !strings.Contains(last.Detail, "(unknown)") {
 		t.Fatalf("expected unknown fallback for missing event, got %+v", last)
 	}
+
+	runtimeEventSkillActivatedHandler(&app, agentruntime.RuntimeEvent{
+		Payload: agentruntime.SessionSkillEventPayload{SkillID: "go\x1b[31m-review"},
+	})
+	last = app.activities[len(app.activities)-1]
+	if strings.Contains(last.Detail, "\x1b") {
+		t.Fatalf("expected sanitized skill id in activity detail, got %+v", last)
+	}
 }
 
 func TestParseSessionSkillEventPayloadBranches(t *testing.T) {

--- a/internal/tui/core/app/update_runtime_events_test.go
+++ b/internal/tui/core/app/update_runtime_events_test.go
@@ -324,4 +324,52 @@ func TestRuntimeSkillEventHandlers(t *testing.T) {
 	if !last.IsError || last.Title != "Skill missing in registry" {
 		t.Fatalf("expected skill missing error activity, got %+v", last)
 	}
+
+	runtimeEventSkillActivatedHandler(&app, agentruntime.RuntimeEvent{
+		Payload: &agentruntime.SessionSkillEventPayload{SkillID: " "},
+	})
+	last = app.activities[len(app.activities)-1]
+	if !strings.Contains(last.Detail, "(unknown)") {
+		t.Fatalf("expected unknown fallback for blank skill id, got %+v", last)
+	}
+
+	if handled := runtimeEventSkillDeactivatedHandler(&app, agentruntime.RuntimeEvent{Payload: map[string]any{}}); handled {
+		t.Fatalf("expected empty map payload to be rejected")
+	}
+	if handled := runtimeEventSkillMissingHandler(&app, agentruntime.RuntimeEvent{Payload: (*agentruntime.SessionSkillEventPayload)(nil)}); handled {
+		t.Fatalf("expected nil pointer payload to be rejected")
+	}
+
+	runtimeEventSkillDeactivatedHandler(&app, agentruntime.RuntimeEvent{
+		Payload: agentruntime.SessionSkillEventPayload{SkillID: " "},
+	})
+	last = app.activities[len(app.activities)-1]
+	if !strings.Contains(last.Detail, "(unknown)") {
+		t.Fatalf("expected unknown fallback for deactivated event, got %+v", last)
+	}
+
+	runtimeEventSkillMissingHandler(&app, agentruntime.RuntimeEvent{
+		Payload: agentruntime.SessionSkillEventPayload{SkillID: ""},
+	})
+	last = app.activities[len(app.activities)-1]
+	if !last.IsError || !strings.Contains(last.Detail, "(unknown)") {
+		t.Fatalf("expected unknown fallback for missing event, got %+v", last)
+	}
+}
+
+func TestParseSessionSkillEventPayloadBranches(t *testing.T) {
+	t.Parallel()
+
+	if payload, ok := parseSessionSkillEventPayload(map[string]any{"skill_id": 42}); !ok || payload.SkillID != "42" {
+		t.Fatalf("expected snake-case skill_id to be parsed, got payload=%+v ok=%v", payload, ok)
+	}
+	if payload, ok := parseSessionSkillEventPayload(map[string]any{"SkillID": " go-review "}); !ok || payload.SkillID != "go-review" {
+		t.Fatalf("expected camel-case SkillID to be parsed, got payload=%+v ok=%v", payload, ok)
+	}
+	if _, ok := parseSessionSkillEventPayload(map[string]any{"unexpected": "value"}); ok {
+		t.Fatalf("expected unknown map keys to be rejected")
+	}
+	if _, ok := parseSessionSkillEventPayload(nil); ok {
+		t.Fatalf("expected nil payload to be rejected")
+	}
 }

--- a/internal/tui/core/app/update_runtime_events_test.go
+++ b/internal/tui/core/app/update_runtime_events_test.go
@@ -133,6 +133,15 @@ func TestRuntimeEventHandlerRegistryContainsRenamedEvents(t *testing.T) {
 	if _, ok := runtimeEventHandlerRegistry[agentruntime.EventCompactApplied]; !ok {
 		t.Fatalf("expected compact_applied handler to be registered")
 	}
+	if _, ok := runtimeEventHandlerRegistry[agentruntime.EventSkillActivated]; !ok {
+		t.Fatalf("expected skill_activated handler to be registered")
+	}
+	if _, ok := runtimeEventHandlerRegistry[agentruntime.EventSkillDeactivated]; !ok {
+		t.Fatalf("expected skill_deactivated handler to be registered")
+	}
+	if _, ok := runtimeEventHandlerRegistry[agentruntime.EventSkillMissing]; !ok {
+		t.Fatalf("expected skill_missing handler to be registered")
+	}
 }
 
 func TestShouldHandleRuntimeEventFiltersBySessionAndRun(t *testing.T) {
@@ -283,5 +292,36 @@ func TestHandleRuntimeEventBindsSessionFromStableEvents(t *testing.T) {
 	})
 	if app.state.ActiveSessionID != "session-context" {
 		t.Fatalf("expected active session from run_context, got %q", app.state.ActiveSessionID)
+	}
+}
+
+func TestRuntimeSkillEventHandlers(t *testing.T) {
+	t.Parallel()
+
+	app, _ := newTestApp(t)
+
+	if handled := runtimeEventSkillActivatedHandler(&app, agentruntime.RuntimeEvent{Payload: 1}); handled {
+		t.Fatalf("expected invalid payload to return false")
+	}
+	runtimeEventSkillActivatedHandler(&app, agentruntime.RuntimeEvent{
+		Payload: agentruntime.SessionSkillEventPayload{SkillID: "go-review"},
+	})
+	if len(app.activities) == 0 || app.activities[len(app.activities)-1].Title != "Skill activated" {
+		t.Fatalf("expected skill activated activity")
+	}
+
+	runtimeEventSkillDeactivatedHandler(&app, agentruntime.RuntimeEvent{
+		Payload: map[string]any{"skill_id": "go-review"},
+	})
+	if app.activities[len(app.activities)-1].Title != "Skill deactivated" {
+		t.Fatalf("expected skill deactivated activity")
+	}
+
+	runtimeEventSkillMissingHandler(&app, agentruntime.RuntimeEvent{
+		Payload: map[string]any{"SkillID": "missing-skill"},
+	})
+	last := app.activities[len(app.activities)-1]
+	if !last.IsError || last.Title != "Skill missing in registry" {
+		t.Fatalf("expected skill missing error activity, got %+v", last)
 	}
 }

--- a/internal/tui/core/app/update_test.go
+++ b/internal/tui/core/app/update_test.go
@@ -2109,7 +2109,7 @@ func TestHandleSkillCommandValidationAndGatewayErrors(t *testing.T) {
 		t.Fatalf("expected /skills usage error, got %q", app.state.StatusText)
 	}
 
-	runtime.activateSkillErr = errors.New("unsupported_action_in_gateway_mode")
+	runtime.activateSkillErr = tuiservices.ErrUnsupportedActionInGatewayMode
 	handled, cmd = app.handleImmediateSlashCommand("/skill use go-review")
 	if !handled || cmd == nil {
 		t.Fatalf("expected /skill use to produce cmd on gateway error")
@@ -4187,4 +4187,39 @@ func TestRebuildActivityWithHeightAndPersistPathGuard(t *testing.T) {
 
 	app.state.ActiveSessionID = "___"
 	app.persistLogEntriesForActiveSession()
+}
+
+func TestUpdateIgnoresStaleSkillCommandResultBySession(t *testing.T) {
+	t.Parallel()
+
+	app, _ := newTestApp(t)
+	app.state.ActiveSessionID = "session-current"
+	app.state.StatusText = "before"
+
+	model, _ := app.Update(skillCommandResultMsg{
+		Notice:           "should be ignored",
+		RequestSessionID: "session-old",
+	})
+	app = model.(App)
+
+	if app.state.StatusText != "before" {
+		t.Fatalf("expected stale skill result to be ignored, got status %q", app.state.StatusText)
+	}
+}
+
+func TestUpdateAcceptsSkillCommandResultForCurrentSession(t *testing.T) {
+	t.Parallel()
+
+	app, _ := newTestApp(t)
+	app.state.ActiveSessionID = "session-current"
+
+	model, _ := app.Update(skillCommandResultMsg{
+		Notice:           "Skill command completed.",
+		RequestSessionID: "session-current",
+	})
+	app = model.(App)
+
+	if app.state.StatusText != "Skill command completed." {
+		t.Fatalf("expected status to be updated, got %q", app.state.StatusText)
+	}
 }

--- a/internal/tui/core/app/update_test.go
+++ b/internal/tui/core/app/update_test.go
@@ -21,6 +21,7 @@ import (
 	agentruntime "neo-code/internal/runtime"
 	approvalflow "neo-code/internal/runtime/approval"
 	agentsession "neo-code/internal/session"
+	"neo-code/internal/skills"
 	"neo-code/internal/tools"
 	tuibootstrap "neo-code/internal/tui/bootstrap"
 	tuiservices "neo-code/internal/tui/services"
@@ -107,24 +108,38 @@ func (s stubProviderService) CreateCustomProvider(
 }
 
 type stubRuntime struct {
-	events          chan agentruntime.RuntimeEvent
-	prepareInputs   []agentruntime.PrepareInput
-	prepareErr      error
-	preparedOutput  agentruntime.UserInput
-	runInputs       []agentruntime.UserInput
-	systemToolCalls []agentruntime.SystemToolInput
-	systemToolRes   tools.ToolResult
-	systemToolErr   error
-	resolveCalls    []agentruntime.PermissionResolutionInput
-	resolveErr      error
-	cancelInvoked   bool
-	listSessions    []agentsession.Summary
-	listSessionsErr error
-	loadSessions    map[string]agentsession.Session
-	loadSessionErr  error
-	logEntriesBySID map[string][]agentruntime.SessionLogEntry
-	loadLogErr      error
-	saveLogErr      error
+	events             chan agentruntime.RuntimeEvent
+	prepareInputs      []agentruntime.PrepareInput
+	prepareErr         error
+	preparedOutput     agentruntime.UserInput
+	runInputs          []agentruntime.UserInput
+	systemToolCalls    []agentruntime.SystemToolInput
+	systemToolRes      tools.ToolResult
+	systemToolErr      error
+	resolveCalls       []agentruntime.PermissionResolutionInput
+	resolveErr         error
+	cancelInvoked      bool
+	listSessions       []agentsession.Summary
+	listSessionsErr    error
+	loadSessions       map[string]agentsession.Session
+	loadSessionErr     error
+	logEntriesBySID    map[string][]agentruntime.SessionLogEntry
+	loadLogErr         error
+	saveLogErr         error
+	activateSkillCalls []struct {
+		SessionID string
+		SkillID   string
+	}
+	activateSkillErr     error
+	deactivateSkillCalls []struct {
+		SessionID string
+		SkillID   string
+	}
+	deactivateSkillErr    error
+	sessionSkillsResult   []agentruntime.SessionSkillState
+	sessionSkillsErr      error
+	availableSkillsResult []agentruntime.AvailableSkillState
+	availableSkillsErr    error
 }
 
 type snapshotRuntime struct {
@@ -224,15 +239,39 @@ func (s *stubRuntime) LoadSession(ctx context.Context, id string) (agentsession.
 }
 
 func (s *stubRuntime) ActivateSessionSkill(ctx context.Context, sessionID string, skillID string) error {
-	return nil
+	s.activateSkillCalls = append(s.activateSkillCalls, struct {
+		SessionID string
+		SkillID   string
+	}{
+		SessionID: sessionID,
+		SkillID:   skillID,
+	})
+	return s.activateSkillErr
 }
 
 func (s *stubRuntime) DeactivateSessionSkill(ctx context.Context, sessionID string, skillID string) error {
-	return nil
+	s.deactivateSkillCalls = append(s.deactivateSkillCalls, struct {
+		SessionID string
+		SkillID   string
+	}{
+		SessionID: sessionID,
+		SkillID:   skillID,
+	})
+	return s.deactivateSkillErr
 }
 
 func (s *stubRuntime) ListSessionSkills(ctx context.Context, sessionID string) ([]agentruntime.SessionSkillState, error) {
-	return nil, nil
+	if s.sessionSkillsErr != nil {
+		return nil, s.sessionSkillsErr
+	}
+	return append([]agentruntime.SessionSkillState(nil), s.sessionSkillsResult...), nil
+}
+
+func (s *stubRuntime) ListAvailableSkills(ctx context.Context, sessionID string) ([]agentruntime.AvailableSkillState, error) {
+	if s.availableSkillsErr != nil {
+		return nil, s.availableSkillsErr
+	}
+	return append([]agentruntime.AvailableSkillState(nil), s.availableSkillsResult...), nil
 }
 
 func (s *stubRuntime) LoadSessionLogEntries(ctx context.Context, sessionID string) ([]agentruntime.SessionLogEntry, error) {
@@ -1973,6 +2012,112 @@ func TestHandleRememberAndForgetValidation(t *testing.T) {
 	}
 	if len(app.activeMessages) == 0 || !strings.Contains(messageText(app.activeMessages[len(app.activeMessages)-1]), "Usage") {
 		t.Fatalf("expected usage message for empty /forget")
+	}
+}
+
+func TestHandleSkillsSlashCommands(t *testing.T) {
+	app, runtime := newTestApp(t)
+	app.state.ActiveSessionID = "session-skills"
+	runtime.availableSkillsResult = []agentruntime.AvailableSkillState{
+		{
+			Descriptor: skills.Descriptor{
+				ID:          "go-review",
+				Description: "review go code",
+				Source:      skills.Source{Kind: skills.SourceKindLocal},
+				Scope:       skills.ScopeSession,
+				Version:     "v1",
+			},
+			Active: true,
+		},
+	}
+
+	handled, cmd := app.handleImmediateSlashCommand("/skills")
+	if !handled || cmd == nil {
+		t.Fatalf("expected /skills command to return async cmd")
+	}
+	model, _ := app.Update(cmd())
+	app = model.(App)
+	if !strings.Contains(app.state.StatusText, "Available skills:") {
+		t.Fatalf("expected available skill notice, got %q", app.state.StatusText)
+	}
+	if len(app.activeMessages) == 0 || !strings.Contains(messageText(app.activeMessages[len(app.activeMessages)-1]), "go-review") {
+		t.Fatalf("expected transcript to include listed skill")
+	}
+}
+
+func TestHandleSkillUseOffAndActiveCommands(t *testing.T) {
+	app, runtime := newTestApp(t)
+	app.state.ActiveSessionID = "session-skills"
+	runtime.sessionSkillsResult = []agentruntime.SessionSkillState{
+		{SkillID: "go-review", Descriptor: &skills.Descriptor{ID: "go-review", Description: "review"}},
+	}
+
+	handled, cmd := app.handleImmediateSlashCommand("/skill use go-review")
+	if !handled || cmd == nil {
+		t.Fatalf("expected /skill use to produce command")
+	}
+	model, _ := app.Update(cmd())
+	app = model.(App)
+	if len(runtime.activateSkillCalls) != 1 || runtime.activateSkillCalls[0].SkillID != "go-review" {
+		t.Fatalf("unexpected activate calls: %+v", runtime.activateSkillCalls)
+	}
+	if !strings.Contains(app.state.StatusText, "Skill activated") {
+		t.Fatalf("expected activate notice, got %q", app.state.StatusText)
+	}
+
+	handled, cmd = app.handleImmediateSlashCommand("/skill off go-review")
+	if !handled || cmd == nil {
+		t.Fatalf("expected /skill off to produce command")
+	}
+	model, _ = app.Update(cmd())
+	app = model.(App)
+	if len(runtime.deactivateSkillCalls) != 1 || runtime.deactivateSkillCalls[0].SkillID != "go-review" {
+		t.Fatalf("unexpected deactivate calls: %+v", runtime.deactivateSkillCalls)
+	}
+	if !strings.Contains(app.state.StatusText, "Skill deactivated") {
+		t.Fatalf("expected deactivate notice, got %q", app.state.StatusText)
+	}
+
+	handled, cmd = app.handleImmediateSlashCommand("/skill active")
+	if !handled || cmd == nil {
+		t.Fatalf("expected /skill active to produce command")
+	}
+	model, _ = app.Update(cmd())
+	app = model.(App)
+	if !strings.Contains(app.state.StatusText, "Active skills:") {
+		t.Fatalf("expected active skill listing, got %q", app.state.StatusText)
+	}
+}
+
+func TestHandleSkillCommandValidationAndGatewayErrors(t *testing.T) {
+	app, runtime := newTestApp(t)
+
+	handled, cmd := app.handleImmediateSlashCommand("/skill use go-review")
+	if !handled || cmd != nil {
+		t.Fatalf("expected missing session branch handled without cmd")
+	}
+	if !strings.Contains(app.state.StatusText, "requires an active session") {
+		t.Fatalf("expected missing session hint, got %q", app.state.StatusText)
+	}
+
+	app.state.ActiveSessionID = "session-skills"
+	handled, cmd = app.handleImmediateSlashCommand("/skills now")
+	if !handled || cmd != nil {
+		t.Fatalf("expected /skills with args to reject usage")
+	}
+	if !strings.Contains(app.state.StatusText, "usage: /skills") {
+		t.Fatalf("expected /skills usage error, got %q", app.state.StatusText)
+	}
+
+	runtime.activateSkillErr = errors.New("unsupported_action_in_gateway_mode")
+	handled, cmd = app.handleImmediateSlashCommand("/skill use go-review")
+	if !handled || cmd == nil {
+		t.Fatalf("expected /skill use to produce cmd on gateway error")
+	}
+	model, _ := app.Update(cmd())
+	app = model.(App)
+	if !strings.Contains(strings.ToLower(app.state.StatusText), "gateway") {
+		t.Fatalf("expected gateway unsupported hint, got %q", app.state.StatusText)
 	}
 }
 

--- a/internal/tui/core/app/update_test.go
+++ b/internal/tui/core/app/update_test.go
@@ -4189,22 +4189,46 @@ func TestRebuildActivityWithHeightAndPersistPathGuard(t *testing.T) {
 	app.persistLogEntriesForActiveSession()
 }
 
+func updateWithSkillCommandResult(t *testing.T, app App, result skillCommandResultMsg) App {
+	t.Helper()
+
+	model, _ := app.Update(result)
+	return model.(App)
+}
+
+func assertIgnoredStaleSkillResultActivity(t *testing.T, app App, beforeActivities int, wantError bool) tuistate.ActivityEntry {
+	t.Helper()
+
+	if len(app.activities) != beforeActivities+1 {
+		t.Fatalf("expected stale skill result to be logged, got %d activities", len(app.activities))
+	}
+	last := app.activities[len(app.activities)-1]
+	if last.Title != "Ignored stale skill command result" {
+		t.Fatalf("expected stale result activity title, got %q", last.Title)
+	}
+	if last.IsError != wantError {
+		t.Fatalf("expected stale result error flag=%v, got %v", wantError, last.IsError)
+	}
+	return last
+}
+
 func TestUpdateIgnoresStaleSkillCommandResultBySession(t *testing.T) {
 	t.Parallel()
 
 	app, _ := newTestApp(t)
 	app.state.ActiveSessionID = "session-current"
 	app.state.StatusText = "before"
+	beforeActivities := len(app.activities)
 
-	model, _ := app.Update(skillCommandResultMsg{
+	app = updateWithSkillCommandResult(t, app, skillCommandResultMsg{
 		Notice:           "should be ignored",
 		RequestSessionID: "session-old",
 	})
-	app = model.(App)
 
 	if app.state.StatusText != "before" {
 		t.Fatalf("expected stale skill result to be ignored, got status %q", app.state.StatusText)
 	}
+	assertIgnoredStaleSkillResultActivity(t, app, beforeActivities, false)
 }
 
 func TestUpdateAcceptsSkillCommandResultForCurrentSession(t *testing.T) {
@@ -4213,13 +4237,34 @@ func TestUpdateAcceptsSkillCommandResultForCurrentSession(t *testing.T) {
 	app, _ := newTestApp(t)
 	app.state.ActiveSessionID = "session-current"
 
-	model, _ := app.Update(skillCommandResultMsg{
+	app = updateWithSkillCommandResult(t, app, skillCommandResultMsg{
 		Notice:           "Skill command completed.",
 		RequestSessionID: "session-current",
 	})
-	app = model.(App)
 
 	if app.state.StatusText != "Skill command completed." {
 		t.Fatalf("expected status to be updated, got %q", app.state.StatusText)
+	}
+}
+
+func TestUpdateLogsStaleSkillCommandErrorBySession(t *testing.T) {
+	t.Parallel()
+
+	app, _ := newTestApp(t)
+	app.state.ActiveSessionID = "session-current"
+	app.state.StatusText = "before"
+	beforeActivities := len(app.activities)
+
+	app = updateWithSkillCommandResult(t, app, skillCommandResultMsg{
+		Err:              errors.New("activate failed"),
+		RequestSessionID: "session-old",
+	})
+
+	if app.state.StatusText != "before" {
+		t.Fatalf("expected stale skill error to keep current status, got %q", app.state.StatusText)
+	}
+	last := assertIgnoredStaleSkillResultActivity(t, app, beforeActivities, true)
+	if !strings.Contains(last.Detail, "activate failed") {
+		t.Fatalf("expected stale error detail to include original error, got %q", last.Detail)
 	}
 }

--- a/internal/tui/services/remote_runtime_adapter.go
+++ b/internal/tui/services/remote_runtime_adapter.go
@@ -25,6 +25,8 @@ const (
 var (
 	newGatewayRPCClientFactory    = NewGatewayRPCClient
 	newGatewayStreamClientFactory = NewGatewayStreamClient
+	// ErrUnsupportedActionInGatewayMode 标记 gateway runtime 当前不支持的本地动作。
+	ErrUnsupportedActionInGatewayMode = errors.New(unsupportedActionInGatewayMode)
 )
 
 // RemoteRuntimeAdapterOptions 描述远程 Runtime 适配器的初始化参数。
@@ -59,10 +61,9 @@ type RemoteRuntimeAdapter struct {
 	done      chan struct{}
 	events    chan agentruntime.RuntimeEvent
 
-	activeMu       sync.Mutex
-	activeRunID    string
-	activeSession  string
-	lastCancelSent time.Time
+	activeMu      sync.Mutex
+	activeRunID   string
+	activeSession string
 }
 
 // NewRemoteRuntimeAdapter 创建远程 Runtime 适配器，并在启动阶段执行 fail-fast 认证连通性检查。
@@ -240,10 +241,8 @@ func (r *RemoteRuntimeAdapter) Compact(ctx context.Context, input agentruntime.C
 }
 
 // ExecuteSystemTool 在 gateway 模式下显式不支持，避免任何本地 fallback。
-func (r *RemoteRuntimeAdapter) ExecuteSystemTool(ctx context.Context, input agentruntime.SystemToolInput) (tools.ToolResult, error) {
-	_ = ctx
-	_ = input
-	return tools.ToolResult{}, errors.New(unsupportedActionInGatewayMode)
+func (r *RemoteRuntimeAdapter) ExecuteSystemTool(context.Context, agentruntime.SystemToolInput) (tools.ToolResult, error) {
+	return tools.ToolResult{}, unsupportedGatewayActionError()
 }
 
 // ResolvePermission 转发 gateway.resolvePermission 请求。
@@ -360,36 +359,26 @@ func (r *RemoteRuntimeAdapter) LoadSession(ctx context.Context, id string) (agen
 }
 
 // ActivateSessionSkill 在 gateway 模式下显式不支持。
-func (r *RemoteRuntimeAdapter) ActivateSessionSkill(ctx context.Context, sessionID string, skillID string) error {
-	_ = ctx
-	_ = sessionID
-	_ = skillID
-	return errors.New(unsupportedActionInGatewayMode)
+func (r *RemoteRuntimeAdapter) ActivateSessionSkill(context.Context, string, string) error {
+	return unsupportedGatewayActionError()
 }
 
 // DeactivateSessionSkill 在 gateway 模式下显式不支持。
-func (r *RemoteRuntimeAdapter) DeactivateSessionSkill(ctx context.Context, sessionID string, skillID string) error {
-	_ = ctx
-	_ = sessionID
-	_ = skillID
-	return errors.New(unsupportedActionInGatewayMode)
+func (r *RemoteRuntimeAdapter) DeactivateSessionSkill(context.Context, string, string) error {
+	return unsupportedGatewayActionError()
 }
 
 // ListSessionSkills 在 gateway 模式下显式不支持。
-func (r *RemoteRuntimeAdapter) ListSessionSkills(ctx context.Context, sessionID string) ([]agentruntime.SessionSkillState, error) {
-	_ = ctx
-	_ = sessionID
-	return nil, errors.New(unsupportedActionInGatewayMode)
+func (r *RemoteRuntimeAdapter) ListSessionSkills(context.Context, string) ([]agentruntime.SessionSkillState, error) {
+	return nil, unsupportedGatewayActionError()
 }
 
 // ListAvailableSkills 在 gateway 模式下显式不支持。
 func (r *RemoteRuntimeAdapter) ListAvailableSkills(
-	ctx context.Context,
-	sessionID string,
+	context.Context,
+	string,
 ) ([]agentruntime.AvailableSkillState, error) {
-	_ = ctx
-	_ = sessionID
-	return nil, errors.New(unsupportedActionInGatewayMode)
+	return nil, unsupportedGatewayActionError()
 }
 
 // Close 关闭远程适配器并结束事件桥接。
@@ -496,11 +485,13 @@ func (r *RemoteRuntimeAdapter) observeEvent(event agentruntime.RuntimeEvent) {
 func (r *RemoteRuntimeAdapter) setActiveRun(runID string, sessionID string) {
 	r.activeMu.Lock()
 	defer r.activeMu.Unlock()
-	if strings.TrimSpace(runID) != "" {
-		r.activeRunID = strings.TrimSpace(runID)
+	normalizedRunID := strings.TrimSpace(runID)
+	normalizedSessionID := strings.TrimSpace(sessionID)
+	if normalizedRunID != "" {
+		r.activeRunID = normalizedRunID
 	}
-	if strings.TrimSpace(sessionID) != "" {
-		r.activeSession = strings.TrimSpace(sessionID)
+	if normalizedSessionID != "" {
+		r.activeSession = normalizedSessionID
 	}
 }
 
@@ -528,6 +519,11 @@ func (r *RemoteRuntimeAdapter) activeRun() (string, string) {
 	r.activeMu.Lock()
 	defer r.activeMu.Unlock()
 	return strings.TrimSpace(r.activeRunID), strings.TrimSpace(r.activeSession)
+}
+
+// unsupportedGatewayActionError 返回 gateway 模式下不支持本地动作时的统一错误。
+func unsupportedGatewayActionError() error {
+	return ErrUnsupportedActionInGatewayMode
 }
 
 func buildGatewayRunParams(sessionID string, runID string, input agentruntime.PrepareInput) protocol.RunParams {

--- a/internal/tui/services/remote_runtime_adapter.go
+++ b/internal/tui/services/remote_runtime_adapter.go
@@ -382,6 +382,16 @@ func (r *RemoteRuntimeAdapter) ListSessionSkills(ctx context.Context, sessionID 
 	return nil, errors.New(unsupportedActionInGatewayMode)
 }
 
+// ListAvailableSkills 在 gateway 模式下显式不支持。
+func (r *RemoteRuntimeAdapter) ListAvailableSkills(
+	ctx context.Context,
+	sessionID string,
+) ([]agentruntime.AvailableSkillState, error) {
+	_ = ctx
+	_ = sessionID
+	return nil, errors.New(unsupportedActionInGatewayMode)
+}
+
 // Close 关闭远程适配器并结束事件桥接。
 func (r *RemoteRuntimeAdapter) Close() error {
 	var closeErr error

--- a/internal/tui/services/remote_runtime_adapter_additional_test.go
+++ b/internal/tui/services/remote_runtime_adapter_additional_test.go
@@ -213,6 +213,9 @@ func TestRemoteRuntimeAdapterUnsupportedSkillMethods(t *testing.T) {
 	if _, err := adapter.ListSessionSkills(context.Background(), "s"); err == nil {
 		t.Fatalf("ListSessionSkills should be unsupported")
 	}
+	if _, err := adapter.ListAvailableSkills(context.Background(), "s"); err == nil {
+		t.Fatalf("ListAvailableSkills should be unsupported")
+	}
 }
 
 func TestRemoteRuntimeAdapterCallFrameAndDecodeHelpers(t *testing.T) {

--- a/internal/tui/services/remote_runtime_adapter_test.go
+++ b/internal/tui/services/remote_runtime_adapter_test.go
@@ -16,6 +16,21 @@ import (
 	"neo-code/internal/tools"
 )
 
+func newRemoteRuntimeAdapterForTest(
+	t *testing.T,
+	rpcClient *stubRemoteRPCClient,
+) (*RemoteRuntimeAdapter, *stubRemoteStreamClient) {
+	t.Helper()
+
+	if rpcClient.notifications == nil {
+		rpcClient.notifications = make(chan gatewayRPCNotification)
+	}
+	streamClient := &stubRemoteStreamClient{events: make(chan agentruntime.RuntimeEvent)}
+	adapter := newRemoteRuntimeAdapterWithClients(rpcClient, streamClient, time.Second, 1)
+	t.Cleanup(func() { _ = adapter.Close() })
+	return adapter, streamClient
+}
+
 func TestRemoteRuntimeAdapterSubmitAuthenticatesBindsPreloadsAndRuns(t *testing.T) {
 	rpcClient := &stubRemoteRPCClient{
 		frames: map[string]gateway.MessageFrame{
@@ -37,11 +52,8 @@ func TestRemoteRuntimeAdapterSubmitAuthenticatesBindsPreloadsAndRuns(t *testing.
 				RunID:     "run-1",
 			},
 		},
-		notifications: make(chan gatewayRPCNotification),
 	}
-	streamClient := &stubRemoteStreamClient{events: make(chan agentruntime.RuntimeEvent)}
-	adapter := newRemoteRuntimeAdapterWithClients(rpcClient, streamClient, time.Second, 1)
-	t.Cleanup(func() { _ = adapter.Close() })
+	adapter, _ := newRemoteRuntimeAdapterForTest(t, rpcClient)
 
 	err := adapter.Submit(context.Background(), agentruntime.PrepareInput{
 		SessionID: "session-1",
@@ -97,12 +109,9 @@ func TestRemoteRuntimeAdapterSubmitAuthenticatesBindsPreloadsAndRuns(t *testing.
 
 func TestRemoteRuntimeAdapterSubmitFailFastOnAuthenticateError(t *testing.T) {
 	rpcClient := &stubRemoteRPCClient{
-		authErr:       errors.New("auth failed"),
-		notifications: make(chan gatewayRPCNotification),
+		authErr: errors.New("auth failed"),
 	}
-	streamClient := &stubRemoteStreamClient{events: make(chan agentruntime.RuntimeEvent)}
-	adapter := newRemoteRuntimeAdapterWithClients(rpcClient, streamClient, time.Second, 1)
-	t.Cleanup(func() { _ = adapter.Close() })
+	adapter, _ := newRemoteRuntimeAdapterForTest(t, rpcClient)
 
 	err := adapter.Submit(context.Background(), agentruntime.PrepareInput{
 		SessionID: "session-1",
@@ -122,11 +131,8 @@ func TestRemoteRuntimeAdapterSubmitFailFastOnBindStreamError(t *testing.T) {
 		callErrs: map[string]error{
 			protocol.MethodGatewayBindStream: errors.New("stream bind failed"),
 		},
-		notifications: make(chan gatewayRPCNotification),
 	}
-	streamClient := &stubRemoteStreamClient{events: make(chan agentruntime.RuntimeEvent)}
-	adapter := newRemoteRuntimeAdapterWithClients(rpcClient, streamClient, time.Second, 1)
-	t.Cleanup(func() { _ = adapter.Close() })
+	adapter, _ := newRemoteRuntimeAdapterForTest(t, rpcClient)
 
 	err := adapter.Submit(context.Background(), agentruntime.PrepareInput{
 		SessionID: "session-1",
@@ -144,15 +150,13 @@ func TestRemoteRuntimeAdapterSubmitFailFastOnBindStreamError(t *testing.T) {
 }
 
 func TestRemoteRuntimeAdapterExecuteSystemToolUnsupported(t *testing.T) {
-	rpcClient := &stubRemoteRPCClient{notifications: make(chan gatewayRPCNotification)}
-	streamClient := &stubRemoteStreamClient{events: make(chan agentruntime.RuntimeEvent)}
-	adapter := newRemoteRuntimeAdapterWithClients(rpcClient, streamClient, time.Second, 1)
-	t.Cleanup(func() { _ = adapter.Close() })
+	rpcClient := &stubRemoteRPCClient{}
+	adapter, _ := newRemoteRuntimeAdapterForTest(t, rpcClient)
 
 	_, err := adapter.ExecuteSystemTool(context.Background(), agentruntime.SystemToolInput{
 		ToolName: "bash",
 	})
-	if err == nil || err.Error() != unsupportedActionInGatewayMode {
+	if err == nil || !errors.Is(err, ErrUnsupportedActionInGatewayMode) {
 		t.Fatalf("expected unsupported_action_in_gateway_mode, got %v", err)
 	}
 }
@@ -180,11 +184,8 @@ func TestRemoteRuntimeAdapterLoadSessionMinimalMapping(t *testing.T) {
 				},
 			},
 		},
-		notifications: make(chan gatewayRPCNotification),
 	}
-	streamClient := &stubRemoteStreamClient{events: make(chan agentruntime.RuntimeEvent)}
-	adapter := newRemoteRuntimeAdapterWithClients(rpcClient, streamClient, time.Second, 1)
-	t.Cleanup(func() { _ = adapter.Close() })
+	adapter, _ := newRemoteRuntimeAdapterForTest(t, rpcClient)
 
 	session, err := adapter.LoadSession(context.Background(), "session-9")
 	if err != nil {
@@ -213,12 +214,9 @@ func TestRemoteRuntimeAdapterCancelActiveRunSendsGatewayCancel(t *testing.T) {
 				Action: gateway.FrameActionCancel,
 			},
 		},
-		notifications: make(chan gatewayRPCNotification),
-		methodCh:      methodCh,
+		methodCh: methodCh,
 	}
-	streamClient := &stubRemoteStreamClient{events: make(chan agentruntime.RuntimeEvent)}
-	adapter := newRemoteRuntimeAdapterWithClients(rpcClient, streamClient, time.Second, 1)
-	t.Cleanup(func() { _ = adapter.Close() })
+	adapter, _ := newRemoteRuntimeAdapterForTest(t, rpcClient)
 
 	if canceled := adapter.CancelActiveRun(); canceled {
 		t.Fatalf("expected no active run to cancel")
@@ -240,9 +238,8 @@ func TestRemoteRuntimeAdapterCancelActiveRunSendsGatewayCancel(t *testing.T) {
 }
 
 func TestRemoteRuntimeAdapterCloseClosesUnderlyingClients(t *testing.T) {
-	rpcClient := &stubRemoteRPCClient{notifications: make(chan gatewayRPCNotification)}
-	streamClient := &stubRemoteStreamClient{events: make(chan agentruntime.RuntimeEvent)}
-	adapter := newRemoteRuntimeAdapterWithClients(rpcClient, streamClient, time.Second, 1)
+	rpcClient := &stubRemoteRPCClient{}
+	adapter, streamClient := newRemoteRuntimeAdapterForTest(t, rpcClient)
 
 	if err := adapter.Close(); err != nil {
 		t.Fatalf("Close() error = %v", err)


### PR DESCRIPTION
## 背景
本 PR 一次性完成 Skills 子任务：
- #259 `feat(skills): 收口 Skills 与 Tools / Security / MCP 的边界`
- #260 `feat(skills): 增加 Skills 用户入口与 Session 可观测能力`
并对齐父任务 #255 的阶段目标。

## 变更摘要
### 1. Runtime 技能能力补全
- 新增 `ListAvailableSkills(ctx, sessionID)` 运行时接口，返回可见 skills + 当前会话激活状态。
- 在 `prepareTurnSnapshot` 接入 skill `tool_hints` 优先级排序：
  - 仅对**已暴露工具**做排序。
  - 不新增工具，不注入未注册 schema，不改权限决策。

### 2. Skills 与 Tools/Security 边界收口
- `tool_hints` 影响范围限定为“模型可见工具顺序提示”。
- 工具执行链路保持不变：`Runtime -> ToolManager -> Security -> Executor`。
- MCP 工具仍由统一 registry/exposure filter/permission 链路治理。

### 3. TUI 用户入口与可观测
- 新增 slash 命令：
  - `/skills`
  - `/skill use <id>`
  - `/skill off <id>`
  - `/skill active`
- 命令执行全部通过 runtime 接口，不直接读取 skill 文件。
- gateway 模式下提供明确错误提示，不静默失败。
- 新增技能事件展示：
  - `skill_activated`
  - `skill_deactivated`
  - `skill_missing`

### 4. 文档补齐
- 新增 [docs/skills-system-design.md](docs/skills-system-design.md)
  - 发现机制
  - 加载机制
  - 激活机制
  - 预期 agent 使用方式
  - 与 tools/security/MCP 边界
- 更新 README 与现有设计文档导航、命令说明、事件说明。

## 关键设计约束（落实结果）
- Skills 不能成为权限豁免入口。
- Skills 不绕过 ask/deny/allow。
- Skills 不直接执行工具。
- Skills 不直接注入未注册工具 schema。

## 测试
已执行：
- `go test ./...`
- `go test ./... -coverprofile=coverage.out`

本次新增测试覆盖：
- runtime: `ListAvailableSkills`、skill `tool_hints` 工具优先级、prepare snapshot 顺序行为。
- tui: slash 命令入口、skills 命令错误路径、skills 事件处理。
- adapter/bootstrap/bridge: runtime 接口扩展后的兼容与不支持分支。

## 关联关闭
- Closes #259
- Closes #260
- Refs #255
