### PR TITLE
docs(gateway): 补齐第三方接入文档体系并接入 API 示例自动生成校验

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Verify gateway docs are generated
+        run: make docs-gateway-check
+
       - name: Build
         run: go build ./...
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
-.PHONY: install-skills
+.PHONY: install-skills docs-gateway docs-gateway-check
 
 install-skills:
 	@./scripts/install_skills.sh
+
+docs-gateway:
+	@go run ./scripts/generate_gateway_rpc_examples
+
+docs-gateway-check:
+	@go run ./scripts/generate_gateway_rpc_examples
+	@git diff --exit-code -- docs/reference/gateway-rpc-api.md

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Gateway 转发与自动拉起说明：
 3. 完成开发并确保改动聚焦、边界清晰。
 4. 本地自检：
    ```bash
+   make docs-gateway-check
    gofmt -w ./cmd ./internal
    go test ./...
    go build ./...

--- a/docs/guides/gateway-integration-guide.md
+++ b/docs/guides/gateway-integration-guide.md
@@ -1,0 +1,300 @@
+# Gateway 第三方接入协作指南
+
+本文面向接入 NeoCode Gateway 的第三方开发者，目标是让你在不阅读源码的前提下完成：
+
+1. 建立连接并通过认证。
+2. 发起一次完整运行并消费事件流。
+3. 在常见错误下快速定位与恢复。
+
+## 1. Getting Started
+
+### 1.1 接入前提
+
+- Gateway 已启动（本地 IPC 或 HTTP/WS/SSE 控制面）。
+- 已获取有效认证 Token（默认来自 `~/.neocode/auth.json`）。
+- 客户端具备 JSON-RPC 2.0 编解码能力。
+
+### 1.2 传输通道选择
+
+| 通道 | 适用场景 | 认证方式 | 备注 |
+|---|---|---|---|
+| IPC | 本地桌面/CLI | `gateway.authenticate` | 延迟低，推荐本机应用 |
+| `POST /rpc` | 单次调用 | `Authorization: Bearer <token>` | 无长连接 |
+| `GET /ws` | 双向长连接 | `gateway.authenticate`（可附带 token） | 适合事件+请求双向复用 |
+| `GET /sse` | 单向事件流 | `?token=<token>` | 仅服务端推送 |
+
+### 1.3 最小握手流程（推荐）
+
+推荐顺序：
+
+1. 连接 WS（或 IPC）。
+2. 调用 `gateway.authenticate`。
+3. 调用 `gateway.bindStream` 绑定 `session_id` 与可选 `run_id`。
+4. 调用 `gateway.run`，收到 `ack`。
+5. 持续消费 `gateway.event` 通知。
+6. 必要时调用 `gateway.cancel`。
+
+### 1.4 示例：`gateway.authenticate`
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-auth-1",
+  "method": "gateway.authenticate",
+  "params": {
+    "token": "<YOUR_TOKEN>"
+  }
+}
+```
+
+成功响应（示例）：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-auth-1",
+  "result": {
+    "type": "ack",
+    "action": "authenticate",
+    "request_id": "req-auth-1",
+    "payload": {
+      "message": "authenticated",
+      "subject_id": "local_admin"
+    }
+  }
+}
+```
+
+## 2. Message Protocol
+
+### 2.1 JSON-RPC 请求/响应
+
+请求：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-123",
+  "method": "gateway.run",
+  "params": {}
+}
+```
+
+成功响应：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-123",
+  "result": {
+    "type": "ack",
+    "action": "run",
+    "request_id": "req-123",
+    "session_id": "session-1",
+    "run_id": "run-1",
+    "payload": {
+      "message": "run accepted"
+    }
+  }
+}
+```
+
+错误响应：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-123",
+  "error": {
+    "code": -32602,
+    "message": "missing required field: params.run_id",
+    "data": {
+      "gateway_code": "missing_required_field"
+    }
+  }
+}
+```
+
+### 2.2 Notification（`gateway.event`）
+
+网关会主动推送：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "gateway.event",
+  "params": {
+    "type": "event",
+    "action": "run",
+    "session_id": "session-1",
+    "run_id": "run-1",
+    "payload": {
+      "event_type": "run_progress",
+      "payload": {
+        "runtime_event_type": "agent_chunk",
+        "turn": 1,
+        "phase": "reasoning",
+        "timestamp": "2026-04-22T09:00:00Z",
+        "payload_version": 2,
+        "payload": "..."
+      }
+    }
+  }
+}
+```
+
+说明：
+
+- `params` 是统一 `MessageFrame`。
+- `payload.event_type` 为网关层三态：`run_progress`、`run_done`、`run_error`。
+- 内层 `payload.payload` 为 runtime 事件 envelope，第三方可按需消费。
+
+### 2.3 方法契约分层
+
+稳定核心方法：
+
+- `gateway.authenticate`
+- `gateway.ping`
+- `gateway.bindStream`
+- `gateway.run`
+- `gateway.compact`
+- `gateway.cancel`
+- `gateway.listSessions`
+- `gateway.loadSession`
+- `gateway.resolvePermission`
+- `gateway.event`
+
+实验扩展：
+
+- `wake.openUrl`
+
+### 2.4 参数约束（高频）
+
+- `gateway.cancel`：`params.run_id` 必填。
+- `gateway.bindStream`：`params.session_id` 必填，`channel` 允许 `all|ipc|ws|sse`。
+- `gateway.run`：`input_text` 或 `input_parts` 至少一个非空。
+- 参数解析为严格模式，未知字段会触发参数错误。
+
+## 3. Status Codes
+
+### 3.1 三层错误信号
+
+1. HTTP 状态码（仅网络入口可见）。
+2. JSON-RPC `error.code`（标准码）。
+3. `error.data.gateway_code`（网关稳定语义码）。
+
+### 3.2 HTTP 映射
+
+| 场景 | HTTP 状态 |
+|---|---|
+| `unauthorized` | `401` |
+| `access_denied` | `403` |
+| 其他业务错误 | `200`（错误在 JSON-RPC `error` 中） |
+
+### 3.3 稳定 `gateway_code`
+
+| gateway_code | 含义 | 建议动作 |
+|---|---|---|
+| `invalid_frame` | 协议帧非法/JSON 解析失败 | 修正请求格式 |
+| `invalid_action` | 方法参数非法或动作无效 | 修正参数值 |
+| `invalid_multimodal_payload` | 多模态输入格式不合法 | 修正 `input_parts` |
+| `missing_required_field` | 缺失必填字段 | 补齐字段 |
+| `unsupported_action` | 方法未实现或不支持 | 升级客户端或降级调用 |
+| `internal_error` | 网关内部错误 | 重试并记录 request_id |
+| `timeout` | 网关下游调用超时 | 指数退避重试 |
+| `unauthorized` | 认证失败 | 刷新 token 并重新认证 |
+| `access_denied` | ACL 或资源权限拒绝 | 检查方法权限 |
+| `resource_not_found` | 目标会话或运行不存在 | 校验 `session_id/run_id` |
+
+## 4. Client Best Practices
+
+### 4.1 连接与重连
+
+- 客户端 `SHOULD` 使用指数退避重连（如 200ms 起步，逐步扩展到 3s 上限）。
+- 每次重连成功后 `MUST` 重新 `authenticate`，并按需重新 `bindStream`。
+- 对于长连接，`SHOULD` 周期性调用 `gateway.ping` 维持活性并刷新绑定。
+
+### 4.2 请求幂等与关联
+
+- `id` `MUST` 全局唯一（至少在进程生命周期内）。
+- `run_id` `SHOULD` 由客户端生成并持久化，便于取消与追踪。
+- 日志中 `SHOULD` 记录 `request_id/session_id/run_id` 三元组。
+
+### 4.3 超时与重试
+
+- `gateway.run` 为异步受理，不应等待“最终模型输出”才算成功。
+- 对 `ping/auth/bindStream/list/load` 这类短调用，`SHOULD` 采用较短超时并允许小次数重试。
+- 对 `timeout` 或网络传输错误，`MAY` 重试；对 `invalid_*` 或 `missing_required_field`，不应盲目重试。
+
+### 4.4 事件消费
+
+- 客户端 `MUST` 区分响应与通知，不能把 `gateway.event` 当作请求响应。
+- 事件消费协程 `SHOULD` 与请求协程解耦，避免背压阻塞导致断连。
+
+### 4.5 安全建议
+
+- Token 只放内存与受控安全存储，不应写入日志。
+- 浏览器场景需遵循 Origin 白名单策略，避免跨站调用失败。
+
+## 5. Failure Playbook
+
+### 5.1 连接失败（dial refused / no such pipe）
+
+排查步骤：
+
+1. 确认 Gateway 进程是否在运行。
+2. 确认地址配置是否与 Gateway 监听地址一致。
+3. 若客户端启用自动拉起，检查自动拉起日志与探测窗口是否超时。
+
+恢复动作：
+
+- 执行指数退避重连；重连后重新认证与绑定。
+
+### 5.2 认证失败（`unauthorized`）
+
+排查步骤：
+
+1. 检查 Token 来源是否正确（是否读取了期望的 token 文件）。
+2. 校验 Header 或 query 参数是否丢失或污染空格。
+
+恢复动作：
+
+- 刷新 token，重新执行 `gateway.authenticate`。
+
+### 5.3 参数错误（`missing_required_field` / `invalid_action`）
+
+排查步骤：
+
+1. 对照方法契约检查必填字段。
+2. 检查是否发送了未定义字段（严格解码会拒绝）。
+
+恢复动作：
+
+- 修正请求体，不要直接重试同一无效请求。
+
+### 5.4 超时（`timeout`）
+
+排查步骤：
+
+1. 区分是网络超时还是 gateway 下游调用超时。
+2. 检查当前并发、请求体大小与运行时负载。
+
+恢复动作：
+
+- 降低并发、启用退避重试、增加调用级超时预算。
+
+### 5.5 连接重置后的恢复
+
+恢复顺序（必须按序）：
+
+1. 重建连接。
+2. 重新认证。
+3. 重新绑定流（`gateway.bindStream`）。
+4. 根据业务状态决定是否补发请求或仅恢复事件订阅。
+
+---
+
+协作约定：
+
+- 当你接入的是“稳定核心方法 + 稳定错误码”，网关小版本升级不应破坏基础兼容性。
+- 当你使用实验扩展（如 `wake.openUrl`），应预留版本探测与降级处理逻辑。

--- a/docs/reference/gateway-compatibility.md
+++ b/docs/reference/gateway-compatibility.md
@@ -1,0 +1,79 @@
+# Gateway Compatibility Spec（兼容性规范）
+
+本文档定义 Gateway 对外协议的兼容性策略，目标是让第三方在版本演进中可预测、可迁移、可回滚。
+
+## 1. 兼容性目标
+
+1. 保证稳定核心接口在小版本演进中默认向后兼容。  
+2. 对破坏性变更提供可观测的迁移窗口，而不是“静默断裂”。  
+3. 用统一规则处理字段新增、字段废弃、错误码演进与实验能力升级。  
+
+## 2. 适用范围
+
+本规范适用于：
+
+1. JSON-RPC 方法名、参数字段、返回字段。  
+2. 稳定错误码（`gateway_code`）集合。  
+3. `/rpc` 的 HTTP 与 JSON-RPC 状态映射约束。  
+4. `gateway.event` 事件 envelope 的结构约束。  
+
+## 3. 稳定性分层
+
+| 层级 | 范围 | 兼容承诺 |
+| --- | --- | --- |
+| Stable Core | `gateway.authenticate`、`gateway.ping`、`gateway.bindStream`、`gateway.run`、`gateway.compact`、`gateway.cancel`、`gateway.listSessions`、`gateway.loadSession`、`gateway.resolvePermission`、`gateway.event` | 小版本（`v1.x`）内默认向后兼容；破坏性变更必须走废弃流程。 |
+| Experimental | `wake.openUrl` 等实验能力 | 允许在小版本内调整；调用方必须具备能力探测与降级路径。 |
+
+## 4. 版本语义
+
+1. `MAJOR`：允许破坏性变更。  
+2. `MINOR`：默认非破坏性，允许新增字段/新增可选能力。  
+3. `PATCH`：仅修复，不应改变对外契约。  
+
+## 5. 什么是破坏性变更
+
+以下变更视为破坏性：
+
+1. 删除 Stable 方法。  
+2. 将原可选字段改为必填字段。  
+3. 修改字段类型（如 `string -> object`）。  
+4. 改变稳定错误码语义或删除稳定错误码。  
+5. 改变已承诺的状态码映射（如 `unauthorized` 不再返回 `401`）。  
+
+## 6. 字段优雅废弃流程（重点）
+
+### 6.1 标准流程
+
+1. `Deprecate` 阶段：文档标注 `Deprecated`，字段仍可读可写。  
+2. `Transition` 阶段：继续兼容旧字段，同时推广新字段；发布迁移指南与双写窗口。  
+3. `Remove` 阶段：删除旧字段支持；若客户端仍发送旧字段，返回可诊断错误。  
+
+### 6.2 规范要求
+
+1. Stable 字段从 `Deprecated` 到 `Remove` 的窗口 `MUST` 至少跨 2 个 `MINOR` 版本。  
+2. 在 `Deprecated` 与 `Transition` 阶段，服务端 `MUST` 保持旧字段语义不变。  
+3. 在 `Remove` 阶段，服务端 `MUST` 返回稳定可判定错误（优先 `invalid_frame` 或 `invalid_action`）。  
+4. 发布方 `MUST` 在发布说明中给出迁移起止版本、替代字段与示例。  
+
+### 6.3 你要求的版本节奏示例
+
+> 示例仅用于说明流程，不代表当前已存在该字段。
+
+| 版本 | 动作 | 对客户端影响 | 服务端行为 |
+| --- | --- | --- | --- |
+| `v1.2` | 标记 `old_field` 为 Deprecated | 客户端应开始迁移到 `new_field` | 同时接受 `old_field/new_field`。 |
+| `v1.3` | 迁移过渡期 | 客户端应完成切换并压测回归 | 继续兼容旧字段，文档明确“下一小版本移除”。 |
+| `v1.4` | 正式移除 `old_field` | 未迁移客户端会失败 | 不再接受旧字段，返回稳定错误并附明确 message。 |
+
+## 7. 当前实现状态与工程建议
+
+1. 当前实现已具备稳定 `gateway_code` 与方法分层。  
+2. 当前实现对“废弃字段”的机器可读告警尚无统一协议字段。  
+3. 在机器告警机制落地前，应以文档、发布说明、迁移指南作为主通知渠道。  
+
+## 8. 客户端兼容性实现建议
+
+1. 客户端 `MUST` 忽略未知返回字段，避免因新增字段崩溃。  
+2. 客户端 `SHOULD` 对 Experimental 方法做能力探测，不应硬编码强依赖。  
+3. 客户端 `SHOULD` 以 `gateway_code` 作为异常分支主键，而非 `message` 文本。  
+4. 客户端 `SHOULD` 在升级前执行双版本回归（当前版本与目标版本）。  

--- a/docs/reference/gateway-error-catalog.md
+++ b/docs/reference/gateway-error-catalog.md
@@ -1,0 +1,39 @@
+# Gateway Error Catalog（错误字典）
+
+本文档用于第三方客户端实现统一异常处理策略，覆盖 Gateway 稳定错误码集合：
+
+`invalid_frame`、`invalid_action`、`invalid_multimodal_payload`、`missing_required_field`、`unsupported_action`、`internal_error`、`timeout`、`unauthorized`、`access_denied`、`resource_not_found`。
+
+## 1. 错误码对照表
+
+| gateway_code | HTTP 状态码（/rpc） | JSON-RPC code | Reasoning（触发逻辑） | 典型触发场景 | 客户端处理建议 |
+| --- | --- | --- | --- | --- | --- |
+| `invalid_frame` | `200` | `-32700` / `-32600` / `-32602` | 请求帧结构或编码不合法。包括 JSON 解析失败、请求体包含多余 JSON 值、`id/jsonrpc` 非法、`params` 严格解码失败。 | 非法 JSON；`id` 为 `null`；`params` 含未知字段。 | 不要直接重试，先修复请求构造器。 |
+| `invalid_action` | `200` | `-32602` | 动作参数值非法，但方法本身存在。 | `params.channel` 不在 `all/ipc/ws/sse`；`params.decision` 非 `allow_once/allow_session/reject`。 | 视为调用方输入错误，修正参数后再发。 |
+| `invalid_multimodal_payload` | `200` | `-32602` | `gateway.run` 的 `input_parts` 结构或字段不满足契约。 | `image` 分片缺少 `media.uri` 或 `media.mime_type`；`text` 分片文本为空。 | 校验输入分片后重试，不做盲重试。 |
+| `missing_required_field` | `200` | `-32600` / `-32602` | 缺失必填字段。请求层字段缺失多映射为 `-32600`，方法参数层字段缺失多映射为 `-32602`。 | 缺失 `id`；缺失 `params`；`cancel` 缺失 `run_id`。 | 调整参数补齐必填项再重试。 |
+| `unsupported_action` | `200` | `-32601` | 方法未注册或不被网关识别。 | 调用不存在的方法名。 | 客户端按能力探测降级，或升级服务端版本。 |
+| `internal_error` | `200` | `-32603` | 网关内部异常或未分类下游异常。 | 结果编码失败；runtime port 不可用；未知运行时错误。 | 采用指数退避重试；持续失败时告警。 |
+| `timeout` | `200` | `-32603` | 网关调用 runtime 超时（`context.DeadlineExceeded`）。 | `run/compact/cancel/loadSession/resolvePermission` 下游调用超时。 | 可重试且建议带幂等键（如固定 `run_id`）。 |
+| `unauthorized` | `401`（仅 /rpc） | `-32602` | 请求未通过认证。 | 未携带 token；token 非法；连接未先 `authenticate`。 | 先刷新凭证并重新认证，认证成功后再发业务请求。 |
+| `access_denied` | `403`（仅 /rpc） | `-32602` | 已认证但不具备该方法或资源权限。 | ACL 拒绝当前来源调用该方法；runtime 返回 access denied。 | 终止当前请求并提示授权不足，不要盲重试。 |
+| `resource_not_found` | `200` | `-32602` | 目标资源不存在或不可见，由 runtime 明确返回 `ErrRuntimeResourceNotFound`。 | `gateway.cancel` 指定的 `run_id` 不存在或已结束。 | 可视为业务态终态，通常无需重试。 |
+
+## 2. resource_not_found 判定边界（重点）
+
+1. `resource_not_found` 不是“参数格式错误”。  
+2. `session_id/run_id` 的格式问题通常归入 `invalid_frame` 或 `missing_required_field`。  
+3. 当前实现中，`resource_not_found` 主要来自 runtime 明确返回“目标不存在”（例如取消不存在的 `run_id`）。  
+4. `gateway.loadSession` 在默认桥接实现下可能自动创建会话，因此“会话不存在”不一定返回 `resource_not_found`。  
+
+## 3. HTTP 与 JSON-RPC 组合规则
+
+1. `/rpc` 默认返回 `HTTP 200`，并在 JSON-RPC `error` 中给出 `gateway_code`。  
+2. 仅当 `gateway_code=unauthorized` 时返回 `HTTP 401`。  
+3. 仅当 `gateway_code=access_denied` 时返回 `HTTP 403`。  
+
+## 4. 客户端 try-catch 推荐顺序
+
+1. 先解析 `error.data.gateway_code`（稳定分支键）。  
+2. 再解析 `error.code`（JSON-RPC 互操作）。  
+3. 最后使用 `error.message` 做日志与人类可读提示。  

--- a/docs/reference/gateway-rpc-api.md
+++ b/docs/reference/gateway-rpc-api.md
@@ -1,0 +1,1332 @@
+# Gateway RPC API
+
+本文档定义 Gateway 对外 JSON-RPC 协议契约，面向第三方客户端实现者。  
+术语遵循 RFC 规范语义：`MUST`、`SHOULD`、`MAY`。
+
+## 0. 通用协议基线
+
+### 0.1 统一请求信封
+
+```go
+type JSONRPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"` // 固定 "2.0"
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+```
+
+规范约束：
+
+1. `jsonrpc` `MUST` 为 `"2.0"`。  
+2. `id` `MUST` 提供，且不可为 `null` 或空字符串。  
+3. `params` `MUST` 通过严格解码（`DisallowUnknownFields`），未知字段会触发错误。  
+
+### 0.2 统一响应信封
+
+```go
+type JSONRPCResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"` // 成功时为 MessageFrame
+	Error   *JSONRPCError   `json:"error,omitempty"`  // 失败时为 JSON-RPC Error
+}
+
+type JSONRPCError struct {
+	Code    int               `json:"code"`
+	Message string            `json:"message"`
+	Data    *JSONRPCErrorData `json:"data,omitempty"`
+}
+
+type JSONRPCErrorData struct {
+	GatewayCode string `json:"gateway_code,omitempty"`
+}
+```
+
+### 0.3 MessageFrame（Result 载荷）
+
+```go
+type MessageFrame struct {
+	Type      FrameType    `json:"type"` // ack / event / error
+	Action    FrameAction  `json:"action,omitempty"`
+	RequestID string       `json:"request_id,omitempty"`
+	RunID     string       `json:"run_id,omitempty"`
+	SessionID string       `json:"session_id,omitempty"`
+	InputText string       `json:"input_text,omitempty"`
+	InputParts []InputPart `json:"input_parts,omitempty"`
+	Workdir   string       `json:"workdir,omitempty"`
+	Payload   any          `json:"payload,omitempty"`
+	Error     *FrameError  `json:"error,omitempty"`
+}
+```
+
+### 0.4 HTTP 与 JSON-RPC 映射
+
+1. `/rpc` 默认 `HTTP 200`，错误通过 JSON-RPC `error` 返回。  
+2. `/rpc` 仅当 `gateway_code=unauthorized` 返回 `HTTP 401`。  
+3. `/rpc` 仅当 `gateway_code=access_denied` 返回 `HTTP 403`。  
+
+### 0.5 观测基线
+
+Observation（通用）：
+
+1. 每个请求都会计入 `gateway_requests_total{source,method,status}`。  
+2. 认证失败会计入 `gateway_auth_failures_total{source,reason}`。  
+3. ACL 拒绝会计入 `gateway_acl_denied_total{source,method}`。  
+4. 请求日志包含 `request_id/session_id/method/source/status/gateway_code/latency_ms`。  
+5. `gateway.ping` 成功日志默认静默，失败仍记录。  
+
+---
+
+## 1. gateway.authenticate
+
+Method: `gateway.authenticate`  
+Stability: `Stable`  
+Auth Required: `No`
+
+Request Schema（JSON Schema）：
+
+```json
+{
+  "type": "object",
+  "required": ["jsonrpc", "id", "method", "params"],
+  "properties": {
+    "jsonrpc": { "const": "2.0" },
+    "id": { "type": ["string", "number"] },
+    "method": { "const": "gateway.authenticate" },
+    "params": {
+      "type": "object",
+      "required": ["token"],
+      "additionalProperties": false,
+      "properties": {
+        "token": { "type": "string", "minLength": 1 }
+      }
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+Response Schema：
+
+1. Success（完整 payload）：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-1",
+  "result": {
+    "type": "ack",
+    "action": "authenticate",
+    "request_id": "req-1",
+    "payload": {
+      "message": "authenticated",
+      "subject_id": "local_admin"
+    }
+  }
+}
+```
+
+2. Failure（完整 payload）：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-1",
+  "error": {
+    "code": -32602,
+    "message": "missing required field: params.token",
+    "data": {
+      "gateway_code": "missing_required_field"
+    }
+  }
+}
+```
+
+Observation：
+
+1. 失败时会增长 `gateway_auth_failures_total`。  
+2. 请求日志会记录认证态（`auth_state`）变化。  
+
+---
+
+## 2. gateway.ping
+
+Method: `gateway.ping`  
+Stability: `Stable`  
+Auth Required: `Yes`
+
+Request Schema（Go Struct）：
+
+```go
+type PingParams struct{}
+```
+
+Response Schema：
+
+1. Success：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-2",
+  "result": {
+    "type": "ack",
+    "action": "ping",
+    "request_id": "req-2",
+    "payload": {
+      "message": "pong",
+      "version": "dev"
+    }
+  }
+}
+```
+
+2. Failure：统一 `error` 信封。
+
+Observation：
+
+1. 成功 `ping` 默认不输出请求日志（降噪）。  
+2. 对已绑定连接，`ping` 会刷新绑定 TTL（续期）。  
+
+---
+
+## 3. gateway.bindStream
+
+Method: `gateway.bindStream`  
+Stability: `Stable`  
+Auth Required: `Yes`
+
+Request Schema（Go Struct）：
+
+```go
+type BindStreamParams struct {
+	SessionID string `json:"session_id"`        // MUST
+	RunID     string `json:"run_id,omitempty"`  // MAY
+	Channel   string `json:"channel,omitempty"` // all|ipc|ws|sse，默认 all
+}
+```
+
+请求约束：
+
+1. `session_id` `MUST` 非空。  
+2. `channel` `MUST` 属于 `all|ipc|ws|sse`。  
+3. 若 `channel != all`，其值 `MUST` 与连接自身通道一致，否则返回 `invalid_action`。  
+4. 单连接绑定数上限为 `128`，超过上限返回 `invalid_action`。  
+
+Response Schema：
+
+1. Success（完整 payload）：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-3",
+  "result": {
+    "type": "ack",
+    "action": "bind_stream",
+    "request_id": "req-3",
+    "session_id": "session-1",
+    "run_id": "run-1",
+    "payload": {
+      "message": "stream binding updated",
+      "channel": "all"
+    }
+  }
+}
+```
+
+2. Failure（完整 payload）：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-3",
+  "error": {
+    "code": -32602,
+    "message": "invalid bind_stream channel",
+    "data": {
+      "gateway_code": "invalid_action"
+    }
+  }
+}
+```
+
+### 双向交互细节（重点）
+
+1. 客户端调用 `gateway.bindStream` 后，先收到 `ack(bind_stream)`。  
+2. 后续 runtime 事件通过 `gateway.event` 反向推送，不再通过 `gateway.bindStream` 响应体承载。  
+3. 绑定匹配规则（运行事件）：
+1. 当事件 `run_id` 非空时：`run_id` 精确绑定可收到；`run_id` 为空的 session 级绑定也可收到。  
+2. 当事件 `run_id` 为空时：仅 session 级绑定（`run_id=""`）可收到。  
+4. 绑定 TTL 为 `15m`，清理周期为 `30s`。客户端 `SHOULD` 周期调用 `gateway.ping` 续期。  
+5. 自动绑定生效规则：
+1. 除 `authenticate`、`bindStream`、`ping` 外，其它请求若携带 `session_id/run_id`，网关会自动续绑。  
+2. 自动续绑不替代显式绑定；第三方客户端仍 `SHOULD` 在重连后主动执行 `bindStream`。  
+
+### 交互时序
+
+```mermaid
+sequenceDiagram
+  participant C as Client
+  participant G as Gateway
+  participant R as Runtime
+
+  C->>G: gateway.bindStream(session_id, run_id?, channel?)
+  G-->>C: ack(bind_stream)
+  C->>G: gateway.run(...)
+  G-->>C: ack(run accepted)
+  R-->>G: runtime event
+  G-->>C: gateway.event(notification)
+```
+
+Observation：
+
+1. `gateway_requests_total{method="gateway.bindStream",status="ok|error"}`。  
+2. `gateway_connections_active{channel}` 反映连接活跃数。  
+3. 慢消费者导致队列满时会增加 `gateway_stream_dropped_total{reason="queue_full"}`。  
+
+---
+
+## 4. gateway.run
+
+Method: `gateway.run`  
+Stability: `Stable`  
+Auth Required: `Yes`
+
+Request Schema（Go Struct）：
+
+```go
+type RunParams struct {
+	SessionID  string         `json:"session_id,omitempty"`  // 推荐显式传递
+	RunID      string         `json:"run_id,omitempty"`      // 可选
+	InputText  string         `json:"input_text,omitempty"`  // 与 input_parts 至少一个非空
+	InputParts []RunInputPart `json:"input_parts,omitempty"` // text|image
+	Workdir    string         `json:"workdir,omitempty"`     // 请求级工作目录覆盖
+}
+
+type RunInputPart struct {
+	Type  string         `json:"type"`            // text|image
+	Text  string         `json:"text,omitempty"`  // text MUST
+	Media *RunInputMedia `json:"media,omitempty"` // image MUST
+}
+```
+
+请求约束：
+
+1. `input_text` 与 `input_parts` 至少一项非空。  
+2. `input_parts` 中：
+1. `type=text` 时 `text` `MUST` 非空。  
+2. `type=image` 时 `media.uri` 与 `media.mime_type` `MUST` 非空。  
+3. 未知字段会因严格解码触发 `invalid_frame`。  
+4. `run_id` 归一化顺序为：显式 `run_id` > `request_id` > 网关生成 `run_<timestamp>`。  
+
+Response Schema：
+
+1. Success（完整 payload，表示“受理成功”而非“执行完成”）：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-4",
+  "result": {
+    "type": "ack",
+    "action": "run",
+    "request_id": "req-4",
+    "session_id": "session-1",
+    "run_id": "run-1",
+    "payload": {
+      "message": "run accepted"
+    }
+  }
+}
+```
+
+2. Failure（完整 payload，发生在受理前校验或授权阶段）：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-4",
+  "error": {
+    "code": -32602,
+    "message": "input_parts[image] requires media.uri",
+    "data": {
+      "gateway_code": "invalid_multimodal_payload"
+    }
+  }
+}
+```
+
+### 双向交互细节（重点）
+
+1. `gateway.run` 采用“异步受理”模型：网关先返回 `ack(run accepted)`。  
+2. 运行结果通过 `gateway.event` 持续回流，客户端 `MUST` 以事件流判断最终状态。  
+3. 事件类型映射：
+1. `run_progress`：常规过程事件。  
+2. `run_done`：运行完成。  
+3. `run_error`：运行失败或取消。  
+4. `gateway.event.params.payload.payload` 载荷中包含 runtime envelope：
+1. `runtime_event_type`  
+2. `turn`  
+3. `phase`  
+4. `timestamp`  
+5. `payload_version`（当前为 `2`）  
+6. `payload`  
+5. HTTP 来源的 `run` 会在网关内部脱离请求取消（`context.WithoutCancel`），避免客户端短连接中断导致任务误取消。  
+6. `ack` 后若 runtime 立即失败，网关仅记录日志（`gateway run async failed`），不会再补发同步 JSON-RPC error。客户端 `SHOULD` 为 run 设置完成超时并结合 `gateway.event` 或 `gateway.cancel` 做兜底。  
+7. 客户端中断执行时，调用 `gateway.cancel`（按 `run_id` 精确取消）。  
+
+### 交互时序
+
+```mermaid
+sequenceDiagram
+  participant C as Client
+  participant G as Gateway
+  participant R as Runtime
+
+  C->>G: gateway.run(session_id, run_id?, input_text/input_parts)
+  G-->>C: ack(run accepted)
+  R-->>G: runtime event(progress...)
+  G-->>C: gateway.event(run_progress)
+  R-->>G: runtime event(done|error)
+  G-->>C: gateway.event(run_done|run_error)
+  C->>G: gateway.cancel(run_id) (optional)
+  G-->>C: ack(cancel)
+```
+
+Observation：
+
+1. `gateway_requests_total{method="gateway.run",status="ok|error"}`。  
+2. 请求日志记录 `latency_ms` 与 `gateway_code`。  
+3. 异步阶段异常会写日志：`gateway run async failed`。  
+
+---
+
+## 5. gateway.compact
+
+Method: `gateway.compact`  
+Stability: `Stable`  
+Auth Required: `Yes`
+
+Request Schema（Go Struct）：
+
+```go
+type CompactParams struct {
+	SessionID string `json:"session_id"`       // MUST
+	RunID     string `json:"run_id,omitempty"` // MAY
+}
+```
+
+Response Schema：
+
+1. Success：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-5",
+  "result": {
+    "type": "ack",
+    "action": "compact",
+    "request_id": "req-5",
+    "session_id": "session-1",
+    "payload": {
+      "applied": true,
+      "before_chars": 12345,
+      "after_chars": 4567,
+      "saved_ratio": 0.63,
+      "trigger_mode": "manual",
+      "transcript_id": "compact-1",
+      "transcript_path": ".neocode/transcripts/compact-1.md"
+    }
+  }
+}
+```
+
+2. Failure：统一 `error` 信封，超时通常为 `gateway_code=timeout`。  
+
+Observation：
+
+1. `gateway_requests_total` 会记录 compact 成败。  
+2. runtime 超时会写入结构化错误日志。  
+
+---
+
+## 6. gateway.cancel
+
+Method: `gateway.cancel`  
+Stability: `Stable`  
+Auth Required: `Yes`
+
+Request Schema（Go Struct）：
+
+```go
+type CancelParams struct {
+	SessionID string `json:"session_id,omitempty"`
+	RunID     string `json:"run_id,omitempty"` // MUST
+}
+```
+
+Response Schema：
+
+1. Success：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-6",
+  "result": {
+    "type": "ack",
+    "action": "cancel",
+    "request_id": "req-6",
+    "payload": {
+      "canceled": true,
+      "run_id": "run-1"
+    }
+  }
+}
+```
+
+2. Failure：统一 `error` 信封，常见 `missing_required_field` 或 `resource_not_found`。  
+
+Observation：
+
+1. 未命中运行目标常由 runtime 桥接映射为 `resource_not_found`。  
+2. 调用行为会被请求日志完整记录。  
+
+---
+
+## 7. gateway.listSessions
+
+Method: `gateway.listSessions`  
+Stability: `Stable`  
+Auth Required: `Yes`
+
+Request Schema（JSON Schema）：
+
+```json
+{
+  "type": "object",
+  "required": ["jsonrpc", "id", "method"],
+  "properties": {
+    "jsonrpc": { "const": "2.0" },
+    "id": { "type": ["string", "number"] },
+    "method": { "const": "gateway.listSessions" }
+  },
+  "additionalProperties": false
+}
+```
+
+Response Schema：
+
+1. Success：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-7",
+  "result": {
+    "type": "ack",
+    "action": "list_sessions",
+    "request_id": "req-7",
+    "payload": {
+      "sessions": [
+        {
+          "id": "session-1",
+          "title": "debug http gateway",
+          "created_at": "2026-04-22T09:00:00Z",
+          "updated_at": "2026-04-22T09:30:00Z"
+        }
+      ]
+    }
+  }
+}
+```
+
+2. Failure：统一 `error` 信封。  
+
+Observation：
+
+1. 仅有请求级指标与日志，无流式副作用。  
+
+---
+
+## 8. gateway.loadSession
+
+Method: `gateway.loadSession`  
+Stability: `Stable`  
+Auth Required: `Yes`
+
+Request Schema（Go Struct）：
+
+```go
+type LoadSessionParams struct {
+	SessionID string `json:"session_id"` // MUST
+}
+```
+
+Response Schema：
+
+1. Success：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-8",
+  "result": {
+    "type": "ack",
+    "action": "load_session",
+    "request_id": "req-8",
+    "session_id": "session-1",
+    "payload": {
+      "id": "session-1",
+      "title": "debug http gateway",
+      "created_at": "2026-04-22T09:00:00Z",
+      "updated_at": "2026-04-22T09:30:00Z",
+      "workdir": "C:/repo",
+      "messages": []
+    }
+  }
+}
+```
+
+2. Failure：统一 `error` 信封，常见 `missing_required_field/access_denied`。  
+
+Observation：
+
+1. 当前默认桥接实现可能在会话不存在时自动创建会话。  
+2. 第三方客户端 `SHOULD` 以响应内容为准，不应假设 “不存在必报错”。  
+
+---
+
+## 9. gateway.resolvePermission
+
+Method: `gateway.resolvePermission`  
+Stability: `Stable`  
+Auth Required: `Yes`
+
+Request Schema（Go Struct）：
+
+```go
+type ResolvePermissionParams struct {
+	RequestID string `json:"request_id"` // MUST
+	Decision  string `json:"decision"`   // allow_once|allow_session|reject
+}
+```
+
+Response Schema：
+
+1. Success：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-9",
+  "result": {
+    "type": "ack",
+    "action": "resolve_permission",
+    "request_id": "req-9",
+    "payload": {
+      "request_id": "perm-1",
+      "decision": "allow_once",
+      "message": "permission resolved"
+    }
+  }
+}
+```
+
+2. Failure：统一 `error` 信封，常见 `missing_required_field/invalid_action`。  
+
+Observation：
+
+1. 建议业务侧按 `request_id` 建立审批链路追踪。  
+
+---
+
+## 10. wake.openUrl
+
+Method: `wake.openUrl`  
+Stability: `Experimental`  
+Auth Required: `Yes`
+
+Request Schema（Go Struct）：
+
+```go
+type WakeIntent struct {
+	Action    string            `json:"action"` // 当前主要为 review
+	SessionID string            `json:"session_id,omitempty"`
+	Workdir   string            `json:"workdir,omitempty"`
+	Params    map[string]string `json:"params,omitempty"`
+	RawURL    string            `json:"raw_url,omitempty"`
+}
+```
+
+Response Schema：
+
+1. Success：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-10",
+  "result": {
+    "type": "ack",
+    "action": "wake.openUrl",
+    "request_id": "req-10",
+    "session_id": "session-1",
+    "payload": {
+      "message": "wake intent accepted",
+      "action": "review",
+      "params": {
+        "path": "README.md"
+      }
+    }
+  }
+}
+```
+
+2. Failure：统一 `error` 信封。实验能力建议调用方具备降级逻辑。  
+
+Observation：
+
+1. 与稳定方法共享同一套指标与日志链路。  
+
+---
+
+## 11. gateway.event（服务端通知）
+
+Method: `gateway.event`  
+Stability: `Stable`  
+Auth Required: `Connection-Scoped Yes`
+
+Request Schema: `N/A`（客户端不可主动调用）  
+
+Response Schema（通知完整 payload）：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "gateway.event",
+  "params": {
+    "type": "event",
+    "action": "run",
+    "session_id": "session-1",
+    "run_id": "run-1",
+    "payload": {
+      "event_type": "run_progress|run_done|run_error",
+      "payload": {
+        "runtime_event_type": "agent_chunk|agent_done|error|...",
+        "turn": 3,
+        "phase": "reasoning",
+        "timestamp": "2026-04-22T09:01:02.123456789Z",
+        "payload_version": 2,
+        "payload": {}
+      }
+    }
+  }
+}
+```
+
+Observation：
+
+1. 连接活跃数通过 `gateway_connections_active{channel}` 观测。  
+2. 事件丢弃通过 `gateway_stream_dropped_total{reason}` 观测。  
+
+---
+
+## 附录：客户端实现要点
+
+1. 重连后固定执行：`authenticate -> bindStream -> ping(保活)`。  
+2. 对 `gateway.run` 必须使用“异步受理”心智：`ack` 仅表示入队受理。  
+3. 异常处理应优先读取 `error.data.gateway_code`，再读取 `message`。  
+4. 事件驱动端建议对每个 `run_id` 建立完成超时，防止 ACK 后无终态事件造成悬挂。  
+
+---
+
+## 附录：结构体自动生成 JSON 示例
+
+本附录由脚本自动生成，确保示例与 Go 结构体一致。  
+生成命令：`go run ./scripts/generate_gateway_rpc_examples`
+
+<!-- AUTO-GENERATED:BEGIN -->
+> 以下 JSON 示例由 `go run ./scripts/generate_gateway_rpc_examples` 自动生成。
+> 如结构体或字段标签发生变更，请重新执行生成命令。
+
+### gateway.authenticate
+
+Request：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-auth-1",
+  "method": "gateway.authenticate",
+  "params": {
+    "token": "\u003cTOKEN\u003e"
+  }
+}
+```
+
+Success Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-auth-1",
+  "result": {
+    "type": "ack",
+    "action": "authenticate",
+    "request_id": "req-auth-1",
+    "payload": {
+      "message": "authenticated",
+      "subject_id": "local_admin"
+    }
+  }
+}
+```
+
+Failure Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-auth-1",
+  "error": {
+    "code": -32602,
+    "message": "invalid auth token",
+    "data": {
+      "gateway_code": "unauthorized"
+    }
+  }
+}
+```
+
+### gateway.ping
+
+Request：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-ping-1",
+  "method": "gateway.ping",
+  "params": {}
+}
+```
+
+Success Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-ping-1",
+  "result": {
+    "type": "ack",
+    "action": "ping",
+    "request_id": "req-ping-1",
+    "payload": {
+      "message": "pong",
+      "version": "dev"
+    }
+  }
+}
+```
+
+Failure Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-ping-1",
+  "error": {
+    "code": -32602,
+    "message": "unauthorized",
+    "data": {
+      "gateway_code": "unauthorized"
+    }
+  }
+}
+```
+
+### gateway.bindStream
+
+Request：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-bind-1",
+  "method": "gateway.bindStream",
+  "params": {
+    "session_id": "session-demo-1",
+    "run_id": "run-demo-1",
+    "channel": "all"
+  }
+}
+```
+
+Success Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-bind-1",
+  "result": {
+    "type": "ack",
+    "action": "bind_stream",
+    "request_id": "req-bind-1",
+    "run_id": "run-demo-1",
+    "session_id": "session-demo-1",
+    "payload": {
+      "channel": "all",
+      "message": "stream binding updated"
+    }
+  }
+}
+```
+
+Failure Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-bind-1",
+  "error": {
+    "code": -32602,
+    "message": "invalid bind_stream channel",
+    "data": {
+      "gateway_code": "invalid_action"
+    }
+  }
+}
+```
+
+Notes：
+
+1. `bindStream` 仅建立订阅绑定，后续运行事件通过 `gateway.event` 推送。
+
+### gateway.run
+
+Request：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-run-1",
+  "method": "gateway.run",
+  "params": {
+    "session_id": "session-demo-1",
+    "run_id": "run-demo-1",
+    "input_text": "请分析这段代码并给出改进建议",
+    "input_parts": [
+      {
+        "type": "text",
+        "text": "补充一段上下文描述"
+      },
+      {
+        "type": "image",
+        "media": {
+          "uri": "file:///tmp/screenshot.png",
+          "mime_type": "image/png",
+          "file_name": "screenshot.png"
+        }
+      }
+    ],
+    "workdir": "C:/workspace/demo"
+  }
+}
+```
+
+Success Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-run-1",
+  "result": {
+    "type": "ack",
+    "action": "run",
+    "request_id": "req-run-1",
+    "run_id": "run-demo-1",
+    "session_id": "session-demo-1",
+    "payload": {
+      "message": "run accepted"
+    }
+  }
+}
+```
+
+Failure Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-run-1",
+  "error": {
+    "code": -32602,
+    "message": "input_parts[image] requires media.uri",
+    "data": {
+      "gateway_code": "invalid_multimodal_payload"
+    }
+  }
+}
+```
+
+Notes：
+
+1. `Success Response` 只代表受理成功，不代表运行完成。
+2. 运行完成或失败需要通过 `gateway.event` 的 `run_done/run_error` 判断。
+
+### gateway.compact
+
+Request：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-compact-1",
+  "method": "gateway.compact",
+  "params": {
+    "session_id": "session-demo-1",
+    "run_id": "run-demo-1"
+  }
+}
+```
+
+Success Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-compact-1",
+  "result": {
+    "type": "ack",
+    "action": "compact",
+    "request_id": "req-compact-1",
+    "run_id": "run-demo-1",
+    "session_id": "session-demo-1",
+    "payload": {
+      "Applied": true,
+      "BeforeChars": 12345,
+      "AfterChars": 4567,
+      "SavedRatio": 0.63,
+      "TriggerMode": "manual",
+      "TranscriptID": "compact-demo-1",
+      "TranscriptPath": ".neocode/transcripts/compact-demo-1.md"
+    }
+  }
+}
+```
+
+Failure Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-compact-1",
+  "error": {
+    "code": -32603,
+    "message": "compact timed out",
+    "data": {
+      "gateway_code": "timeout"
+    }
+  }
+}
+```
+
+### gateway.cancel
+
+Request：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-cancel-1",
+  "method": "gateway.cancel",
+  "params": {
+    "session_id": "session-demo-1",
+    "run_id": "run-demo-1"
+  }
+}
+```
+
+Success Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-cancel-1",
+  "result": {
+    "type": "ack",
+    "action": "cancel",
+    "request_id": "req-cancel-1",
+    "payload": {
+      "canceled": true,
+      "run_id": "run-demo-1"
+    }
+  }
+}
+```
+
+Failure Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-cancel-1",
+  "error": {
+    "code": -32602,
+    "message": "cancel target not found",
+    "data": {
+      "gateway_code": "resource_not_found"
+    }
+  }
+}
+```
+
+### gateway.listSessions
+
+Request：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-list-1",
+  "method": "gateway.listSessions"
+}
+```
+
+Success Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-list-1",
+  "result": {
+    "type": "ack",
+    "action": "list_sessions",
+    "request_id": "req-list-1",
+    "payload": {
+      "sessions": [
+        {
+          "id": "session-demo-1",
+          "title": "gateway 文档联调",
+          "created_at": "2026-04-22T09:00:00Z",
+          "updated_at": "2026-04-22T09:10:00Z"
+        }
+      ]
+    }
+  }
+}
+```
+
+Failure Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-list-1",
+  "error": {
+    "code": -32602,
+    "message": "unauthorized",
+    "data": {
+      "gateway_code": "unauthorized"
+    }
+  }
+}
+```
+
+### gateway.loadSession
+
+Request：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-load-1",
+  "method": "gateway.loadSession",
+  "params": {
+    "session_id": "session-demo-1"
+  }
+}
+```
+
+Success Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-load-1",
+  "result": {
+    "type": "ack",
+    "action": "load_session",
+    "request_id": "req-load-1",
+    "session_id": "session-demo-1",
+    "payload": {
+      "id": "session-demo-1",
+      "title": "gateway 文档联调",
+      "created_at": "2026-04-22T09:00:00Z",
+      "updated_at": "2026-04-22T09:10:00Z",
+      "workdir": "C:/workspace/demo"
+    }
+  }
+}
+```
+
+Failure Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-load-1",
+  "error": {
+    "code": -32602,
+    "message": "load_session access denied",
+    "data": {
+      "gateway_code": "access_denied"
+    }
+  }
+}
+```
+
+### gateway.resolvePermission
+
+Request：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-permission-1",
+  "method": "gateway.resolvePermission",
+  "params": {
+    "request_id": "perm-request-1",
+    "decision": "allow_once"
+  }
+}
+```
+
+Success Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-permission-1",
+  "result": {
+    "type": "ack",
+    "action": "resolve_permission",
+    "request_id": "req-permission-1",
+    "payload": {
+      "decision": "allow_once",
+      "message": "permission resolved",
+      "request_id": "perm-request-1"
+    }
+  }
+}
+```
+
+Failure Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-permission-1",
+  "error": {
+    "code": -32602,
+    "message": "invalid resolve_permission decision",
+    "data": {
+      "gateway_code": "invalid_action"
+    }
+  }
+}
+```
+
+### wake.openUrl
+
+Request：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-wake-1",
+  "method": "wake.openUrl",
+  "params": {
+    "action": "review",
+    "session_id": "session-demo-1",
+    "workdir": "C:/workspace/demo",
+    "params": {
+      "path": "README.md"
+    },
+    "raw_url": "neocode://review?path=README.md"
+  }
+}
+```
+
+Success Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-wake-1",
+  "result": {
+    "type": "ack",
+    "action": "wake.openUrl",
+    "request_id": "req-wake-1",
+    "session_id": "session-demo-1",
+    "payload": {
+      "action": "review",
+      "message": "wake intent accepted",
+      "params": {
+        "path": "README.md"
+      }
+    }
+  }
+}
+```
+
+Failure Response：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-wake-1",
+  "error": {
+    "code": -32602,
+    "message": "missing required field: params.path",
+    "data": {
+      "gateway_code": "missing_required_field"
+    }
+  }
+}
+```
+
+### gateway.event
+
+Notification：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "gateway.event",
+  "params": {
+    "type": "event",
+    "action": "run",
+    "run_id": "run-demo-1",
+    "session_id": "session-demo-1",
+    "payload": {
+      "event_type": "run_progress",
+      "payload": {
+        "payload": {
+          "delta": "正在分析请求..."
+        },
+        "payload_version": 2,
+        "phase": "reasoning",
+        "runtime_event_type": "agent_chunk",
+        "timestamp": "2026-04-22T09:01:02.123456789Z",
+        "turn": 3
+      }
+    }
+  }
+}
+```
+<!-- AUTO-GENERATED:END -->

--- a/scripts/generate_gateway_rpc_examples/main.go
+++ b/scripts/generate_gateway_rpc_examples/main.go
@@ -1,0 +1,555 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"neo-code/internal/gateway"
+	"neo-code/internal/gateway/protocol"
+	"neo-code/internal/runtime/controlplane"
+)
+
+const (
+	// targetDocPath 表示需要回填自动生成示例的目标文档路径。
+	targetDocPath = "docs/reference/gateway-rpc-api.md"
+	// beginMarker 标记自动生成区块起始位置。
+	beginMarker = "<!-- AUTO-GENERATED:BEGIN -->"
+	// endMarker 标记自动生成区块结束位置。
+	endMarker = "<!-- AUTO-GENERATED:END -->"
+)
+
+// methodExample 描述单个方法在文档中的自动生成示例片段。
+type methodExample struct {
+	Method       string
+	Request      any
+	Success      any
+	Failure      any
+	Notification any
+	Notes        []string
+}
+
+// main 生成 Gateway JSON 示例并回填至 API 文档标记区块。
+func main() {
+	documentPath := filepath.Clean(targetDocPath)
+	originalContent, err := os.ReadFile(documentPath)
+	if err != nil {
+		exitWithError("读取 API 文档失败", err)
+	}
+
+	generatedBlock, err := renderGeneratedBlock()
+	if err != nil {
+		exitWithError("渲染自动生成区块失败", err)
+	}
+
+	updatedContent, err := replaceGeneratedBlock(string(originalContent), generatedBlock)
+	if err != nil {
+		exitWithError("回填自动生成区块失败", err)
+	}
+
+	if updatedContent == string(originalContent) {
+		fmt.Printf("Gateway JSON 示例已是最新，无需更新：%s\n", documentPath)
+		return
+	}
+
+	if err := os.WriteFile(documentPath, []byte(updatedContent), 0o644); err != nil {
+		exitWithError("写入 API 文档失败", err)
+	}
+
+	fmt.Printf("Gateway JSON 示例已更新：%s\n", documentPath)
+}
+
+// renderGeneratedBlock 渲染附录中的自动生成内容。
+func renderGeneratedBlock() (string, error) {
+	examples, err := buildMethodExamples()
+	if err != nil {
+		return "", err
+	}
+
+	var builder strings.Builder
+	builder.WriteString("> 以下 JSON 示例由 `go run ./scripts/generate_gateway_rpc_examples` 自动生成。\n")
+	builder.WriteString("> 如结构体或字段标签发生变更，请重新执行生成命令。\n\n")
+
+	for _, example := range examples {
+		builder.WriteString("### ")
+		builder.WriteString(example.Method)
+		builder.WriteString("\n\n")
+
+		if example.Request != nil {
+			builder.WriteString("Request：\n\n```json\n")
+			builder.WriteString(mustPrettyJSON(example.Request))
+			builder.WriteString("\n```\n\n")
+		}
+		if example.Success != nil {
+			builder.WriteString("Success Response：\n\n```json\n")
+			builder.WriteString(mustPrettyJSON(example.Success))
+			builder.WriteString("\n```\n\n")
+		}
+		if example.Failure != nil {
+			builder.WriteString("Failure Response：\n\n```json\n")
+			builder.WriteString(mustPrettyJSON(example.Failure))
+			builder.WriteString("\n```\n\n")
+		}
+		if example.Notification != nil {
+			builder.WriteString("Notification：\n\n```json\n")
+			builder.WriteString(mustPrettyJSON(example.Notification))
+			builder.WriteString("\n```\n\n")
+		}
+		if len(example.Notes) > 0 {
+			builder.WriteString("Notes：\n\n")
+			for index, note := range example.Notes {
+				builder.WriteString(strconv.Itoa(index + 1))
+				builder.WriteString(". ")
+				builder.WriteString(note)
+				builder.WriteString("\n")
+			}
+			builder.WriteString("\n")
+		}
+	}
+
+	return strings.TrimRight(builder.String(), "\n"), nil
+}
+
+// buildMethodExamples 基于 Go 结构体构造 RPC 方法示例集合。
+func buildMethodExamples() ([]methodExample, error) {
+	runRequestID := "req-run-1"
+	runID := "run-demo-1"
+	sessionID := "session-demo-1"
+
+	authenticateRequest := buildRequest(
+		"req-auth-1",
+		protocol.MethodGatewayAuthenticate,
+		protocol.AuthenticateParams{Token: "<TOKEN>"},
+	)
+	authenticateSuccess := buildSuccessResponse("req-auth-1", gateway.MessageFrame{
+		Type:      gateway.FrameTypeAck,
+		Action:    gateway.FrameActionAuthenticate,
+		RequestID: "req-auth-1",
+		Payload: map[string]string{
+			"message":    "authenticated",
+			"subject_id": "local_admin",
+		},
+	})
+	authenticateFailure := buildFailureResponse(
+		"req-auth-1",
+		protocol.MapGatewayCodeToJSONRPCCode(gateway.ErrorCodeUnauthorized.String()),
+		"invalid auth token",
+		gateway.ErrorCodeUnauthorized.String(),
+	)
+
+	pingRequest := buildRequest("req-ping-1", protocol.MethodGatewayPing, map[string]any{})
+	pingSuccess := buildSuccessResponse("req-ping-1", gateway.MessageFrame{
+		Type:      gateway.FrameTypeAck,
+		Action:    gateway.FrameActionPing,
+		RequestID: "req-ping-1",
+		Payload: map[string]string{
+			"message": "pong",
+			"version": "dev",
+		},
+	})
+	pingFailure := buildFailureResponse(
+		"req-ping-1",
+		protocol.MapGatewayCodeToJSONRPCCode(gateway.ErrorCodeUnauthorized.String()),
+		"unauthorized",
+		gateway.ErrorCodeUnauthorized.String(),
+	)
+
+	bindRequest := buildRequest("req-bind-1", protocol.MethodGatewayBindStream, protocol.BindStreamParams{
+		SessionID: sessionID,
+		RunID:     runID,
+		Channel:   string(gateway.StreamChannelAll),
+	})
+	bindSuccess := buildSuccessResponse("req-bind-1", gateway.MessageFrame{
+		Type:      gateway.FrameTypeAck,
+		Action:    gateway.FrameActionBindStream,
+		RequestID: "req-bind-1",
+		SessionID: sessionID,
+		RunID:     runID,
+		Payload: map[string]any{
+			"message": "stream binding updated",
+			"channel": string(gateway.StreamChannelAll),
+		},
+	})
+	bindFailure := buildFailureResponse(
+		"req-bind-1",
+		protocol.MapGatewayCodeToJSONRPCCode(gateway.ErrorCodeInvalidAction.String()),
+		"invalid bind_stream channel",
+		gateway.ErrorCodeInvalidAction.String(),
+	)
+
+	runRequest := buildRequest(runRequestID, protocol.MethodGatewayRun, protocol.RunParams{
+		SessionID: sessionID,
+		RunID:     runID,
+		InputText: "请分析这段代码并给出改进建议",
+		InputParts: []protocol.RunInputPart{
+			{
+				Type: "text",
+				Text: "补充一段上下文描述",
+			},
+			{
+				Type: "image",
+				Media: &protocol.RunInputMedia{
+					URI:      "file:///tmp/screenshot.png",
+					MimeType: "image/png",
+					FileName: "screenshot.png",
+				},
+			},
+		},
+		Workdir: "C:/workspace/demo",
+	})
+	runSuccess := buildSuccessResponse(runRequestID, gateway.MessageFrame{
+		Type:      gateway.FrameTypeAck,
+		Action:    gateway.FrameActionRun,
+		RequestID: runRequestID,
+		SessionID: sessionID,
+		RunID:     runID,
+		Payload: map[string]string{
+			"message": "run accepted",
+		},
+	})
+	runFailure := buildFailureResponse(
+		runRequestID,
+		protocol.MapGatewayCodeToJSONRPCCode(gateway.ErrorCodeInvalidMultimodalPayload.String()),
+		"input_parts[image] requires media.uri",
+		gateway.ErrorCodeInvalidMultimodalPayload.String(),
+	)
+
+	compactRequest := buildRequest("req-compact-1", protocol.MethodGatewayCompact, protocol.CompactParams{
+		SessionID: sessionID,
+		RunID:     runID,
+	})
+	compactSuccess := buildSuccessResponse("req-compact-1", gateway.MessageFrame{
+		Type:      gateway.FrameTypeAck,
+		Action:    gateway.FrameActionCompact,
+		RequestID: "req-compact-1",
+		SessionID: sessionID,
+		RunID:     runID,
+		Payload: gateway.CompactResult{
+			Applied:        true,
+			BeforeChars:    12345,
+			AfterChars:     4567,
+			SavedRatio:     0.63,
+			TriggerMode:    "manual",
+			TranscriptID:   "compact-demo-1",
+			TranscriptPath: ".neocode/transcripts/compact-demo-1.md",
+		},
+	})
+	compactFailure := buildFailureResponse(
+		"req-compact-1",
+		protocol.MapGatewayCodeToJSONRPCCode(gateway.ErrorCodeTimeout.String()),
+		"compact timed out",
+		gateway.ErrorCodeTimeout.String(),
+	)
+
+	cancelRequest := buildRequest("req-cancel-1", protocol.MethodGatewayCancel, protocol.CancelParams{
+		SessionID: sessionID,
+		RunID:     runID,
+	})
+	cancelSuccess := buildSuccessResponse("req-cancel-1", gateway.MessageFrame{
+		Type:      gateway.FrameTypeAck,
+		Action:    gateway.FrameActionCancel,
+		RequestID: "req-cancel-1",
+		Payload: map[string]any{
+			"canceled": true,
+			"run_id":   runID,
+		},
+	})
+	cancelFailure := buildFailureResponse(
+		"req-cancel-1",
+		protocol.MapGatewayCodeToJSONRPCCode(gateway.ErrorCodeResourceNotFound.String()),
+		"cancel target not found",
+		gateway.ErrorCodeResourceNotFound.String(),
+	)
+
+	listSessionsRequest := buildRequest("req-list-1", protocol.MethodGatewayListSessions, nil)
+	listSessionsSuccess := buildSuccessResponse("req-list-1", gateway.MessageFrame{
+		Type:      gateway.FrameTypeAck,
+		Action:    gateway.FrameActionListSessions,
+		RequestID: "req-list-1",
+		Payload: map[string]any{
+			"sessions": []gateway.SessionSummary{
+				{
+					ID:        sessionID,
+					Title:     "gateway 文档联调",
+					CreatedAt: mustParseTime("2026-04-22T09:00:00Z"),
+					UpdatedAt: mustParseTime("2026-04-22T09:10:00Z"),
+				},
+			},
+		},
+	})
+	listSessionsFailure := buildFailureResponse(
+		"req-list-1",
+		protocol.MapGatewayCodeToJSONRPCCode(gateway.ErrorCodeUnauthorized.String()),
+		"unauthorized",
+		gateway.ErrorCodeUnauthorized.String(),
+	)
+
+	loadSessionRequest := buildRequest("req-load-1", protocol.MethodGatewayLoadSession, protocol.LoadSessionParams{
+		SessionID: sessionID,
+	})
+	loadSessionSuccess := buildSuccessResponse("req-load-1", gateway.MessageFrame{
+		Type:      gateway.FrameTypeAck,
+		Action:    gateway.FrameActionLoadSession,
+		RequestID: "req-load-1",
+		SessionID: sessionID,
+		Payload: gateway.Session{
+			ID:        sessionID,
+			Title:     "gateway 文档联调",
+			CreatedAt: mustParseTime("2026-04-22T09:00:00Z"),
+			UpdatedAt: mustParseTime("2026-04-22T09:10:00Z"),
+			Workdir:   "C:/workspace/demo",
+			Messages:  []gateway.SessionMessage{},
+		},
+	})
+	loadSessionFailure := buildFailureResponse(
+		"req-load-1",
+		protocol.MapGatewayCodeToJSONRPCCode(gateway.ErrorCodeAccessDenied.String()),
+		"load_session access denied",
+		gateway.ErrorCodeAccessDenied.String(),
+	)
+
+	resolvePermissionRequest := buildRequest(
+		"req-permission-1",
+		protocol.MethodGatewayResolvePermission,
+		protocol.ResolvePermissionParams{
+			RequestID: "perm-request-1",
+			Decision:  string(gateway.PermissionResolutionAllowOnce),
+		},
+	)
+	resolvePermissionSuccess := buildSuccessResponse("req-permission-1", gateway.MessageFrame{
+		Type:      gateway.FrameTypeAck,
+		Action:    gateway.FrameActionResolvePermission,
+		RequestID: "req-permission-1",
+		Payload: map[string]any{
+			"request_id": "perm-request-1",
+			"decision":   string(gateway.PermissionResolutionAllowOnce),
+			"message":    "permission resolved",
+		},
+	})
+	resolvePermissionFailure := buildFailureResponse(
+		"req-permission-1",
+		protocol.MapGatewayCodeToJSONRPCCode(gateway.ErrorCodeInvalidAction.String()),
+		"invalid resolve_permission decision",
+		gateway.ErrorCodeInvalidAction.String(),
+	)
+
+	wakeRequest := buildRequest("req-wake-1", protocol.MethodWakeOpenURL, protocol.WakeIntent{
+		Action:    protocol.WakeActionReview,
+		SessionID: sessionID,
+		Workdir:   "C:/workspace/demo",
+		Params: map[string]string{
+			"path": "README.md",
+		},
+		RawURL: "neocode://review?path=README.md",
+	})
+	wakeSuccess := buildSuccessResponse("req-wake-1", gateway.MessageFrame{
+		Type:      gateway.FrameTypeAck,
+		Action:    gateway.FrameActionWakeOpenURL,
+		RequestID: "req-wake-1",
+		SessionID: sessionID,
+		Payload: map[string]any{
+			"message": "wake intent accepted",
+			"action":  protocol.WakeActionReview,
+			"params": map[string]string{
+				"path": "README.md",
+			},
+		},
+	})
+	wakeFailure := buildFailureResponse(
+		"req-wake-1",
+		protocol.MapGatewayCodeToJSONRPCCode(gateway.ErrorCodeMissingRequiredField.String()),
+		"missing required field: params.path",
+		gateway.ErrorCodeMissingRequiredField.String(),
+	)
+
+	eventNotification := protocol.NewJSONRPCNotification(protocol.MethodGatewayEvent, gateway.MessageFrame{
+		Type:      gateway.FrameTypeEvent,
+		Action:    gateway.FrameActionRun,
+		SessionID: sessionID,
+		RunID:     runID,
+		Payload: map[string]any{
+			"event_type": string(gateway.RuntimeEventTypeRunProgress),
+			"payload": map[string]any{
+				"runtime_event_type": "agent_chunk",
+				"turn":               3,
+				"phase":              "reasoning",
+				"timestamp":          "2026-04-22T09:01:02.123456789Z",
+				"payload_version":    controlplane.PayloadVersion,
+				"payload": map[string]any{
+					"delta": "正在分析请求...",
+				},
+			},
+		},
+	})
+
+	examples := []methodExample{
+		{
+			Method:  protocol.MethodGatewayAuthenticate,
+			Request: authenticateRequest,
+			Success: authenticateSuccess,
+			Failure: authenticateFailure,
+		},
+		{
+			Method:  protocol.MethodGatewayPing,
+			Request: pingRequest,
+			Success: pingSuccess,
+			Failure: pingFailure,
+		},
+		{
+			Method:  protocol.MethodGatewayBindStream,
+			Request: bindRequest,
+			Success: bindSuccess,
+			Failure: bindFailure,
+			Notes: []string{
+				"`bindStream` 仅建立订阅绑定，后续运行事件通过 `gateway.event` 推送。",
+			},
+		},
+		{
+			Method:  protocol.MethodGatewayRun,
+			Request: runRequest,
+			Success: runSuccess,
+			Failure: runFailure,
+			Notes: []string{
+				"`Success Response` 只代表受理成功，不代表运行完成。",
+				"运行完成或失败需要通过 `gateway.event` 的 `run_done/run_error` 判断。",
+			},
+		},
+		{
+			Method:  protocol.MethodGatewayCompact,
+			Request: compactRequest,
+			Success: compactSuccess,
+			Failure: compactFailure,
+		},
+		{
+			Method:  protocol.MethodGatewayCancel,
+			Request: cancelRequest,
+			Success: cancelSuccess,
+			Failure: cancelFailure,
+		},
+		{
+			Method:  protocol.MethodGatewayListSessions,
+			Request: listSessionsRequest,
+			Success: listSessionsSuccess,
+			Failure: listSessionsFailure,
+		},
+		{
+			Method:  protocol.MethodGatewayLoadSession,
+			Request: loadSessionRequest,
+			Success: loadSessionSuccess,
+			Failure: loadSessionFailure,
+		},
+		{
+			Method:  protocol.MethodGatewayResolvePermission,
+			Request: resolvePermissionRequest,
+			Success: resolvePermissionSuccess,
+			Failure: resolvePermissionFailure,
+		},
+		{
+			Method:  protocol.MethodWakeOpenURL,
+			Request: wakeRequest,
+			Success: wakeSuccess,
+			Failure: wakeFailure,
+		},
+		{
+			Method:       protocol.MethodGatewayEvent,
+			Notification: eventNotification,
+		},
+	}
+
+	return examples, nil
+}
+
+// buildRequest 构建标准 JSON-RPC 请求对象。
+func buildRequest(requestID, method string, params any) protocol.JSONRPCRequest {
+	request := protocol.JSONRPCRequest{
+		JSONRPC: protocol.JSONRPCVersion,
+		ID:      quotedID(requestID),
+		Method:  strings.TrimSpace(method),
+	}
+	if params != nil {
+		request.Params = marshalRawJSON(params)
+	}
+	return request
+}
+
+// buildSuccessResponse 基于 MessageFrame 生成 JSON-RPC 成功响应。
+func buildSuccessResponse(requestID string, frame gateway.MessageFrame) protocol.JSONRPCResponse {
+	response, err := protocol.NewJSONRPCResultResponse(quotedID(requestID), frame)
+	if err != nil {
+		panic(fmt.Errorf("构造成功响应失败: %v", err))
+	}
+	return response
+}
+
+// buildFailureResponse 构建 JSON-RPC 失败响应。
+func buildFailureResponse(requestID string, code int, message, gatewayCode string) protocol.JSONRPCResponse {
+	return protocol.NewJSONRPCErrorResponse(
+		quotedID(requestID),
+		protocol.NewJSONRPCError(code, strings.TrimSpace(message), strings.TrimSpace(gatewayCode)),
+	)
+}
+
+// replaceGeneratedBlock 将文档中标记区块替换为新生成的文本内容。
+func replaceGeneratedBlock(documentContent, generatedContent string) (string, error) {
+	startIndex := strings.Index(documentContent, beginMarker)
+	if startIndex < 0 {
+		return "", fmt.Errorf("未找到自动生成起始标记 %q", beginMarker)
+	}
+	endIndex := strings.Index(documentContent, endMarker)
+	if endIndex < 0 {
+		return "", fmt.Errorf("未找到自动生成结束标记 %q", endMarker)
+	}
+	if endIndex < startIndex {
+		return "", fmt.Errorf("自动生成区块标记顺序非法")
+	}
+
+	contentStart := startIndex + len(beginMarker)
+	replaced := documentContent[:contentStart] + "\n" + generatedContent + "\n" + documentContent[endIndex:]
+	return replaced, nil
+}
+
+// quotedID 将请求 ID 转换为 JSON-RPC 合法的 RawMessage 字面量。
+func quotedID(requestID string) json.RawMessage {
+	return json.RawMessage(strconv.Quote(strings.TrimSpace(requestID)))
+}
+
+// marshalRawJSON 将任意结构体编码为 RawMessage。
+func marshalRawJSON(value any) json.RawMessage {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		panic(fmt.Errorf("编码 RawMessage 失败: %w", err))
+	}
+	return json.RawMessage(raw)
+}
+
+// mustPrettyJSON 将对象编码为缩进 JSON 字符串。
+func mustPrettyJSON(value any) string {
+	raw, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		panic(fmt.Errorf("编码 JSON 示例失败: %w", err))
+	}
+	return string(raw)
+}
+
+// mustParseTime 将 RFC3339 时间文本解析为 time.Time，失败时直接 panic。
+func mustParseTime(raw string) time.Time {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		panic("时间文本不能为空")
+	}
+	parsed, err := time.Parse(time.RFC3339, trimmed)
+	if err != nil {
+		panic(fmt.Errorf("解析时间失败: %w", err))
+	}
+	return parsed
+}
+
+// exitWithError 统一输出错误并结束进程。
+func exitWithError(message string, err error) {
+	_, _ = fmt.Fprintf(os.Stderr, "%s: %v\n", message, err)
+	os.Exit(1)
+}

--- a/scripts/generate_gateway_rpc_examples/main.go
+++ b/scripts/generate_gateway_rpc_examples/main.go
@@ -499,15 +499,16 @@ func replaceGeneratedBlock(documentContent, generatedContent string) (string, er
 	if startIndex < 0 {
 		return "", fmt.Errorf("未找到自动生成起始标记 %q", beginMarker)
 	}
-	endIndex := strings.Index(documentContent, endMarker)
-	if endIndex < 0 {
+	contentStart := startIndex + len(beginMarker)
+	endOffset := strings.Index(documentContent[contentStart:], endMarker)
+	if endOffset < 0 {
 		return "", fmt.Errorf("未找到自动生成结束标记 %q", endMarker)
 	}
+	endIndex := contentStart + endOffset
 	if endIndex < startIndex {
 		return "", fmt.Errorf("自动生成区块标记顺序非法")
 	}
 
-	contentStart := startIndex + len(beginMarker)
 	replaced := documentContent[:contentStart] + "\n" + generatedContent + "\n" + documentContent[endIndex:]
 	return replaced, nil
 }

--- a/scripts/generate_gateway_rpc_examples/main_test.go
+++ b/scripts/generate_gateway_rpc_examples/main_test.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"neo-code/internal/gateway"
+	"neo-code/internal/gateway/protocol"
+)
+
+func TestBuildMethodExamples(t *testing.T) {
+	examples, err := buildMethodExamples()
+	if err != nil {
+		t.Fatalf("buildMethodExamples() error = %v", err)
+	}
+
+	if len(examples) != 11 {
+		t.Fatalf("len(examples) = %d, want 11", len(examples))
+	}
+
+	if examples[0].Method != protocol.MethodGatewayAuthenticate {
+		t.Fatalf("examples[0].Method = %q, want %q", examples[0].Method, protocol.MethodGatewayAuthenticate)
+	}
+
+	if examples[len(examples)-1].Method != protocol.MethodGatewayEvent {
+		t.Fatalf("last method = %q, want %q", examples[len(examples)-1].Method, protocol.MethodGatewayEvent)
+	}
+}
+
+func TestRenderGeneratedBlock(t *testing.T) {
+	block, err := renderGeneratedBlock()
+	if err != nil {
+		t.Fatalf("renderGeneratedBlock() error = %v", err)
+	}
+
+	mustContain := []string{
+		"### " + protocol.MethodGatewayRun,
+		"### " + protocol.MethodGatewayBindStream,
+		"### " + protocol.MethodGatewayEvent,
+		"```json",
+		"Notes：",
+	}
+	for _, item := range mustContain {
+		if !strings.Contains(block, item) {
+			t.Fatalf("rendered block missing %q", item)
+		}
+	}
+}
+
+func TestReplaceGeneratedBlockSuccess(t *testing.T) {
+	doc := strings.Join([]string{
+		"intro",
+		endMarker,
+		"noise",
+		beginMarker,
+		"old",
+		endMarker,
+		"tail",
+	}, "\n")
+
+	replaced, err := replaceGeneratedBlock(doc, "NEW-CONTENT")
+	if err != nil {
+		t.Fatalf("replaceGeneratedBlock() error = %v", err)
+	}
+
+	expected := strings.Join([]string{
+		"intro",
+		endMarker,
+		"noise",
+		beginMarker,
+		"NEW-CONTENT",
+		endMarker,
+		"tail",
+	}, "\n")
+	if replaced != expected {
+		t.Fatalf("replaceGeneratedBlock()\n got: %q\nwant: %q", replaced, expected)
+	}
+}
+
+func TestReplaceGeneratedBlockErrors(t *testing.T) {
+	if _, err := replaceGeneratedBlock("content only", "x"); err == nil || !strings.Contains(err.Error(), "起始标记") {
+		t.Fatalf("missing begin marker should return start marker error, got %v", err)
+	}
+
+	docWithoutEnd := beginMarker + "\nold\n"
+	if _, err := replaceGeneratedBlock(docWithoutEnd, "x"); err == nil || !strings.Contains(err.Error(), "结束标记") {
+		t.Fatalf("missing end marker should return end marker error, got %v", err)
+	}
+}
+
+func TestMainUpdatesAndNoop(t *testing.T) {
+	tmp := t.TempDir()
+	docPath := filepath.Join(tmp, targetDocPath)
+	if err := os.MkdirAll(filepath.Dir(docPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	initialDoc := strings.Join([]string{
+		"# API",
+		beginMarker,
+		"old content",
+		endMarker,
+	}, "\n")
+	if err := os.WriteFile(docPath, []byte(initialDoc), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(oldWD)
+	}()
+
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("Chdir() error = %v", err)
+	}
+
+	main()
+
+	first, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("ReadFile() after first main error = %v", err)
+	}
+	if !strings.Contains(string(first), "### "+protocol.MethodGatewayRun) {
+		t.Fatalf("generated doc does not contain %q section", protocol.MethodGatewayRun)
+	}
+
+	main()
+
+	second, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("ReadFile() after second main error = %v", err)
+	}
+	if string(first) != string(second) {
+		t.Fatalf("second main() should be noop update")
+	}
+}
+
+func TestHelpers(t *testing.T) {
+	request := buildRequest("  req-1  ", protocol.MethodGatewayPing, map[string]string{"k": "v"})
+	if string(request.ID) != `"req-1"` {
+		t.Fatalf("request.ID = %s, want %s", string(request.ID), `"req-1"`)
+	}
+	if request.Method != protocol.MethodGatewayPing {
+		t.Fatalf("request.Method = %q, want %q", request.Method, protocol.MethodGatewayPing)
+	}
+
+	requestNoParams := buildRequest("req-2", protocol.MethodGatewayListSessions, nil)
+	if len(requestNoParams.Params) != 0 {
+		t.Fatalf("requestNoParams.Params should be empty")
+	}
+
+	success := buildSuccessResponse("req-3", gateway.MessageFrame{
+		Type:   gateway.FrameTypeAck,
+		Action: gateway.FrameActionPing,
+	})
+	if success.Error != nil {
+		t.Fatalf("success response should not carry error")
+	}
+
+	failure := buildFailureResponse("req-4", -32000, "  bad  ", "  gateway.bad  ")
+	if failure.Error == nil {
+		t.Fatalf("failure response should carry error")
+	}
+	if failure.Error.Message != "bad" {
+		t.Fatalf("failure message = %q, want %q", failure.Error.Message, "bad")
+	}
+
+	raw := marshalRawJSON(map[string]string{"hello": "world"})
+	decoded := map[string]string{}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if decoded["hello"] != "world" {
+		t.Fatalf("decoded[hello] = %q, want %q", decoded["hello"], "world")
+	}
+
+	pretty := mustPrettyJSON(map[string]int{"a": 1})
+	if !strings.Contains(pretty, "\n") {
+		t.Fatalf("mustPrettyJSON() should include indentation")
+	}
+
+	parsed := mustParseTime("2026-04-22T09:00:00Z")
+	if parsed.IsZero() {
+		t.Fatalf("mustParseTime() returned zero value")
+	}
+
+	mustPanic(t, func() {
+		_ = mustParseTime("  ")
+	})
+	mustPanic(t, func() {
+		_ = mustParseTime("not-a-time")
+	})
+
+	mustPanic(t, func() {
+		_ = marshalRawJSON(func() {})
+	})
+
+	mustPanic(t, func() {
+		_ = mustPrettyJSON(func() {})
+	})
+
+	mustPanic(t, func() {
+		_ = buildSuccessResponse("req-5", gateway.MessageFrame{
+			Type:    gateway.FrameTypeAck,
+			Action:  gateway.FrameActionPing,
+			Payload: func() {},
+		})
+	})
+}
+
+func TestExitWithError(t *testing.T) {
+	if os.Getenv("TEST_EXIT_WITH_ERROR") == "1" {
+		exitWithError("boom", os.ErrNotExist)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestExitWithError")
+	cmd.Env = append(os.Environ(), "TEST_EXIT_WITH_ERROR=1")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("exitWithError should terminate process with non-zero exit code")
+	}
+
+	content := string(output)
+	if !strings.Contains(content, "boom") {
+		t.Fatalf("stderr should contain message, got %q", content)
+	}
+	if !strings.Contains(content, os.ErrNotExist.Error()) {
+		t.Fatalf("stderr should contain wrapped error, got %q", content)
+	}
+}
+
+func mustPanic(t *testing.T, fn func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("expected panic, got nil")
+		}
+	}()
+	fn()
+}


### PR DESCRIPTION
## 关联 Issue
- Closes #403 

## 变更摘要
- 建立 Gateway 双文档与参考文档体系，明确内部/外部读者边界。
- 细化 `gateway.run` 与 `gateway.bindStream` 双向交互规范。
- 新增错误字典与兼容性规范，统一第三方异常处理与升级策略。
- 引入“基于 Go 结构体自动生成 JSON 示例”机制，并在 CI 强制校验，避免文实不符。

## 主要改动
- 新增第三方接入文档：
  - `docs/guides/gateway-integration-guide.md`
- 新增参考文档：
  - `docs/reference/gateway-rpc-api.md`
  - `docs/reference/gateway-error-catalog.md`
  - `docs/reference/gateway-compatibility.md`
- 新增自动生成脚本：
  - `scripts/generate_gateway_rpc_examples/main.go`
- 新增构建命令：
  - `Makefile` 增加 `docs-gateway`、`docs-gateway-check`
- 新增 CI 校验：
  - `.github/workflows/ci.yml` 增加 `make docs-gateway-check`
- 更新文档导航与本地自检：
  - `README.md`

## 重点说明
- `gateway-rpc-api.md` 采用 XGO 风格模板化描述每个方法：`Method / Stability / Auth Required / Request Schema / Response Schema / Observation`。
- `gateway-rpc-api.md` 中 `gateway.run`、`gateway.bindStream` 增补了 ACK 与异步事件回流的细节、终态判定与取消路径。
- `gateway-error-catalog.md` 以表格统一 `HTTP`、`JSON-RPC code`、`gateway_code`，并补充 `Reasoning` 便于第三方编写 try-catch。
- `gateway-compatibility.md` 给出字段优雅废弃机制与版本节奏示例（`v1.2 Deprecated -> v1.4 Removed`）。

## 验证结果
- `go run ./scripts/generate_gateway_rpc_examples`
- `go test ./scripts/...`
- `make docs-gateway-check`

## 影响范围
- 文档与 CI 流程变更为主，不修改运行时业务逻辑。
- PR 合并后，Gateway API 示例将受 CI 约束，结构体变更需要同步更新文档生成结果。

## Checklist
- [x] 文档语言与术语统一为中文工程表达
- [x] 关键行为与当前实现对齐（方法、错误码、状态码映射）
- [x] 自动生成示例具备幂等性
- [x] CI 已接入一致性校验
