### PR TITLE
feat: Git Bash 语义权限治理与回滚安全能力

### DIFF
--- a/docs/tools-and-tui-integration.md
+++ b/docs/tools-and-tui-integration.md
@@ -24,6 +24,16 @@
 - `memo_list`
 - `memo_remove`
 
+## Bash Git 语义治理
+- 不新增 `git_*` 工具，Git 能力统一走 `bash`，并在工具层执行前做语义解析。
+- `bash` 调用会被归类为：`read_only`、`local_mutation`、`remote_op`、`destructive`、`unknown`。
+- 推荐策略默认：
+  - `bash_git_read_only` 允许直接执行（例如 `git status`、`git diff`、`git log`、`git show`）。
+  - `bash_git_remote_op`、`bash_git_destructive`、`bash_git_local_mutation`、`bash_git_unknown` 统一走审批。
+  - 非 Git 或无法判定语义的 `bash` 命令走兜底审批。
+- Session 级权限记忆基于 `permission_fingerprint`，同义写法可复用授权；`remote_op` 不复用 `allow_session`，每次都要求审批。
+- `bash` ToolResult 会附带结构化字段：`ok`、`classification`、`normalized_intent`、`permission_fingerprint`、`exit_code`，并通过 `status/ok/meta.*` 回灌模型。
+
 ## Memo 能力集成
 - `memo_remember`、`memo_recall`、`memo_list`、`memo_remove` 作为标准工具暴露给模型，沿 `Runtime -> Tool Manager -> internal/tools/memo` 链路执行。
 - 自动记忆提取不作为单独工具暴露给模型，也不由 TUI 直接触发；它在 runtime 完成最终回复后由 memo 子系统后台调度。

--- a/docs/tools-and-tui-integration.md
+++ b/docs/tools-and-tui-integration.md
@@ -28,8 +28,7 @@
 - 不新增 `git_*` 工具，Git 能力统一走 `bash`，并在工具层执行前做语义解析。
 - `bash` 调用会被归类为：`read_only`、`local_mutation`、`remote_op`、`destructive`、`unknown`。
 - 推荐策略默认：
-  - `bash_git_read_only` 允许直接执行（例如 `git status`、`git diff`、`git log`、`git show`）。
-  - `bash_git_remote_op`、`bash_git_destructive`、`bash_git_local_mutation`、`bash_git_unknown` 统一走审批。
+  - `bash_git_read_only`、`bash_git_remote_op`、`bash_git_destructive`、`bash_git_local_mutation`、`bash_git_unknown` 统一走审批。
   - 非 Git 或无法判定语义的 `bash` 命令走兜底审批。
 - Session 级权限记忆基于 `permission_fingerprint`，同义写法可复用授权；`remote_op` 不复用 `allow_session`，每次都要求审批。
 - `bash` ToolResult 会附带结构化字段：`ok`、`classification`、`normalized_intent`、`permission_fingerprint`、`exit_code`，并通过 `status/ok/meta.*` 回灌模型。

--- a/internal/context/metadata.go
+++ b/internal/context/metadata.go
@@ -15,6 +15,8 @@ type GitState struct {
 	Available bool
 	Branch    string
 	Dirty     bool
+	Ahead     int
+	Behind    int
 }
 
 // SystemState is the summarized runtime metadata exposed to the prompt builder.

--- a/internal/context/prompt_test.go
+++ b/internal/context/prompt_test.go
@@ -158,8 +158,14 @@ func TestDefaultToolUsagePromptIncludesPermissionAndAntiLoopGuidance(t *testing.
 	if !strings.Contains(toolUsage, "stop using tools and give the user the result") {
 		t.Fatalf("expected Tool Usage to tell the agent when to stop, got %q", toolUsage)
 	}
-	if !strings.Contains(toolUsage, "`status`, `truncated`, `tool_call_id`, `meta.*`, and `content`") {
+	if !strings.Contains(toolUsage, "`status`, `ok`, `truncated`, `tool_call_id`, `meta.*`, and `content`") {
 		t.Fatalf("expected Tool Usage to explain structured tool results, got %q", toolUsage)
+	}
+	if !strings.Contains(toolUsage, "inspect (`git status`/`git diff`/`git log`)") {
+		t.Fatalf("expected Tool Usage to describe git inspection order, got %q", toolUsage)
+	}
+	if !strings.Contains(toolUsage, "Prefer rollback primitives in this order: `git restore`") {
+		t.Fatalf("expected Tool Usage to describe git rollback order, got %q", toolUsage)
 	}
 	if !strings.Contains(failureRecovery, "change something concrete") {
 		t.Fatalf("expected Failure Recovery to discourage identical retries, got %q", failureRecovery)

--- a/internal/context/source_system.go
+++ b/internal/context/source_system.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -59,29 +60,65 @@ func parseGitStatusSummary(output string) GitState {
 	state := GitState{Available: true}
 	firstLine := trimmed[0]
 	if strings.HasPrefix(firstLine, "## ") {
-		state.Branch = parseGitBranchLine(strings.TrimPrefix(firstLine, "## "))
+		state.Branch, state.Ahead, state.Behind = parseGitBranchLine(strings.TrimPrefix(firstLine, "## "))
 		trimmed = trimmed[1:]
 	}
 	state.Dirty = len(trimmed) > 0
 	return state
 }
 
-// parseGitBranchLine 从 git branch 摘要行中提取用户可读的分支名称。
-func parseGitBranchLine(line string) string {
+// parseGitBranchLine 从 git branch 摘要行中提取分支名与 ahead/behind 计数。
+func parseGitBranchLine(line string) (string, int, int) {
 	line = strings.TrimSpace(line)
 	switch {
 	case line == "":
-		return ""
+		return "", 0, 0
 	case strings.HasPrefix(line, "No commits yet on "):
-		return strings.TrimSpace(strings.TrimPrefix(line, "No commits yet on "))
+		return strings.TrimSpace(strings.TrimPrefix(line, "No commits yet on ")), 0, 0
 	case strings.HasPrefix(line, "HEAD "):
-		return "detached"
+		return "detached", 0, 0
 	default:
+		ahead, behind := parseGitTrackingCounters(line)
 		if index := strings.Index(line, "..."); index >= 0 {
 			line = line[:index]
 		}
-		return strings.TrimSpace(line)
+		return strings.TrimSpace(line), ahead, behind
 	}
+}
+
+// parseGitTrackingCounters 解析 [ahead N, behind M] 片段中的追踪计数。
+func parseGitTrackingCounters(line string) (int, int) {
+	start := strings.Index(line, "[")
+	end := strings.LastIndex(line, "]")
+	if start < 0 || end <= start {
+		return 0, 0
+	}
+
+	segment := strings.TrimSpace(line[start+1 : end])
+	if segment == "" {
+		return 0, 0
+	}
+
+	parts := strings.Split(segment, ",")
+	ahead := 0
+	behind := 0
+	for _, part := range parts {
+		fields := strings.Fields(strings.TrimSpace(part))
+		if len(fields) != 2 {
+			continue
+		}
+		value, err := strconv.Atoi(fields[1])
+		if err != nil {
+			continue
+		}
+		switch strings.ToLower(fields[0]) {
+		case "ahead":
+			ahead = value
+		case "behind":
+			behind = value
+		}
+	}
+	return ahead, behind
 }
 
 func renderSystemStateSection(state SystemState) promptSection {
@@ -97,7 +134,13 @@ func renderSystemStateSection(state SystemState) promptSection {
 		if state.Git.Dirty {
 			dirty = "dirty"
 		}
-		lines = append(lines, fmt.Sprintf("- git: branch=`%s`, dirty=`%s`", promptValue(state.Git.Branch), dirty))
+		lines = append(lines, fmt.Sprintf(
+			"- git: branch=`%s`, dirty=`%s`, ahead=`%d`, behind=`%d`",
+			promptValue(state.Git.Branch),
+			dirty,
+			state.Git.Ahead,
+			state.Git.Behind,
+		))
 	} else {
 		lines = append(lines, "- git: unavailable")
 	}

--- a/internal/context/source_system_test.go
+++ b/internal/context/source_system_test.go
@@ -36,7 +36,7 @@ func TestCollectSystemStateIncludesGitSummaryFromSingleCall(t *testing.T) {
 		if strings.Join(args, " ") != "status --short --branch" {
 			return "", errors.New("unexpected git command")
 		}
-		return "## feature/context...origin/feature/context\n M internal/context/builder.go\n", nil
+		return "## feature/context...origin/feature/context [ahead 2, behind 1]\n M internal/context/builder.go\n", nil
 	}
 
 	state, err := collectSystemState(context.Background(), testMetadata("/workspace"), runner)
@@ -56,6 +56,9 @@ func TestCollectSystemStateIncludesGitSummaryFromSingleCall(t *testing.T) {
 	if !state.Git.Dirty {
 		t.Fatalf("expected dirty git state")
 	}
+	if state.Git.Ahead != 2 || state.Git.Behind != 1 {
+		t.Fatalf("expected ahead=2 behind=1, got %+v", state.Git)
+	}
 
 	section := renderPromptSection(renderSystemStateSection(state))
 	if !strings.Contains(section, "branch=`feature/context`") {
@@ -63,6 +66,9 @@ func TestCollectSystemStateIncludesGitSummaryFromSingleCall(t *testing.T) {
 	}
 	if !strings.Contains(section, "dirty=`dirty`") {
 		t.Fatalf("expected dirty marker in system section, got %q", section)
+	}
+	if !strings.Contains(section, "ahead=`2`, behind=`1`") {
+		t.Fatalf("expected ahead/behind counters in system section, got %q", section)
 	}
 	if strings.Contains(section, "internal/context/builder.go") {
 		t.Fatalf("did not expect full git status output in system section, got %q", section)
@@ -149,10 +155,23 @@ func TestParseGitStatusSummaryHandlesCleanDetachedAndBranchlessOutput(t *testing
 		t.Fatalf("unexpected dirty state without branch header: %+v", dirtyWithoutBranch)
 	}
 
-	if got := parseGitBranchLine("No commits yet on feature/bootstrap"); got != "feature/bootstrap" {
-		t.Fatalf("expected unborn branch name, got %q", got)
+	branch, ahead, behind := parseGitBranchLine("No commits yet on feature/bootstrap")
+	if branch != "feature/bootstrap" {
+		t.Fatalf("expected unborn branch name, got %q", branch)
 	}
-	if got := parseGitBranchLine("HEAD detached at abc123"); got != "detached" {
-		t.Fatalf("expected detached HEAD marker, got %q", got)
+	if ahead != 0 || behind != 0 {
+		t.Fatalf("expected unborn branch counters to be zero, got ahead=%d behind=%d", ahead, behind)
+	}
+	branch, ahead, behind = parseGitBranchLine("HEAD detached at abc123")
+	if branch != "detached" {
+		t.Fatalf("expected detached HEAD marker, got %q", branch)
+	}
+	if ahead != 0 || behind != 0 {
+		t.Fatalf("expected detached counters to be zero, got ahead=%d behind=%d", ahead, behind)
+	}
+
+	branch, ahead, behind = parseGitBranchLine("main...origin/main [ahead 2, behind 3]")
+	if branch != "main" || ahead != 2 || behind != 3 {
+		t.Fatalf("expected ahead/behind parsed, got branch=%q ahead=%d behind=%d", branch, ahead, behind)
 	}
 }

--- a/internal/promptasset/templates/core/tool_usage.md
+++ b/internal/promptasset/templates/core/tool_usage.md
@@ -4,7 +4,7 @@
 - Prefer structured workspace tools over `bash`: use `filesystem_read_file`, `filesystem_grep`, and `filesystem_glob` for reading and searching.
 - Use `filesystem_glob` to discover file patterns before opening individual files.
 - Use `filesystem_grep` to locate symbols or keywords across the codebase efficiently.
-- Read tool results carefully before acting. Treat `status`, `truncated`, `tool_call_id`, `meta.*`, and `content` as the authoritative outcome of that call.
+- Read tool results carefully before acting. Treat `status`, `ok`, `truncated`, `tool_call_id`, `meta.*`, and `content` as the authoritative outcome of that call.
 
 ## Modification phase
 - Use `filesystem_edit` for precise edits to existing files.
@@ -27,6 +27,8 @@
 ## Bash usage
 - When using `bash`, avoid interactive or blocking commands and pass non-interactive flags when they are available.
 - Stay within the current workspace unless the user clearly asks for something else.
+- Use Git through `bash` with this order: inspect (`git status`/`git diff`/`git log`), then mutate, then verify (`git status`/`git diff`), then summarize.
+- Prefer rollback primitives in this order: `git restore` (file-level), `git revert` (commit-safe), and only use destructive rollback (`git reset --hard`) when explicitly approved by permission flow.
 
 ## Permission and decision flow
 - For risky operations, call the relevant tool first and let the runtime permission layer decide ask/allow/deny.

--- a/internal/runtime/runtime_internal_helpers_test.go
+++ b/internal/runtime/runtime_internal_helpers_test.go
@@ -482,6 +482,7 @@ func TestAppendToolMessageAndSaveMarksExitCodeNonZeroAsError(t *testing.T) {
 		{name: "int", exitCode: 1},
 		{name: "string", exitCode: "2"},
 		{name: "float", exitCode: 3.0},
+		{name: "float fractional", exitCode: 0.5},
 	}
 
 	for _, tt := range tests {

--- a/internal/runtime/runtime_internal_helpers_test.go
+++ b/internal/runtime/runtime_internal_helpers_test.go
@@ -375,6 +375,37 @@ func TestAppendToolMessageAndSaveFallsBackToCallNameForToolMetadata(t *testing.T
 	}
 }
 
+func TestAppendToolMessageAndSaveMarksMetadataOkFalseAsError(t *testing.T) {
+	t.Parallel()
+
+	store := newMemoryStore()
+	session := newRuntimeSession("session-append-tool-ok-false")
+	store.sessions[session.ID] = cloneSession(session)
+
+	service := &Service{sessionStore: store}
+	state := newRunState("run-append-tool-ok-false", session)
+	call := providertypes.ToolCall{ID: "call-1", Name: "bash"}
+	result := tools.ToolResult{
+		Name:    "bash",
+		Content: "",
+		Metadata: map[string]any{
+			"ok": false,
+		},
+	}
+
+	if err := service.appendToolMessageAndSave(context.Background(), &state, call, result); err != nil {
+		t.Fatalf("appendToolMessageAndSave() error = %v", err)
+	}
+
+	msg := state.session.Messages[0]
+	if !msg.IsError {
+		t.Fatalf("expected message to be marked as error when metadata ok=false")
+	}
+	if got := renderPartsForTest(msg.Parts); got != "tool execution failed (ok=false)" {
+		t.Fatalf("expected fallback error content, got %q", got)
+	}
+}
+
 func TestAppendToolMessageAndSaveUnlocksStateBeforePersist(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/runtime_internal_helpers_test.go
+++ b/internal/runtime/runtime_internal_helpers_test.go
@@ -406,6 +406,144 @@ func TestAppendToolMessageAndSaveMarksMetadataOkFalseAsError(t *testing.T) {
 	}
 }
 
+func TestAppendToolMessageAndSaveMarksStringAndNumericOkFalseAsError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		metadata map[string]any
+	}{
+		{
+			name: "string false",
+			metadata: map[string]any{
+				"ok": "false",
+			},
+		},
+		{
+			name: "string zero",
+			metadata: map[string]any{
+				"ok": "0",
+			},
+		},
+		{
+			name: "numeric zero",
+			metadata: map[string]any{
+				"ok": 0,
+			},
+		},
+		{
+			name: "float zero",
+			metadata: map[string]any{
+				"ok": 0.0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := newMemoryStore()
+			session := newRuntimeSession("session-append-tool-ok-false-" + strings.ReplaceAll(tt.name, " ", "-"))
+			store.sessions[session.ID] = cloneSession(session)
+
+			service := &Service{sessionStore: store}
+			state := newRunState("run-append-tool-ok-false-"+strings.ReplaceAll(tt.name, " ", "-"), session)
+			call := providertypes.ToolCall{ID: "call-1", Name: "bash"}
+			result := tools.ToolResult{
+				Name:     "bash",
+				Content:  "",
+				Metadata: tt.metadata,
+			}
+
+			if err := service.appendToolMessageAndSave(context.Background(), &state, call, result); err != nil {
+				t.Fatalf("appendToolMessageAndSave() error = %v", err)
+			}
+
+			msg := state.session.Messages[0]
+			if !msg.IsError {
+				t.Fatalf("expected message to be marked as error when metadata ok=%v", tt.metadata["ok"])
+			}
+			if got := renderPartsForTest(msg.Parts); got != "tool execution failed (ok=false)" {
+				t.Fatalf("expected fallback error content, got %q", got)
+			}
+		})
+	}
+}
+
+func TestAppendToolMessageAndSaveMarksExitCodeNonZeroAsError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		exitCode any
+	}{
+		{name: "int", exitCode: 1},
+		{name: "string", exitCode: "2"},
+		{name: "float", exitCode: 3.0},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := newMemoryStore()
+			session := newRuntimeSession("session-append-tool-exit-code-" + tt.name)
+			store.sessions[session.ID] = cloneSession(session)
+
+			service := &Service{sessionStore: store}
+			state := newRunState("run-append-tool-exit-code-"+tt.name, session)
+			call := providertypes.ToolCall{ID: "call-1", Name: "bash"}
+			result := tools.ToolResult{
+				Name:    "bash",
+				Content: "",
+				Metadata: map[string]any{
+					"exit_code": tt.exitCode,
+				},
+			}
+
+			if err := service.appendToolMessageAndSave(context.Background(), &state, call, result); err != nil {
+				t.Fatalf("appendToolMessageAndSave() error = %v", err)
+			}
+
+			msg := state.session.Messages[0]
+			if !msg.IsError {
+				t.Fatalf("expected message to be marked as error when metadata exit_code=%v", tt.exitCode)
+			}
+		})
+	}
+}
+
+func TestAppendToolMessageAndSaveDoesNotMarkInvalidOkStringAsError(t *testing.T) {
+	t.Parallel()
+
+	store := newMemoryStore()
+	session := newRuntimeSession("session-append-tool-invalid-ok")
+	store.sessions[session.ID] = cloneSession(session)
+
+	service := &Service{sessionStore: store}
+	state := newRunState("run-append-tool-invalid-ok", session)
+	call := providertypes.ToolCall{ID: "call-1", Name: "bash"}
+	result := tools.ToolResult{
+		Name:    "bash",
+		Content: "",
+		Metadata: map[string]any{
+			"ok": "not-bool",
+		},
+	}
+
+	if err := service.appendToolMessageAndSave(context.Background(), &state, call, result); err != nil {
+		t.Fatalf("appendToolMessageAndSave() error = %v", err)
+	}
+
+	msg := state.session.Messages[0]
+	if msg.IsError {
+		t.Fatalf("expected invalid ok string to keep non-error result")
+	}
+}
+
 func TestAppendToolMessageAndSaveUnlocksStateBeforePersist(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/session_mutation.go
+++ b/internal/runtime/session_mutation.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"math"
 	"strconv"
 	"strings"
 
@@ -215,9 +216,9 @@ func parseToolResultExitCode(raw any) (int, bool) {
 	case uint64:
 		return int(value), true
 	case float32:
-		return int(value), true
+		return parseFloatExitCode(float64(value))
 	case float64:
-		return int(value), true
+		return parseFloatExitCode(value)
 	case string:
 		trimmed := strings.TrimSpace(value)
 		if trimmed == "" {
@@ -231,6 +232,24 @@ func parseToolResultExitCode(raw any) (int, bool) {
 	default:
 		return 0, false
 	}
+}
+
+// parseFloatExitCode 将浮点退出码折叠为稳定整数，避免 0<|x|<1 被截断为 0。
+func parseFloatExitCode(value float64) (int, bool) {
+	if value == 0 {
+		return 0, true
+	}
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, false
+	}
+	parsed := int(value)
+	if parsed == 0 {
+		if value > 0 {
+			return 1, true
+		}
+		return -1, true
+	}
+	return parsed, true
 }
 
 // createSessionInputFromSession 将运行态 session 转为建库时使用的会话头输入。

--- a/internal/runtime/session_mutation.go
+++ b/internal/runtime/session_mutation.go
@@ -101,15 +101,19 @@ func normalizeToolMessageForPersistence(call providertypes.ToolCall, result tool
 
 	sanitizedMetadata := tools.SanitizeToolMetadata(toolName, result.Metadata)
 	content := result.Content
-	if !result.IsError && strings.TrimSpace(content) == "" && !hasNonToolNameToolMetadata(sanitizedMetadata) {
+	isError := result.IsError || toolResultMarkedFailed(result.Metadata)
+	if !isError && strings.TrimSpace(content) == "" && !hasNonToolNameToolMetadata(sanitizedMetadata) {
 		content = "ok"
+	}
+	if isError && strings.TrimSpace(content) == "" {
+		content = "tool execution failed (ok=false)"
 	}
 
 	return providertypes.Message{
 		Role:         providertypes.RoleTool,
 		Parts:        []providertypes.ContentPart{providertypes.NewTextPart(content)},
 		ToolCallID:   call.ID,
-		IsError:      result.IsError,
+		IsError:      isError,
 		ToolMetadata: sanitizedMetadata,
 	}
 }
@@ -122,6 +126,19 @@ func hasNonToolNameToolMetadata(metadata map[string]string) bool {
 		}
 	}
 	return false
+}
+
+// toolResultMarkedFailed 根据工具元数据中的 ok 字段判断是否应强制标记为失败。
+func toolResultMarkedFailed(metadata map[string]any) bool {
+	if len(metadata) == 0 {
+		return false
+	}
+	raw, exists := metadata["ok"]
+	if !exists {
+		return false
+	}
+	ok, cast := raw.(bool)
+	return cast && !ok
 }
 
 // createSessionInputFromSession 将运行态 session 转为建库时使用的会话头输入。

--- a/internal/runtime/session_mutation.go
+++ b/internal/runtime/session_mutation.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"strconv"
 	"strings"
 
 	providertypes "neo-code/internal/provider/types"
@@ -133,12 +134,103 @@ func toolResultMarkedFailed(metadata map[string]any) bool {
 	if len(metadata) == 0 {
 		return false
 	}
-	raw, exists := metadata["ok"]
-	if !exists {
-		return false
+	if raw, exists := metadata["ok"]; exists {
+		if ok, resolved := parseToolResultOK(raw); resolved {
+			return !ok
+		}
 	}
-	ok, cast := raw.(bool)
-	return cast && !ok
+	if rawExitCode, exists := metadata["exit_code"]; exists {
+		if exitCode, resolved := parseToolResultExitCode(rawExitCode); resolved {
+			return exitCode != 0
+		}
+	}
+	return false
+}
+
+// parseToolResultOK 解析工具元数据里的 ok 字段，兼容 bool/数字/字符串等常见序列化形态。
+func parseToolResultOK(raw any) (bool, bool) {
+	switch value := raw.(type) {
+	case bool:
+		return value, true
+	case string:
+		trimmed := strings.ToLower(strings.TrimSpace(value))
+		switch trimmed {
+		case "true", "1", "yes", "y":
+			return true, true
+		case "false", "0", "no", "n":
+			return false, true
+		default:
+			return false, false
+		}
+	case int:
+		return value != 0, true
+	case int8:
+		return value != 0, true
+	case int16:
+		return value != 0, true
+	case int32:
+		return value != 0, true
+	case int64:
+		return value != 0, true
+	case uint:
+		return value != 0, true
+	case uint8:
+		return value != 0, true
+	case uint16:
+		return value != 0, true
+	case uint32:
+		return value != 0, true
+	case uint64:
+		return value != 0, true
+	case float32:
+		return value != 0, true
+	case float64:
+		return value != 0, true
+	default:
+		return false, false
+	}
+}
+
+// parseToolResultExitCode 解析工具元数据里的 exit_code 字段，兼容数字和字符串。
+func parseToolResultExitCode(raw any) (int, bool) {
+	switch value := raw.(type) {
+	case int:
+		return value, true
+	case int8:
+		return int(value), true
+	case int16:
+		return int(value), true
+	case int32:
+		return int(value), true
+	case int64:
+		return int(value), true
+	case uint:
+		return int(value), true
+	case uint8:
+		return int(value), true
+	case uint16:
+		return int(value), true
+	case uint32:
+		return int(value), true
+	case uint64:
+		return int(value), true
+	case float32:
+		return int(value), true
+	case float64:
+		return int(value), true
+	case string:
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			return 0, false
+		}
+		parsed, err := strconv.Atoi(trimmed)
+		if err != nil {
+			return 0, false
+		}
+		return parsed, true
+	default:
+		return 0, false
+	}
 }
 
 // createSessionInputFromSession 将运行态 session 转为建库时使用的会话头输入。

--- a/internal/security/policy.go
+++ b/internal/security/policy.go
@@ -144,9 +144,14 @@ func (e *PolicyEngine) Check(ctx context.Context, action Action) (CheckResult, e
 }
 
 // NewRecommendedPolicyEngine 返回推荐安全策略：
-// bash=ask, filesystem write=ask, filesystem read敏感路径=ask/deny, webfetch白名单allow其余ask。
+// git 只读 bash=allow，其余 bash=ask，filesystem write=ask，filesystem read敏感路径=ask/deny，webfetch 白名单 allow 其余 ask。
 func NewRecommendedPolicyEngine() (*PolicyEngine, error) {
 	const (
+		reasonAllowGitReadOnly    = "git read-only command is allowed"
+		reasonAskGitRemote        = "git remote operation requires approval"
+		reasonAskGitDestructive   = "git destructive operation requires approval"
+		reasonAskGitMutation      = "git local mutation requires approval"
+		reasonAskGitUnknown       = "git command semantic unknown, requires approval"
 		reasonAskBash             = "bash command requires approval"
 		reasonAskFilesystemWrite  = "filesystem write requires approval"
 		reasonDenyPrivateKeyRead  = "reading private key material is blocked"
@@ -180,6 +185,46 @@ func NewRecommendedPolicyEngine() (*PolicyEngine, error) {
 			TargetTypes:          []TargetType{TargetTypePath, TargetTypeDirectory},
 			RequireHostMissing:   false,
 			RequireHostMatch:     false,
+		},
+		{
+			ID:               "allow-bash-git-read-only",
+			Priority:         860,
+			Decision:         DecisionAllow,
+			Reason:           reasonAllowGitReadOnly,
+			ActionTypes:      []ActionType{ActionTypeBash},
+			ResourcePatterns: []string{"bash_git_read_only"},
+		},
+		{
+			ID:               "ask-bash-git-remote-op",
+			Priority:         855,
+			Decision:         DecisionAsk,
+			Reason:           reasonAskGitRemote,
+			ActionTypes:      []ActionType{ActionTypeBash},
+			ResourcePatterns: []string{"bash_git_remote_op"},
+		},
+		{
+			ID:               "ask-bash-git-destructive",
+			Priority:         850,
+			Decision:         DecisionAsk,
+			Reason:           reasonAskGitDestructive,
+			ActionTypes:      []ActionType{ActionTypeBash},
+			ResourcePatterns: []string{"bash_git_destructive"},
+		},
+		{
+			ID:               "ask-bash-git-local-mutation",
+			Priority:         845,
+			Decision:         DecisionAsk,
+			Reason:           reasonAskGitMutation,
+			ActionTypes:      []ActionType{ActionTypeBash},
+			ResourcePatterns: []string{"bash_git_local_mutation"},
+		},
+		{
+			ID:               "ask-bash-git-unknown",
+			Priority:         840,
+			Decision:         DecisionAsk,
+			Reason:           reasonAskGitUnknown,
+			ActionTypes:      []ActionType{ActionTypeBash},
+			ResourcePatterns: []string{"bash_git_unknown"},
 		},
 		{
 			ID:               "ask-all-bash",

--- a/internal/security/policy.go
+++ b/internal/security/policy.go
@@ -144,10 +144,10 @@ func (e *PolicyEngine) Check(ctx context.Context, action Action) (CheckResult, e
 }
 
 // NewRecommendedPolicyEngine 返回推荐安全策略：
-// git 只读 bash=allow，其余 bash=ask，filesystem write=ask，filesystem read敏感路径=ask/deny，webfetch 白名单 allow 其余 ask。
+// git 语义命令均需审批，filesystem write=ask，filesystem read敏感路径=ask/deny，webfetch 白名单 allow 其余 ask。
 func NewRecommendedPolicyEngine() (*PolicyEngine, error) {
 	const (
-		reasonAllowGitReadOnly    = "git read-only command is allowed"
+		reasonAskGitReadOnly      = "git read-only operation requires approval"
 		reasonAskGitRemote        = "git remote operation requires approval"
 		reasonAskGitDestructive   = "git destructive operation requires approval"
 		reasonAskGitMutation      = "git local mutation requires approval"
@@ -187,10 +187,10 @@ func NewRecommendedPolicyEngine() (*PolicyEngine, error) {
 			RequireHostMatch:     false,
 		},
 		{
-			ID:               "allow-bash-git-read-only",
+			ID:               "ask-bash-git-read-only",
 			Priority:         860,
-			Decision:         DecisionAllow,
-			Reason:           reasonAllowGitReadOnly,
+			Decision:         DecisionAsk,
+			Reason:           reasonAskGitReadOnly,
 			ActionTypes:      []ActionType{ActionTypeBash},
 			ResourcePatterns: []string{"bash_git_read_only"},
 		},

--- a/internal/security/policy_test.go
+++ b/internal/security/policy_test.go
@@ -22,7 +22,60 @@ func TestPolicyEngineRecommendedRules(t *testing.T) {
 		wantRuleID   string
 	}{
 		{
-			name: "bash always ask",
+			name: "git read-only bash allow",
+			action: Action{
+				Type: ActionTypeBash,
+				Payload: ActionPayload{
+					ToolName:              "bash",
+					Resource:              "bash_git_read_only",
+					Operation:             "git_status",
+					SemanticType:          "git",
+					SemanticClass:         "read_only",
+					NormalizedIntent:      "git status",
+					TargetType:            TargetTypeCommand,
+					Target:                "git status --short --branch",
+					PermissionFingerprint: "bash.git|read_only|status",
+				},
+			},
+			wantDecision: DecisionAllow,
+			wantRuleID:   "allow-bash-git-read-only",
+		},
+		{
+			name: "git remote bash ask",
+			action: Action{
+				Type: ActionTypeBash,
+				Payload: ActionPayload{
+					ToolName:      "bash",
+					Resource:      "bash_git_remote_op",
+					Operation:     "git_push",
+					SemanticType:  "git",
+					SemanticClass: "remote_op",
+					TargetType:    TargetTypeCommand,
+					Target:        "git push origin main",
+				},
+			},
+			wantDecision: DecisionAsk,
+			wantRuleID:   "ask-bash-git-remote-op",
+		},
+		{
+			name: "git destructive bash ask",
+			action: Action{
+				Type: ActionTypeBash,
+				Payload: ActionPayload{
+					ToolName:      "bash",
+					Resource:      "bash_git_destructive",
+					Operation:     "git_reset",
+					SemanticType:  "git",
+					SemanticClass: "destructive",
+					TargetType:    TargetTypeCommand,
+					Target:        "git reset --hard HEAD~1",
+				},
+			},
+			wantDecision: DecisionAsk,
+			wantRuleID:   "ask-bash-git-destructive",
+		},
+		{
+			name: "bash fallback ask",
 			action: Action{
 				Type: ActionTypeBash,
 				Payload: ActionPayload{

--- a/internal/security/policy_test.go
+++ b/internal/security/policy_test.go
@@ -22,7 +22,7 @@ func TestPolicyEngineRecommendedRules(t *testing.T) {
 		wantRuleID   string
 	}{
 		{
-			name: "git read-only bash allow",
+			name: "git read-only bash ask",
 			action: Action{
 				Type: ActionTypeBash,
 				Payload: ActionPayload{
@@ -37,8 +37,8 @@ func TestPolicyEngineRecommendedRules(t *testing.T) {
 					PermissionFingerprint: "bash.git|read_only|status",
 				},
 			},
-			wantDecision: DecisionAllow,
-			wantRuleID:   "allow-bash-git-read-only",
+			wantDecision: DecisionAsk,
+			wantRuleID:   "ask-bash-git-read-only",
 		},
 		{
 			name: "git remote bash ask",

--- a/internal/security/types.go
+++ b/internal/security/types.go
@@ -58,15 +58,23 @@ const (
 
 // ActionPayload is the normalized structured context used by policy and sandbox.
 type ActionPayload struct {
-	ToolName   string
-	Resource   string
-	Operation  string
-	SessionID  string
-	TaskID     string
-	AgentID    string
-	Workdir    string
-	TargetType TargetType
-	Target     string
+	ToolName  string
+	Resource  string
+	Operation string
+	// SemanticType 表示可选的语义域，例如 git。
+	SemanticType string
+	// SemanticClass 表示语义分类，例如 read_only/remote_op/destructive。
+	SemanticClass string
+	// NormalizedIntent 保存归一化后的语义意图文本，用于审计与展示。
+	NormalizedIntent string
+	// PermissionFingerprint 保存用于会话级权限复用的稳定指纹。
+	PermissionFingerprint string
+	SessionID             string
+	TaskID                string
+	AgentID               string
+	Workdir               string
+	TargetType            TargetType
+	Target                string
 	// SandboxTargetType is the target kind used specifically for workspace boundary
 	// checks. It falls back to TargetType when unset so callers can keep permission
 	// display metadata separate from the path actually validated by the sandbox.

--- a/internal/tools/bash/executor.go
+++ b/internal/tools/bash/executor.go
@@ -64,6 +64,7 @@ func (e *defaultSecurityExecutor) Execute(
 		err := errors.New("bash: command is empty")
 		return tools.NewErrorResult("bash", tools.NormalizeErrorReason("bash", err), "", nil), err
 	}
+	intent := tools.AnalyzeBashCommand(command)
 
 	base := strings.TrimSpace(call.Workdir)
 	if base == "" {
@@ -86,26 +87,54 @@ func (e *defaultSecurityExecutor) Execute(
 	binary, args := shellCommand(e.shell, command)
 	output, runErr := e.runner.CombinedOutput(runCtx, binary, args, workdir)
 	content := string(output)
+	metadata := bashResultMetadata(workdir, intent, commandExitCode(runErr), runErr == nil)
 	if runErr != nil {
 		result := tools.NewErrorResult(
 			"bash",
 			tools.NormalizeErrorReason("bash", runErr),
 			content,
-			map[string]any{"workdir": workdir},
+			metadata,
 		)
 		result = tools.ApplyOutputLimit(result, tools.DefaultOutputLimitBytes)
 		return result, runErr
 	}
 
 	result := tools.ToolResult{
-		Name:    "bash",
-		Content: content,
-		Metadata: map[string]any{
-			"workdir": workdir,
-		},
+		Name:     "bash",
+		Content:  content,
+		Metadata: metadata,
 	}
 	result = tools.ApplyOutputLimit(result, tools.DefaultOutputLimitBytes)
 	return result, nil
+}
+
+// bashResultMetadata 构造 bash 工具统一元数据，确保模型可见执行语义与成功标记。
+func bashResultMetadata(workdir string, intent tools.BashSemanticIntent, exitCode int, ok bool) map[string]any {
+	metadata := map[string]any{
+		"workdir":        workdir,
+		"ok":             ok,
+		"exit_code":      exitCode,
+		"classification": strings.TrimSpace(intent.Classification),
+	}
+	if normalized := strings.TrimSpace(intent.NormalizedIntent); normalized != "" {
+		metadata["normalized_intent"] = normalized
+	}
+	if fingerprint := strings.TrimSpace(intent.PermissionFingerprint); fingerprint != "" {
+		metadata["permission_fingerprint"] = fingerprint
+	}
+	return metadata
+}
+
+// commandExitCode 提取命令退出码；无法确定时返回 -1。
+func commandExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr interface{ ExitCode() int }
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
 }
 
 func shellCommand(shell string, command string) (string, []string) {

--- a/internal/tools/bash/executor_test.go
+++ b/internal/tools/bash/executor_test.go
@@ -131,6 +131,17 @@ func TestDefaultSecurityExecutorExecute(t *testing.T) {
 					t.Fatalf("expected workdir metadata containing %q, got %q", tt.expectMeta, got)
 				}
 			}
+			if tt.expectMeta != "" {
+				if _, exists := result.Metadata["ok"]; !exists {
+					t.Fatalf("expected ok metadata to exist, got %#v", result.Metadata)
+				}
+				if _, exists := result.Metadata["exit_code"]; !exists {
+					t.Fatalf("expected exit_code metadata to exist, got %#v", result.Metadata)
+				}
+				if _, exists := result.Metadata["classification"]; !exists {
+					t.Fatalf("expected classification metadata to exist, got %#v", result.Metadata)
+				}
+			}
 		})
 	}
 }

--- a/internal/tools/bash/tool_test.go
+++ b/internal/tools/bash/tool_test.go
@@ -164,6 +164,17 @@ func TestToolExecuteErrorFormattingAndTruncation(t *testing.T) {
 			if tt.expectMetadata && result.Metadata["workdir"] == "" {
 				t.Fatalf("expected workdir metadata, got %#v", result.Metadata)
 			}
+			if tt.expectMetadata {
+				if _, exists := result.Metadata["ok"]; !exists {
+					t.Fatalf("expected ok metadata, got %#v", result.Metadata)
+				}
+				if _, exists := result.Metadata["exit_code"]; !exists {
+					t.Fatalf("expected exit_code metadata, got %#v", result.Metadata)
+				}
+				if _, exists := result.Metadata["classification"]; !exists {
+					t.Fatalf("expected classification metadata, got %#v", result.Metadata)
+				}
+			}
 			if truncated, _ := result.Metadata["truncated"].(bool); truncated != tt.expectTruncate {
 				t.Fatalf("expected truncated=%v, got %#v", tt.expectTruncate, result.Metadata["truncated"])
 			}

--- a/internal/tools/format.go
+++ b/internal/tools/format.go
@@ -15,31 +15,36 @@ const (
 	DefaultOutputLimitBytes = 64 * 1024
 	truncatedSuffix         = "\n...[truncated]"
 
-	maxProjectedToolMetadataKeys     = 6
+	maxProjectedToolMetadataKeys     = 12
 	maxProjectedToolMetadataValueLen = 160
 )
 
 var projectedToolMetadataAllowlist = map[string]struct{}{
-	"bytes":              {},
-	"count":              {},
-	"emitted_bytes":      {},
-	"filtered_count":     {},
-	"http_status":        {},
-	"matched_count":      {},
-	"matched_files":      {},
-	"matched_lines":      {},
-	"mcp_server_id":      {},
-	"mcp_tool_name":      {},
-	"path":               {},
-	"relative_path":      {},
-	"replacement_length": {},
-	"returned_count":     {},
-	"root":               {},
-	"search_length":      {},
-	"status_code":        {},
-	"tool_name":          {},
-	"truncated":          {},
-	"workdir":            {},
+	"bytes":                  {},
+	"count":                  {},
+	"emitted_bytes":          {},
+	"filtered_count":         {},
+	"http_status":            {},
+	"matched_count":          {},
+	"matched_files":          {},
+	"matched_lines":          {},
+	"mcp_server_id":          {},
+	"mcp_tool_name":          {},
+	"ok":                     {},
+	"classification":         {},
+	"normalized_intent":      {},
+	"permission_fingerprint": {},
+	"exit_code":              {},
+	"path":                   {},
+	"relative_path":          {},
+	"replacement_length":     {},
+	"returned_count":         {},
+	"root":                   {},
+	"search_length":          {},
+	"status_code":            {},
+	"tool_name":              {},
+	"truncated":              {},
+	"workdir":                {},
 }
 
 // ApplyOutputLimit truncates tool output content and adds a truncated metadata flag.
@@ -115,6 +120,7 @@ func FormatToolMessageForModel(message providertypes.Message) string {
 		status = "error"
 	}
 	lines = append(lines, "status: "+status)
+	lines = append(lines, fmt.Sprintf("ok: %t", !message.IsError))
 
 	if toolCallID := strings.TrimSpace(message.ToolCallID); toolCallID != "" {
 		lines = append(lines, "tool_call_id: "+toolCallID)

--- a/internal/tools/format_test.go
+++ b/internal/tools/format_test.go
@@ -283,6 +283,7 @@ func TestFormatToolMessageForModel(t *testing.T) {
 		"tool result",
 		"tool: filesystem_edit",
 		"status: ok",
+		"ok: true",
 		"tool_call_id: call-1",
 		"truncated: true",
 		"meta.path: internal/context/prompt.go",

--- a/internal/tools/git_intent.go
+++ b/internal/tools/git_intent.go
@@ -157,9 +157,18 @@ func AnalyzeBashCommand(command string) BashSemanticIntent {
 func containsShellControlOperators(command string) bool {
 	inSingle := false
 	inDouble := false
+	escaped := false
 	runes := []rune(command)
 	for idx := 0; idx < len(runes); idx++ {
 		ch := runes[idx]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if ch == '\\' && !inSingle {
+			escaped = true
+			continue
+		}
 		switch ch {
 		case '\'':
 			if !inDouble {
@@ -170,16 +179,23 @@ func containsShellControlOperators(command string) bool {
 				inDouble = !inDouble
 			}
 		}
-		if inSingle || inDouble {
+		if inSingle {
+			continue
+		}
+		if ch == '`' {
+			return true
+		}
+		if ch == '$' && idx+1 < len(runes) && runes[idx+1] == '(' {
+			return true
+		}
+		if inDouble {
 			continue
 		}
 		switch ch {
 		case ';', '\n', '\r', '|', '>', '<':
 			return true
 		case '&':
-			if idx+1 < len(runes) && runes[idx+1] == '&' {
-				return true
-			}
+			return true
 		}
 	}
 	return false
@@ -390,21 +406,33 @@ func hasGitArgument(args []string, candidate string) bool {
 	return false
 }
 
-// buildNormalizedGitIntent 构造用于展示的稳定 git 语义文本。
+// buildNormalizedGitIntent 构造用于展示的稳定 git 语义文本，避免暴露原始参数。
 func buildNormalizedGitIntent(subcommand string, flags []string, args []string) string {
 	parts := []string{"git", subcommand}
 	if len(flags) > 0 {
-		parts = append(parts, "flags:"+strings.Join(flags, ","))
+		keys := make([]string, 0, len(flags))
+		for _, flag := range flags {
+			key := strings.TrimSpace(flag)
+			if idx := strings.Index(key, "="); idx > 0 {
+				key = key[:idx]
+			}
+			if key == "" {
+				continue
+			}
+			keys = append(keys, strings.ToLower(key))
+		}
+		sort.Strings(keys)
+		parts = append(parts, "flags:"+strings.Join(keys, ","))
 	}
 	if len(args) > 0 {
-		parts = append(parts, "args:"+strings.Join(args, ","))
+		parts = append(parts, "args_count:"+strconv.Itoa(len(args)))
 	}
 	return strings.Join(parts, " ")
 }
 
 // buildGitPermissionFingerprint 构造用于权限记忆的稳定指纹。
 func buildGitPermissionFingerprint(classification string, subcommand string, flags []string, args []string) string {
-	normalizedIntent := buildNormalizedGitIntent(subcommand, flags, args)
+	normalizedIntent := buildGitFingerprintMaterial(subcommand, flags, args)
 	return buildSemanticFingerprint(
 		strings.Join([]string{
 			"bash.git",
@@ -413,6 +441,18 @@ func buildGitPermissionFingerprint(classification string, subcommand string, fla
 		}, "|"),
 		normalizedIntent,
 	)
+}
+
+// buildGitFingerprintMaterial 构造用于哈希指纹的稳定原始语义材料，允许包含参数明文。
+func buildGitFingerprintMaterial(subcommand string, flags []string, args []string) string {
+	parts := []string{"git", subcommand}
+	if len(flags) > 0 {
+		parts = append(parts, "flags:"+strings.Join(flags, ","))
+	}
+	if len(args) > 0 {
+		parts = append(parts, "args:"+strings.Join(args, ","))
+	}
+	return strings.Join(parts, " ")
 }
 
 // normalizeCommandTokens 将普通命令 token 归一为稳定文本。

--- a/internal/tools/git_intent.go
+++ b/internal/tools/git_intent.go
@@ -183,9 +183,9 @@ func parseGitCommandParts(tokens []string) (string, []string, []string, bool) {
 				value = strings.ToLower(strings.TrimSpace(tokens[cursor]))
 			}
 			if value == "" {
-				globalFlags = append(globalFlags, strings.ToLower(key))
+				globalFlags = append(globalFlags, canonicalizeGitFlagKey(key))
 			} else {
-				globalFlags = append(globalFlags, strings.ToLower(key)+"="+value)
+				globalFlags = append(globalFlags, canonicalizeGitFlagKey(key)+"="+value)
 			}
 			continue
 		}
@@ -342,9 +342,9 @@ func normalizeGitArgs(tokens []string) ([]string, []string) {
 				value = strings.ToLower(strings.TrimSpace(tokens[idx]))
 			}
 			if value == "" {
-				flags = append(flags, strings.ToLower(key))
+				flags = append(flags, canonicalizeGitFlagKey(key))
 			} else {
-				flags = append(flags, strings.ToLower(key)+"="+value)
+				flags = append(flags, canonicalizeGitFlagKey(key)+"="+value)
 			}
 			continue
 		}
@@ -363,6 +363,15 @@ func splitGitFlagToken(token string) (string, string) {
 		return key, value
 	}
 	return trimmed, ""
+}
+
+// canonicalizeGitFlagKey 规范化 flag key，保留短参数大小写语义并统一长参数大小写。
+func canonicalizeGitFlagKey(key string) string {
+	trimmed := strings.TrimSpace(key)
+	if strings.HasPrefix(trimmed, "--") {
+		return strings.ToLower(trimmed)
+	}
+	return trimmed
 }
 
 // shouldConsumeGitFlagValue 判断当前 flag 是否应消费后继值。
@@ -439,16 +448,19 @@ func classifyGitIntent(subcommand string, flags []string, args []string) string 
 
 // hasRiskyGitConfigFlag 判断是否包含可能改变 Git 执行语义的配置注入参数。
 func hasRiskyGitConfigFlag(flags []string) bool {
-	return hasGitFlag(flags, "-c", "--config-env")
+	for _, raw := range flags {
+		key := gitFlagKey(raw)
+		if key == "-c" || strings.EqualFold(key, "--config-env") {
+			return true
+		}
+	}
+	return false
 }
 
 // hasGitFlag 判断 flags 中是否命中指定 flag（支持 key=value 形式）。
 func hasGitFlag(flags []string, candidates ...string) bool {
 	for _, raw := range flags {
-		key := raw
-		if idx := strings.Index(key, "="); idx > 0 {
-			key = key[:idx]
-		}
+		key := gitFlagKey(raw)
 		for _, candidate := range candidates {
 			if strings.EqualFold(key, candidate) {
 				return true
@@ -469,16 +481,22 @@ func hasGitArgument(args []string, candidate string) bool {
 	return false
 }
 
+// gitFlagKey 提取并归一化 flag key，去除前后空白与 key=value 的 value 段。
+func gitFlagKey(raw string) string {
+	key := strings.TrimSpace(raw)
+	if idx := strings.Index(key, "="); idx > 0 {
+		key = key[:idx]
+	}
+	return strings.TrimSpace(key)
+}
+
 // buildNormalizedGitIntent 构造用于展示的稳定 git 语义文本，避免暴露原始参数。
 func buildNormalizedGitIntent(subcommand string, flags []string, args []string) string {
 	parts := []string{"git", subcommand}
 	if len(flags) > 0 {
 		keys := make([]string, 0, len(flags))
 		for _, flag := range flags {
-			key := strings.TrimSpace(flag)
-			if idx := strings.Index(key, "="); idx > 0 {
-				key = key[:idx]
-			}
+			key := gitFlagKey(flag)
 			if key == "" {
 				continue
 			}

--- a/internal/tools/git_intent.go
+++ b/internal/tools/git_intent.go
@@ -1,0 +1,446 @@
+package tools
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+const (
+	// BashIntentClassificationUnknown 表示无法确认语义或复合命令。
+	BashIntentClassificationUnknown = "unknown"
+	// BashIntentClassificationReadOnly 表示只读 Git 操作。
+	BashIntentClassificationReadOnly = "read_only"
+	// BashIntentClassificationLocalMutation 表示本地变更型 Git 操作。
+	BashIntentClassificationLocalMutation = "local_mutation"
+	// BashIntentClassificationRemoteOp 表示远端交互型 Git 操作。
+	BashIntentClassificationRemoteOp = "remote_op"
+	// BashIntentClassificationDestructive 表示破坏性 Git 操作。
+	BashIntentClassificationDestructive = "destructive"
+)
+
+// BashSemanticIntent 描述 bash 命令的语义解析结果。
+type BashSemanticIntent struct {
+	IsGit                 bool
+	Classification        string
+	Subcommand            string
+	NormalizedIntent      string
+	PermissionFingerprint string
+	Composite             bool
+	ParseError            bool
+}
+
+var gitSubcommandReadOnly = map[string]struct{}{
+	"status":    {},
+	"diff":      {},
+	"log":       {},
+	"show":      {},
+	"rev-parse": {},
+	"describe":  {},
+	"blame":     {},
+}
+
+var gitSubcommandRemote = map[string]struct{}{
+	"fetch":     {},
+	"pull":      {},
+	"push":      {},
+	"clone":     {},
+	"ls-remote": {},
+}
+
+var gitSubcommandLocalMutation = map[string]struct{}{
+	"add":         {},
+	"commit":      {},
+	"merge":       {},
+	"rebase":      {},
+	"cherry-pick": {},
+	"restore":     {},
+	"revert":      {},
+	"stash":       {},
+	"checkout":    {},
+	"switch":      {},
+	"rm":          {},
+	"mv":          {},
+	"apply":       {},
+	"am":          {},
+	"tag":         {},
+	"branch":      {},
+}
+
+var gitFlagMayCarryValue = map[string]struct{}{
+	"-c":                {},
+	"-C":                {},
+	"-n":                {},
+	"-m":                {},
+	"--max-count":       {},
+	"--pretty":          {},
+	"--format":          {},
+	"--author":          {},
+	"--since":           {},
+	"--until":           {},
+	"--grep":            {},
+	"--work-tree":       {},
+	"--git-dir":         {},
+	"--depth":           {},
+	"--branch":          {},
+	"--strategy":        {},
+	"--strategy-option": {},
+	"--message":         {},
+	"--file":            {},
+}
+
+// AnalyzeBashCommand 解析 bash 命令并输出稳定语义分类与权限指纹。
+func AnalyzeBashCommand(command string) BashSemanticIntent {
+	trimmed := strings.TrimSpace(command)
+	if trimmed == "" {
+		return BashSemanticIntent{
+			Classification:        BashIntentClassificationUnknown,
+			PermissionFingerprint: "bash.command.empty",
+		}
+	}
+
+	if containsShellControlOperators(trimmed) {
+		return BashSemanticIntent{
+			Classification:        BashIntentClassificationUnknown,
+			NormalizedIntent:      "composite-shell-command",
+			PermissionFingerprint: buildSemanticFingerprint("bash.command.composite", trimmed),
+			Composite:             true,
+		}
+	}
+
+	tokens, parseErr := tokenizeShellCommand(trimmed)
+	if parseErr != nil || len(tokens) == 0 {
+		return BashSemanticIntent{
+			Classification:        BashIntentClassificationUnknown,
+			NormalizedIntent:      normalizeCommandText(trimmed),
+			PermissionFingerprint: buildSemanticFingerprint("bash.command.parse_error", trimmed),
+			ParseError:            true,
+		}
+	}
+
+	if !isGitBinary(tokens[0]) {
+		normalized := normalizeCommandTokens(tokens)
+		return BashSemanticIntent{
+			Classification:        BashIntentClassificationUnknown,
+			NormalizedIntent:      normalized,
+			PermissionFingerprint: buildSemanticFingerprint("bash.command", normalized),
+		}
+	}
+	if len(tokens) < 2 {
+		return BashSemanticIntent{
+			IsGit:                 true,
+			Classification:        BashIntentClassificationUnknown,
+			NormalizedIntent:      "git",
+			PermissionFingerprint: buildSemanticFingerprint("bash.git.unknown", trimmed),
+			ParseError:            true,
+		}
+	}
+
+	subcommand := strings.ToLower(strings.TrimSpace(tokens[1]))
+	flags, args := normalizeGitArgs(tokens[2:])
+	classification := classifyGitIntent(subcommand, flags, args)
+	normalizedIntent := buildNormalizedGitIntent(subcommand, flags, args)
+	return BashSemanticIntent{
+		IsGit:                 true,
+		Classification:        classification,
+		Subcommand:            subcommand,
+		NormalizedIntent:      normalizedIntent,
+		PermissionFingerprint: buildGitPermissionFingerprint(classification, subcommand, flags, args),
+	}
+}
+
+// containsShellControlOperators 检测命令中是否存在复合控制符。
+func containsShellControlOperators(command string) bool {
+	inSingle := false
+	inDouble := false
+	runes := []rune(command)
+	for idx := 0; idx < len(runes); idx++ {
+		ch := runes[idx]
+		switch ch {
+		case '\'':
+			if !inDouble {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle {
+				inDouble = !inDouble
+			}
+		}
+		if inSingle || inDouble {
+			continue
+		}
+		switch ch {
+		case ';', '\n', '\r', '|', '>', '<':
+			return true
+		case '&':
+			if idx+1 < len(runes) && runes[idx+1] == '&' {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// tokenizeShellCommand 以轻量规则切分命令行，保留引号内空格。
+func tokenizeShellCommand(command string) ([]string, error) {
+	tokens := make([]string, 0, 8)
+	var current strings.Builder
+	inSingle := false
+	inDouble := false
+	escaped := false
+	for _, ch := range command {
+		if escaped {
+			current.WriteRune(ch)
+			escaped = false
+			continue
+		}
+		if ch == '\\' && inDouble {
+			escaped = true
+			continue
+		}
+		switch ch {
+		case '\'':
+			if !inDouble {
+				inSingle = !inSingle
+				continue
+			}
+		case '"':
+			if !inSingle {
+				inDouble = !inDouble
+				continue
+			}
+		}
+		if unicode.IsSpace(ch) && !inSingle && !inDouble {
+			if current.Len() > 0 {
+				tokens = append(tokens, strings.TrimSpace(current.String()))
+				current.Reset()
+			}
+			continue
+		}
+		current.WriteRune(ch)
+	}
+	if escaped || inSingle || inDouble {
+		return nil, strconv.ErrSyntax
+	}
+	if current.Len() > 0 {
+		tokens = append(tokens, strings.TrimSpace(current.String()))
+	}
+	filtered := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		if strings.TrimSpace(token) == "" {
+			continue
+		}
+		filtered = append(filtered, token)
+	}
+	return filtered, nil
+}
+
+// isGitBinary 判断首 token 是否为 git 可执行文件。
+func isGitBinary(token string) bool {
+	base := strings.ToLower(strings.TrimSpace(filepath.Base(token)))
+	base = strings.TrimSuffix(base, ".exe")
+	return base == "git"
+}
+
+// normalizeGitArgs 归一化 git 参数，输出稳定 flags 与 positional 参数。
+func normalizeGitArgs(tokens []string) ([]string, []string) {
+	flags := make([]string, 0, len(tokens))
+	args := make([]string, 0, len(tokens))
+	for idx := 0; idx < len(tokens); idx++ {
+		token := strings.TrimSpace(tokens[idx])
+		if token == "" {
+			continue
+		}
+		if token == "--" {
+			for j := idx + 1; j < len(tokens); j++ {
+				arg := strings.ToLower(strings.TrimSpace(tokens[j]))
+				if arg != "" {
+					args = append(args, arg)
+				}
+			}
+			break
+		}
+		if strings.HasPrefix(token, "-") {
+			key, value := splitGitFlagToken(token)
+			if value == "" && idx+1 < len(tokens) && shouldConsumeGitFlagValue(key, tokens[idx+1]) {
+				idx++
+				value = strings.ToLower(strings.TrimSpace(tokens[idx]))
+			}
+			if value == "" {
+				flags = append(flags, strings.ToLower(key))
+			} else {
+				flags = append(flags, strings.ToLower(key)+"="+value)
+			}
+			continue
+		}
+		args = append(args, strings.ToLower(token))
+	}
+	sort.Strings(flags)
+	return flags, args
+}
+
+// splitGitFlagToken 将 --flag=value 形式拆分为 key/value。
+func splitGitFlagToken(token string) (string, string) {
+	trimmed := strings.TrimSpace(token)
+	if idx := strings.Index(trimmed, "="); idx > 0 {
+		key := strings.TrimSpace(trimmed[:idx])
+		value := strings.ToLower(strings.TrimSpace(trimmed[idx+1:]))
+		return key, value
+	}
+	return trimmed, ""
+}
+
+// shouldConsumeGitFlagValue 判断当前 flag 是否应消费后继值。
+func shouldConsumeGitFlagValue(flag string, _ string) bool {
+	flag = strings.TrimSpace(strings.ToLower(flag))
+	if _, ok := gitFlagMayCarryValue[flag]; ok {
+		return true
+	}
+	return false
+}
+
+// classifyGitIntent 根据子命令与参数推导权限分类。
+func classifyGitIntent(subcommand string, flags []string, args []string) string {
+	if _, ok := gitSubcommandRemote[subcommand]; ok {
+		return BashIntentClassificationRemoteOp
+	}
+	if _, ok := gitSubcommandReadOnly[subcommand]; ok {
+		return BashIntentClassificationReadOnly
+	}
+
+	switch subcommand {
+	case "branch":
+		if hasGitFlag(flags, "-d", "-D", "--delete") {
+			return BashIntentClassificationDestructive
+		}
+		if len(args) > 0 || hasGitFlag(
+			flags,
+			"-m",
+			"-M",
+			"--move",
+			"-c",
+			"-C",
+			"--copy",
+			"-f",
+			"--force",
+			"--set-upstream-to",
+			"--unset-upstream",
+		) {
+			return BashIntentClassificationLocalMutation
+		}
+		return BashIntentClassificationReadOnly
+	case "tag":
+		if hasGitFlag(flags, "-d", "--delete") {
+			return BashIntentClassificationDestructive
+		}
+		if len(args) == 0 && hasGitFlag(flags, "-l", "--list", "--contains", "--points-at") {
+			return BashIntentClassificationReadOnly
+		}
+		return BashIntentClassificationLocalMutation
+	case "reset":
+		if hasGitFlag(flags, "--hard") {
+			return BashIntentClassificationDestructive
+		}
+		return BashIntentClassificationLocalMutation
+	case "clean":
+		return BashIntentClassificationDestructive
+	case "remote":
+		return BashIntentClassificationRemoteOp
+	case "checkout":
+		if hasGitArgument(args, ".") {
+			return BashIntentClassificationDestructive
+		}
+		return BashIntentClassificationLocalMutation
+	}
+
+	if _, ok := gitSubcommandLocalMutation[subcommand]; ok {
+		return BashIntentClassificationLocalMutation
+	}
+	return BashIntentClassificationUnknown
+}
+
+// hasGitFlag 判断 flags 中是否命中指定 flag（支持 key=value 形式）。
+func hasGitFlag(flags []string, candidates ...string) bool {
+	for _, raw := range flags {
+		key := raw
+		if idx := strings.Index(key, "="); idx > 0 {
+			key = key[:idx]
+		}
+		for _, candidate := range candidates {
+			if strings.EqualFold(key, candidate) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hasGitArgument 判断 positional 参数中是否存在目标值。
+func hasGitArgument(args []string, candidate string) bool {
+	want := strings.ToLower(strings.TrimSpace(candidate))
+	for _, arg := range args {
+		if strings.EqualFold(strings.TrimSpace(arg), want) {
+			return true
+		}
+	}
+	return false
+}
+
+// buildNormalizedGitIntent 构造用于展示的稳定 git 语义文本。
+func buildNormalizedGitIntent(subcommand string, flags []string, args []string) string {
+	parts := []string{"git", subcommand}
+	if len(flags) > 0 {
+		parts = append(parts, "flags:"+strings.Join(flags, ","))
+	}
+	if len(args) > 0 {
+		parts = append(parts, "args:"+strings.Join(args, ","))
+	}
+	return strings.Join(parts, " ")
+}
+
+// buildGitPermissionFingerprint 构造用于权限记忆的稳定指纹。
+func buildGitPermissionFingerprint(classification string, subcommand string, flags []string, args []string) string {
+	normalizedIntent := buildNormalizedGitIntent(subcommand, flags, args)
+	return buildSemanticFingerprint(
+		strings.Join([]string{
+			"bash.git",
+			strings.ToLower(strings.TrimSpace(classification)),
+			strings.ToLower(strings.TrimSpace(subcommand)),
+		}, "|"),
+		normalizedIntent,
+	)
+}
+
+// normalizeCommandTokens 将普通命令 token 归一为稳定文本。
+func normalizeCommandTokens(tokens []string) string {
+	if len(tokens) == 0 {
+		return "empty"
+	}
+	normalized := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		token = strings.ToLower(strings.TrimSpace(token))
+		if token == "" {
+			continue
+		}
+		normalized = append(normalized, token)
+	}
+	if len(normalized) == 0 {
+		return "empty"
+	}
+	return strings.Join(normalized, " ")
+}
+
+// normalizeCommandText 将原始命令文本压缩为空白归一形式。
+func normalizeCommandText(command string) string {
+	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(command)), " "))
+}
+
+// buildSemanticFingerprint 基于归一化语义文本生成哈希指纹，避免泄漏原始参数。
+func buildSemanticFingerprint(prefix string, normalizedText string) string {
+	digest := sha256.Sum256([]byte(strings.TrimSpace(normalizedText)))
+	return strings.TrimSpace(prefix) + "|sha256=" + hex.EncodeToString(digest[:12])
+}

--- a/internal/tools/git_intent.go
+++ b/internal/tools/git_intent.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -307,9 +306,15 @@ func tokenizeShellCommand(command string) ([]string, error) {
 
 // isGitBinary 判断首 token 是否为 git 可执行文件。
 func isGitBinary(token string) bool {
-	base := strings.ToLower(strings.TrimSpace(filepath.Base(token)))
-	base = strings.TrimSuffix(base, ".exe")
-	return base == "git"
+	normalized := strings.ToLower(strings.TrimSpace(token))
+	if normalized == "" {
+		return false
+	}
+	// 仅允许裸命令 git/git.exe，拒绝路径形式（例如 ./git、C:\tmp\git.exe）防止可执行文件伪装绕过审批。
+	if strings.ContainsAny(normalized, `/\:`) {
+		return false
+	}
+	return normalized == "git" || normalized == "git.exe"
 }
 
 // normalizeGitArgs 归一化 git 参数，输出稳定 flags 与 positional 参数。

--- a/internal/tools/git_intent.go
+++ b/internal/tools/git_intent.go
@@ -131,17 +131,13 @@ func AnalyzeBashCommand(command string) BashSemanticIntent {
 		}
 	}
 	if len(tokens) < 2 {
-		return BashSemanticIntent{
-			IsGit:                 true,
-			Classification:        BashIntentClassificationUnknown,
-			NormalizedIntent:      "git",
-			PermissionFingerprint: buildSemanticFingerprint("bash.git.unknown", trimmed),
-			ParseError:            true,
-		}
+		return buildUnknownGitIntent(trimmed)
 	}
 
-	subcommand := strings.ToLower(strings.TrimSpace(tokens[1]))
-	flags, args := normalizeGitArgs(tokens[2:])
+	subcommand, flags, args, ok := parseGitCommandParts(tokens)
+	if !ok {
+		return buildUnknownGitIntent(trimmed)
+	}
 	classification := classifyGitIntent(subcommand, flags, args)
 	normalizedIntent := buildNormalizedGitIntent(subcommand, flags, args)
 	return BashSemanticIntent{
@@ -151,6 +147,60 @@ func AnalyzeBashCommand(command string) BashSemanticIntent {
 		NormalizedIntent:      normalizedIntent,
 		PermissionFingerprint: buildGitPermissionFingerprint(classification, subcommand, flags, args),
 	}
+}
+
+// buildUnknownGitIntent 构建 git 命令解析失败时的统一返回结构。
+func buildUnknownGitIntent(command string) BashSemanticIntent {
+	return BashSemanticIntent{
+		IsGit:                 true,
+		Classification:        BashIntentClassificationUnknown,
+		NormalizedIntent:      "git",
+		PermissionFingerprint: buildSemanticFingerprint("bash.git.unknown", command),
+		ParseError:            true,
+	}
+}
+
+// parseGitCommandParts 解析 git 全局参数与子命令，避免将 -c 等全局参数误判为子命令。
+func parseGitCommandParts(tokens []string) (string, []string, []string, bool) {
+	if len(tokens) < 2 {
+		return "", nil, nil, false
+	}
+
+	globalFlags := make([]string, 0, len(tokens))
+	cursor := 1
+	subcommand := ""
+	for ; cursor < len(tokens); cursor++ {
+		token := strings.TrimSpace(tokens[cursor])
+		if token == "" {
+			continue
+		}
+		if token == "--" {
+			break
+		}
+		if strings.HasPrefix(token, "-") {
+			key, value := splitGitFlagToken(token)
+			if value == "" && cursor+1 < len(tokens) && shouldConsumeGitFlagValue(key, tokens[cursor+1]) {
+				cursor++
+				value = strings.ToLower(strings.TrimSpace(tokens[cursor]))
+			}
+			if value == "" {
+				globalFlags = append(globalFlags, strings.ToLower(key))
+			} else {
+				globalFlags = append(globalFlags, strings.ToLower(key)+"="+value)
+			}
+			continue
+		}
+		subcommand = strings.ToLower(token)
+		cursor++
+		break
+	}
+	if subcommand == "" {
+		return "", nil, nil, false
+	}
+	flags, args := normalizeGitArgs(tokens[cursor:])
+	flags = append(flags, globalFlags...)
+	sort.Strings(flags)
+	return subcommand, flags, args, true
 }
 
 // containsShellControlOperators 检测命令中是否存在复合控制符。
@@ -321,6 +371,9 @@ func shouldConsumeGitFlagValue(flag string, _ string) bool {
 
 // classifyGitIntent 根据子命令与参数推导权限分类。
 func classifyGitIntent(subcommand string, flags []string, args []string) string {
+	if hasRiskyGitConfigFlag(flags) {
+		return BashIntentClassificationUnknown
+	}
 	if _, ok := gitSubcommandRemote[subcommand]; ok {
 		return BashIntentClassificationRemoteOp
 	}
@@ -377,6 +430,11 @@ func classifyGitIntent(subcommand string, flags []string, args []string) string 
 		return BashIntentClassificationLocalMutation
 	}
 	return BashIntentClassificationUnknown
+}
+
+// hasRiskyGitConfigFlag 判断是否包含可能改变 Git 执行语义的配置注入参数。
+func hasRiskyGitConfigFlag(flags []string) bool {
+	return hasGitFlag(flags, "-c", "--config-env")
 }
 
 // hasGitFlag 判断 flags 中是否命中指定 flag（支持 key=value 形式）。

--- a/internal/tools/git_intent.go
+++ b/internal/tools/git_intent.go
@@ -180,12 +180,13 @@ func parseGitCommandParts(tokens []string) (string, []string, []string, bool) {
 			key, value := splitGitFlagToken(token)
 			if value == "" && cursor+1 < len(tokens) && shouldConsumeGitFlagValue(key, tokens[cursor+1]) {
 				cursor++
-				value = strings.ToLower(strings.TrimSpace(tokens[cursor]))
+				value = strings.TrimSpace(tokens[cursor])
 			}
+			normalizedFlag := canonicalizeGitFlagKey(key)
 			if value == "" {
-				globalFlags = append(globalFlags, canonicalizeGitFlagKey(key))
+				globalFlags = append(globalFlags, normalizedFlag)
 			} else {
-				globalFlags = append(globalFlags, canonicalizeGitFlagKey(key)+"="+value)
+				globalFlags = append(globalFlags, normalizedFlag+"="+value)
 			}
 			continue
 		}
@@ -328,7 +329,7 @@ func normalizeGitArgs(tokens []string) ([]string, []string) {
 		}
 		if token == "--" {
 			for j := idx + 1; j < len(tokens); j++ {
-				arg := strings.ToLower(strings.TrimSpace(tokens[j]))
+				arg := strings.TrimSpace(tokens[j])
 				if arg != "" {
 					args = append(args, arg)
 				}
@@ -339,16 +340,17 @@ func normalizeGitArgs(tokens []string) ([]string, []string) {
 			key, value := splitGitFlagToken(token)
 			if value == "" && idx+1 < len(tokens) && shouldConsumeGitFlagValue(key, tokens[idx+1]) {
 				idx++
-				value = strings.ToLower(strings.TrimSpace(tokens[idx]))
+				value = strings.TrimSpace(tokens[idx])
 			}
+			normalizedFlag := canonicalizeGitFlagKey(key)
 			if value == "" {
-				flags = append(flags, canonicalizeGitFlagKey(key))
+				flags = append(flags, normalizedFlag)
 			} else {
-				flags = append(flags, canonicalizeGitFlagKey(key)+"="+value)
+				flags = append(flags, normalizedFlag+"="+value)
 			}
 			continue
 		}
-		args = append(args, strings.ToLower(token))
+		args = append(args, token)
 	}
 	sort.Strings(flags)
 	return flags, args
@@ -359,7 +361,7 @@ func splitGitFlagToken(token string) (string, string) {
 	trimmed := strings.TrimSpace(token)
 	if idx := strings.Index(trimmed, "="); idx > 0 {
 		key := strings.TrimSpace(trimmed[:idx])
-		value := strings.ToLower(strings.TrimSpace(trimmed[idx+1:]))
+		value := strings.TrimSpace(trimmed[idx+1:])
 		return key, value
 	}
 	return trimmed, ""

--- a/internal/tools/git_intent_test.go
+++ b/internal/tools/git_intent_test.go
@@ -82,6 +82,14 @@ func TestAnalyzeBashCommandClassifiesGitCommand(t *testing.T) {
 			wantPrefix: "bash.git|unknown|status",
 		},
 		{
+			name:       "git push with uppercase -C keeps remote classification",
+			command:    "git -C ../repo push origin main",
+			wantIsGit:  true,
+			wantClass:  BashIntentClassificationRemoteOp,
+			wantSubcmd: "push",
+			wantPrefix: "bash.git|remote_op|push",
+		},
+		{
 			name:        "non git command is unknown",
 			command:     "Get-ChildItem -Force",
 			wantIsGit:   false,

--- a/internal/tools/git_intent_test.go
+++ b/internal/tools/git_intent_test.go
@@ -190,3 +190,422 @@ func TestAnalyzeBashCommandFingerprintDoesNotLeakRawArguments(t *testing.T) {
 		t.Fatalf("expected normalized intent to contain redacted args count, got %q", intent.NormalizedIntent)
 	}
 }
+
+func TestAnalyzeBashCommandGitWithoutSubcommandFallsBackToUnknownIntent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		command string
+	}{
+		{
+			name:    "git only",
+			command: "git",
+		},
+		{
+			name:    "git global flags only",
+			command: "git -c core.editor=vim",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			intent := AnalyzeBashCommand(tt.command)
+			if !intent.IsGit {
+				t.Fatalf("expected git intent, got %+v", intent)
+			}
+			if intent.Classification != BashIntentClassificationUnknown {
+				t.Fatalf("expected unknown classification, got %q", intent.Classification)
+			}
+			if !intent.ParseError {
+				t.Fatalf("expected parse error marker for git without subcommand")
+			}
+			if intent.NormalizedIntent != "git" {
+				t.Fatalf("expected normalized intent git, got %q", intent.NormalizedIntent)
+			}
+			if !strings.HasPrefix(intent.PermissionFingerprint, "bash.git.unknown|sha256=") {
+				t.Fatalf("unexpected fingerprint %q", intent.PermissionFingerprint)
+			}
+		})
+	}
+}
+
+func TestClassifyGitIntentSpecialCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		subcommand string
+		flags      []string
+		args       []string
+		want       string
+	}{
+		{
+			name:       "branch delete is destructive",
+			subcommand: "branch",
+			flags:      []string{"-D"},
+			want:       BashIntentClassificationDestructive,
+		},
+		{
+			name:       "tag list remains read only",
+			subcommand: "tag",
+			flags:      []string{"--list"},
+			want:       BashIntentClassificationReadOnly,
+		},
+		{
+			name:       "tag delete is destructive",
+			subcommand: "tag",
+			flags:      []string{"--delete"},
+			want:       BashIntentClassificationDestructive,
+		},
+		{
+			name:       "reset soft is local mutation",
+			subcommand: "reset",
+			flags:      []string{"--soft"},
+			want:       BashIntentClassificationLocalMutation,
+		},
+		{
+			name:       "branch move flag is local mutation",
+			subcommand: "branch",
+			flags:      []string{"--move"},
+			want:       BashIntentClassificationLocalMutation,
+		},
+		{
+			name:       "tag create with args is local mutation",
+			subcommand: "tag",
+			args:       []string{"v1.2.3"},
+			want:       BashIntentClassificationLocalMutation,
+		},
+		{
+			name:       "clean is destructive",
+			subcommand: "clean",
+			flags:      []string{"-fd"},
+			want:       BashIntentClassificationDestructive,
+		},
+		{
+			name:       "remote command is remote op",
+			subcommand: "remote",
+			args:       []string{"-v"},
+			want:       BashIntentClassificationRemoteOp,
+		},
+		{
+			name:       "checkout dot is destructive",
+			subcommand: "checkout",
+			args:       []string{"."},
+			want:       BashIntentClassificationDestructive,
+		},
+		{
+			name:       "local mutation fallback list",
+			subcommand: "stash",
+			want:       BashIntentClassificationLocalMutation,
+		},
+		{
+			name:       "unknown subcommand stays unknown",
+			subcommand: "foobar",
+			want:       BashIntentClassificationUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := classifyGitIntent(tt.subcommand, tt.flags, tt.args)
+			if got != tt.want {
+				t.Fatalf("classifyGitIntent() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeCommandTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		tokens []string
+		want   string
+	}{
+		{
+			name:   "empty tokens return empty marker",
+			tokens: nil,
+			want:   "empty",
+		},
+		{
+			name:   "blank tokens return empty marker",
+			tokens: []string{" ", "\t"},
+			want:   "empty",
+		},
+		{
+			name:   "normalizes case and spacing",
+			tokens: []string{"  Git  ", " STATUS "},
+			want:   "git status",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := normalizeCommandTokens(tt.tokens); got != tt.want {
+				t.Fatalf("normalizeCommandTokens() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseGitCommandParts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		tokens     []string
+		wantOK     bool
+		wantSubcmd string
+		wantFlags  []string
+		wantArgs   []string
+	}{
+		{
+			name:   "too short tokens",
+			tokens: []string{"git"},
+			wantOK: false,
+		},
+		{
+			name:   "global flag only without subcommand",
+			tokens: []string{"git", "--"},
+			wantOK: false,
+		},
+		{
+			name:       "parses global flags and subcommand args",
+			tokens:     []string{"git", "-c", "core.editor=vim", "--config-env=core.fsmonitor=GIT_FSMONITOR", "status", "--short", "README.md"},
+			wantOK:     true,
+			wantSubcmd: "status",
+			wantFlags:  []string{"--config-env=core.fsmonitor=git_fsmonitor", "--short", "-c=core.editor=vim"},
+			wantArgs:   []string{"readme.md"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotSubcmd, gotFlags, gotArgs, gotOK := parseGitCommandParts(tt.tokens)
+			if gotOK != tt.wantOK {
+				t.Fatalf("parseGitCommandParts() ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if gotSubcmd != tt.wantSubcmd {
+				t.Fatalf("parseGitCommandParts() subcommand = %q, want %q", gotSubcmd, tt.wantSubcmd)
+			}
+			if strings.Join(gotFlags, ",") != strings.Join(tt.wantFlags, ",") {
+				t.Fatalf("parseGitCommandParts() flags = %v, want %v", gotFlags, tt.wantFlags)
+			}
+			if strings.Join(gotArgs, ",") != strings.Join(tt.wantArgs, ",") {
+				t.Fatalf("parseGitCommandParts() args = %v, want %v", gotArgs, tt.wantArgs)
+			}
+		})
+	}
+}
+
+func TestContainsShellControlOperators(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		{
+			name:    "plain git command is safe",
+			command: "git status --short",
+			want:    false,
+		},
+		{
+			name:    "quoted ampersand is not treated as operator",
+			command: `git status "&"`,
+			want:    false,
+		},
+		{
+			name:    "operator inside single quote is ignored",
+			command: "git status ';'",
+			want:    false,
+		},
+		{
+			name:    "operator inside double quote is ignored",
+			command: `git status "|"`,
+			want:    false,
+		},
+		{
+			name:    "single ampersand is operator",
+			command: "git status & git log -1",
+			want:    true,
+		},
+		{
+			name:    "command substitution operator",
+			command: "git status $(whoami)",
+			want:    true,
+		},
+		{
+			name:    "backtick substitution operator",
+			command: "git status `whoami`",
+			want:    true,
+		},
+		{
+			name:    "semicolon operator",
+			command: "git status; git log -1",
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := containsShellControlOperators(tt.command); got != tt.want {
+				t.Fatalf("containsShellControlOperators() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTokenizeShellCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tokenizes quoted arguments", func(t *testing.T) {
+		t.Parallel()
+
+		tokens, err := tokenizeShellCommand(`git log --pretty "%h %s"`)
+		if err != nil {
+			t.Fatalf("tokenizeShellCommand() error = %v", err)
+		}
+		got := strings.Join(tokens, "|")
+		want := "git|log|--pretty|%h %s"
+		if got != want {
+			t.Fatalf("tokenizeShellCommand() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("supports escaped characters inside double quote", func(t *testing.T) {
+		t.Parallel()
+
+		tokens, err := tokenizeShellCommand(`git log --grep "hello\\ world"`)
+		if err != nil {
+			t.Fatalf("tokenizeShellCommand() error = %v", err)
+		}
+		got := strings.Join(tokens, "|")
+		want := "git|log|--grep|hello\\ world"
+		if got != want {
+			t.Fatalf("tokenizeShellCommand() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("returns syntax error on unclosed quote", func(t *testing.T) {
+		t.Parallel()
+
+		if _, err := tokenizeShellCommand(`git log "unterminated`); err == nil {
+			t.Fatalf("expected syntax error for unterminated quote")
+		}
+	})
+}
+
+func TestNormalizeGitArgs(t *testing.T) {
+	t.Parallel()
+
+	flags, args := normalizeGitArgs([]string{"--max-count", "5", "--pretty=oneline", "--", "README.md", "docs/Guide.md"})
+	if strings.Join(flags, ",") != "--max-count=5,--pretty=oneline" {
+		t.Fatalf("unexpected flags: %v", flags)
+	}
+	if strings.Join(args, ",") != "readme.md,docs/guide.md" {
+		t.Fatalf("unexpected args: %v", args)
+	}
+}
+
+func TestFlagHelpers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("splitGitFlagToken handles key-value and key-only", func(t *testing.T) {
+		t.Parallel()
+
+		key, value := splitGitFlagToken("--pretty=oneline")
+		if key != "--pretty" || value != "oneline" {
+			t.Fatalf("unexpected split result key=%q value=%q", key, value)
+		}
+		key, value = splitGitFlagToken("--pretty")
+		if key != "--pretty" || value != "" {
+			t.Fatalf("unexpected split result key=%q value=%q", key, value)
+		}
+	})
+
+	t.Run("shouldConsumeGitFlagValue recognizes configured flags", func(t *testing.T) {
+		t.Parallel()
+
+		if !shouldConsumeGitFlagValue("--max-count", "5") {
+			t.Fatalf("expected --max-count to consume value")
+		}
+		if shouldConsumeGitFlagValue("--oneline", "1") {
+			t.Fatalf("expected --oneline not to consume value")
+		}
+	})
+
+	t.Run("hasGitArgument matches and mismatches", func(t *testing.T) {
+		t.Parallel()
+
+		if !hasGitArgument([]string{"HEAD", "."}, ".") {
+			t.Fatalf("expected hasGitArgument to match dot")
+		}
+		if hasGitArgument([]string{"HEAD", "docs"}, "src") {
+			t.Fatalf("expected hasGitArgument mismatch")
+		}
+	})
+}
+
+func TestBuildNormalizedGitIntent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		subcommand string
+		flags      []string
+		args       []string
+		want       string
+	}{
+		{
+			name:       "only subcommand",
+			subcommand: "status",
+			want:       "git status",
+		},
+		{
+			name:       "includes sorted flags and arg count",
+			subcommand: "log",
+			flags:      []string{"--pretty=oneline", "--max-count=5"},
+			args:       []string{"HEAD"},
+			want:       "git log flags:--max-count,--pretty args_count:1",
+		},
+		{
+			name:       "ignores blank flags",
+			subcommand: "show",
+			flags:      []string{" ", "--oneline"},
+			want:       "git show flags:--oneline",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := buildNormalizedGitIntent(tt.subcommand, tt.flags, tt.args); got != tt.want {
+				t.Fatalf("buildNormalizedGitIntent() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tools/git_intent_test.go
+++ b/internal/tools/git_intent_test.go
@@ -82,6 +82,30 @@ func TestAnalyzeBashCommandClassifiesGitCommand(t *testing.T) {
 			wantUnknown: true,
 		},
 		{
+			name:        "single ampersand is composite",
+			command:     "git status & git log -1",
+			wantIsGit:   false,
+			wantClass:   BashIntentClassificationUnknown,
+			wantPrefix:  "bash.command.composite",
+			wantUnknown: true,
+		},
+		{
+			name:        "command substitution is composite",
+			command:     "git status $(whoami)",
+			wantIsGit:   false,
+			wantClass:   BashIntentClassificationUnknown,
+			wantPrefix:  "bash.command.composite",
+			wantUnknown: true,
+		},
+		{
+			name:        "backtick substitution is composite",
+			command:     "git status `whoami`",
+			wantIsGit:   false,
+			wantClass:   BashIntentClassificationUnknown,
+			wantPrefix:  "bash.command.composite",
+			wantUnknown: true,
+		},
+		{
 			name:        "parse error command is unknown",
 			command:     "git status \"unterminated",
 			wantIsGit:   false,
@@ -142,5 +166,11 @@ func TestAnalyzeBashCommandFingerprintDoesNotLeakRawArguments(t *testing.T) {
 	}
 	if strings.Contains(intent.PermissionFingerprint, "token-123456") {
 		t.Fatalf("expected fingerprint to avoid leaking raw arguments, got %q", intent.PermissionFingerprint)
+	}
+	if strings.Contains(intent.NormalizedIntent, "token-123456") {
+		t.Fatalf("expected normalized intent to avoid leaking raw arguments, got %q", intent.NormalizedIntent)
+	}
+	if !strings.Contains(intent.NormalizedIntent, "args_count:1") {
+		t.Fatalf("expected normalized intent to contain redacted args count, got %q", intent.NormalizedIntent)
 	}
 }

--- a/internal/tools/git_intent_test.go
+++ b/internal/tools/git_intent_test.go
@@ -1,0 +1,146 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAnalyzeBashCommandClassifiesGitCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		command     string
+		wantIsGit   bool
+		wantClass   string
+		wantSubcmd  string
+		wantPrefix  string
+		wantUnknown bool
+	}{
+		{
+			name:       "git status is read only",
+			command:    "git status --short --branch",
+			wantIsGit:  true,
+			wantClass:  BashIntentClassificationReadOnly,
+			wantSubcmd: "status",
+			wantPrefix: "bash.git|read_only|status",
+		},
+		{
+			name:       "git push is remote op",
+			command:    "git push origin main",
+			wantIsGit:  true,
+			wantClass:  BashIntentClassificationRemoteOp,
+			wantSubcmd: "push",
+			wantPrefix: "bash.git|remote_op|push",
+		},
+		{
+			name:       "git reset hard is destructive",
+			command:    "git reset --hard HEAD~1",
+			wantIsGit:  true,
+			wantClass:  BashIntentClassificationDestructive,
+			wantSubcmd: "reset",
+			wantPrefix: "bash.git|destructive|reset",
+		},
+		{
+			name:       "git revert is local mutation",
+			command:    "git revert HEAD~1 --no-edit",
+			wantIsGit:  true,
+			wantClass:  BashIntentClassificationLocalMutation,
+			wantSubcmd: "revert",
+			wantPrefix: "bash.git|local_mutation|revert",
+		},
+		{
+			name:       "git branch create is local mutation",
+			command:    "git branch feature/new-branch",
+			wantIsGit:  true,
+			wantClass:  BashIntentClassificationLocalMutation,
+			wantSubcmd: "branch",
+			wantPrefix: "bash.git|local_mutation|branch",
+		},
+		{
+			name:       "git branch list is read only",
+			command:    "git branch --list",
+			wantIsGit:  true,
+			wantClass:  BashIntentClassificationReadOnly,
+			wantSubcmd: "branch",
+			wantPrefix: "bash.git|read_only|branch",
+		},
+		{
+			name:        "non git command is unknown",
+			command:     "Get-ChildItem -Force",
+			wantIsGit:   false,
+			wantClass:   BashIntentClassificationUnknown,
+			wantPrefix:  "bash.command|sha256=",
+			wantUnknown: true,
+		},
+		{
+			name:        "composite command is unknown",
+			command:     "git status && git log -1",
+			wantIsGit:   false,
+			wantClass:   BashIntentClassificationUnknown,
+			wantPrefix:  "bash.command.composite",
+			wantUnknown: true,
+		},
+		{
+			name:        "parse error command is unknown",
+			command:     "git status \"unterminated",
+			wantIsGit:   false,
+			wantClass:   BashIntentClassificationUnknown,
+			wantPrefix:  "bash.command.parse_error",
+			wantUnknown: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := AnalyzeBashCommand(tt.command)
+			if got.IsGit != tt.wantIsGit {
+				t.Fatalf("AnalyzeBashCommand() is_git = %v, want %v", got.IsGit, tt.wantIsGit)
+			}
+			if got.Classification != tt.wantClass {
+				t.Fatalf("AnalyzeBashCommand() classification = %q, want %q", got.Classification, tt.wantClass)
+			}
+			if got.Subcommand != tt.wantSubcmd {
+				t.Fatalf("AnalyzeBashCommand() subcommand = %q, want %q", got.Subcommand, tt.wantSubcmd)
+			}
+			if tt.wantPrefix != "" && !strings.HasPrefix(got.PermissionFingerprint, tt.wantPrefix) {
+				t.Fatalf("AnalyzeBashCommand() fingerprint = %q, want prefix %q", got.PermissionFingerprint, tt.wantPrefix)
+			}
+			if tt.wantUnknown && got.NormalizedIntent == "" {
+				t.Fatalf("expected normalized intent for unknown command")
+			}
+		})
+	}
+}
+
+func TestAnalyzeBashCommandNormalizesGitFlagOrderAndQuotes(t *testing.T) {
+	t.Parallel()
+
+	first := AnalyzeBashCommand(`git log --max-count "5" --oneline`)
+	second := AnalyzeBashCommand(`git log --oneline --max-count='5'`)
+
+	if first.Classification != BashIntentClassificationReadOnly || second.Classification != BashIntentClassificationReadOnly {
+		t.Fatalf("expected read_only classification, got %q and %q", first.Classification, second.Classification)
+	}
+	if first.PermissionFingerprint != second.PermissionFingerprint {
+		t.Fatalf("expected same fingerprint, got %q vs %q", first.PermissionFingerprint, second.PermissionFingerprint)
+	}
+	if first.NormalizedIntent != second.NormalizedIntent {
+		t.Fatalf("expected same normalized intent, got %q vs %q", first.NormalizedIntent, second.NormalizedIntent)
+	}
+}
+
+func TestAnalyzeBashCommandFingerprintDoesNotLeakRawArguments(t *testing.T) {
+	t.Parallel()
+
+	intent := AnalyzeBashCommand(`git clone https://token-123456@example.com/private/repo.git`)
+	if !intent.IsGit || intent.Classification != BashIntentClassificationRemoteOp {
+		t.Fatalf("expected git remote classification, got %+v", intent)
+	}
+	if strings.Contains(intent.PermissionFingerprint, "token-123456") {
+		t.Fatalf("expected fingerprint to avoid leaking raw arguments, got %q", intent.PermissionFingerprint)
+	}
+}

--- a/internal/tools/git_intent_test.go
+++ b/internal/tools/git_intent_test.go
@@ -409,8 +409,8 @@ func TestParseGitCommandParts(t *testing.T) {
 			tokens:     []string{"git", "-c", "core.editor=vim", "--config-env=core.fsmonitor=GIT_FSMONITOR", "status", "--short", "README.md"},
 			wantOK:     true,
 			wantSubcmd: "status",
-			wantFlags:  []string{"--config-env=core.fsmonitor=git_fsmonitor", "--short", "-c=core.editor=vim"},
-			wantArgs:   []string{"readme.md"},
+			wantFlags:  []string{"--config-env=core.fsmonitor=GIT_FSMONITOR", "--short", "-c=core.editor=vim"},
+			wantArgs:   []string{"README.md"},
 		},
 	}
 
@@ -548,8 +548,21 @@ func TestNormalizeGitArgs(t *testing.T) {
 	if strings.Join(flags, ",") != "--max-count=5,--pretty=oneline" {
 		t.Fatalf("unexpected flags: %v", flags)
 	}
-	if strings.Join(args, ",") != "readme.md,docs/guide.md" {
+	if strings.Join(args, ",") != "README.md,docs/Guide.md" {
 		t.Fatalf("unexpected args: %v", args)
+	}
+}
+
+func TestAnalyzeBashCommandFingerprintDistinguishesCaseSensitiveArgs(t *testing.T) {
+	t.Parallel()
+
+	upper := AnalyzeBashCommand("git checkout Feature")
+	lower := AnalyzeBashCommand("git checkout feature")
+	if upper.Classification != BashIntentClassificationLocalMutation || lower.Classification != BashIntentClassificationLocalMutation {
+		t.Fatalf("expected local mutation classification, got %q and %q", upper.Classification, lower.Classification)
+	}
+	if upper.PermissionFingerprint == lower.PermissionFingerprint {
+		t.Fatalf("expected different fingerprint for case-sensitive args, got %q", upper.PermissionFingerprint)
 	}
 }
 

--- a/internal/tools/git_intent_test.go
+++ b/internal/tools/git_intent_test.go
@@ -90,6 +90,22 @@ func TestAnalyzeBashCommandClassifiesGitCommand(t *testing.T) {
 			wantUnknown: true,
 		},
 		{
+			name:        "path based git binary is treated as unknown",
+			command:     ".\\git status --short",
+			wantIsGit:   false,
+			wantClass:   BashIntentClassificationUnknown,
+			wantPrefix:  "bash.command|sha256=",
+			wantUnknown: true,
+		},
+		{
+			name:        "absolute path git binary is treated as unknown",
+			command:     "C:\\tmp\\git.exe status --short",
+			wantIsGit:   false,
+			wantClass:   BashIntentClassificationUnknown,
+			wantPrefix:  "bash.command|sha256=",
+			wantUnknown: true,
+		},
+		{
 			name:        "composite command is unknown",
 			command:     "git status && git log -1",
 			wantIsGit:   false,

--- a/internal/tools/git_intent_test.go
+++ b/internal/tools/git_intent_test.go
@@ -66,6 +66,22 @@ func TestAnalyzeBashCommandClassifiesGitCommand(t *testing.T) {
 			wantPrefix: "bash.git|read_only|branch",
 		},
 		{
+			name:       "git status with -c config injection is unknown",
+			command:    "git -c core.fsmonitor='echo pwn' status",
+			wantIsGit:  true,
+			wantClass:  BashIntentClassificationUnknown,
+			wantSubcmd: "status",
+			wantPrefix: "bash.git|unknown|status",
+		},
+		{
+			name:       "git status with config-env is unknown",
+			command:    "git --config-env=core.fsmonitor=GIT_FSMONITOR status",
+			wantIsGit:  true,
+			wantClass:  BashIntentClassificationUnknown,
+			wantSubcmd: "status",
+			wantPrefix: "bash.git|unknown|status",
+		},
+		{
 			name:        "non git command is unknown",
 			command:     "Get-ChildItem -Force",
 			wantIsGit:   false,

--- a/internal/tools/manager.go
+++ b/internal/tools/manager.go
@@ -331,23 +331,23 @@ func (m *DefaultManager) Execute(ctx context.Context, input ToolCallInput) (Tool
 		return result, permissionErrorFromDecision(decision)
 	}
 
-		plan, err := m.sandbox.Check(ctx, action)
-		if err != nil {
-			if decision, decisionMatched := resolveSandboxOutsideWriteDecision(input, action, err, m.sessionDecisions); decisionMatched {
-				if decision.Decision != security.DecisionAllow {
-					result := blockedToolResult(input, decision)
-					return result, permissionErrorFromDecision(decision)
-				}
-				m.auditCapabilityDecision(action, string(security.DecisionAllow), decision.Reason)
-				return m.executor.Execute(ctx, input)
-			} else {
-				result := NewErrorResult(input.Name, "workspace sandbox rejected action", sandboxErrorDetails(action, err), actionMetadata(action))
-				result.ToolCallID = input.ID
-				return result, err
+	plan, err := m.sandbox.Check(ctx, action)
+	if err != nil {
+		if decision, decisionMatched := resolveSandboxOutsideWriteDecision(input, action, err, m.sessionDecisions); decisionMatched {
+			if decision.Decision != security.DecisionAllow {
+				result := blockedToolResult(input, decision)
+				return result, permissionErrorFromDecision(decision)
 			}
-		} else if plan != nil {
-			input.WorkspacePlan = plan
+			m.auditCapabilityDecision(action, string(security.DecisionAllow), decision.Reason)
+			return m.executor.Execute(ctx, input)
+		} else {
+			result := NewErrorResult(input.Name, "workspace sandbox rejected action", sandboxErrorDetails(action, err), actionMetadata(action))
+			result.ToolCallID = input.ID
+			return result, err
 		}
+	} else if plan != nil {
+		input.WorkspacePlan = plan
+	}
 	m.auditCapabilityDecision(action, string(security.DecisionAllow), "")
 
 	return m.executor.Execute(ctx, input)
@@ -801,6 +801,18 @@ func actionMetadata(action security.Action) map[string]any {
 	if action.Payload.SandboxTarget != "" {
 		metadata["permission_sandbox_target"] = action.Payload.SandboxTarget
 	}
+	if semanticType := strings.TrimSpace(action.Payload.SemanticType); semanticType != "" {
+		metadata["permission_semantic_type"] = semanticType
+	}
+	if semanticClass := strings.TrimSpace(action.Payload.SemanticClass); semanticClass != "" {
+		metadata["permission_semantic_class"] = semanticClass
+	}
+	if normalizedIntent := strings.TrimSpace(action.Payload.NormalizedIntent); normalizedIntent != "" {
+		metadata["permission_normalized_intent"] = normalizedIntent
+	}
+	if fingerprint := strings.TrimSpace(action.Payload.PermissionFingerprint); fingerprint != "" {
+		metadata["permission_fingerprint"] = fingerprint
+	}
 	if strings.TrimSpace(action.Payload.TaskID) != "" {
 		metadata["permission_task_id"] = strings.TrimSpace(action.Payload.TaskID)
 	}
@@ -821,6 +833,18 @@ func permissionDetails(decision security.CheckResult) string {
 	}
 	if decision.Action.Payload.TargetType != "" && strings.TrimSpace(decision.Action.Payload.Target) != "" {
 		parts = append(parts, fmt.Sprintf("%s: %s", decision.Action.Payload.TargetType, decision.Action.Payload.Target))
+	}
+	if semanticType := strings.TrimSpace(decision.Action.Payload.SemanticType); semanticType != "" {
+		parts = append(parts, "semantic_type: "+semanticType)
+	}
+	if semanticClass := strings.TrimSpace(decision.Action.Payload.SemanticClass); semanticClass != "" {
+		parts = append(parts, "semantic_class: "+semanticClass)
+	}
+	if normalizedIntent := strings.TrimSpace(decision.Action.Payload.NormalizedIntent); normalizedIntent != "" {
+		parts = append(parts, "normalized_intent: "+normalizedIntent)
+	}
+	if fingerprint := strings.TrimSpace(decision.Action.Payload.PermissionFingerprint); fingerprint != "" {
+		parts = append(parts, "permission_fingerprint: "+fingerprint)
 	}
 	if strings.TrimSpace(decision.Reason) != "" {
 		parts = append(parts, "policy: "+strings.TrimSpace(decision.Reason))

--- a/internal/tools/manager_test.go
+++ b/internal/tools/manager_test.go
@@ -621,7 +621,7 @@ func TestSandboxOutsideWriteUtilityHelpers(t *testing.T) {
 				SandboxTarget: "/tmp/final.txt",
 			},
 		}
-		if got := resolveActionSandboxTargetPath(actionWithSandboxTarget); filepath.Clean(got) != filepath.Clean("/tmp/final.txt") {
+		if got := resolveActionSandboxTargetPath(actionWithSandboxTarget); !strings.HasSuffix(filepath.ToSlash(got), "/tmp/final.txt") {
 			t.Fatalf("expected sandbox target to win, got %q", got)
 		}
 	})
@@ -672,7 +672,7 @@ func TestSandboxOutsideWriteUtilityHelpers(t *testing.T) {
 		if !isSystemProtectedPathForOS(`C:\Users\tester\AppData\Roaming\config`, "windows") {
 			t.Fatalf("expected appdata path to be protected")
 		}
-		if !isSystemProtectedPathForOS(`C:`, "windows") {
+		if !isSystemProtectedPathForOS(`C:\`, "windows") {
 			t.Fatalf("expected windows drive root to be protected")
 		}
 		if isSystemProtectedPathForOS(`C:\Users\tester\Desktop\note.txt`, "windows") {
@@ -1470,6 +1470,9 @@ func TestBuildPermissionAction(t *testing.T) {
 		wantResource string
 		wantTarget   string
 		wantSandbox  string
+		wantSemantic string
+		wantClass    string
+		wantFPPrefix string
 		wantErr      string
 	}{
 		{
@@ -1482,6 +1485,8 @@ func TestBuildPermissionAction(t *testing.T) {
 			wantResource: "bash",
 			wantTarget:   "echo hi",
 			wantSandbox:  "scripts",
+			wantClass:    BashIntentClassificationUnknown,
+			wantFPPrefix: "bash.command|sha256=",
 		},
 		{
 			name: "bash defaults sandbox workdir to dot",
@@ -1493,6 +1498,36 @@ func TestBuildPermissionAction(t *testing.T) {
 			wantResource: "bash",
 			wantTarget:   "echo hi",
 			wantSandbox:  ".",
+			wantClass:    BashIntentClassificationUnknown,
+			wantFPPrefix: "bash.command|sha256=",
+		},
+		{
+			name: "git read-only bash maps semantic resource",
+			input: ToolCallInput{
+				Name:      "bash",
+				Arguments: []byte(`{"command":"git status --short --branch"}`),
+			},
+			wantType:     security.ActionTypeBash,
+			wantResource: "bash_git_read_only",
+			wantTarget:   "git status --short --branch",
+			wantSandbox:  ".",
+			wantSemantic: "git",
+			wantClass:    BashIntentClassificationReadOnly,
+			wantFPPrefix: "bash.git|read_only|status",
+		},
+		{
+			name: "git remote bash maps semantic resource",
+			input: ToolCallInput{
+				Name:      "bash",
+				Arguments: []byte(`{"command":"git push origin main"}`),
+			},
+			wantType:     security.ActionTypeBash,
+			wantResource: "bash_git_remote_op",
+			wantTarget:   "git push origin main",
+			wantSandbox:  ".",
+			wantSemantic: "git",
+			wantClass:    BashIntentClassificationRemoteOp,
+			wantFPPrefix: "bash.git|remote_op|push",
 		},
 		{
 			name: "read file maps to read action",
@@ -1637,6 +1672,15 @@ func TestBuildPermissionAction(t *testing.T) {
 			}
 			if action.Payload.SandboxTarget != tt.wantSandbox {
 				t.Fatalf("expected sandbox target %q, got %q", tt.wantSandbox, action.Payload.SandboxTarget)
+			}
+			if action.Payload.SemanticType != tt.wantSemantic {
+				t.Fatalf("expected semantic type %q, got %q", tt.wantSemantic, action.Payload.SemanticType)
+			}
+			if action.Payload.SemanticClass != tt.wantClass {
+				t.Fatalf("expected semantic class %q, got %q", tt.wantClass, action.Payload.SemanticClass)
+			}
+			if tt.wantFPPrefix != "" && !strings.HasPrefix(action.Payload.PermissionFingerprint, tt.wantFPPrefix) {
+				t.Fatalf("expected permission fingerprint prefix %q, got %q", tt.wantFPPrefix, action.Payload.PermissionFingerprint)
 			}
 		})
 	}

--- a/internal/tools/manager_test.go
+++ b/internal/tools/manager_test.go
@@ -1468,6 +1468,7 @@ func TestBuildPermissionAction(t *testing.T) {
 		input        ToolCallInput
 		wantType     security.ActionType
 		wantResource string
+		wantOp       string
 		wantTarget   string
 		wantSandbox  string
 		wantSemantic string
@@ -1483,6 +1484,7 @@ func TestBuildPermissionAction(t *testing.T) {
 			},
 			wantType:     security.ActionTypeBash,
 			wantResource: "bash",
+			wantOp:       "command",
 			wantTarget:   "echo hi",
 			wantSandbox:  "scripts",
 			wantClass:    BashIntentClassificationUnknown,
@@ -1496,6 +1498,7 @@ func TestBuildPermissionAction(t *testing.T) {
 			},
 			wantType:     security.ActionTypeBash,
 			wantResource: "bash",
+			wantOp:       "command",
 			wantTarget:   "echo hi",
 			wantSandbox:  ".",
 			wantClass:    BashIntentClassificationUnknown,
@@ -1509,6 +1512,7 @@ func TestBuildPermissionAction(t *testing.T) {
 			},
 			wantType:     security.ActionTypeBash,
 			wantResource: "bash_git_read_only",
+			wantOp:       "git_status",
 			wantTarget:   "git status --short --branch",
 			wantSandbox:  ".",
 			wantSemantic: "git",
@@ -1523,11 +1527,42 @@ func TestBuildPermissionAction(t *testing.T) {
 			},
 			wantType:     security.ActionTypeBash,
 			wantResource: "bash_git_remote_op",
+			wantOp:       "git_push",
 			wantTarget:   "git push origin main",
 			wantSandbox:  ".",
 			wantSemantic: "git",
 			wantClass:    BashIntentClassificationRemoteOp,
 			wantFPPrefix: "bash.git|remote_op|push",
+		},
+		{
+			name: "git checkout dot maps destructive semantic resource",
+			input: ToolCallInput{
+				Name:      "bash",
+				Arguments: []byte(`{"command":"git checkout ."}`),
+			},
+			wantType:     security.ActionTypeBash,
+			wantResource: "bash_git_destructive",
+			wantOp:       "git_checkout",
+			wantTarget:   "git checkout .",
+			wantSandbox:  ".",
+			wantSemantic: "git",
+			wantClass:    BashIntentClassificationDestructive,
+			wantFPPrefix: "bash.git|destructive|checkout",
+		},
+		{
+			name: "git only maps unknown semantic operation",
+			input: ToolCallInput{
+				Name:      "bash",
+				Arguments: []byte(`{"command":"git -c core.editor=vim"}`),
+			},
+			wantType:     security.ActionTypeBash,
+			wantResource: "bash_git_unknown",
+			wantOp:       "git_unknown",
+			wantTarget:   "git -c core.editor=vim",
+			wantSandbox:  ".",
+			wantSemantic: "git",
+			wantClass:    BashIntentClassificationUnknown,
+			wantFPPrefix: "bash.git.unknown|sha256=",
 		},
 		{
 			name: "read file maps to read action",
@@ -1537,6 +1572,7 @@ func TestBuildPermissionAction(t *testing.T) {
 			},
 			wantType:     security.ActionTypeRead,
 			wantResource: "filesystem_read_file",
+			wantOp:       "read_file",
 			wantTarget:   "main.go",
 			wantSandbox:  "main.go",
 		},
@@ -1548,6 +1584,7 @@ func TestBuildPermissionAction(t *testing.T) {
 			},
 			wantType:     security.ActionTypeRead,
 			wantResource: "filesystem_grep",
+			wantOp:       "grep",
 			wantTarget:   "internal",
 			wantSandbox:  "internal",
 		},
@@ -1559,6 +1596,7 @@ func TestBuildPermissionAction(t *testing.T) {
 			},
 			wantType:     security.ActionTypeRead,
 			wantResource: "filesystem_glob",
+			wantOp:       "glob",
 			wantTarget:   "cmd",
 			wantSandbox:  "cmd",
 		},
@@ -1570,6 +1608,7 @@ func TestBuildPermissionAction(t *testing.T) {
 			},
 			wantType:     security.ActionTypeWrite,
 			wantResource: "filesystem_write_file",
+			wantOp:       "write_file",
 			wantTarget:   "main.go",
 			wantSandbox:  "main.go",
 		},
@@ -1581,6 +1620,7 @@ func TestBuildPermissionAction(t *testing.T) {
 			},
 			wantType:     security.ActionTypeRead,
 			wantResource: "webfetch",
+			wantOp:       "fetch",
 			wantTarget:   "https://example.com",
 		},
 		{
@@ -1591,6 +1631,7 @@ func TestBuildPermissionAction(t *testing.T) {
 			},
 			wantType:     security.ActionTypeWrite,
 			wantResource: "filesystem_edit",
+			wantOp:       "edit",
 			wantTarget:   "main.go",
 			wantSandbox:  "main.go",
 		},
@@ -1602,6 +1643,7 @@ func TestBuildPermissionAction(t *testing.T) {
 			},
 			wantType:     security.ActionTypeWrite,
 			wantResource: "todo_write",
+			wantOp:       "todo_write",
 			wantTarget:   "todo-1",
 		},
 		{
@@ -1612,6 +1654,7 @@ func TestBuildPermissionAction(t *testing.T) {
 			},
 			wantType:     security.ActionTypeWrite,
 			wantResource: ToolNameSpawnSubAgent,
+			wantOp:       ToolNameSpawnSubAgent,
 			wantTarget:   "task-a,task-b",
 		},
 		{
@@ -1630,6 +1673,7 @@ func TestBuildPermissionAction(t *testing.T) {
 			},
 			wantType:     security.ActionTypeMCP,
 			wantResource: "mcp.github.create_issue",
+			wantOp:       "invoke",
 			wantTarget:   "mcp.github.create_issue",
 		},
 		{
@@ -1666,6 +1710,9 @@ func TestBuildPermissionAction(t *testing.T) {
 			}
 			if action.Payload.Resource != tt.wantResource {
 				t.Fatalf("expected resource %q, got %q", tt.wantResource, action.Payload.Resource)
+			}
+			if tt.wantOp != "" && action.Payload.Operation != tt.wantOp {
+				t.Fatalf("expected operation %q, got %q", tt.wantOp, action.Payload.Operation)
 			}
 			if action.Payload.Target != tt.wantTarget {
 				t.Fatalf("expected target %q, got %q", tt.wantTarget, action.Payload.Target)

--- a/internal/tools/permission_mapper.go
+++ b/internal/tools/permission_mapper.go
@@ -29,10 +29,34 @@ func buildPermissionAction(input ToolCallInput) (security.Action, error) {
 
 	switch strings.ToLower(toolName) {
 	case ToolNameBash:
+		intent := AnalyzeBashCommand(extractStringArgument(input.Arguments, "command"))
 		action.Type = security.ActionTypeBash
 		action.Payload.Operation = "command"
 		action.Payload.TargetType = security.TargetTypeCommand
 		action.Payload.Target = extractStringArgument(input.Arguments, "command")
+		action.Payload.SemanticType = ""
+		action.Payload.SemanticClass = intent.Classification
+		action.Payload.NormalizedIntent = intent.NormalizedIntent
+		action.Payload.PermissionFingerprint = intent.PermissionFingerprint
+		if intent.IsGit {
+			action.Payload.SemanticType = "git"
+			action.Payload.Operation = "git_" + strings.TrimSpace(intent.Subcommand)
+			switch intent.Classification {
+			case BashIntentClassificationReadOnly:
+				action.Payload.Resource = "bash_git_read_only"
+			case BashIntentClassificationLocalMutation:
+				action.Payload.Resource = "bash_git_local_mutation"
+			case BashIntentClassificationRemoteOp:
+				action.Payload.Resource = "bash_git_remote_op"
+			case BashIntentClassificationDestructive:
+				action.Payload.Resource = "bash_git_destructive"
+			default:
+				action.Payload.Resource = "bash_git_unknown"
+			}
+			if strings.TrimSpace(intent.Subcommand) == "" {
+				action.Payload.Operation = "git_unknown"
+			}
+		}
 		action.Payload.SandboxTargetType = security.TargetTypeDirectory
 		action.Payload.SandboxTarget = extractStringArgument(input.Arguments, "workdir")
 		if action.Payload.SandboxTarget == "" {

--- a/internal/tools/session_memory.go
+++ b/internal/tools/session_memory.go
@@ -75,6 +75,9 @@ func (m *sessionPermissionMemory) remember(sessionID string, action security.Act
 	default:
 		return fmt.Errorf("tools: unsupported session permission scope %q", scope)
 	}
+	if shouldSkipSessionPermissionRemember(action) {
+		return nil
+	}
 
 	actionKey := sessionPermissionActionKey(action)
 	m.mu.Lock()
@@ -150,6 +153,13 @@ func sessionPermissionCategory(action security.Action) string {
 			return "filesystem_write"
 		}
 	case security.ActionTypeBash:
+		if strings.EqualFold(strings.TrimSpace(action.Payload.SemanticType), "git") {
+			semanticClass := strings.ToLower(strings.TrimSpace(action.Payload.SemanticClass))
+			if semanticClass == "" {
+				semanticClass = BashIntentClassificationUnknown
+			}
+			return "bash_git_" + semanticClass
+		}
 		return "bash"
 	case security.ActionTypeMCP:
 		if serverIdentity := mcpServerTarget(action.Payload.Target); serverIdentity != "" {
@@ -167,6 +177,11 @@ func sessionPermissionCategory(action security.Action) string {
 
 // sessionPermissionTargetScope 基于 action 的 target 生成最小授权范围键。
 func sessionPermissionTargetScope(action security.Action) string {
+	if action.Type == security.ActionTypeBash {
+		if fingerprint := strings.TrimSpace(action.Payload.PermissionFingerprint); fingerprint != "" {
+			return strings.ToLower(fingerprint)
+		}
+	}
 	target := strings.TrimSpace(action.Payload.Target)
 	if target == "" {
 		return "*"
@@ -220,4 +235,15 @@ func normalizePermissionCommandTarget(raw string) string {
 	trimmed = strings.ReplaceAll(trimmed, "\r\n", "\n")
 	trimmed = strings.ReplaceAll(trimmed, "\r", "\n")
 	return strings.ToLower(strings.Join(strings.Fields(trimmed), " "))
+}
+
+// shouldSkipSessionPermissionRemember 判断当前 action 是否应跳过会话级记忆。
+func shouldSkipSessionPermissionRemember(action security.Action) bool {
+	if action.Type != security.ActionTypeBash {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(action.Payload.SemanticType), "git") {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(action.Payload.SemanticClass), BashIntentClassificationRemoteOp)
 }

--- a/internal/tools/session_memory.go
+++ b/internal/tools/session_memory.go
@@ -179,7 +179,7 @@ func sessionPermissionCategory(action security.Action) string {
 func sessionPermissionTargetScope(action security.Action) string {
 	if action.Type == security.ActionTypeBash {
 		if fingerprint := strings.TrimSpace(action.Payload.PermissionFingerprint); fingerprint != "" {
-			return strings.ToLower(fingerprint)
+			return fingerprint
 		}
 	}
 	target := strings.TrimSpace(action.Payload.Target)

--- a/internal/tools/session_memory.go
+++ b/internal/tools/session_memory.go
@@ -75,7 +75,7 @@ func (m *sessionPermissionMemory) remember(sessionID string, action security.Act
 	default:
 		return fmt.Errorf("tools: unsupported session permission scope %q", scope)
 	}
-	if shouldSkipSessionPermissionRemember(action) {
+	if shouldSkipSessionPermissionRemember(action, scope) {
 		return nil
 	}
 
@@ -237,13 +237,14 @@ func normalizePermissionCommandTarget(raw string) string {
 	return strings.ToLower(strings.Join(strings.Fields(trimmed), " "))
 }
 
-// shouldSkipSessionPermissionRemember 判断当前 action 是否应跳过会话级记忆。
-func shouldSkipSessionPermissionRemember(action security.Action) bool {
+// shouldSkipSessionPermissionRemember 判断当前 action 在给定 scope 下是否应跳过会话级记忆。
+func shouldSkipSessionPermissionRemember(action security.Action, scope SessionPermissionScope) bool {
 	if action.Type != security.ActionTypeBash {
 		return false
 	}
 	if !strings.EqualFold(strings.TrimSpace(action.Payload.SemanticType), "git") {
 		return false
 	}
-	return strings.EqualFold(strings.TrimSpace(action.Payload.SemanticClass), BashIntentClassificationRemoteOp)
+	return scope == SessionPermissionScopeAlways &&
+		strings.EqualFold(strings.TrimSpace(action.Payload.SemanticClass), BashIntentClassificationRemoteOp)
 }

--- a/internal/tools/session_memory_test.go
+++ b/internal/tools/session_memory_test.go
@@ -463,3 +463,35 @@ func TestSessionPermissionMemoryAllowsRemoteGitRememberForNonAlwaysScopes(t *tes
 		})
 	}
 }
+
+func TestNormalizePermissionCommandTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "empty returns wildcard",
+			raw:  " \n\t ",
+			want: "*",
+		},
+		{
+			name: "normalizes line endings and spaces",
+			raw:  "Get-ChildItem   -Force\r\n|   Select-String    'TODO'\r",
+			want: "get-childitem -force | select-string 'todo'",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := normalizePermissionCommandTarget(tt.raw); got != tt.want {
+				t.Fatalf("normalizePermissionCommandTarget() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tools/session_memory_test.go
+++ b/internal/tools/session_memory_test.go
@@ -153,6 +153,17 @@ func TestSessionPermissionCategoryAndActionKey(t *testing.T) {
 			expected: "bash",
 		},
 		{
+			name: "bash git category",
+			action: security.Action{
+				Type: security.ActionTypeBash,
+				Payload: security.ActionPayload{
+					SemanticType:  "git",
+					SemanticClass: BashIntentClassificationRemoteOp,
+				},
+			},
+			expected: "bash_git_remote_op",
+		},
+		{
 			name: "mcp with target",
 			action: security.Action{
 				Type: security.ActionTypeMCP,
@@ -337,10 +348,11 @@ func TestSessionPermissionMemoryResolveMatchesNormalizedCommandScope(t *testing.
 	remembered := security.Action{
 		Type: security.ActionTypeBash,
 		Payload: security.ActionPayload{
-			ToolName:   "bash",
-			Resource:   "bash",
-			TargetType: security.TargetTypeCommand,
-			Target:     "Get-ChildItem   -Force\r\n|   Select-String    'TODO'",
+			ToolName:              "bash",
+			Resource:              "bash",
+			TargetType:            security.TargetTypeCommand,
+			Target:                "Get-ChildItem   -Force\r\n|   Select-String    'TODO'",
+			PermissionFingerprint: "bash.command.get-childitem -force | select-string 'todo'",
 		},
 	}
 	if err := memory.remember(sessionID, remembered, SessionPermissionScopeAlways); err != nil {
@@ -350,13 +362,40 @@ func TestSessionPermissionMemoryResolveMatchesNormalizedCommandScope(t *testing.
 	normalizedEquivalent := security.Action{
 		Type: security.ActionTypeBash,
 		Payload: security.ActionPayload{
-			ToolName:   "bash",
-			Resource:   "bash",
-			TargetType: security.TargetTypeCommand,
-			Target:     "Get-ChildItem -Force | Select-String 'TODO'",
+			ToolName:              "bash",
+			Resource:              "bash",
+			TargetType:            security.TargetTypeCommand,
+			Target:                "Get-ChildItem -Force | Select-String 'TODO'",
+			PermissionFingerprint: "bash.command.get-childitem -force | select-string 'todo'",
 		},
 	}
 	if _, _, ok := memory.resolve(sessionID, normalizedEquivalent); !ok {
 		t.Fatalf("expected normalized-equivalent command to hit session memory")
+	}
+}
+
+func TestSessionPermissionMemorySkipsRemoteGitRemember(t *testing.T) {
+	t.Parallel()
+
+	memory := newSessionPermissionMemory()
+	sessionID := "session-git-remote-no-cache"
+	remoteAction := security.Action{
+		Type: security.ActionTypeBash,
+		Payload: security.ActionPayload{
+			ToolName:              "bash",
+			Resource:              "bash_git_remote_op",
+			TargetType:            security.TargetTypeCommand,
+			Target:                "git push origin main",
+			SemanticType:          "git",
+			SemanticClass:         BashIntentClassificationRemoteOp,
+			PermissionFingerprint: "bash.git|remote_op|push|a=origin,main",
+		},
+	}
+
+	if err := memory.remember(sessionID, remoteAction, SessionPermissionScopeAlways); err != nil {
+		t.Fatalf("remember remote action: %v", err)
+	}
+	if _, _, ok := memory.resolve(sessionID, remoteAction); ok {
+		t.Fatalf("expected remote git action not to be cached")
 	}
 }

--- a/internal/tools/session_memory_test.go
+++ b/internal/tools/session_memory_test.go
@@ -399,3 +399,67 @@ func TestSessionPermissionMemorySkipsRemoteGitRemember(t *testing.T) {
 		t.Fatalf("expected remote git action not to be cached")
 	}
 }
+
+func TestSessionPermissionMemoryAllowsRemoteGitRememberForNonAlwaysScopes(t *testing.T) {
+	t.Parallel()
+
+	remoteAction := security.Action{
+		Type: security.ActionTypeBash,
+		Payload: security.ActionPayload{
+			ToolName:              "bash",
+			Resource:              "bash_git_remote_op",
+			TargetType:            security.TargetTypeCommand,
+			Target:                "git push origin main",
+			SemanticType:          "git",
+			SemanticClass:         BashIntentClassificationRemoteOp,
+			PermissionFingerprint: "bash.git|remote_op|push|a=origin,main",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		sessionID string
+		scope     SessionPermissionScope
+		validate  func(t *testing.T, memory *sessionPermissionMemory)
+	}{
+		{
+			name:      "once can be remembered for remote git",
+			sessionID: "session-git-remote-once",
+			scope:     SessionPermissionScopeOnce,
+			validate: func(t *testing.T, memory *sessionPermissionMemory) {
+				t.Helper()
+				if _, _, ok := memory.resolve("session-git-remote-once", remoteAction); !ok {
+					t.Fatalf("expected remote git once decision to be cached")
+				}
+				if _, _, ok := memory.resolve("session-git-remote-once", remoteAction); ok {
+					t.Fatalf("expected remote git once decision to be consumed")
+				}
+			},
+		},
+		{
+			name:      "reject can be remembered for remote git",
+			sessionID: "session-git-remote-reject",
+			scope:     SessionPermissionScopeReject,
+			validate: func(t *testing.T, memory *sessionPermissionMemory) {
+				t.Helper()
+				decision, scope, ok := memory.resolve("session-git-remote-reject", remoteAction)
+				if !ok || decision != security.DecisionDeny || scope != SessionPermissionScopeReject {
+					t.Fatalf("expected remote git reject decision to be cached, got decision=%q scope=%q ok=%v", decision, scope, ok)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			memory := newSessionPermissionMemory()
+			if err := memory.remember(tt.sessionID, remoteAction, tt.scope); err != nil {
+				t.Fatalf("remember remote action: %v", err)
+			}
+			tt.validate(t, memory)
+		})
+	}
+}

--- a/internal/tools/session_memory_test.go
+++ b/internal/tools/session_memory_test.go
@@ -374,6 +374,38 @@ func TestSessionPermissionMemoryResolveMatchesNormalizedCommandScope(t *testing.
 	}
 }
 
+func TestSessionPermissionMemoryUsesCaseSensitiveFingerprintScope(t *testing.T) {
+	t.Parallel()
+
+	memory := newSessionPermissionMemory()
+	sessionID := "session-bash-fingerprint-case"
+	remembered := security.Action{
+		Type: security.ActionTypeBash,
+		Payload: security.ActionPayload{
+			ToolName:              "bash",
+			Resource:              "bash_git_local_mutation",
+			TargetType:            security.TargetTypeCommand,
+			Target:                "git checkout Feature",
+			SemanticType:          "git",
+			SemanticClass:         BashIntentClassificationLocalMutation,
+			PermissionFingerprint: "bash.git|local_mutation|checkout|sha256=ABCDEF",
+		},
+	}
+	if err := memory.remember(sessionID, remembered, SessionPermissionScopeAlways); err != nil {
+		t.Fatalf("remember bash action: %v", err)
+	}
+
+	if _, _, ok := memory.resolve(sessionID, remembered); !ok {
+		t.Fatalf("expected same fingerprint to hit session memory")
+	}
+
+	differentCase := remembered
+	differentCase.Payload.PermissionFingerprint = "bash.git|local_mutation|checkout|sha256=abcdef"
+	if _, _, ok := memory.resolve(sessionID, differentCase); ok {
+		t.Fatalf("expected different-case fingerprint to miss session memory")
+	}
+}
+
 func TestSessionPermissionMemorySkipsRemoteGitRemember(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 变更摘要
- 新增 `bash` 下的 Git 语义解析与分类：`read_only` / `local_mutation` / `remote_op` / `destructive` / `unknown`
- 权限策略改为语义优先：Git 只读直通；远端操作、破坏性操作、未知语义统一走审批
- 会话级权限记忆改为 `permission_fingerprint` 复用；`remote_op` 不复用 `allow_session`
- Bash 工具结果增加结构化字段：`ok`、`classification`、`normalized_intent`、`permission_fingerprint`、`exit_code`
- Runtime 在 `ok=false` 时强制按失败处理，避免“工具失败但模型误报成功”
- System State 增加轻量 Git 摘要：`ahead` / `behind`
- 同步更新提示词与文档：Git 操作顺序与回滚优先级（`restore` -> `revert` -> `reset --hard`，危险操作必须审批）

## 验证
- `go test ./internal/tools ./internal/security ./internal/context ./internal/runtime -cover`
- `go test ./internal/tools/... ./internal/security/... ./internal/context/... ./internal/runtime/... -cover`

Close #397
Refs
- #395
