### PR TITLE
tui: 修复 Transcript 选区拖拽渲染与复制

### DIFF
--- a/internal/tui/core/app/app.go
+++ b/internal/tui/core/app/app.go
@@ -136,9 +136,19 @@ type appRuntimeState struct {
 	logPersistVersion       int
 	transcriptContent       string
 	transcriptScrollbarDrag bool
-	footerErrorLast         string
-	footerErrorText         string
-	footerErrorUntil        time.Time
+
+	textSelection struct {
+		active    bool
+		dragging  bool
+		startLine int
+		startCol  int
+		endLine   int
+		endCol    int
+	}
+
+	footerErrorLast  string
+	footerErrorText  string
+	footerErrorUntil time.Time
 }
 
 type pendingImageAttachment struct {
@@ -257,6 +267,23 @@ func newApp(container tuibootstrap.Container) (App, error) {
 
 	h := help.New()
 	h.ShowAll = false
+	h.ShortSeparator = " • "
+	h.Styles.ShortKey = lipgloss.NewStyle().
+		Foreground(lipgloss.Color(selectionFg)).
+		Bold(true).
+		Underline(true)
+	h.Styles.ShortDesc = lipgloss.NewStyle().
+		Foreground(lipgloss.Color(lightText)).
+		Bold(true)
+	h.Styles.ShortSeparator = lipgloss.NewStyle().
+		Foreground(lipgloss.Color(coralAccent)).
+		Bold(true)
+	h.Styles.FullKey = h.Styles.ShortKey.Copy()
+	h.Styles.FullDesc = h.Styles.ShortDesc.Copy()
+	h.Styles.FullSeparator = h.Styles.ShortSeparator.Copy()
+	h.Styles.Ellipsis = lipgloss.NewStyle().
+		Foreground(lipgloss.Color(warningYellow)).
+		Bold(true)
 
 	commandMenu := newCommandMenuModel(uiStyles)
 

--- a/internal/tui/core/app/copy_code.go
+++ b/internal/tui/core/app/copy_code.go
@@ -269,11 +269,8 @@ func (a App) textSelectionRange(lines []string) (startLine int, startCol int, en
 	if !a.textSelection.active || len(lines) == 0 {
 		return 0, 0, 0, 0, false
 	}
-	sLine, sCol, sOk := a.normalizeSelectionPosition(lines, a.textSelection.startLine, a.textSelection.startCol)
-	eLine, eCol, eOk := a.normalizeSelectionPosition(lines, a.textSelection.endLine, a.textSelection.endCol)
-	if !sOk || !eOk {
-		return 0, 0, 0, 0, false
-	}
+	sLine, sCol, _ := a.normalizeSelectionPosition(lines, a.textSelection.startLine, a.textSelection.startCol)
+	eLine, eCol, _ := a.normalizeSelectionPosition(lines, a.textSelection.endLine, a.textSelection.endCol)
 	if sLine > eLine || (sLine == eLine && sCol > eCol) {
 		sLine, eLine = eLine, sLine
 		sCol, eCol = eCol, sCol
@@ -358,15 +355,6 @@ func (a *App) copySelectionToClipboard() {
 		}
 		if i == endLine {
 			to = endCol
-		}
-		if from < 0 {
-			from = 0
-		}
-		if to > lineWidth {
-			to = lineWidth
-		}
-		if to < from {
-			to = from
 		}
 		selectedLines = append(selectedLines, ansi.Cut(plain, from, to))
 	}

--- a/internal/tui/core/app/copy_code.go
+++ b/internal/tui/core/app/copy_code.go
@@ -262,6 +262,9 @@ func (a App) selectionPositionAtMouse(msg tea.MouseMsg) (line int, col int, ok b
 	currentLine := a.transcript.YOffset + (msg.Y - y)
 	currentCol := msg.X - x
 	lines := a.selectionLines()
+	if len(lines) == 0 || currentLine < 0 || currentLine >= len(lines) {
+		return 0, 0, false
+	}
 	return a.normalizeSelectionPosition(lines, currentLine, currentCol)
 }
 
@@ -308,6 +311,9 @@ func (a *App) updateTextSelection(msg tea.MouseMsg) bool {
 	line, col, ok := a.selectionPositionAtMouse(msg)
 	if !ok {
 		return false
+	}
+	if a.textSelection.endLine == line && a.textSelection.endCol == col {
+		return true
 	}
 	a.textSelection.endLine = line
 	a.textSelection.endCol = col

--- a/internal/tui/core/app/copy_code.go
+++ b/internal/tui/core/app/copy_code.go
@@ -1,9 +1,7 @@
 package tui
 
 import (
-	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -32,9 +30,8 @@ type markdownSegment struct {
 }
 
 var (
-	copyCodeButtonPattern = regexp.MustCompile(`\[Copy code #([0-9]+)\]`)
-	copyCodeANSIPattern   = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
-	clipboardWriteAll     = tuiinfra.CopyText
+	copyCodeANSIPattern = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
+	clipboardWriteAll   = tuiinfra.CopyText
 )
 
 func splitMarkdownSegments(content string) []markdownSegment {
@@ -229,88 +226,6 @@ func trimCodeIndent(line string) string {
 		return line[4:]
 	}
 	return line
-}
-
-func (a *App) setCodeCopyBlocks(bindings []copyCodeButtonBinding) {
-	a.codeCopyBlocks = make(map[int]string, len(bindings))
-	for _, binding := range bindings {
-		a.codeCopyBlocks[binding.ID] = binding.Code
-	}
-}
-
-func parseCopyCodeButton(line string) (id int, startCol int, endCol int, ok bool) {
-	clean := copyCodeANSIPattern.ReplaceAllString(line, "")
-	matches := copyCodeButtonPattern.FindStringSubmatchIndex(clean)
-	if len(matches) < 4 {
-		return 0, 0, 0, false
-	}
-
-	buttonText := clean[matches[0]:matches[1]]
-	idText := clean[matches[2]:matches[3]]
-	id, err := strconv.Atoi(idText)
-	if err != nil {
-		return 0, 0, 0, false
-	}
-
-	startCol = lipgloss.Width(clean[:matches[0]])
-	endCol = startCol + lipgloss.Width(buttonText)
-	return id, startCol, endCol, true
-}
-
-func (a *App) copyButtonIDAtMouse(msg tea.MouseMsg) (int, bool) {
-	line, relativeX, ok := a.transcriptLineAtMouse(msg)
-	if !ok {
-		return 0, false
-	}
-
-	buttonID, startCol, endCol, ok := parseCopyCodeButton(line)
-	if !ok {
-		return 0, false
-	}
-	if relativeX < startCol || relativeX >= endCol {
-		return 0, false
-	}
-	return buttonID, true
-}
-
-func (a *App) copyCodeBlockByID(buttonID int) bool {
-	code, ok := a.codeCopyBlocks[buttonID]
-	if !ok {
-		a.state.ExecutionError = statusCodeCopyError
-		a.state.StatusText = statusCodeCopyError
-		a.appendActivity("clipboard", statusCodeCopyError, fmt.Sprintf("button #%d", buttonID), true)
-		return true
-	}
-
-	if err := clipboardWriteAll(code); err != nil {
-		a.state.ExecutionError = err.Error()
-		a.state.StatusText = statusCodeCopyError
-		a.appendActivity("clipboard", statusCodeCopyError, err.Error(), true)
-		return true
-	}
-
-	a.state.ExecutionError = ""
-	a.state.StatusText = fmt.Sprintf(statusCodeCopied, buttonID)
-	a.appendActivity("clipboard", "Copied code block", fmt.Sprintf("#%d", buttonID), false)
-	return true
-}
-
-func (a App) transcriptLineAtMouse(msg tea.MouseMsg) (line string, relativeX int, ok bool) {
-	if !a.isMouseWithinTranscript(msg) {
-		return "", 0, false
-	}
-
-	x, y, _, _ := a.transcriptBounds()
-	lineIndex := msg.Y - y
-	if lineIndex < 0 {
-		return "", 0, false
-	}
-
-	lines := strings.Split(a.transcript.View(), "\n")
-	if lineIndex >= len(lines) {
-		return "", 0, false
-	}
-	return lines[lineIndex], msg.X - x, true
 }
 
 func (a App) selectionLines() []string {

--- a/internal/tui/core/app/copy_code.go
+++ b/internal/tui/core/app/copy_code.go
@@ -1,10 +1,478 @@
 package tui
 
-import "regexp"
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	tuiinfra "neo-code/internal/tui/infra"
+)
 
 type copyCodeButtonBinding struct {
 	ID   int
 	Code string
 }
 
-var copyCodeANSIPattern = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
+type markdownSegmentKind int
+
+const (
+	markdownSegmentText markdownSegmentKind = iota
+	markdownSegmentCode
+)
+
+type markdownSegment struct {
+	Kind   markdownSegmentKind
+	Text   string
+	Fenced string
+	Code   string
+}
+
+var (
+	copyCodeButtonPattern = regexp.MustCompile(`\[Copy code #([0-9]+)\]`)
+	copyCodeANSIPattern   = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
+	clipboardWriteAll     = tuiinfra.CopyText
+)
+
+func splitMarkdownSegments(content string) []markdownSegment {
+	if !strings.Contains(content, "```") {
+		return splitIndentedCodeSegments(content)
+	}
+
+	lines := strings.Split(content, "\n")
+	segments := make([]markdownSegment, 0, 8)
+	textLines := make([]string, 0, len(lines))
+	codeLines := make([]string, 0, len(lines))
+	inFence := false
+	fenceInfo := ""
+	sawFence := false
+
+	flushText := func() {
+		if len(textLines) == 0 {
+			return
+		}
+		segments = append(segments, markdownSegment{
+			Kind: markdownSegmentText,
+			Text: strings.Join(textLines, "\n"),
+		})
+		textLines = textLines[:0]
+	}
+	flushCode := func() {
+		if len(codeLines) == 0 {
+			codeLines = codeLines[:0]
+			return
+		}
+		code := strings.Join(codeLines, "\n")
+		code = strings.TrimRight(code, "\n")
+		if strings.TrimSpace(code) == "" {
+			codeLines = codeLines[:0]
+			return
+		}
+		fenced := "```"
+		if fenceInfo != "" {
+			fenced += fenceInfo
+		}
+		fenced += "\n" + code + "\n```"
+		segments = append(segments, markdownSegment{
+			Kind:   markdownSegmentCode,
+			Fenced: fenced,
+			Code:   code,
+		})
+		codeLines = codeLines[:0]
+	}
+
+	for _, line := range lines {
+		if !inFence {
+			if info, ok := parseFenceOpenLine(line); ok {
+				sawFence = true
+				flushText()
+				inFence = true
+				fenceInfo = info
+				continue
+			}
+			textLines = append(textLines, line)
+			continue
+		}
+
+		if isFenceCloseLine(line) {
+			flushCode()
+			inFence = false
+			fenceInfo = ""
+			continue
+		}
+		codeLines = append(codeLines, line)
+	}
+
+	if inFence {
+		flushCode()
+	}
+	flushText()
+
+	if sawFence && len(segments) > 0 {
+		return segments
+	}
+
+	return splitIndentedCodeSegments(content)
+}
+
+func splitIndentedCodeSegments(content string) []markdownSegment {
+	lines := strings.Split(content, "\n")
+	segments := make([]markdownSegment, 0, 4)
+	textLines := make([]string, 0, len(lines))
+	codeLines := make([]string, 0, len(lines))
+	inCode := false
+
+	flushText := func() {
+		if len(textLines) == 0 {
+			return
+		}
+		segments = append(segments, markdownSegment{
+			Kind: markdownSegmentText,
+			Text: strings.Join(textLines, "\n"),
+		})
+		textLines = textLines[:0]
+	}
+	flushCode := func() {
+		if len(codeLines) == 0 {
+			return
+		}
+		code := strings.Join(codeLines, "\n")
+		code = strings.TrimSpace(code)
+		if code == "" {
+			codeLines = codeLines[:0]
+			return
+		}
+		segments = append(segments, markdownSegment{
+			Kind:   markdownSegmentCode,
+			Fenced: "```\n" + code + "\n```",
+			Code:   code,
+		})
+		codeLines = codeLines[:0]
+	}
+
+	for _, line := range lines {
+		indented := isIndentedCodeLine(line)
+		if inCode {
+			if indented {
+				codeLines = append(codeLines, trimCodeIndent(line))
+				continue
+			}
+			if strings.TrimSpace(line) == "" {
+				codeLines = append(codeLines, "")
+				continue
+			}
+			if len(codeLines) > 0 {
+				flushCode()
+			}
+			inCode = false
+		}
+
+		if indented {
+			if !inCode {
+				flushText()
+				inCode = true
+			}
+			codeLines = append(codeLines, trimCodeIndent(line))
+			continue
+		}
+
+		textLines = append(textLines, line)
+	}
+
+	if inCode {
+		flushCode()
+	}
+	flushText()
+
+	if len(segments) == 0 {
+		return []markdownSegment{{Kind: markdownSegmentText, Text: content}}
+	}
+	return segments
+}
+
+func extractFencedCodeBlocks(content string) []string {
+	segments := splitMarkdownSegments(content)
+	blocks := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		if segment.Kind == markdownSegmentCode && strings.TrimSpace(segment.Code) != "" {
+			blocks = append(blocks, segment.Code)
+		}
+	}
+	return blocks
+}
+
+func parseFenceOpenLine(line string) (string, bool) {
+	trimmed := strings.TrimLeft(line, " \t")
+	if !strings.HasPrefix(trimmed, "```") {
+		return "", false
+	}
+	return strings.TrimSpace(strings.TrimPrefix(trimmed, "```")), true
+}
+
+func isFenceCloseLine(line string) bool {
+	trimmed := strings.TrimLeft(line, " \t")
+	return strings.TrimSpace(trimmed) == "```"
+}
+
+func isIndentedCodeLine(line string) bool {
+	return strings.HasPrefix(line, "\t") || strings.HasPrefix(line, "    ")
+}
+
+func trimCodeIndent(line string) string {
+	if strings.HasPrefix(line, "\t") {
+		return strings.TrimPrefix(line, "\t")
+	}
+	if strings.HasPrefix(line, "    ") {
+		return line[4:]
+	}
+	return line
+}
+
+func (a *App) setCodeCopyBlocks(bindings []copyCodeButtonBinding) {
+	a.codeCopyBlocks = make(map[int]string, len(bindings))
+	for _, binding := range bindings {
+		a.codeCopyBlocks[binding.ID] = binding.Code
+	}
+}
+
+func parseCopyCodeButton(line string) (id int, startCol int, endCol int, ok bool) {
+	clean := copyCodeANSIPattern.ReplaceAllString(line, "")
+	matches := copyCodeButtonPattern.FindStringSubmatchIndex(clean)
+	if len(matches) < 4 {
+		return 0, 0, 0, false
+	}
+
+	buttonText := clean[matches[0]:matches[1]]
+	idText := clean[matches[2]:matches[3]]
+	id, err := strconv.Atoi(idText)
+	if err != nil {
+		return 0, 0, 0, false
+	}
+
+	startCol = lipgloss.Width(clean[:matches[0]])
+	endCol = startCol + lipgloss.Width(buttonText)
+	return id, startCol, endCol, true
+}
+
+func (a *App) copyButtonIDAtMouse(msg tea.MouseMsg) (int, bool) {
+	line, relativeX, ok := a.transcriptLineAtMouse(msg)
+	if !ok {
+		return 0, false
+	}
+
+	buttonID, startCol, endCol, ok := parseCopyCodeButton(line)
+	if !ok {
+		return 0, false
+	}
+	if relativeX < startCol || relativeX >= endCol {
+		return 0, false
+	}
+	return buttonID, true
+}
+
+func (a *App) copyCodeBlockByID(buttonID int) bool {
+	code, ok := a.codeCopyBlocks[buttonID]
+	if !ok {
+		a.state.ExecutionError = statusCodeCopyError
+		a.state.StatusText = statusCodeCopyError
+		a.appendActivity("clipboard", statusCodeCopyError, fmt.Sprintf("button #%d", buttonID), true)
+		return true
+	}
+
+	if err := clipboardWriteAll(code); err != nil {
+		a.state.ExecutionError = err.Error()
+		a.state.StatusText = statusCodeCopyError
+		a.appendActivity("clipboard", statusCodeCopyError, err.Error(), true)
+		return true
+	}
+
+	a.state.ExecutionError = ""
+	a.state.StatusText = fmt.Sprintf(statusCodeCopied, buttonID)
+	a.appendActivity("clipboard", "Copied code block", fmt.Sprintf("#%d", buttonID), false)
+	return true
+}
+
+func (a App) transcriptLineAtMouse(msg tea.MouseMsg) (line string, relativeX int, ok bool) {
+	if !a.isMouseWithinTranscript(msg) {
+		return "", 0, false
+	}
+
+	x, y, _, _ := a.transcriptBounds()
+	lineIndex := msg.Y - y
+	if lineIndex < 0 {
+		return "", 0, false
+	}
+
+	lines := strings.Split(a.transcript.View(), "\n")
+	if lineIndex >= len(lines) {
+		return "", 0, false
+	}
+	return lines[lineIndex], msg.X - x, true
+}
+
+func (a App) selectionLines() []string {
+	return strings.Split(a.transcriptContent, "\n")
+}
+
+func (a App) normalizeSelectionPosition(lines []string, line int, col int) (int, int, bool) {
+	if len(lines) == 0 {
+		return 0, 0, false
+	}
+	if line < 0 {
+		line = 0
+	}
+	if line >= len(lines) {
+		line = len(lines) - 1
+	}
+	plain := copyCodeANSIPattern.ReplaceAllString(lines[line], "")
+	lineWidth := lipgloss.Width(plain)
+	if col < 0 {
+		col = 0
+	}
+	if col > lineWidth {
+		col = lineWidth
+	}
+	return line, col, true
+}
+
+func (a App) selectionPositionAtMouse(msg tea.MouseMsg) (line int, col int, ok bool) {
+	if !a.isMouseWithinTranscript(msg) {
+		return 0, 0, false
+	}
+
+	x, y, _, _ := a.transcriptBounds()
+	currentLine := a.transcript.YOffset + (msg.Y - y)
+	currentCol := msg.X - x
+	lines := a.selectionLines()
+	return a.normalizeSelectionPosition(lines, currentLine, currentCol)
+}
+
+func (a App) textSelectionRange(lines []string) (startLine int, startCol int, endLine int, endCol int, ok bool) {
+	if !a.textSelection.active || len(lines) == 0 {
+		return 0, 0, 0, 0, false
+	}
+	sLine, sCol, sOk := a.normalizeSelectionPosition(lines, a.textSelection.startLine, a.textSelection.startCol)
+	eLine, eCol, eOk := a.normalizeSelectionPosition(lines, a.textSelection.endLine, a.textSelection.endCol)
+	if !sOk || !eOk {
+		return 0, 0, 0, 0, false
+	}
+	if sLine > eLine || (sLine == eLine && sCol > eCol) {
+		sLine, eLine = eLine, sLine
+		sCol, eCol = eCol, sCol
+	}
+	if sLine == eLine && sCol == eCol {
+		return 0, 0, 0, 0, false
+	}
+	return sLine, sCol, eLine, eCol, true
+}
+
+func (a App) hasTextSelection() bool {
+	_, _, _, _, ok := a.textSelectionRange(a.selectionLines())
+	return ok
+}
+
+func (a *App) beginTextSelection(msg tea.MouseMsg) bool {
+	line, col, ok := a.selectionPositionAtMouse(msg)
+	if !ok {
+		return false
+	}
+	a.textSelection.active = true
+	a.textSelection.dragging = true
+	a.textSelection.startLine = line
+	a.textSelection.startCol = col
+	a.textSelection.endLine = line
+	a.textSelection.endCol = col
+	a.refreshTranscriptHighlight()
+	return true
+}
+
+func (a *App) updateTextSelection(msg tea.MouseMsg) bool {
+	if !a.textSelection.dragging {
+		return false
+	}
+	line, col, ok := a.selectionPositionAtMouse(msg)
+	if !ok {
+		return false
+	}
+	a.textSelection.endLine = line
+	a.textSelection.endCol = col
+	a.refreshTranscriptHighlight()
+	return true
+}
+
+func (a *App) finishTextSelection() bool {
+	if !a.textSelection.dragging {
+		return false
+	}
+	a.textSelection.dragging = false
+	if !a.hasTextSelection() {
+		a.clearTextSelection()
+		return true
+	}
+	a.refreshTranscriptHighlight()
+	return true
+}
+
+func (a *App) refreshTranscriptHighlight() {
+	if a.hasTextSelection() {
+		highlighted := a.highlightTranscriptContent(a.transcriptContent)
+		a.transcript.SetContent(highlighted)
+		return
+	}
+	a.transcript.SetContent(a.transcriptContent)
+}
+
+func (a *App) copySelectionToClipboard() {
+	lines := a.selectionLines()
+	startLine, startCol, endLine, endCol, ok := a.textSelectionRange(lines)
+	if !ok {
+		return
+	}
+
+	selectedLines := make([]string, 0, endLine-startLine+1)
+	for i := startLine; i <= endLine && i < len(lines); i++ {
+		plain := copyCodeANSIPattern.ReplaceAllString(lines[i], "")
+		lineWidth := lipgloss.Width(plain)
+		from := 0
+		to := lineWidth
+		if i == startLine {
+			from = startCol
+		}
+		if i == endLine {
+			to = endCol
+		}
+		if from < 0 {
+			from = 0
+		}
+		if to > lineWidth {
+			to = lineWidth
+		}
+		if to < from {
+			to = from
+		}
+		selectedLines = append(selectedLines, ansi.Cut(plain, from, to))
+	}
+
+	content := strings.Join(selectedLines, "\n")
+	if err := clipboardWriteAll(content); err != nil {
+		a.state.StatusText = "Failed to copy selection"
+		return
+	}
+
+	a.state.StatusText = "Copied selected text"
+	a.clearTextSelection()
+}
+
+func (a *App) clearTextSelection() {
+	a.textSelection.active = false
+	a.textSelection.dragging = false
+	a.textSelection.startLine = 0
+	a.textSelection.startCol = 0
+	a.textSelection.endLine = 0
+	a.textSelection.endCol = 0
+
+	a.transcript.SetContent(a.transcriptContent)
+}

--- a/internal/tui/core/app/copy_code_test.go
+++ b/internal/tui/core/app/copy_code_test.go
@@ -213,6 +213,89 @@ func TestSelectionPositionAndDragGuardBranches(t *testing.T) {
 	}
 }
 
+func TestSelectionPositionAtMouseRejectsBlankViewportRows(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.width = 100
+	app.height = 24
+	app.applyComponentLayout(true)
+	app.setTranscriptContent("only-one-line")
+
+	x, y, _, h := app.transcriptBounds()
+	if h < 2 {
+		t.Fatalf("expected transcript viewport with spare rows, got height=%d", h)
+	}
+
+	if _, _, ok := app.selectionPositionAtMouse(tea.MouseMsg{X: x + 1, Y: y + h - 1}); ok {
+		t.Fatalf("expected blank viewport row to be ignored")
+	}
+}
+
+func TestSetTranscriptContentClearsSelectionAfterContentChange(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.width = 100
+	app.height = 24
+	app.applyComponentLayout(true)
+	app.setTranscriptContent("line-one")
+	app.textSelection.active = true
+	app.textSelection.startLine = 0
+	app.textSelection.startCol = 0
+	app.textSelection.endLine = 0
+	app.textSelection.endCol = 4
+	app.refreshTranscriptHighlight()
+
+	app.setTranscriptContent("line-two")
+	if app.textSelection.active || app.textSelection.dragging {
+		t.Fatalf("expected selection to be cleared after transcript content changes")
+	}
+	if app.hasTextSelection() {
+		t.Fatalf("expected no valid selection range after transcript content changes")
+	}
+}
+
+func TestUpdateTextSelectionSkipsUnchangedPosition(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.width = 100
+	app.height = 24
+	app.applyComponentLayout(true)
+	app.setTranscriptContent("alpha\nbeta")
+
+	x, y, _, _ := app.transcriptBounds()
+	if !app.beginTextSelection(tea.MouseMsg{X: x + 1, Y: y + 1}) {
+		t.Fatalf("expected beginTextSelection to succeed")
+	}
+	if !app.updateTextSelection(tea.MouseMsg{X: x + 2, Y: y + 1}) {
+		t.Fatalf("expected first updateTextSelection to succeed")
+	}
+
+	app.transcript.SetContent("sentinel-marker")
+	if !app.updateTextSelection(tea.MouseMsg{X: x + 2, Y: y + 1}) {
+		t.Fatalf("expected unchanged motion to be handled")
+	}
+	if !strings.Contains(app.transcript.View(), "sentinel-marker") {
+		t.Fatalf("expected unchanged motion to skip redraw")
+	}
+}
+
+func TestHighlightTranscriptContentPreservesANSIOutsideSelection(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.width = 100
+	app.height = 24
+	app.applyComponentLayout(true)
+	app.textSelection.active = true
+	app.textSelection.startLine = 0
+	app.textSelection.startCol = 6
+	app.textSelection.endLine = 0
+	app.textSelection.endCol = 11
+
+	highlighted := app.highlightTranscriptContent("\x1b[31mhello world\x1b[0m")
+	if !strings.Contains(highlighted, "\x1b[31m") {
+		t.Fatalf("expected highlighted content to preserve existing ANSI style runs")
+	}
+	if plain := copyCodeANSIPattern.ReplaceAllString(highlighted, ""); plain != "hello world" {
+		t.Fatalf("expected highlighted content to preserve visible text, got %q", plain)
+	}
+}
+
 func TestCopySelectionToClipboardNoSelectionNoop(t *testing.T) {
 	app, _ := newTestApp(t)
 	app.setTranscriptContent("hello")

--- a/internal/tui/core/app/copy_code_test.go
+++ b/internal/tui/core/app/copy_code_test.go
@@ -1,0 +1,224 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	providertypes "neo-code/internal/provider/types"
+)
+
+func TestRebuildTranscriptDoesNotCollapseAssistantAcrossToolBoundary(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.width = 120
+	app.height = 32
+	app.applyComponentLayout(true)
+	app.activeMessages = []providertypes.Message{
+		{Role: roleAssistant, Parts: []providertypes.ContentPart{providertypes.NewTextPart("before tool")}},
+		{Role: roleTool, Parts: []providertypes.ContentPart{providertypes.NewTextPart("tool output")}},
+		{Role: roleAssistant, Parts: []providertypes.ContentPart{providertypes.NewTextPart("after tool")}},
+	}
+
+	app.rebuildTranscript()
+	plain := copyCodeANSIPattern.ReplaceAllString(app.transcriptContent, "")
+	if count := strings.Count(plain, messageTagAgent); count != 2 {
+		t.Fatalf("expected two agent tags across tool boundary, got %d in %q", count, plain)
+	}
+}
+
+func TestHandleTranscriptMouseDragMotionWithButtonNone(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.width = 100
+	app.height = 24
+	app.applyComponentLayout(true)
+	app.setTranscriptContent(strings.Repeat("line\n", 40))
+
+	x, y, _, _ := app.transcriptBounds()
+	if !app.handleTranscriptMouse(tea.MouseMsg{
+		X:      x + 2,
+		Y:      y + 1,
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+	}) {
+		t.Fatalf("expected press to begin selection")
+	}
+
+	if !app.handleTranscriptMouse(tea.MouseMsg{
+		X:      x + 6,
+		Y:      y + 2,
+		Button: tea.MouseButtonNone,
+		Action: tea.MouseActionMotion,
+		Type:   tea.MouseMotion,
+	}) {
+		t.Fatalf("expected motion with button none while dragging to be handled")
+	}
+	if app.textSelection.endLine != 2 || app.textSelection.endCol <= app.textSelection.startCol {
+		t.Fatalf("expected selection to update on motion with button none, got line=%d col=%d", app.textSelection.endLine, app.textSelection.endCol)
+	}
+}
+
+func TestHighlightTranscriptContentKeepsStyleWhenZeroWidthOnLine(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.width = 100
+	app.height = 24
+	app.applyComponentLayout(true)
+	app.textSelection.active = true
+	app.textSelection.startLine = 0
+	app.textSelection.startCol = 1
+	app.textSelection.endLine = 1
+	app.textSelection.endCol = 0
+
+	content := "\x1b[31mabc\x1b[0m\n\x1b[32mxyz\x1b[0m"
+	highlighted := app.highlightTranscriptContent(content)
+	lines := strings.Split(highlighted, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected two lines, got %d", len(lines))
+	}
+	if !strings.Contains(lines[1], "\x1b[32m") {
+		t.Fatalf("expected zero-width selected line to keep existing ANSI style, got %q", lines[1])
+	}
+}
+
+func TestCopySelectionToClipboardFailureKeepsSelection(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.width = 100
+	app.height = 24
+	app.applyComponentLayout(true)
+	app.setTranscriptContent("hello world")
+	app.textSelection.active = true
+	app.textSelection.startLine = 0
+	app.textSelection.startCol = 0
+	app.textSelection.endLine = 0
+	app.textSelection.endCol = 5
+
+	originalClipboard := clipboardWriteAll
+	clipboardWriteAll = func(string) error {
+		return fmt.Errorf("clipboard failed")
+	}
+	defer func() { clipboardWriteAll = originalClipboard }()
+
+	app.copySelectionToClipboard()
+	if app.state.StatusText != "Failed to copy selection" {
+		t.Fatalf("expected status on copy error, got %q", app.state.StatusText)
+	}
+	if !app.textSelection.active {
+		t.Fatalf("expected selection to remain active on copy failure")
+	}
+}
+
+func TestHandleTranscriptMouseRightClickWithoutSelectionNoop(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.width = 100
+	app.height = 24
+	app.applyComponentLayout(true)
+	app.setTranscriptContent("line")
+	x, y, _, _ := app.transcriptBounds()
+	if app.handleTranscriptMouse(tea.MouseMsg{
+		X:      x + 1,
+		Y:      y + 1,
+		Button: tea.MouseButtonRight,
+		Action: tea.MouseActionPress,
+	}) {
+		t.Fatalf("expected right click without selection to be ignored")
+	}
+}
+
+func TestSelectionHelpersGuardAndClampBranches(t *testing.T) {
+	app, _ := newTestApp(t)
+	if _, _, _, _, ok := app.textSelectionRange([]string{"x"}); ok {
+		t.Fatalf("expected inactive selection to return false")
+	}
+	if _, _, ok := app.normalizeSelectionPosition(nil, 0, 0); ok {
+		t.Fatalf("expected normalizeSelectionPosition to reject empty lines")
+	}
+
+	lines := []string{"abc", "de"}
+	line, col, ok := app.normalizeSelectionPosition(lines, -3, 99)
+	if !ok || line != 0 || col != 3 {
+		t.Fatalf("expected clamp to first line end, got line=%d col=%d ok=%v", line, col, ok)
+	}
+	line, col, ok = app.normalizeSelectionPosition(lines, 9, -4)
+	if !ok || line != 1 || col != 0 {
+		t.Fatalf("expected clamp to last line start, got line=%d col=%d ok=%v", line, col, ok)
+	}
+
+	app.textSelection.active = true
+	app.textSelection.startLine = 1
+	app.textSelection.startCol = 2
+	app.textSelection.endLine = 0
+	app.textSelection.endCol = 1
+	startLine, startCol, endLine, endCol, rangeOK := app.textSelectionRange(lines)
+	if !rangeOK || startLine != 0 || startCol != 1 || endLine != 1 || endCol != 2 {
+		t.Fatalf("expected reversed range to normalize ordering, got %d:%d -> %d:%d ok=%v", startLine, startCol, endLine, endCol, rangeOK)
+	}
+
+	app.textSelection.endLine = app.textSelection.startLine
+	app.textSelection.endCol = app.textSelection.startCol
+	if _, _, _, _, equalOK := app.textSelectionRange(lines); equalOK {
+		t.Fatalf("expected empty range to be treated as no selection")
+	}
+}
+
+func TestSplitMarkdownSegmentsFallbackWhenFenceHasNoCode(t *testing.T) {
+	segments := splitMarkdownSegments("```go\n```")
+	if len(segments) != 1 {
+		t.Fatalf("expected fallback text segment count 1, got %d", len(segments))
+	}
+	if segments[0].Kind != markdownSegmentText {
+		t.Fatalf("expected fallback text segment, got kind=%v", segments[0].Kind)
+	}
+
+	indented := splitIndentedCodeSegments("    \n")
+	if len(indented) != 1 || indented[0].Kind != markdownSegmentText {
+		t.Fatalf("expected blank indented content to stay text, got %+v", indented)
+	}
+}
+
+func TestSelectionPositionAndDragGuardBranches(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.width = 100
+	app.height = 24
+	app.applyComponentLayout(true)
+	app.setTranscriptContent("alpha\nbeta")
+
+	if _, _, ok := app.selectionPositionAtMouse(tea.MouseMsg{X: -1, Y: -1}); ok {
+		t.Fatalf("expected outside transcript mouse position to be rejected")
+	}
+	if app.beginTextSelection(tea.MouseMsg{X: -1, Y: -1}) {
+		t.Fatalf("expected beginTextSelection outside transcript to fail")
+	}
+	if app.updateTextSelection(tea.MouseMsg{X: 0, Y: 0}) {
+		t.Fatalf("expected updateTextSelection to fail when not dragging")
+	}
+	if app.finishTextSelection() {
+		t.Fatalf("expected finishTextSelection to fail when not dragging")
+	}
+
+	x, y, _, _ := app.transcriptBounds()
+	if !app.beginTextSelection(tea.MouseMsg{X: x + 1, Y: y + 1}) {
+		t.Fatalf("expected beginTextSelection to succeed in transcript")
+	}
+	if app.updateTextSelection(tea.MouseMsg{X: x - 2, Y: y - 1}) {
+		t.Fatalf("expected updateTextSelection to fail when mouse moved outside transcript")
+	}
+
+	app.textSelection.endLine = app.textSelection.startLine
+	app.textSelection.endCol = app.textSelection.startCol
+	if !app.finishTextSelection() {
+		t.Fatalf("expected finishTextSelection to handle empty selection")
+	}
+	if app.textSelection.active {
+		t.Fatalf("expected empty finished selection to be cleared")
+	}
+}
+
+func TestCopySelectionToClipboardNoSelectionNoop(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.setTranscriptContent("hello")
+	app.state.StatusText = "unchanged"
+	app.copySelectionToClipboard()
+	if app.state.StatusText != "unchanged" {
+		t.Fatalf("expected no-selection copy to be noop, got status %q", app.state.StatusText)
+	}
+}

--- a/internal/tui/core/app/styles.go
+++ b/internal/tui/core/app/styles.go
@@ -18,6 +18,8 @@ const (
 	purpleAccent = "#a78bfa"
 	purpleLight  = "#c4b5fd"
 	coralAccent  = "#f09070"
+	selectionBg  = "#355070"
+	selectionFg  = "#f7fafc"
 
 	errorRed      = "#f87171"
 	successGreen  = "#34d399"
@@ -80,7 +82,6 @@ type styles struct {
 }
 
 func newStyles() styles {
-	subtleText := lipgloss.AdaptiveColor{Light: oliveGray, Dark: lightText2}
 	headerAccent := lipgloss.AdaptiveColor{Light: coralAccent, Dark: purpleLight}
 
 	panel := lipgloss.NewStyle().
@@ -191,7 +192,8 @@ func newStyles() styles {
 			BorderForeground(lipgloss.Color(purpleAccent)).
 			Padding(0, 1),
 		footer: lipgloss.NewStyle().
-			Foreground(subtleText),
+			Foreground(lipgloss.Color(lightText)).
+			Bold(true),
 		badgeUser:    badge("", purpleAccent),
 		badgeAgent:   badge("", coralAccent),
 		badgeSuccess: badge("", successGreen),

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -1847,12 +1847,10 @@ func (a *App) handleTranscriptMouse(msg tea.MouseMsg) bool {
 
 	switch {
 	case msg.Button == tea.MouseButtonLeft && msg.Action == tea.MouseActionPress:
-		a.pendingCopyID = 0
 		return a.beginTextSelection(msg)
 	case msg.Button == tea.MouseButtonLeft && (msg.Action == tea.MouseActionMotion || msg.Type == tea.MouseMotion):
 		return a.updateTextSelection(msg)
 	case msg.Action == tea.MouseActionRelease || msg.Type == tea.MouseRelease:
-		a.pendingCopyID = 0
 		return a.finishTextSelection()
 	case msg.Button == tea.MouseButtonRight && msg.Action == tea.MouseActionPress:
 		if a.hasTextSelection() {
@@ -2304,7 +2302,6 @@ func (a *App) normalizeComposerHeight() {
 
 func (a *App) rebuildTranscript() {
 	width := max(24, a.transcript.Width)
-	a.setCodeCopyBlocks(nil)
 	if len(a.activeMessages) == 0 {
 		a.setTranscriptContent(a.styles.empty.Width(width).Render(emptyConversationText))
 		a.transcript.GotoTop()

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -2344,6 +2344,15 @@ func (a *App) rebuildTranscript() {
 
 func (a *App) setTranscriptContent(content string) {
 	normalized := normalizeTranscriptForDisplay(content)
+	contentChanged := a.transcriptContent != normalized
+	if contentChanged && a.textSelection.active && !a.textSelection.dragging {
+		a.textSelection.active = false
+		a.textSelection.dragging = false
+		a.textSelection.startLine = 0
+		a.textSelection.startCol = 0
+		a.textSelection.endLine = 0
+		a.textSelection.endCol = 0
+	}
 	a.transcriptContent = normalized
 	if a.hasTextSelection() {
 		a.transcript.SetContent(a.highlightTranscriptContent(normalized))
@@ -2364,8 +2373,7 @@ func (a *App) highlightTranscriptContent(content string) string {
 		Foreground(lipgloss.Color(selectionFg))
 
 	for i := startLine; i <= endLine && i < len(lines); i++ {
-		plain := copyCodeANSIPattern.ReplaceAllString(lines[i], "")
-		lineWidth := lipgloss.Width(plain)
+		lineWidth := ansi.StringWidth(lines[i])
 		selStart := 0
 		selEnd := lineWidth
 		if i == startLine {
@@ -2379,9 +2387,9 @@ func (a *App) highlightTranscriptContent(content string) string {
 		if selEnd <= selStart {
 			continue
 		}
-		prefix := ansi.Cut(plain, 0, selStart)
-		selected := ansi.Cut(plain, selStart, selEnd)
-		suffix := ansi.Cut(plain, selEnd, lineWidth)
+		prefix := ansi.Cut(lines[i], 0, selStart)
+		selected := ansi.Cut(lines[i], selStart, selEnd)
+		suffix := ansi.Cut(lines[i], selEnd, lineWidth)
 		lines[i] = prefix + highlightStyle.Render(selected) + suffix
 	}
 	return strings.Join(lines, "\n")

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -1848,7 +1848,7 @@ func (a *App) handleTranscriptMouse(msg tea.MouseMsg) bool {
 	switch {
 	case msg.Button == tea.MouseButtonLeft && msg.Action == tea.MouseActionPress:
 		return a.beginTextSelection(msg)
-	case msg.Button == tea.MouseButtonLeft && (msg.Action == tea.MouseActionMotion || msg.Type == tea.MouseMotion):
+	case (msg.Action == tea.MouseActionMotion || msg.Type == tea.MouseMotion) && a.textSelection.dragging:
 		return a.updateTextSelection(msg)
 	case msg.Action == tea.MouseActionRelease || msg.Type == tea.MouseRelease:
 		return a.finishTextSelection()
@@ -2314,6 +2314,8 @@ func (a *App) rebuildTranscript() {
 	previousRole := ""
 	for _, message := range a.activeMessages {
 		if message.Role == roleTool {
+			// tool 消息在 transcript 中不直接展示，但需要打断 assistant 连续分段。
+			previousRole = roleTool
 			continue
 		}
 		continuation := message.Role == roleAssistant && previousRole == roleAssistant
@@ -2375,7 +2377,6 @@ func (a *App) highlightTranscriptContent(content string) string {
 		selStart = max(0, min(selStart, lineWidth))
 		selEnd = max(selStart, min(selEnd, lineWidth))
 		if selEnd <= selStart {
-			lines[i] = plain
 			continue
 		}
 		prefix := ansi.Cut(plain, 0, selStart)

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -16,6 +16,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 
 	"neo-code/internal/config"
 	configstate "neo-code/internal/config/state"
@@ -50,7 +51,7 @@ const providerAddManualModelsJSONTemplate = "[\n  {\n    \"id\": \"model-id\",\n
 const sessionSwitchBusyMessage = "cannot switch sessions while run or compact is active"
 const logViewerEntryLimit = 500
 const logViewerPersistDebounce = 300 * time.Millisecond
-const footerErrorFlashDuration = 4 * time.Second
+const footerErrorFlashDuration = 8 * time.Second
 
 type sessionLogPersistenceRuntime interface {
 	LoadSessionLogEntries(ctx context.Context, sessionID string) ([]agentruntime.SessionLogEntry, error)
@@ -305,6 +306,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, tea.Batch(cmds...)
 		}
 		if key.Matches(typed, a.keys.FocusInput) {
+			a.clearTextSelection()
 			a.focus = panelInput
 			a.applyFocus()
 			return a, tea.Batch(cmds...)
@@ -1838,14 +1840,25 @@ func (a *App) handleTranscriptMouse(msg tea.MouseMsg) bool {
 	if !a.isMouseWithinTranscript(msg) {
 		if msg.Action == tea.MouseActionRelease || msg.Type == tea.MouseRelease {
 			a.transcriptScrollbarDrag = false
+			a.finishTextSelection()
 		}
 		return false
 	}
 
 	switch {
 	case msg.Button == tea.MouseButtonLeft && msg.Action == tea.MouseActionPress:
-		return false
+		a.pendingCopyID = 0
+		return a.beginTextSelection(msg)
+	case msg.Button == tea.MouseButtonLeft && (msg.Action == tea.MouseActionMotion || msg.Type == tea.MouseMotion):
+		return a.updateTextSelection(msg)
 	case msg.Action == tea.MouseActionRelease || msg.Type == tea.MouseRelease:
+		a.pendingCopyID = 0
+		return a.finishTextSelection()
+	case msg.Button == tea.MouseButtonRight && msg.Action == tea.MouseActionPress:
+		if a.hasTextSelection() {
+			a.copySelectionToClipboard()
+			return true
+		}
 		return false
 	default:
 		return false
@@ -2291,6 +2304,7 @@ func (a *App) normalizeComposerHeight() {
 
 func (a *App) rebuildTranscript() {
 	width := max(24, a.transcript.Width)
+	a.setCodeCopyBlocks(nil)
 	if len(a.activeMessages) == 0 {
 		a.setTranscriptContent(a.styles.empty.Width(width).Render(emptyConversationText))
 		a.transcript.GotoTop()
@@ -2303,8 +2317,6 @@ func (a *App) rebuildTranscript() {
 	previousRole := ""
 	for _, message := range a.activeMessages {
 		if message.Role == roleTool {
-			// tool 消息在 transcript 中不直接展示，但必须打断 assistant 连续分段判断。
-			previousRole = roleTool
 			continue
 		}
 		continuation := message.Role == roleAssistant && previousRole == roleAssistant
@@ -2334,7 +2346,47 @@ func (a *App) rebuildTranscript() {
 func (a *App) setTranscriptContent(content string) {
 	normalized := normalizeTranscriptForDisplay(content)
 	a.transcriptContent = normalized
+	if a.hasTextSelection() {
+		a.transcript.SetContent(a.highlightTranscriptContent(normalized))
+		return
+	}
 	a.transcript.SetContent(normalized)
+}
+
+func (a *App) highlightTranscriptContent(content string) string {
+	lines := strings.Split(content, "\n")
+	startLine, startCol, endLine, endCol, ok := a.textSelectionRange(lines)
+	if !ok {
+		return content
+	}
+
+	highlightStyle := lipgloss.NewStyle().
+		Background(lipgloss.Color(selectionBg)).
+		Foreground(lipgloss.Color(selectionFg))
+
+	for i := startLine; i <= endLine && i < len(lines); i++ {
+		plain := copyCodeANSIPattern.ReplaceAllString(lines[i], "")
+		lineWidth := lipgloss.Width(plain)
+		selStart := 0
+		selEnd := lineWidth
+		if i == startLine {
+			selStart = startCol
+		}
+		if i == endLine {
+			selEnd = endCol
+		}
+		selStart = max(0, min(selStart, lineWidth))
+		selEnd = max(selStart, min(selEnd, lineWidth))
+		if selEnd <= selStart {
+			lines[i] = plain
+			continue
+		}
+		prefix := ansi.Cut(plain, 0, selStart)
+		selected := ansi.Cut(plain, selStart, selEnd)
+		suffix := ansi.Cut(plain, selEnd, lineWidth)
+		lines[i] = prefix + highlightStyle.Render(selected) + suffix
+	}
+	return strings.Join(lines, "\n")
 }
 
 func normalizeTranscriptForDisplay(content string) string {

--- a/internal/tui/core/app/update_test.go
+++ b/internal/tui/core/app/update_test.go
@@ -958,71 +958,6 @@ func TestExtractFencedCodeBlocks(t *testing.T) {
 	}
 }
 
-func TestParseCopyCodeButton(t *testing.T) {
-	id, start, end, ok := parseCopyCodeButton("[Copy code #12]")
-	if !ok || id != 12 || start >= end {
-		t.Fatalf("unexpected parse result: id=%d start=%d end=%d ok=%v", id, start, end, ok)
-	}
-	if _, _, _, ok := parseCopyCodeButton("no button"); ok {
-		t.Fatalf("expected no button parse")
-	}
-}
-
-func TestCopyCodeBlockByIDSuccess(t *testing.T) {
-	app, _ := newTestApp(t)
-
-	var got string
-	originalClipboard := clipboardWriteAll
-	clipboardWriteAll = func(text string) error {
-		got = text
-		return nil
-	}
-	defer func() { clipboardWriteAll = originalClipboard }()
-
-	app.setCodeCopyBlocks([]copyCodeButtonBinding{{ID: 1, Code: "code"}})
-	ok := app.copyCodeBlockByID(1)
-	if !ok {
-		t.Fatalf("expected handled copy")
-	}
-	if got != "code" {
-		t.Fatalf("expected clipboard content, got %q", got)
-	}
-	if app.state.StatusText == "" {
-		t.Fatalf("expected status text to be set")
-	}
-}
-
-func TestCopyCodeBlockByIDMissing(t *testing.T) {
-	app, _ := newTestApp(t)
-
-	ok := app.copyCodeBlockByID(99)
-	if !ok {
-		t.Fatalf("expected handled copy")
-	}
-	if app.state.StatusText != statusCodeCopyError {
-		t.Fatalf("expected error status, got %s", app.state.StatusText)
-	}
-}
-
-func TestCopyCodeBlockByIDClipboardError(t *testing.T) {
-	app, _ := newTestApp(t)
-
-	originalClipboard := clipboardWriteAll
-	clipboardWriteAll = func(text string) error {
-		return errors.New("fail")
-	}
-	defer func() { clipboardWriteAll = originalClipboard }()
-
-	app.setCodeCopyBlocks([]copyCodeButtonBinding{{ID: 2, Code: "code"}})
-	ok := app.copyCodeBlockByID(2)
-	if !ok {
-		t.Fatalf("expected handled copy")
-	}
-	if app.state.StatusText != statusCodeCopyError {
-		t.Fatalf("expected error status, got %s", app.state.StatusText)
-	}
-}
-
 func TestIsWorkspaceCommandInput(t *testing.T) {
 	if !isWorkspaceCommandInput("& ls -la") {
 		t.Fatalf("expected workspace command prefix to be detected")
@@ -4068,7 +4003,6 @@ func TestHandleTranscriptMouseWheelAndClickFallback(t *testing.T) {
 		t.Fatalf("expected transcript wheel down to be handled")
 	}
 
-	app.pendingCopyID = 9
 	if !app.handleTranscriptMouse(tea.MouseMsg{
 		X:      x + 1,
 		Y:      y + 1,
@@ -4076,9 +4010,6 @@ func TestHandleTranscriptMouseWheelAndClickFallback(t *testing.T) {
 		Action: tea.MouseActionPress,
 	}) {
 		t.Fatalf("expected left click in transcript to begin selection")
-	}
-	if app.pendingCopyID != 0 {
-		t.Fatalf("expected pendingCopyID reset when click does not hit copy button, got %d", app.pendingCopyID)
 	}
 	if !app.textSelection.dragging {
 		t.Fatalf("expected left click to enter selection dragging mode")

--- a/internal/tui/core/app/update_test.go
+++ b/internal/tui/core/app/update_test.go
@@ -856,6 +856,173 @@ func TestRuntimeEventAgentDoneHandlerAppendsMessage(t *testing.T) {
 	}
 }
 
+func TestParseFenceOpenLine(t *testing.T) {
+	info, ok := parseFenceOpenLine("```go")
+	if !ok || info != "go" {
+		t.Fatalf("expected fence info, got %q ok=%v", info, ok)
+	}
+	info, ok = parseFenceOpenLine(" not a fence")
+	if ok || info != "" {
+		t.Fatalf("expected no fence")
+	}
+}
+
+func TestIsFenceCloseLine(t *testing.T) {
+	if !isFenceCloseLine("```") {
+		t.Fatalf("expected fence close")
+	}
+	if isFenceCloseLine("```go") {
+		t.Fatalf("expected not fence close")
+	}
+}
+
+func TestIsIndentedCodeLine(t *testing.T) {
+	if !isIndentedCodeLine("\tcode") {
+		t.Fatalf("expected tab-indented code")
+	}
+	if !isIndentedCodeLine("    code") {
+		t.Fatalf("expected space-indented code")
+	}
+	if isIndentedCodeLine("code") {
+		t.Fatalf("expected non-indented line")
+	}
+}
+
+func TestTrimCodeIndent(t *testing.T) {
+	if got := trimCodeIndent("\tcode"); got != "code" {
+		t.Fatalf("expected trimmed tab indent, got %q", got)
+	}
+	if got := trimCodeIndent("    code"); got != "code" {
+		t.Fatalf("expected trimmed space indent, got %q", got)
+	}
+	if got := trimCodeIndent("code"); got != "code" {
+		t.Fatalf("expected unchanged line, got %q", got)
+	}
+}
+
+func TestSplitMarkdownSegmentsFenced(t *testing.T) {
+	content := "hello\n```go\nfmt.Println(\"ok\")\n```\nworld"
+	segments := splitMarkdownSegments(content)
+	if len(segments) < 2 {
+		t.Fatalf("expected multiple segments, got %d", len(segments))
+	}
+	if segments[1].Kind != markdownSegmentCode || segments[1].Code == "" {
+		t.Fatalf("expected code segment")
+	}
+}
+
+func TestSplitMarkdownSegmentsIndented(t *testing.T) {
+	content := "hello\n    code line\nworld"
+	segments := splitMarkdownSegments(content)
+	if len(segments) < 2 {
+		t.Fatalf("expected multiple segments, got %d", len(segments))
+	}
+	foundCode := false
+	for _, seg := range segments {
+		if seg.Kind == markdownSegmentCode && seg.Code != "" {
+			foundCode = true
+		}
+	}
+	if !foundCode {
+		t.Fatalf("expected indented code segment")
+	}
+}
+
+func TestSplitIndentedCodeSegmentsDoesNotGuessByKeywords(t *testing.T) {
+	content := "func main() {\nreturn 1\n}\nplain text"
+	segments := splitIndentedCodeSegments(content)
+	if len(segments) != 1 {
+		t.Fatalf("expected plain text segment only, got %d", len(segments))
+	}
+	if segments[0].Kind != markdownSegmentText {
+		t.Fatalf("expected text segment, got kind=%v", segments[0].Kind)
+	}
+}
+
+func TestSplitMarkdownSegmentsMarkdownSyntaxNotMisclassifiedAsCode(t *testing.T) {
+	content := "# Title\n- item one\n- item two\n\n**bold** and `inline`"
+	segments := splitMarkdownSegments(content)
+	if len(segments) != 1 {
+		t.Fatalf("expected markdown to stay as one text segment, got %d", len(segments))
+	}
+	if segments[0].Kind != markdownSegmentText {
+		t.Fatalf("expected text segment, got kind=%v", segments[0].Kind)
+	}
+}
+
+func TestExtractFencedCodeBlocks(t *testing.T) {
+	content := "text\n```go\nfmt.Println(\"ok\")\n```\nend"
+	blocks := extractFencedCodeBlocks(content)
+	if len(blocks) != 1 || blocks[0] == "" {
+		t.Fatalf("expected one code block")
+	}
+}
+
+func TestParseCopyCodeButton(t *testing.T) {
+	id, start, end, ok := parseCopyCodeButton("[Copy code #12]")
+	if !ok || id != 12 || start >= end {
+		t.Fatalf("unexpected parse result: id=%d start=%d end=%d ok=%v", id, start, end, ok)
+	}
+	if _, _, _, ok := parseCopyCodeButton("no button"); ok {
+		t.Fatalf("expected no button parse")
+	}
+}
+
+func TestCopyCodeBlockByIDSuccess(t *testing.T) {
+	app, _ := newTestApp(t)
+
+	var got string
+	originalClipboard := clipboardWriteAll
+	clipboardWriteAll = func(text string) error {
+		got = text
+		return nil
+	}
+	defer func() { clipboardWriteAll = originalClipboard }()
+
+	app.setCodeCopyBlocks([]copyCodeButtonBinding{{ID: 1, Code: "code"}})
+	ok := app.copyCodeBlockByID(1)
+	if !ok {
+		t.Fatalf("expected handled copy")
+	}
+	if got != "code" {
+		t.Fatalf("expected clipboard content, got %q", got)
+	}
+	if app.state.StatusText == "" {
+		t.Fatalf("expected status text to be set")
+	}
+}
+
+func TestCopyCodeBlockByIDMissing(t *testing.T) {
+	app, _ := newTestApp(t)
+
+	ok := app.copyCodeBlockByID(99)
+	if !ok {
+		t.Fatalf("expected handled copy")
+	}
+	if app.state.StatusText != statusCodeCopyError {
+		t.Fatalf("expected error status, got %s", app.state.StatusText)
+	}
+}
+
+func TestCopyCodeBlockByIDClipboardError(t *testing.T) {
+	app, _ := newTestApp(t)
+
+	originalClipboard := clipboardWriteAll
+	clipboardWriteAll = func(text string) error {
+		return errors.New("fail")
+	}
+	defer func() { clipboardWriteAll = originalClipboard }()
+
+	app.setCodeCopyBlocks([]copyCodeButtonBinding{{ID: 2, Code: "code"}})
+	ok := app.copyCodeBlockByID(2)
+	if !ok {
+		t.Fatalf("expected handled copy")
+	}
+	if app.state.StatusText != statusCodeCopyError {
+		t.Fatalf("expected error status, got %s", app.state.StatusText)
+	}
+}
+
 func TestIsWorkspaceCommandInput(t *testing.T) {
 	if !isWorkspaceCommandInput("& ls -la") {
 		t.Fatalf("expected workspace command prefix to be detected")
@@ -3428,24 +3595,6 @@ func TestRebuildTranscriptCollapsesConsecutiveAssistantTags(t *testing.T) {
 	}
 }
 
-func TestRebuildTranscriptDoesNotCollapseAssistantAcrossToolBoundary(t *testing.T) {
-	app, _ := newTestApp(t)
-	app.width = 120
-	app.height = 32
-	app.applyComponentLayout(true)
-	app.activeMessages = []providertypes.Message{
-		{Role: roleAssistant, Parts: []providertypes.ContentPart{providertypes.NewTextPart("before tool")}},
-		{Role: roleTool, Parts: []providertypes.ContentPart{providertypes.NewTextPart("tool output")}},
-		{Role: roleAssistant, Parts: []providertypes.ContentPart{providertypes.NewTextPart("after tool")}},
-	}
-
-	app.rebuildTranscript()
-	plain := copyCodeANSIPattern.ReplaceAllString(app.transcriptContent, "")
-	if count := strings.Count(plain, messageTagAgent); count != 2 {
-		t.Fatalf("expected two agent tags across tool boundary, got %d in %q", count, plain)
-	}
-}
-
 func TestTranscriptManualScrollPersistsWhileBusy(t *testing.T) {
 	app, _ := newTestApp(t)
 	app.width = 120
@@ -3919,13 +4068,112 @@ func TestHandleTranscriptMouseWheelAndClickFallback(t *testing.T) {
 		t.Fatalf("expected transcript wheel down to be handled")
 	}
 
-	if app.handleTranscriptMouse(tea.MouseMsg{
+	app.pendingCopyID = 9
+	if !app.handleTranscriptMouse(tea.MouseMsg{
 		X:      x + 1,
 		Y:      y + 1,
 		Button: tea.MouseButtonLeft,
 		Action: tea.MouseActionPress,
 	}) {
-		t.Fatalf("expected plain left click without copy button hit to return false")
+		t.Fatalf("expected left click in transcript to begin selection")
+	}
+	if app.pendingCopyID != 0 {
+		t.Fatalf("expected pendingCopyID reset when click does not hit copy button, got %d", app.pendingCopyID)
+	}
+	if !app.textSelection.dragging {
+		t.Fatalf("expected left click to enter selection dragging mode")
+	}
+}
+
+func TestMouseSelectionUsesYOffsetAndCopiesExactRange(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.width = 100
+	app.height = 24
+	app.applyComponentLayout(true)
+	lines := make([]string, 0, 40)
+	for i := 0; i < 40; i++ {
+		lines = append(lines, fmt.Sprintf("row-%02d-abcdef", i))
+	}
+	app.setTranscriptContent(strings.Join(lines, "\n"))
+	app.transcript.SetYOffset(10)
+
+	x, y, _, _ := app.transcriptBounds()
+	if !app.handleTranscriptMouse(tea.MouseMsg{
+		X:      x + 5,
+		Y:      y + 2,
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+	}) {
+		t.Fatalf("expected left press to begin selection")
+	}
+	if got := app.textSelection.startLine; got != 12 {
+		t.Fatalf("expected selection start line to include y-offset, got %d", got)
+	}
+
+	if !app.handleTranscriptMouse(tea.MouseMsg{
+		X:      x + 9,
+		Y:      y + 3,
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionMotion,
+		Type:   tea.MouseMotion,
+	}) {
+		t.Fatalf("expected mouse drag motion to update selection")
+	}
+	if !app.handleTranscriptMouse(tea.MouseMsg{
+		X:      x + 9,
+		Y:      y + 3,
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionRelease,
+		Type:   tea.MouseRelease,
+	}) {
+		t.Fatalf("expected release to finish selection")
+	}
+
+	originalClipboard := clipboardWriteAll
+	var copied string
+	clipboardWriteAll = func(text string) error {
+		copied = text
+		return nil
+	}
+	defer func() { clipboardWriteAll = originalClipboard }()
+
+	if !app.handleTranscriptMouse(tea.MouseMsg{
+		X:      x + 9,
+		Y:      y + 3,
+		Button: tea.MouseButtonRight,
+		Action: tea.MouseActionPress,
+	}) {
+		t.Fatalf("expected right click to copy selected text")
+	}
+
+	want := "2-abcdef\nrow-13-ab"
+	if copied != want {
+		t.Fatalf("expected copied selection %q, got %q", want, copied)
+	}
+	if app.textSelection.active {
+		t.Fatalf("expected selection to be cleared after copy")
+	}
+}
+
+func TestHighlightTranscriptContentUsesColumnRange(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.width = 100
+	app.height = 24
+	app.applyComponentLayout(true)
+	app.textSelection.active = true
+	app.textSelection.startLine = 0
+	app.textSelection.startCol = 6
+	app.textSelection.endLine = 0
+	app.textSelection.endCol = 11
+	app.setTranscriptContent("\x1b[31mhello world\x1b[0m")
+
+	highlighted := app.highlightTranscriptContent(app.transcriptContent)
+	plain := copyCodeANSIPattern.ReplaceAllString(highlighted, "")
+	if plain != "hello world" {
+		t.Fatalf("expected highlighted output to preserve visible text, got %q", plain)
+	}
+	if app.transcriptContent != "\x1b[31mhello world\x1b[0m" {
+		t.Fatalf("expected transcriptContent to keep raw normalized content")
 	}
 }
 

--- a/internal/tui/core/app/view.go
+++ b/internal/tui/core/app/view.go
@@ -125,6 +125,13 @@ func (a App) renderWaterfall(width int, height int) string {
 			Italic(true)
 		parts = append(parts, thinkingStyle.Render("Thinking..."))
 	}
+	if a.hasTextSelection() {
+		selStyle := lipgloss.NewStyle().
+			Foreground(lipgloss.Color(selectionFg)).
+			Background(lipgloss.Color(selectionBg)).
+			Padding(0, 1)
+		parts = append(parts, selStyle.Render("已选择内容，右键复制"))
+	}
 	if todo := a.renderTodoPreview(width); todo != "" {
 		parts = append(parts, todo)
 	}

--- a/internal/tui/core/app/view_test.go
+++ b/internal/tui/core/app/view_test.go
@@ -125,6 +125,22 @@ func TestRenderWaterfallThinkingState(t *testing.T) {
 	}
 }
 
+func TestRenderWaterfallSelectionHint(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.state.ActivePicker = pickerNone
+	app.textSelection.active = true
+	app.textSelection.startLine = 0
+	app.textSelection.startCol = 0
+	app.textSelection.endLine = 0
+	app.textSelection.endCol = 1
+	app.setTranscriptContent("hello")
+
+	view := app.renderWaterfall(80, 24)
+	if !strings.Contains(view, "已选择内容，右键复制") {
+		t.Fatalf("expected selection hint in waterfall view")
+	}
+}
+
 func TestApplyComponentLayoutKeepsTranscriptHeightInSyncWithWaterfall(t *testing.T) {
 	app, _ := newTestApp(t)
 	app.width = 100

--- a/internal/tui/core/app/view_test.go
+++ b/internal/tui/core/app/view_test.go
@@ -128,12 +128,12 @@ func TestRenderWaterfallThinkingState(t *testing.T) {
 func TestRenderWaterfallSelectionHint(t *testing.T) {
 	app, _ := newTestApp(t)
 	app.state.ActivePicker = pickerNone
+	app.setTranscriptContent("hello")
 	app.textSelection.active = true
 	app.textSelection.startLine = 0
 	app.textSelection.startCol = 0
 	app.textSelection.endLine = 0
 	app.textSelection.endCol = 1
-	app.setTranscriptContent("hello")
 
 	view := app.renderWaterfall(80, 24)
 	if !strings.Contains(view, "已选择内容，右键复制") {


### PR DESCRIPTION
本次主要修复 TUI 中 Transcript 的鼠标选区体验问题（选区位置偏移、渲染遮挡/污染），并同步优化底部提示栏的可读性；同时在与主线/远端分支同步后，清理了 rebase 过程中带入的陈旧复制逻辑，保证分支可稳定编译和测试通过。

## 主要改动
1.Transcript 文本拖拽选区修复
- 增加完整的选区生命周期：左键按下开始、拖动更新、释放结束。
- 选区坐标改为内容坐标（包含 YOffset），修复“鼠标位置和高亮起点不一致”问题。
- 右键复制改为按“行+列区间”精确复制，不再整行复制。

2.底部提示栏优化
- 错误提示闪现时长由 4s 调整为 8s。

## 测试与验证
已通过以下测试：
- go test ./internal/tui/core/app
- go test ./internal/tui/...
## 影响范围
internal/tui/core/app 相关交互与渲染逻辑（鼠标事件、transcript 渲染、help/footer 样式、测试用例）。
## 风险说明
- 主要风险集中在 TUI 鼠标交互分支；已补充/更新对应测试覆盖，风险可控。
