### PR TITLE
feat: 实现 runtime 验收闭环与 verifier 双门控

### DIFF
--- a/docs/compatibility-fallback-lifecycle.md
+++ b/docs/compatibility-fallback-lifecycle.md
@@ -1,0 +1,21 @@
+# Compatibility Fallback Lifecycle
+
+## 为什么 fallback 只能短期存在
+- completion-only 旧路径会绕过 verifier gate，破坏双门控与单一裁决层。
+- 长期保留会形成双真源，增加状态不一致风险。
+
+## 触发条件
+- `runtime.verification.enabled=false` 时进入兼容路径。
+
+## 事件与日志要求
+- 兼容路径必须输出结构化 stop reason：`compatibility_fallback`。
+- acceptance 事件中保留内部摘要，标记这是 fallback 行为。
+
+## 移除条件
+- 验收与 verifier 在主链路稳定后，移除 `enabled=false` 作为常规运行路径。
+- 仅保留灰度发布窗口内的短期开关。
+
+## 禁止长期双轨原因
+- 终态语义会被分裂为“old completion-only”与“new dual-gate”两套规则。
+- TUI / runtime / persistence 难以保证统一解释，容易引发回归。
+

--- a/docs/runtime-finalization-flow.md
+++ b/docs/runtime-finalization-flow.md
@@ -1,0 +1,26 @@
+# Runtime Finalization Flow
+
+## 旧流程
+- assistant final 且无 tool call 时，可直接进入完成路径。
+
+## 新流程
+- assistant final -> completion gate -> `beforeAcceptFinal` -> verifier engine -> acceptance decision -> decider stop reason -> runtime 终态。
+
+## beforeAcceptFinal 插入点
+- 在 runtime 主循环中，`len(tool_calls)==0` 的 final 候选分支。
+- 先发 `verification_started`，后执行 acceptance engine。
+
+## 分支行为
+- `accepted`: `verification_completed` -> `acceptance_decided` -> `agent_done`
+- `continue`: `verification_finished` -> 注入 runtime reminder -> 下一轮
+- `incomplete`: `acceptance_decided` + `stop_reason_decided` -> `agent_done`
+- `failed`: `verification_failed` + `acceptance_decided` + `stop_reason_decided` -> `agent_done`
+
+## completion_gate vs verification_gate
+- completion gate 只控制“能否尝试收尾”。
+- verification gate 才决定“是否允许最终完成”。
+
+## decider 位置与真源关系
+- decider 在 run 退出时统一发 `stop_reason_decided`。
+- acceptance 输出写入 runtime 终态快照，由 decider 统一编码原因。
+

--- a/docs/stop-reason-and-decision-priority.md
+++ b/docs/stop-reason-and-decision-priority.md
@@ -1,0 +1,31 @@
+# Stop Reason And Decision Priority
+
+## StopReason 全集
+- `user_interrupt`
+- `fatal_error`
+- `budget_exceeded`
+- `max_turn_exceeded`
+- `retry_exhausted`
+- `verification_failed`
+- `accepted`
+- `todo_not_converged`
+- `todo_waiting_external`
+- `no_progress_after_final_intercept`
+- `max_turn_exceeded_with_unconverged_todos`
+- `max_turn_exceeded_with_failed_verification`
+- `verification_config_missing`
+- `verification_execution_denied`
+- `verification_execution_error`
+- `compatibility_fallback`
+
+## 优先级
+- `user_interrupt` > `fatal_error` > `budget_exceeded` > `max_turn_exceeded` > `retry_exhausted` > `verification_failed` > `accepted`
+
+## 决议互斥关系
+- decider 返回单一 stop reason。
+- acceptance/verifier 只提供输入，不直接终裁。
+
+## 与 ErrorClass 的关系
+- `ErrorClass` 只描述失败分类（compile/test/lint/type/timeout/permission 等）。
+- stop reason 描述终止归因；error class 描述失败类型，二者不重复表达。
+

--- a/docs/task-acceptance-design.md
+++ b/docs/task-acceptance-design.md
@@ -1,0 +1,38 @@
+# Task Acceptance Design
+
+## 背景问题
+- 旧流程中，模型输出 final 且无 tool call 时，runtime 可能直接完成。
+- 这会导致“文本 final”与“任务真实完成”混淆。
+
+## 为什么模型 final 不能直接等于完成
+- final 仅代表模型主观结束意图，不代表 required todo、文件产物或验证命令已满足。
+- 真实完成必须由 runtime 验收层裁决。
+
+## completion / verification / acceptance 区分
+- `completion_gate`：判断当前回合是否可尝试收尾（必要非充分）。
+- `verification_gate`：由 verifier engine 判断任务是否满足验收条件。
+- `acceptance_decision`：聚合两者输出 `accepted/continue/incomplete/failed`。
+
+## 双门控模型
+- `completed = completion_gate.passed && verification_gate.passed`
+- 任一门未通过都不能直接 `agent_done`。
+
+## 状态机
+- provider final -> `beforeAcceptFinal` -> verification -> acceptance_decided
+- `accepted` -> `agent_done`
+- `continue` -> 注入系统提醒继续推理
+- `incomplete/failed` -> 结束 run 并输出 stop reason
+
+## StopReason 设计
+- stop reason 由 controlplane decider 统一输出。
+- 新增 `verification_failed`、`todo_not_converged`、`retry_exhausted` 等枚举。
+
+## 与 todo / subagent / runtime 的关系
+- todo 是 verifier 输入，不直接决定终态。
+- subagent 完成不等于主任务完成，仍需通过 verifier gate。
+- runtime 只消费 decider 输出，不再平行判定终态。
+
+## decider 单一裁决层
+- 终态只由 decider 输出。
+- events / TUI / persistence 统一消费 decider 决议。
+

--- a/docs/todo-schema-migration.md
+++ b/docs/todo-schema-migration.md
@@ -1,0 +1,20 @@
+# Todo Schema Migration
+
+## 新增字段
+- `required`：是否参与 final 收口拦截，默认 `true`。
+- `blocked_reason`：`internal_dependency / permission_wait / user_input_wait / external_resource_wait / unknown`。
+
+## 兼容策略
+- 旧数据缺失 `required` 时，按 `true` 处理。
+- 旧数据缺失 `blocked_reason` 时，按 `unknown` 处理。
+- 旧 blocked todo 不会因新字段缺失导致反序列化失败。
+
+## 默认值语义
+- `required=nil` 视为 required=true（兼容旧 session）。
+- `blocked_reason=""` 规整为 `unknown`。
+
+## 持久化迁移注意事项
+- `CurrentTodoVersion` 升级到 `5`。
+- 归一化流程在加载与写入两侧都应用缺省值规则。
+- 工具层 schema 与 patch 同步支持新字段，避免 runtime/工具协议漂移。
+

--- a/docs/verifier-configuration-and-policy.md
+++ b/docs/verifier-configuration-and-policy.md
@@ -1,0 +1,28 @@
+# Verifier Configuration And Policy
+
+## 配置来源
+- 全局：`~/.neocode/config.yaml` 的 `runtime.verification`。
+- 仓库级扩展预留：`.neocode/verification.yaml`（本阶段先保留接口与策略位）。
+
+## 优先级
+- 仓库级 > 全局级 > 内建默认值（策略已按该优先级设计）。
+
+## 命令来源
+- 所有命令型 verifier 从 `runtime.verification.verifiers.<name>.command` 读取。
+- verifier 内禁止硬编码项目命令。
+
+## 启停规则
+- verifier 支持独立 `enabled/required`。
+- 未配置 command 时：
+  - required=true -> 返回显式 soft_block/fail
+  - required=false -> skip（显式结果，不 silent pass）
+
+## required / optional 行为
+- required verifier 失败会阻断 final。
+- optional verifier 缺省可跳过，但仍有事件与结果记录。
+
+## non-interactive policy
+- verifier 命令走独立 `execution_policy`，不走普通 ask 权限链路。
+- 默认白名单命令（go/git/test/lint/typecheck 等）。
+- 明确拒绝高风险命令（如 `rm`、`sudo`）。
+

--- a/docs/verifier-engine-design.md
+++ b/docs/verifier-engine-design.md
@@ -1,0 +1,28 @@
+# Verifier Engine Design
+
+## Verifier 接口
+- `FinalVerifier{Name, VerifyFinal}`
+- 输入为 `FinalVerifyInput`（session/run/task/workdir/messages/todos/runtime state/config）。
+- 输出为 `VerificationResult`（status/reason/error_class/evidence）。
+
+## Verifier 分类
+- P0：`todo_convergence`
+- P1：`file_exists`、`content_match`、`command_success`、`git_diff`
+- P1 代码任务：`build/test/lint/typecheck`（命令驱动）
+
+## Orchestrator 流程
+- 按策略解析 verifier 列表并顺序执行。
+- 汇总 `VerificationGateDecision{Passed, Reason, Results}`。
+
+## 聚合规则
+- 任一 `fail` -> `verification_failed`
+- 否则任一 `hard_block` -> `todo_waiting_external` 或 `todo_not_converged`
+- 否则任一 `soft_block` -> `todo_not_converged`
+- 全部 `pass` -> `accepted`
+
+## Task policy 映射
+- `unknown`: todo_convergence
+- `create_file/docs`: todo_convergence + file_exists + content_match
+- `config`: todo_convergence + file_exists + content_match + command_success
+- `edit_code/fix_bug/refactor`: todo_convergence + git_diff + build/test/lint/typecheck(按策略启停)
+

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -18,6 +18,7 @@ type RuntimeConfig struct {
 	MaxNoProgressStreak  int                 `yaml:"max_no_progress_streak,omitempty"`
 	MaxRepeatCycleStreak int                 `yaml:"max_repeat_cycle_streak,omitempty"`
 	MaxTurns             int                 `yaml:"max_turns,omitempty"`
+	Verification         VerificationConfig  `yaml:"verification,omitempty"`
 	Assets               RuntimeAssetsConfig `yaml:"assets,omitempty"`
 }
 
@@ -33,6 +34,7 @@ func defaultRuntimeConfig() RuntimeConfig {
 		MaxNoProgressStreak:  DefaultMaxNoProgressStreak,
 		MaxRepeatCycleStreak: DefaultMaxRepeatCycleStreak,
 		MaxTurns:             DefaultMaxTurns,
+		Verification:         defaultVerificationConfig(),
 		Assets:               defaultRuntimeAssetsConfig(),
 	}
 }
@@ -51,6 +53,7 @@ func (c RuntimeConfig) Clone() RuntimeConfig {
 		MaxNoProgressStreak:  c.MaxNoProgressStreak,
 		MaxRepeatCycleStreak: c.MaxRepeatCycleStreak,
 		MaxTurns:             c.MaxTurns,
+		Verification:         c.Verification.Clone(),
 		Assets:               c.Assets.Clone(),
 	}
 }
@@ -69,6 +72,7 @@ func (c *RuntimeConfig) ApplyDefaults(defaults RuntimeConfig) {
 	if c.MaxTurns <= 0 {
 		c.MaxTurns = defaults.MaxTurns
 	}
+	c.Verification.ApplyDefaults(defaults.Verification)
 	c.Assets.ApplyDefaults(defaults.Assets)
 }
 
@@ -82,6 +86,11 @@ func (c RuntimeConfig) Validate() error {
 	}
 	if c.MaxTurns < 0 {
 		return errors.New("max_turns must be greater than or equal to 0")
+	}
+	verification := c.Verification.Clone()
+	verification.ApplyDefaults(defaultVerificationConfig())
+	if err := verification.Validate(); err != nil {
+		return err
 	}
 	if err := c.Assets.Validate(); err != nil {
 		return err

--- a/internal/config/runtime_test.go
+++ b/internal/config/runtime_test.go
@@ -144,6 +144,27 @@ func TestRuntimeConfigValidate(t *testing.T) {
 	}).Validate(); err == nil {
 		t.Fatal("expected validation error for assets.max_session_assets_total_bytes=-1")
 	}
+
+	if err := (RuntimeConfig{
+		MaxNoProgressStreak:  1,
+		MaxRepeatCycleStreak: 1,
+		MaxTurns:             1,
+		Verification: VerificationConfig{
+			DefaultTaskPolicy: "unknown",
+			MaxNoProgress:     1,
+			MaxRetries:        0,
+			Verifiers: map[string]VerifierConfig{
+				"todo_convergence": {FailOpen: true, FailClosed: true},
+			},
+			ExecutionPolicy: VerificationExecutionPolicyConfig{
+				Mode:             "non_interactive",
+				DefaultTimeout:   1,
+				DefaultOutputCap: 1,
+			},
+		},
+	}).Validate(); err == nil {
+		t.Fatal("expected validation error for invalid verification config")
+	}
 }
 
 func TestRuntimeAssetsConfigZeroValuesResolveToDefaults(t *testing.T) {

--- a/internal/config/runtime_test.go
+++ b/internal/config/runtime_test.go
@@ -171,3 +171,47 @@ func TestRuntimeAssetsConfigZeroValuesResolveToDefaults(t *testing.T) {
 		)
 	}
 }
+
+func TestRuntimeConfigVerificationDefaultsApplied(t *testing.T) {
+	t.Parallel()
+
+	defaults := defaultRuntimeConfig()
+	cfg := RuntimeConfig{}
+	cfg.ApplyDefaults(defaults)
+	if !cfg.Verification.EnabledValue() {
+		t.Fatalf("expected verification enabled by default")
+	}
+	if !cfg.Verification.FinalInterceptValue() {
+		t.Fatalf("expected verification final intercept enabled by default")
+	}
+	if cfg.Verification.MaxNoProgress <= 0 {
+		t.Fatalf("expected max_no_progress > 0, got %d", cfg.Verification.MaxNoProgress)
+	}
+	if len(cfg.Verification.Verifiers) == 0 {
+		t.Fatal("expected default verifiers to be populated")
+	}
+}
+
+func TestRuntimeConfigVerificationExplicitFalsePreserved(t *testing.T) {
+	t.Parallel()
+
+	defaults := defaultRuntimeConfig()
+	cfg := RuntimeConfig{
+		Verification: VerificationConfig{
+			Enabled:        boolPtrTest(false),
+			FinalIntercept: boolPtrTest(false),
+		},
+	}
+	cfg.ApplyDefaults(defaults)
+	if cfg.Verification.EnabledValue() {
+		t.Fatalf("expected explicit verification.enabled=false to be preserved")
+	}
+	if cfg.Verification.FinalInterceptValue() {
+		t.Fatalf("expected explicit verification.final_intercept=false to be preserved")
+	}
+}
+
+func boolPtrTest(value bool) *bool {
+	v := value
+	return &v
+}

--- a/internal/config/verification.go
+++ b/internal/config/verification.go
@@ -1,0 +1,499 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	verificationTaskPolicyUnknown = "unknown"
+)
+
+const (
+	verifierTodoConvergence = "todo_convergence"
+	verifierFileExists      = "file_exists"
+	verifierContentMatch    = "content_match"
+	verifierCommandSuccess  = "command_success"
+	verifierGitDiff         = "git_diff"
+	verifierBuild           = "build"
+	verifierTest            = "test"
+	verifierLint            = "lint"
+	verifierTypecheck       = "typecheck"
+)
+
+const (
+	verificationHookBeforeVerification       = "before_verification"
+	verificationHookAfterVerification        = "after_verification"
+	verificationHookBeforeCompletionDecision = "before_completion_decision"
+)
+
+const (
+	verificationHookFailurePolicyFailClosed = "fail_closed"
+	verificationHookFailurePolicyFailOpen   = "fail_open"
+)
+
+const (
+	verificationScopeProject = "project"
+)
+
+const (
+	verificationExecModeNonInteractive = "non_interactive"
+)
+
+var defaultVerificationAllowedCommands = []string{
+	"go",
+	"git",
+	"npm",
+	"pnpm",
+	"yarn",
+	"make",
+	"cargo",
+	"python",
+	"pytest",
+	"ruff",
+	"eslint",
+	"tsc",
+	"golangci-lint",
+}
+
+var defaultVerificationDeniedCommands = []string{
+	"rm",
+	"sudo",
+	"curl",
+	"wget",
+}
+
+// VerificationConfig 定义 runtime final 验收阶段的 verifier 编排配置。
+type VerificationConfig struct {
+	Enabled           *bool                             `yaml:"enabled,omitempty"`
+	DefaultTaskPolicy string                            `yaml:"default_task_policy,omitempty"`
+	FinalIntercept    *bool                             `yaml:"final_intercept,omitempty"`
+	MaxNoProgress     int                               `yaml:"max_no_progress,omitempty"`
+	MaxRetries        int                               `yaml:"max_retries,omitempty"`
+	Verifiers         map[string]VerifierConfig         `yaml:"verifiers,omitempty"`
+	ExecutionPolicy   VerificationExecutionPolicyConfig `yaml:"execution_policy,omitempty"`
+	Hooks             VerificationHookConfig            `yaml:"hooks,omitempty"`
+}
+
+// VerifierConfig 定义单个 verifier 的启停、命令与失败策略。
+type VerifierConfig struct {
+	Enabled        bool   `yaml:"enabled,omitempty"`
+	Required       bool   `yaml:"required,omitempty"`
+	Command        string `yaml:"command,omitempty"`
+	TimeoutSec     int    `yaml:"timeout_sec,omitempty"`
+	OutputCapBytes int    `yaml:"output_cap_bytes,omitempty"`
+	Scope          string `yaml:"scope,omitempty"`
+	FailOpen       bool   `yaml:"fail_open,omitempty"`
+	FailClosed     bool   `yaml:"fail_closed,omitempty"`
+}
+
+// VerificationHookConfig 定义验证前后内置 hook 的执行策略。
+type VerificationHookConfig struct {
+	BeforeVerification       HookSpec `yaml:"before_verification,omitempty"`
+	AfterVerification        HookSpec `yaml:"after_verification,omitempty"`
+	BeforeCompletionDecision HookSpec `yaml:"before_completion_decision,omitempty"`
+}
+
+// HookSpec 定义单个 hook 的开关、超时、优先级与失败策略。
+type HookSpec struct {
+	Enabled       bool   `yaml:"enabled,omitempty"`
+	TimeoutSec    int    `yaml:"timeout_sec,omitempty"`
+	FailurePolicy string `yaml:"failure_policy,omitempty"`
+	Priority      int    `yaml:"priority,omitempty"`
+}
+
+// VerificationExecutionPolicyConfig 定义 verifier 命令的非交互执行策略。
+type VerificationExecutionPolicyConfig struct {
+	Mode             string   `yaml:"mode,omitempty"`
+	NonInteractive   bool     `yaml:"non_interactive,omitempty"`
+	AllowedCommands  []string `yaml:"allowed_commands,omitempty"`
+	DeniedCommands   []string `yaml:"denied_commands,omitempty"`
+	DefaultTimeout   int      `yaml:"default_timeout_sec,omitempty"`
+	DefaultOutputCap int      `yaml:"default_output_cap_bytes,omitempty"`
+}
+
+// defaultVerificationConfig 返回验证引擎默认策略。
+func defaultVerificationConfig() VerificationConfig {
+	return VerificationConfig{
+		Enabled:           boolPtrConfig(true),
+		DefaultTaskPolicy: verificationTaskPolicyUnknown,
+		FinalIntercept:    boolPtrConfig(true),
+		MaxNoProgress:     3,
+		MaxRetries:        2,
+		Verifiers: map[string]VerifierConfig{
+			verifierTodoConvergence: {
+				Enabled:        true,
+				Required:       true,
+				TimeoutSec:     5,
+				OutputCapBytes: 32 * 1024,
+				Scope:          verificationScopeProject,
+				FailClosed:     true,
+			},
+			verifierFileExists: {
+				Enabled:        true,
+				Required:       false,
+				TimeoutSec:     5,
+				OutputCapBytes: 32 * 1024,
+				Scope:          verificationScopeProject,
+				FailClosed:     true,
+			},
+			verifierContentMatch: {
+				Enabled:        true,
+				Required:       false,
+				TimeoutSec:     5,
+				OutputCapBytes: 32 * 1024,
+				Scope:          verificationScopeProject,
+				FailClosed:     true,
+			},
+			verifierCommandSuccess: {
+				Enabled:        false,
+				Required:       false,
+				TimeoutSec:     120,
+				OutputCapBytes: 128 * 1024,
+				Scope:          verificationScopeProject,
+				FailClosed:     true,
+			},
+			verifierGitDiff: {
+				Enabled:        true,
+				Required:       false,
+				Command:        "git diff --name-only",
+				TimeoutSec:     15,
+				OutputCapBytes: 64 * 1024,
+				Scope:          verificationScopeProject,
+				FailClosed:     true,
+			},
+			verifierBuild: {
+				Enabled:        false,
+				Required:       false,
+				TimeoutSec:     300,
+				OutputCapBytes: 256 * 1024,
+				Scope:          verificationScopeProject,
+				FailClosed:     true,
+			},
+			verifierTest: {
+				Enabled:        false,
+				Required:       false,
+				TimeoutSec:     300,
+				OutputCapBytes: 256 * 1024,
+				Scope:          verificationScopeProject,
+				FailClosed:     true,
+			},
+			verifierLint: {
+				Enabled:        false,
+				Required:       false,
+				TimeoutSec:     180,
+				OutputCapBytes: 256 * 1024,
+				Scope:          verificationScopeProject,
+				FailClosed:     true,
+			},
+			verifierTypecheck: {
+				Enabled:        false,
+				Required:       false,
+				TimeoutSec:     180,
+				OutputCapBytes: 256 * 1024,
+				Scope:          verificationScopeProject,
+				FailClosed:     true,
+			},
+		},
+		ExecutionPolicy: defaultVerificationExecutionPolicyConfig(),
+		Hooks: VerificationHookConfig{
+			BeforeVerification: HookSpec{
+				Enabled:       true,
+				TimeoutSec:    2,
+				FailurePolicy: verificationHookFailurePolicyFailClosed,
+				Priority:      10,
+			},
+			AfterVerification: HookSpec{
+				Enabled:       true,
+				TimeoutSec:    2,
+				FailurePolicy: verificationHookFailurePolicyFailOpen,
+				Priority:      20,
+			},
+			BeforeCompletionDecision: HookSpec{
+				Enabled:       true,
+				TimeoutSec:    2,
+				FailurePolicy: verificationHookFailurePolicyFailClosed,
+				Priority:      30,
+			},
+		},
+	}
+}
+
+// defaultVerificationExecutionPolicyConfig 返回 verifier 默认执行策略。
+func defaultVerificationExecutionPolicyConfig() VerificationExecutionPolicyConfig {
+	return VerificationExecutionPolicyConfig{
+		Mode:             verificationExecModeNonInteractive,
+		NonInteractive:   true,
+		AllowedCommands:  append([]string(nil), defaultVerificationAllowedCommands...),
+		DeniedCommands:   append([]string(nil), defaultVerificationDeniedCommands...),
+		DefaultTimeout:   120,
+		DefaultOutputCap: 128 * 1024,
+	}
+}
+
+// Clone 复制 verification 配置，避免 map/slice 共享底层数据。
+func (c VerificationConfig) Clone() VerificationConfig {
+	cloned := VerificationConfig{
+		Enabled:           cloneBoolPtr(c.Enabled),
+		DefaultTaskPolicy: c.DefaultTaskPolicy,
+		FinalIntercept:    cloneBoolPtr(c.FinalIntercept),
+		MaxNoProgress:     c.MaxNoProgress,
+		MaxRetries:        c.MaxRetries,
+		ExecutionPolicy:   c.ExecutionPolicy.Clone(),
+		Hooks:             c.Hooks.Clone(),
+	}
+	if len(c.Verifiers) > 0 {
+		cloned.Verifiers = make(map[string]VerifierConfig, len(c.Verifiers))
+		for name, cfg := range c.Verifiers {
+			cloned.Verifiers[name] = cfg.Clone()
+		}
+	}
+	return cloned
+}
+
+// ApplyDefaults 在配置缺失时补齐 verification 默认值。
+func (c *VerificationConfig) ApplyDefaults(defaults VerificationConfig) {
+	if c == nil {
+		return
+	}
+	if c.Enabled == nil {
+		c.Enabled = cloneBoolPtr(defaults.Enabled)
+	}
+	if c.FinalIntercept == nil {
+		c.FinalIntercept = cloneBoolPtr(defaults.FinalIntercept)
+	}
+	if strings.TrimSpace(c.DefaultTaskPolicy) == "" {
+		c.DefaultTaskPolicy = defaults.DefaultTaskPolicy
+	}
+	if c.MaxNoProgress <= 0 {
+		c.MaxNoProgress = defaults.MaxNoProgress
+	}
+	if c.MaxRetries < 0 {
+		c.MaxRetries = defaults.MaxRetries
+	}
+	if c.Verifiers == nil {
+		c.Verifiers = make(map[string]VerifierConfig, len(defaults.Verifiers))
+	}
+	for name, def := range defaults.Verifiers {
+		current, exists := c.Verifiers[name]
+		if !exists {
+			c.Verifiers[name] = def
+			continue
+		}
+		current.ApplyDefaults(def)
+		c.Verifiers[name] = current
+	}
+	c.ExecutionPolicy.ApplyDefaults(defaults.ExecutionPolicy)
+	c.Hooks.ApplyDefaults(defaults.Hooks)
+}
+
+// EnabledValue 返回 verification 总开关的最终布尔值；未设置时返回 false。
+func (c VerificationConfig) EnabledValue() bool {
+	if c.Enabled == nil {
+		return false
+	}
+	return *c.Enabled
+}
+
+// FinalInterceptValue 返回 final 拦截开关的最终布尔值；未设置时返回 false。
+func (c VerificationConfig) FinalInterceptValue() bool {
+	if c.FinalIntercept == nil {
+		return false
+	}
+	return *c.FinalIntercept
+}
+
+// Validate 校验 verification 配置合法性。
+func (c VerificationConfig) Validate() error {
+	if strings.TrimSpace(c.DefaultTaskPolicy) == "" {
+		return errors.New("runtime.verification.default_task_policy is required")
+	}
+	if c.MaxNoProgress <= 0 {
+		return errors.New("runtime.verification.max_no_progress must be greater than 0")
+	}
+	if c.MaxRetries < 0 {
+		return errors.New("runtime.verification.max_retries must be greater than or equal to 0")
+	}
+	for name, verifier := range c.Verifiers {
+		if strings.TrimSpace(name) == "" {
+			return errors.New("runtime.verification.verifiers has empty name")
+		}
+		if err := verifier.Validate(); err != nil {
+			return fmt.Errorf("runtime.verification.verifiers.%s: %w", name, err)
+		}
+	}
+	if err := c.ExecutionPolicy.Validate(); err != nil {
+		return err
+	}
+	if err := c.Hooks.Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Clone 复制 verifier 配置。
+func (c VerifierConfig) Clone() VerifierConfig {
+	return c
+}
+
+// ApplyDefaults 在 verifier 配置缺失时补齐默认值。
+func (c *VerifierConfig) ApplyDefaults(defaults VerifierConfig) {
+	if c == nil {
+		return
+	}
+	if c.TimeoutSec <= 0 {
+		c.TimeoutSec = defaults.TimeoutSec
+	}
+	if c.OutputCapBytes <= 0 {
+		c.OutputCapBytes = defaults.OutputCapBytes
+	}
+	if strings.TrimSpace(c.Scope) == "" {
+		c.Scope = defaults.Scope
+	}
+	if !c.FailOpen && !c.FailClosed {
+		c.FailOpen = defaults.FailOpen
+		c.FailClosed = defaults.FailClosed
+	}
+}
+
+// Validate 校验单个 verifier 配置合法性。
+func (c VerifierConfig) Validate() error {
+	if c.FailOpen && c.FailClosed {
+		return errors.New("fail_open and fail_closed are mutually exclusive")
+	}
+	if c.TimeoutSec < 0 {
+		return errors.New("timeout_sec must be greater than or equal to 0")
+	}
+	if c.OutputCapBytes < 0 {
+		return errors.New("output_cap_bytes must be greater than or equal to 0")
+	}
+	return nil
+}
+
+// Clone 复制 hook 配置。
+func (c VerificationHookConfig) Clone() VerificationHookConfig {
+	return VerificationHookConfig{
+		BeforeVerification:       c.BeforeVerification.Clone(),
+		AfterVerification:        c.AfterVerification.Clone(),
+		BeforeCompletionDecision: c.BeforeCompletionDecision.Clone(),
+	}
+}
+
+// ApplyDefaults 在 hook 配置缺失时回填默认值。
+func (c *VerificationHookConfig) ApplyDefaults(defaults VerificationHookConfig) {
+	if c == nil {
+		return
+	}
+	c.BeforeVerification.ApplyDefaults(defaults.BeforeVerification)
+	c.AfterVerification.ApplyDefaults(defaults.AfterVerification)
+	c.BeforeCompletionDecision.ApplyDefaults(defaults.BeforeCompletionDecision)
+}
+
+// Validate 校验 hook 配置是否合法。
+func (c VerificationHookConfig) Validate() error {
+	if err := c.BeforeVerification.Validate(); err != nil {
+		return fmt.Errorf("%s: %w", verificationHookBeforeVerification, err)
+	}
+	if err := c.AfterVerification.Validate(); err != nil {
+		return fmt.Errorf("%s: %w", verificationHookAfterVerification, err)
+	}
+	if err := c.BeforeCompletionDecision.Validate(); err != nil {
+		return fmt.Errorf("%s: %w", verificationHookBeforeCompletionDecision, err)
+	}
+	return nil
+}
+
+// Clone 复制单个 hook 定义。
+func (c HookSpec) Clone() HookSpec {
+	return c
+}
+
+// ApplyDefaults 在 hook 缺失时补齐默认值。
+func (c *HookSpec) ApplyDefaults(defaults HookSpec) {
+	if c == nil {
+		return
+	}
+	if c.TimeoutSec <= 0 {
+		c.TimeoutSec = defaults.TimeoutSec
+	}
+	if strings.TrimSpace(c.FailurePolicy) == "" {
+		c.FailurePolicy = defaults.FailurePolicy
+	}
+}
+
+// Validate 校验 hook 配置是否合法。
+func (c HookSpec) Validate() error {
+	if c.TimeoutSec < 0 {
+		return errors.New("timeout_sec must be greater than or equal to 0")
+	}
+	switch strings.TrimSpace(c.FailurePolicy) {
+	case verificationHookFailurePolicyFailClosed, verificationHookFailurePolicyFailOpen:
+		return nil
+	default:
+		return fmt.Errorf("unsupported failure_policy %q", c.FailurePolicy)
+	}
+}
+
+// Clone 复制执行策略配置。
+func (c VerificationExecutionPolicyConfig) Clone() VerificationExecutionPolicyConfig {
+	return VerificationExecutionPolicyConfig{
+		Mode:             c.Mode,
+		NonInteractive:   c.NonInteractive,
+		AllowedCommands:  append([]string(nil), c.AllowedCommands...),
+		DeniedCommands:   append([]string(nil), c.DeniedCommands...),
+		DefaultTimeout:   c.DefaultTimeout,
+		DefaultOutputCap: c.DefaultOutputCap,
+	}
+}
+
+// ApplyDefaults 在执行策略缺失时补齐默认值。
+func (c *VerificationExecutionPolicyConfig) ApplyDefaults(defaults VerificationExecutionPolicyConfig) {
+	if c == nil {
+		return
+	}
+	if strings.TrimSpace(c.Mode) == "" {
+		c.Mode = defaults.Mode
+	}
+	if len(c.AllowedCommands) == 0 {
+		c.AllowedCommands = append([]string(nil), defaults.AllowedCommands...)
+	}
+	if len(c.DeniedCommands) == 0 {
+		c.DeniedCommands = append([]string(nil), defaults.DeniedCommands...)
+	}
+	if c.DefaultTimeout <= 0 {
+		c.DefaultTimeout = defaults.DefaultTimeout
+	}
+	if c.DefaultOutputCap <= 0 {
+		c.DefaultOutputCap = defaults.DefaultOutputCap
+	}
+}
+
+// Validate 校验执行策略配置。
+func (c VerificationExecutionPolicyConfig) Validate() error {
+	if strings.TrimSpace(c.Mode) == "" {
+		return errors.New("runtime.verification.execution_policy.mode is required")
+	}
+	if c.DefaultTimeout <= 0 {
+		return errors.New("runtime.verification.execution_policy.default_timeout_sec must be greater than 0")
+	}
+	if c.DefaultOutputCap <= 0 {
+		return errors.New("runtime.verification.execution_policy.default_output_cap_bytes must be greater than 0")
+	}
+	return nil
+}
+
+// boolPtr 构造 bool 指针，便于配置默认值与序列化结构复用。
+func boolPtrConfig(value bool) *bool {
+	v := value
+	return &v
+}
+
+// cloneBoolPtr 复制 bool 指针，避免 Clone 后共享底层地址。
+func cloneBoolPtr(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	v := *value
+	return &v
+}

--- a/internal/config/verification_test.go
+++ b/internal/config/verification_test.go
@@ -1,0 +1,287 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVerificationConfigApplyDefaultsAndAccessors(t *testing.T) {
+	t.Parallel()
+
+	defaults := defaultVerificationConfig()
+	cfg := VerificationConfig{}
+	cfg.ApplyDefaults(defaults)
+
+	if !cfg.EnabledValue() {
+		t.Fatalf("EnabledValue() = false, want true")
+	}
+	if !cfg.FinalInterceptValue() {
+		t.Fatalf("FinalInterceptValue() = false, want true")
+	}
+	if cfg.DefaultTaskPolicy == "" || cfg.MaxNoProgress <= 0 || cfg.MaxRetries < 0 {
+		t.Fatalf("unexpected defaults: %+v", cfg)
+	}
+	if len(cfg.Verifiers) != len(defaults.Verifiers) {
+		t.Fatalf("verifier count = %d, want %d", len(cfg.Verifiers), len(defaults.Verifiers))
+	}
+
+	cfg.Enabled = nil
+	if cfg.EnabledValue() {
+		t.Fatalf("EnabledValue() should be false when pointer is nil")
+	}
+	cfg.FinalIntercept = nil
+	if cfg.FinalInterceptValue() {
+		t.Fatalf("FinalInterceptValue() should be false when pointer is nil")
+	}
+
+	var nilCfg *VerificationConfig
+	nilCfg.ApplyDefaults(defaults)
+}
+
+func TestVerificationConfigApplyDefaultsPreservesExistingVerifierAndFillsMissing(t *testing.T) {
+	t.Parallel()
+
+	defaults := defaultVerificationConfig()
+	cfg := VerificationConfig{
+		Enabled:           boolPtrConfig(false),
+		FinalIntercept:    boolPtrConfig(false),
+		DefaultTaskPolicy: "custom",
+		MaxNoProgress:     8,
+		MaxRetries:        -3,
+		Verifiers: map[string]VerifierConfig{
+			verifierGitDiff: {
+				Enabled:        true,
+				TimeoutSec:     0,
+				OutputCapBytes: 0,
+				Scope:          "",
+			},
+		},
+		ExecutionPolicy: VerificationExecutionPolicyConfig{},
+	}
+	cfg.ApplyDefaults(defaults)
+
+	if cfg.EnabledValue() {
+		t.Fatalf("enabled should keep explicit false")
+	}
+	if cfg.FinalInterceptValue() {
+		t.Fatalf("final_intercept should keep explicit false")
+	}
+	if cfg.DefaultTaskPolicy != "custom" || cfg.MaxNoProgress != 8 || cfg.MaxRetries != defaults.MaxRetries {
+		t.Fatalf("expected explicit values preserved, got %+v", cfg)
+	}
+	gitDiff := cfg.Verifiers[verifierGitDiff]
+	if gitDiff.TimeoutSec <= 0 || gitDiff.OutputCapBytes <= 0 || strings.TrimSpace(gitDiff.Scope) == "" {
+		t.Fatalf("expected verifier defaults merged, got %+v", gitDiff)
+	}
+	if _, ok := cfg.Verifiers[verifierTodoConvergence]; !ok {
+		t.Fatalf("missing default verifier %q", verifierTodoConvergence)
+	}
+}
+
+func TestVerificationConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	valid := defaultVerificationConfig()
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	t.Run("default task policy required", func(t *testing.T) {
+		cfg := defaultVerificationConfig()
+		cfg.DefaultTaskPolicy = "  "
+		if err := cfg.Validate(); err == nil {
+			t.Fatalf("expected default_task_policy validation error")
+		}
+	})
+
+	t.Run("max no progress must be positive", func(t *testing.T) {
+		cfg := defaultVerificationConfig()
+		cfg.MaxNoProgress = 0
+		if err := cfg.Validate(); err == nil {
+			t.Fatalf("expected max_no_progress validation error")
+		}
+	})
+
+	t.Run("max retries cannot be negative", func(t *testing.T) {
+		cfg := defaultVerificationConfig()
+		cfg.MaxRetries = -1
+		if err := cfg.Validate(); err == nil {
+			t.Fatalf("expected max_retries validation error")
+		}
+	})
+
+	t.Run("empty verifier name rejected", func(t *testing.T) {
+		cfg := defaultVerificationConfig()
+		cfg.Verifiers[" "] = VerifierConfig{}
+		if err := cfg.Validate(); err == nil {
+			t.Fatalf("expected empty verifier name validation error")
+		}
+	})
+
+	t.Run("verifier validation wrapped", func(t *testing.T) {
+		cfg := defaultVerificationConfig()
+		cfg.Verifiers[verifierTodoConvergence] = VerifierConfig{FailOpen: true, FailClosed: true}
+		err := cfg.Validate()
+		if err == nil || !strings.Contains(err.Error(), verifierTodoConvergence) {
+			t.Fatalf("expected wrapped verifier error, got %v", err)
+		}
+	})
+
+	t.Run("execution policy validation", func(t *testing.T) {
+		cfg := defaultVerificationConfig()
+		cfg.ExecutionPolicy.Mode = ""
+		if err := cfg.Validate(); err == nil {
+			t.Fatalf("expected execution policy validation error")
+		}
+	})
+
+	t.Run("hooks validation", func(t *testing.T) {
+		cfg := defaultVerificationConfig()
+		cfg.Hooks.BeforeVerification.FailurePolicy = "bad"
+		err := cfg.Validate()
+		if err == nil || !strings.Contains(err.Error(), verificationHookBeforeVerification) {
+			t.Fatalf("expected hook validation error, got %v", err)
+		}
+	})
+
+	t.Run("hooks after_verification validation", func(t *testing.T) {
+		cfg := defaultVerificationConfig()
+		cfg.Hooks.AfterVerification.FailurePolicy = "bad"
+		err := cfg.Validate()
+		if err == nil || !strings.Contains(err.Error(), verificationHookAfterVerification) {
+			t.Fatalf("expected hook validation error, got %v", err)
+		}
+	})
+}
+
+func TestVerifierConfigApplyDefaultsAndValidate(t *testing.T) {
+	t.Parallel()
+
+	defaults := VerifierConfig{TimeoutSec: 5, OutputCapBytes: 9, Scope: verificationScopeProject, FailClosed: true}
+	cfg := VerifierConfig{}
+	cfg.ApplyDefaults(defaults)
+	if cfg.TimeoutSec != 5 || cfg.OutputCapBytes != 9 || cfg.Scope != verificationScopeProject || !cfg.FailClosed {
+		t.Fatalf("ApplyDefaults() mismatch: %+v", cfg)
+	}
+
+	cfg = VerifierConfig{FailOpen: true}
+	cfg.ApplyDefaults(defaults)
+	if !cfg.FailOpen || cfg.FailClosed {
+		t.Fatalf("existing fail policy should be preserved: %+v", cfg)
+	}
+
+	var nilCfg *VerifierConfig
+	nilCfg.ApplyDefaults(defaults)
+
+	if err := (VerifierConfig{}).Validate(); err != nil {
+		t.Fatalf("VerifierConfig.Validate() unexpected error: %v", err)
+	}
+	if err := (VerifierConfig{FailOpen: true, FailClosed: true}).Validate(); err == nil {
+		t.Fatalf("expected mutually exclusive fail policy validation error")
+	}
+	if err := (VerifierConfig{TimeoutSec: -1}).Validate(); err == nil {
+		t.Fatalf("expected timeout validation error")
+	}
+	if err := (VerifierConfig{OutputCapBytes: -1}).Validate(); err == nil {
+		t.Fatalf("expected output cap validation error")
+	}
+}
+
+func TestHookSpecAndHookConfig(t *testing.T) {
+	t.Parallel()
+
+	hookDefaults := HookSpec{Enabled: true, TimeoutSec: 2, FailurePolicy: verificationHookFailurePolicyFailClosed}
+	hook := HookSpec{}
+	hook.ApplyDefaults(hookDefaults)
+	if hook.TimeoutSec != 2 || hook.FailurePolicy != verificationHookFailurePolicyFailClosed {
+		t.Fatalf("HookSpec.ApplyDefaults() mismatch: %+v", hook)
+	}
+
+	var nilHook *HookSpec
+	nilHook.ApplyDefaults(hookDefaults)
+
+	if err := (HookSpec{TimeoutSec: -1, FailurePolicy: verificationHookFailurePolicyFailClosed}).Validate(); err == nil {
+		t.Fatalf("expected timeout validation error")
+	}
+	if err := (HookSpec{TimeoutSec: 1, FailurePolicy: "bad"}).Validate(); err == nil {
+		t.Fatalf("expected failure_policy validation error")
+	}
+	if err := (HookSpec{TimeoutSec: 1, FailurePolicy: verificationHookFailurePolicyFailOpen}).Validate(); err != nil {
+		t.Fatalf("expected fail_open to be valid, got %v", err)
+	}
+
+	hooks := VerificationHookConfig{}
+	hooks.ApplyDefaults(defaultVerificationConfig().Hooks)
+	if err := hooks.Validate(); err != nil {
+		t.Fatalf("VerificationHookConfig.Validate() error = %v", err)
+	}
+
+	hooks.BeforeCompletionDecision.FailurePolicy = "bad"
+	err := hooks.Validate()
+	if err == nil || !strings.Contains(err.Error(), verificationHookBeforeCompletionDecision) {
+		t.Fatalf("expected before_completion_decision error, got %v", err)
+	}
+
+	var nilHooks *VerificationHookConfig
+	nilHooks.ApplyDefaults(defaultVerificationConfig().Hooks)
+}
+
+func TestVerificationExecutionPolicyConfig(t *testing.T) {
+	t.Parallel()
+
+	defaults := defaultVerificationExecutionPolicyConfig()
+	cfg := VerificationExecutionPolicyConfig{}
+	cfg.ApplyDefaults(defaults)
+	if cfg.Mode != verificationExecModeNonInteractive || cfg.DefaultTimeout <= 0 || cfg.DefaultOutputCap <= 0 {
+		t.Fatalf("ApplyDefaults() mismatch: %+v", cfg)
+	}
+	if len(cfg.AllowedCommands) == 0 || len(cfg.DeniedCommands) == 0 {
+		t.Fatalf("command lists should be defaulted")
+	}
+
+	cfg.AllowedCommands[0] = "changed"
+	if defaults.AllowedCommands[0] == "changed" {
+		t.Fatalf("ApplyDefaults() should copy allowed commands")
+	}
+	cfg.DeniedCommands[0] = "changed"
+	if defaults.DeniedCommands[0] == "changed" {
+		t.Fatalf("ApplyDefaults() should copy denied commands")
+	}
+
+	var nilCfg *VerificationExecutionPolicyConfig
+	nilCfg.ApplyDefaults(defaults)
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() unexpected error: %v", err)
+	}
+	if err := (VerificationExecutionPolicyConfig{DefaultTimeout: 1, DefaultOutputCap: 1}).Validate(); err == nil {
+		t.Fatalf("expected missing mode validation error")
+	}
+	if err := (VerificationExecutionPolicyConfig{Mode: verificationExecModeNonInteractive, DefaultTimeout: 0, DefaultOutputCap: 1}).Validate(); err == nil {
+		t.Fatalf("expected default timeout validation error")
+	}
+	if err := (VerificationExecutionPolicyConfig{Mode: verificationExecModeNonInteractive, DefaultTimeout: 1, DefaultOutputCap: 0}).Validate(); err == nil {
+		t.Fatalf("expected default output cap validation error")
+	}
+}
+
+func TestVerificationCloneHelpers(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultVerificationConfig()
+	cloned := cfg.Clone()
+	if cloned.Enabled == cfg.Enabled || cloned.FinalIntercept == cfg.FinalIntercept {
+		t.Fatalf("Clone() should deep copy bool pointers")
+	}
+	if cloned.Verifiers[verifierTodoConvergence].TimeoutSec != cfg.Verifiers[verifierTodoConvergence].TimeoutSec {
+		t.Fatalf("Clone() should preserve verifier content")
+	}
+	cloned.ExecutionPolicy.AllowedCommands[0] = "mutated"
+	if cfg.ExecutionPolicy.AllowedCommands[0] == "mutated" {
+		t.Fatalf("Clone() should copy execution policy slices")
+	}
+
+	if got := cloneBoolPtr(nil); got != nil {
+		t.Fatalf("cloneBoolPtr(nil) = %v, want nil", got)
+	}
+}

--- a/internal/runtime/acceptance/config.go
+++ b/internal/runtime/acceptance/config.go
@@ -1,0 +1,7 @@
+package acceptance
+
+// Config 定义 acceptance 引擎运行期开关。
+type Config struct {
+	// CompatibilityFallbackEnabled 表示是否允许 verification 关闭时走兼容收尾路径。
+	CompatibilityFallbackEnabled bool
+}

--- a/internal/runtime/acceptance/decider.go
+++ b/internal/runtime/acceptance/decider.go
@@ -1,0 +1,17 @@
+package acceptance
+
+import "neo-code/internal/runtime/controlplane"
+
+// TerminalStatusFromAcceptance 将 acceptance 决策映射到 runtime 终态枚举。
+func TerminalStatusFromAcceptance(status AcceptanceStatus) controlplane.TerminalStatus {
+	switch status {
+	case AcceptanceAccepted:
+		return controlplane.TerminalStatusCompleted
+	case AcceptanceFailed:
+		return controlplane.TerminalStatusFailed
+	case AcceptanceIncomplete:
+		return controlplane.TerminalStatusIncomplete
+	default:
+		return controlplane.TerminalStatusContinue
+	}
+}

--- a/internal/runtime/acceptance/decider_test.go
+++ b/internal/runtime/acceptance/decider_test.go
@@ -1,0 +1,32 @@
+package acceptance
+
+import (
+	"testing"
+
+	"neo-code/internal/runtime/controlplane"
+)
+
+func TestTerminalStatusFromAcceptance(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		status AcceptanceStatus
+		want   controlplane.TerminalStatus
+	}{
+		{status: AcceptanceAccepted, want: controlplane.TerminalStatusCompleted},
+		{status: AcceptanceFailed, want: controlplane.TerminalStatusFailed},
+		{status: AcceptanceIncomplete, want: controlplane.TerminalStatusIncomplete},
+		{status: AcceptanceContinue, want: controlplane.TerminalStatusContinue},
+		{status: AcceptanceStatus("other"), want: controlplane.TerminalStatusContinue},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(string(tc.status), func(t *testing.T) {
+			t.Parallel()
+			if got := TerminalStatusFromAcceptance(tc.status); got != tc.want {
+				t.Fatalf("TerminalStatusFromAcceptance(%q) = %q, want %q", tc.status, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/acceptance/engine.go
+++ b/internal/runtime/acceptance/engine.go
@@ -142,9 +142,13 @@ func runHookStage(
 func aggregateVerificationDecision(gate verify.VerificationGateDecision) AcceptanceDecision {
 	firstFail := firstResultByStatus(gate.Results, verify.VerificationFail)
 	if firstFail != nil {
+		stopReason := gate.Reason
+		if stopReason == "" || stopReason == controlplane.StopReasonAccepted {
+			stopReason = controlplane.StopReasonVerificationFailed
+		}
 		return AcceptanceDecision{
 			Status:             AcceptanceFailed,
-			StopReason:         controlplane.StopReasonVerificationFailed,
+			StopReason:         stopReason,
 			ErrorClass:         firstFail.ErrorClass,
 			UserVisibleSummary: "验证未通过，任务失败。",
 			InternalSummary:    "at least one verifier returned fail",

--- a/internal/runtime/acceptance/engine.go
+++ b/internal/runtime/acceptance/engine.go
@@ -1,0 +1,164 @@
+package acceptance
+
+import (
+	"context"
+	"fmt"
+
+	"neo-code/internal/runtime/controlplane"
+	"neo-code/internal/runtime/verify"
+)
+
+// Engine 聚合 completion gate 与 verifier 结果，输出统一验收决策。
+type Engine struct {
+	policy AcceptancePolicy
+}
+
+// NewEngine 创建 acceptance engine。
+func NewEngine(policy AcceptancePolicy) *Engine {
+	if policy == nil {
+		policy = DefaultPolicy{}
+	}
+	return &Engine{policy: policy}
+}
+
+// EvaluateFinal 执行 final 验收并输出结构化决策。
+func (e *Engine) EvaluateFinal(ctx context.Context, input FinalAcceptanceInput) (AcceptanceDecision, error) {
+	if !input.CompletionGate.Passed {
+		return AcceptanceDecision{
+			Status:             AcceptanceContinue,
+			StopReason:         controlplane.StopReasonTodoNotConverged,
+			UserVisibleSummary: "当前回合尚未达到可收尾条件，继续执行。",
+			InternalSummary:    "completion gate did not pass",
+			ContinueHint:       "There are unfinished required todos or unmet acceptance checks. Continue execution. Do not finalize yet.",
+			HasProgress:        false,
+		}, nil
+	}
+
+	if !input.VerificationInput.VerificationConfig.EnabledValue() {
+		return AcceptanceDecision{
+			Status:             AcceptanceAccepted,
+			StopReason:         controlplane.StopReasonCompatibilityFallback,
+			UserVisibleSummary: "已通过兼容路径接受 final（验证引擎关闭）。",
+			InternalSummary:    "verification disabled, compatibility fallback accepted",
+			HasProgress:        true,
+		}, nil
+	}
+
+	verifiers := e.policy.ResolveVerifiers(input.VerificationInput)
+	orch := verify.Orchestrator{Verifiers: verifiers}
+	gateDecision, err := orch.RunFinalVerification(ctx, input.VerificationInput)
+	if err != nil {
+		return AcceptanceDecision{}, err
+	}
+
+	decision := aggregateVerificationDecision(gateDecision)
+	if input.NoProgressExceeded && decision.Status == AcceptanceContinue {
+		decision.Status = AcceptanceIncomplete
+		decision.StopReason = controlplane.StopReasonNoProgressAfterFinalIntercept
+		decision.UserVisibleSummary = "多次拦截 final 且无进展，已停止并标记为未完成。"
+		decision.InternalSummary = "no-progress breaker triggered after repeated final interception"
+	}
+
+	if input.MaxTurnsReached && decision.Status == AcceptanceContinue {
+		decision.Status = AcceptanceIncomplete
+		if decision.StopReason == controlplane.StopReasonVerificationFailed {
+			decision.StopReason = controlplane.StopReasonMaxTurnExceededWithFailedVerification
+		} else {
+			decision.StopReason = controlplane.StopReasonMaxTurnExceededWithUnconvergedTodos
+		}
+		decision.UserVisibleSummary = fmt.Sprintf("达到最大轮次限制（%d），任务未完成。", input.MaxTurnsLimit)
+		decision.InternalSummary = "max turn reached while final was still intercepted"
+	}
+
+	if hasRetryExhausted(input.VerificationInput.Todos) {
+		decision.Status = AcceptanceFailed
+		decision.StopReason = controlplane.StopReasonRetryExhausted
+		decision.UserVisibleSummary = "存在重试耗尽的待办项，任务失败。"
+		decision.InternalSummary = "todo retry exhausted"
+	}
+
+	return decision, nil
+}
+
+// aggregateVerificationDecision 按 fail -> hard_block -> soft_block -> pass 规则聚合结果。
+func aggregateVerificationDecision(gate verify.VerificationGateDecision) AcceptanceDecision {
+	firstFail := firstResultByStatus(gate.Results, verify.VerificationFail)
+	if firstFail != nil {
+		return AcceptanceDecision{
+			Status:             AcceptanceFailed,
+			StopReason:         controlplane.StopReasonVerificationFailed,
+			ErrorClass:         firstFail.ErrorClass,
+			UserVisibleSummary: "验证未通过，任务失败。",
+			InternalSummary:    "at least one verifier returned fail",
+			VerifierResults:    append([]verify.VerificationResult(nil), gate.Results...),
+			Retryable:          firstFail.Retryable,
+			HasProgress:        false,
+		}
+	}
+
+	firstHard := firstResultByStatus(gate.Results, verify.VerificationHardBlock)
+	if firstHard != nil {
+		reason := controlplane.StopReasonTodoNotConverged
+		if firstHard.WaitingExternal {
+			reason = controlplane.StopReasonTodoWaitingExternal
+		}
+		return AcceptanceDecision{
+			Status:             AcceptanceIncomplete,
+			StopReason:         reason,
+			UserVisibleSummary: "任务仍依赖外部条件，当前以未完成状态结束。",
+			InternalSummary:    "at least one verifier returned hard_block",
+			VerifierResults:    append([]verify.VerificationResult(nil), gate.Results...),
+			HasProgress:        false,
+			WaitingExternal:    firstHard.WaitingExternal,
+		}
+	}
+
+	firstSoft := firstResultByStatus(gate.Results, verify.VerificationSoftBlock)
+	if firstSoft != nil {
+		return AcceptanceDecision{
+			Status:             AcceptanceContinue,
+			StopReason:         controlplane.StopReasonTodoNotConverged,
+			UserVisibleSummary: "仍有未满足的验收条件，继续执行。",
+			InternalSummary:    "at least one verifier returned soft_block",
+			ContinueHint:       "There are unfinished required todos or unmet acceptance checks. Continue execution. Do not finalize yet.",
+			VerifierResults:    append([]verify.VerificationResult(nil), gate.Results...),
+			HasProgress:        false,
+		}
+	}
+
+	return AcceptanceDecision{
+		Status:             AcceptanceAccepted,
+		StopReason:         controlplane.StopReasonAccepted,
+		UserVisibleSummary: "任务通过验收，已完成。",
+		InternalSummary:    "completion gate and verification gate both passed",
+		VerifierResults:    append([]verify.VerificationResult(nil), gate.Results...),
+		HasProgress:        true,
+	}
+}
+
+// firstResultByStatus 返回首个匹配状态的 verifier 结果。
+func firstResultByStatus(results []verify.VerificationResult, status verify.VerificationStatus) *verify.VerificationResult {
+	for _, result := range results {
+		if result.Status == status {
+			cloned := result
+			return &cloned
+		}
+	}
+	return nil
+}
+
+// hasRetryExhausted 判断 todo 快照中是否存在重试耗尽项。
+func hasRetryExhausted(todos []verify.TodoSnapshot) bool {
+	for _, todo := range todos {
+		if !todo.Required {
+			continue
+		}
+		if todo.RetryLimit <= 0 {
+			continue
+		}
+		if todo.RetryCount >= todo.RetryLimit {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/acceptance/engine.go
+++ b/internal/runtime/acceptance/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"neo-code/internal/config"
 	"neo-code/internal/runtime/controlplane"
 	"neo-code/internal/runtime/verify"
 )
@@ -34,24 +35,56 @@ func (e *Engine) EvaluateFinal(ctx context.Context, input FinalAcceptanceInput) 
 		}, nil
 	}
 
-	if !input.VerificationInput.VerificationConfig.EnabledValue() {
-		return AcceptanceDecision{
+	verificationCfg := input.VerificationInput.VerificationConfig
+	hookCfg := verificationCfg.Hooks
+	verifierEnabled := verificationCfg.EnabledValue()
+
+	var decision AcceptanceDecision
+	if verifierEnabled {
+		verifiers := e.policy.ResolveVerifiers(input.VerificationInput)
+		if hookDecision, failed := runHookStage(
+			ctx,
+			hookCfg.BeforeVerification,
+			hookStageBeforeVerification,
+			beforeVerificationHooks(len(verifiers)),
+			input,
+		); failed {
+			return hookDecision, nil
+		}
+
+		orch := verify.Orchestrator{Verifiers: verifiers}
+		gateDecision, err := orch.RunFinalVerification(ctx, input.VerificationInput)
+		if err != nil {
+			return AcceptanceDecision{}, err
+		}
+		if hookDecision, failed := runHookStage(
+			ctx,
+			hookCfg.AfterVerification,
+			hookStageAfterVerification,
+			afterVerificationHooks(len(gateDecision.Results)),
+			input,
+		); failed {
+			return hookDecision, nil
+		}
+		decision = aggregateVerificationDecision(gateDecision)
+	} else {
+		decision = AcceptanceDecision{
 			Status:             AcceptanceAccepted,
 			StopReason:         controlplane.StopReasonCompatibilityFallback,
 			UserVisibleSummary: "已通过兼容路径接受 final（验证引擎关闭）。",
 			InternalSummary:    "verification disabled, compatibility fallback accepted",
 			HasProgress:        true,
-		}, nil
+		}
 	}
-
-	verifiers := e.policy.ResolveVerifiers(input.VerificationInput)
-	orch := verify.Orchestrator{Verifiers: verifiers}
-	gateDecision, err := orch.RunFinalVerification(ctx, input.VerificationInput)
-	if err != nil {
-		return AcceptanceDecision{}, err
+	if hookDecision, failed := runHookStage(
+		ctx,
+		hookCfg.BeforeCompletionDecision,
+		hookStageBeforeCompletionDecision,
+		beforeCompletionDecisionHooks(),
+		input,
+	); failed {
+		return hookDecision, nil
 	}
-
-	decision := aggregateVerificationDecision(gateDecision)
 	if input.NoProgressExceeded && decision.Status == AcceptanceContinue {
 		decision.Status = AcceptanceIncomplete
 		decision.StopReason = controlplane.StopReasonNoProgressAfterFinalIntercept
@@ -78,6 +111,31 @@ func (e *Engine) EvaluateFinal(ctx context.Context, input FinalAcceptanceInput) 
 	}
 
 	return decision, nil
+}
+
+const (
+	hookStageBeforeVerification       = "before_verification"
+	hookStageAfterVerification        = "after_verification"
+	hookStageBeforeCompletionDecision = "before_completion_decision"
+	hookFailurePolicyFailOpen         = "fail_open"
+)
+
+// runHookStage 在指定阶段执行内置 hook，并根据 failure policy 决定是否终止验收。
+func runHookStage(
+	ctx context.Context,
+	spec config.HookSpec,
+	stage string,
+	hooks []prioritizedHook,
+	input FinalAcceptanceInput,
+) (AcceptanceDecision, bool) {
+	err := runConfiguredHooks(ctx, spec, stage, hooks, input)
+	if err == nil {
+		return AcceptanceDecision{}, false
+	}
+	if isFailOpenPolicy(spec.FailurePolicy) {
+		return AcceptanceDecision{}, false
+	}
+	return hookFailureDecision(stage, err), true
 }
 
 // aggregateVerificationDecision 按 fail -> hard_block -> soft_block -> pass 规则聚合结果。

--- a/internal/runtime/acceptance/engine_additional_test.go
+++ b/internal/runtime/acceptance/engine_additional_test.go
@@ -1,0 +1,195 @@
+package acceptance
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"neo-code/internal/config"
+	"neo-code/internal/runtime/controlplane"
+	"neo-code/internal/runtime/verify"
+)
+
+func TestNewEngineWithNilPolicy(t *testing.T) {
+	t.Parallel()
+
+	engine := NewEngine(nil)
+	cfg := verifyEnabledConfig()
+	disableAllHooks(&cfg)
+	decision, err := engine.EvaluateFinal(context.Background(), FinalAcceptanceInput{
+		CompletionGate: CompletionGateDecision{Passed: true},
+		VerificationInput: verify.FinalVerifyInput{
+			VerificationConfig: cfg,
+		},
+	})
+	if err != nil {
+		t.Fatalf("EvaluateFinal() error = %v", err)
+	}
+	if decision.Status != AcceptanceAccepted {
+		t.Fatalf("status = %q, want %q", decision.Status, AcceptanceAccepted)
+	}
+}
+
+func TestEngineEvaluateFinalAdditionalBranches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("verification disabled compatibility fallback", func(t *testing.T) {
+		t.Parallel()
+		cfg := verifyEnabledConfig()
+		cfg.Enabled = boolPtr(false)
+		disableAllHooks(&cfg)
+		decision, err := NewEngine(staticPolicy{}).EvaluateFinal(context.Background(), FinalAcceptanceInput{
+			CompletionGate: CompletionGateDecision{Passed: true},
+			VerificationInput: verify.FinalVerifyInput{
+				VerificationConfig: cfg,
+			},
+		})
+		if err != nil {
+			t.Fatalf("EvaluateFinal() error = %v", err)
+		}
+		if decision.Status != AcceptanceAccepted || decision.StopReason != controlplane.StopReasonCompatibilityFallback {
+			t.Fatalf("unexpected decision: %+v", decision)
+		}
+	})
+
+	t.Run("hook fail closed before verification", func(t *testing.T) {
+		t.Parallel()
+		cfg := verifyEnabledConfig()
+		cfg.Hooks.BeforeVerification.Enabled = true
+		cfg.Hooks.BeforeVerification.FailurePolicy = "fail_closed"
+		decision, err := NewEngine(staticPolicy{}).EvaluateFinal(context.Background(), FinalAcceptanceInput{
+			CompletionGate:    CompletionGateDecision{Passed: true},
+			VerificationInput: verify.FinalVerifyInput{VerificationConfig: cfg},
+		})
+		if err != nil {
+			t.Fatalf("EvaluateFinal() error = %v", err)
+		}
+		if decision.Status != AcceptanceFailed {
+			t.Fatalf("status = %q, want failed", decision.Status)
+		}
+	})
+
+	t.Run("no progress breaker", func(t *testing.T) {
+		t.Parallel()
+		cfg := verifyEnabledConfig()
+		disableAllHooks(&cfg)
+		decision, err := NewEngine(staticPolicy{verifiers: []verify.FinalVerifier{
+			staticVerifier{name: "todo", result: verify.VerificationResult{Name: "todo", Status: verify.VerificationSoftBlock}},
+		}}).EvaluateFinal(context.Background(), FinalAcceptanceInput{
+			CompletionGate:     CompletionGateDecision{Passed: true},
+			VerificationInput:  verify.FinalVerifyInput{VerificationConfig: cfg},
+			NoProgressExceeded: true,
+		})
+		if err != nil {
+			t.Fatalf("EvaluateFinal() error = %v", err)
+		}
+		if decision.Status != AcceptanceIncomplete || decision.StopReason != controlplane.StopReasonNoProgressAfterFinalIntercept {
+			t.Fatalf("unexpected decision: %+v", decision)
+		}
+	})
+
+	t.Run("max turns with unconverged todos", func(t *testing.T) {
+		t.Parallel()
+		cfg := verifyEnabledConfig()
+		disableAllHooks(&cfg)
+		decision, err := NewEngine(staticPolicy{verifiers: []verify.FinalVerifier{
+			staticVerifier{name: "todo", result: verify.VerificationResult{Name: "todo", Status: verify.VerificationSoftBlock}},
+		}}).EvaluateFinal(context.Background(), FinalAcceptanceInput{
+			CompletionGate:    CompletionGateDecision{Passed: true},
+			VerificationInput: verify.FinalVerifyInput{VerificationConfig: cfg},
+			MaxTurnsReached:   true,
+			MaxTurnsLimit:     9,
+		})
+		if err != nil {
+			t.Fatalf("EvaluateFinal() error = %v", err)
+		}
+		if decision.StopReason != controlplane.StopReasonMaxTurnExceededWithUnconvergedTodos {
+			t.Fatalf("stop reason = %q", decision.StopReason)
+		}
+	})
+
+	t.Run("retry exhausted helper", func(t *testing.T) {
+		t.Parallel()
+		if hasRetryExhausted(nil) {
+			t.Fatalf("nil todos should not exhaust retry")
+		}
+		if hasRetryExhausted([]verify.TodoSnapshot{{RetryLimit: 0, RetryCount: 99}}) {
+			t.Fatalf("retry limit <=0 should be ignored")
+		}
+		if !hasRetryExhausted([]verify.TodoSnapshot{{Required: true, RetryLimit: 1, RetryCount: 1}}) {
+			t.Fatalf("expected retry exhausted")
+		}
+	})
+
+	t.Run("firstResultByStatus no match", func(t *testing.T) {
+		t.Parallel()
+		if got := firstResultByStatus([]verify.VerificationResult{{Status: verify.VerificationPass}}, verify.VerificationFail); got != nil {
+			t.Fatalf("unexpected matched result")
+		}
+	})
+}
+
+func TestRunHookWithTimeout(t *testing.T) {
+	t.Parallel()
+
+	if err := runHookWithTimeout(context.Background(), 0, nil, FinalAcceptanceInput{}); err != nil {
+		t.Fatalf("nil hook should return nil: %v", err)
+	}
+
+	hook := namedHook{name: "sleep", run: func(ctx context.Context, _ FinalAcceptanceInput) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}}
+	err := runHookWithTimeout(context.Background(), 1, hook, FinalAcceptanceInput{})
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+
+	quick := namedHook{name: "ok", run: func(context.Context, FinalAcceptanceInput) error { return nil }}
+	if err := runHookWithTimeout(context.Background(), int((2*time.Second)/time.Second), quick, FinalAcceptanceInput{}); err != nil {
+		t.Fatalf("quick hook error = %v", err)
+	}
+}
+
+func TestDefaultPolicyBuildVerifierCoversAllNames(t *testing.T) {
+	t.Parallel()
+
+	policy := DefaultPolicy{Executor: verify.PolicyCommandExecutor{}}
+	for _, name := range []string{"file_exists", "content_match", "command_success", "git_diff", "build", "test", "lint", "typecheck"} {
+		if v := policy.buildVerifier(name); v == nil {
+			t.Fatalf("buildVerifier(%q) returned nil", name)
+		}
+	}
+}
+
+func TestDecideStopReasonAdditionalBranches(t *testing.T) {
+	t.Parallel()
+
+	reason, detail := controlplane.DecideStopReason(controlplane.StopInput{
+		PreDecidedReason: controlplane.StopReasonCompatibilityFallback,
+		PreDecidedDetail: "  keep  ",
+	})
+	if reason != controlplane.StopReasonCompatibilityFallback || detail != "keep" {
+		t.Fatalf("pre-decided mismatch: %q %q", reason, detail)
+	}
+
+	reason, _ = controlplane.DecideStopReason(controlplane.StopInput{MaxTurnsReached: true})
+	if reason != controlplane.StopReasonMaxTurnExceeded {
+		t.Fatalf("reason = %q", reason)
+	}
+	reason, _ = controlplane.DecideStopReason(controlplane.StopInput{RetryExhausted: true})
+	if reason != controlplane.StopReasonRetryExhausted {
+		t.Fatalf("reason = %q", reason)
+	}
+	reason, _ = controlplane.DecideStopReason(controlplane.StopInput{VerificationFailed: true})
+	if reason != controlplane.StopReasonVerificationFailed {
+		t.Fatalf("reason = %q", reason)
+	}
+}
+
+func disableAllHooks(cfg *config.VerificationConfig) {
+	cfg.Hooks.BeforeVerification.Enabled = false
+	cfg.Hooks.AfterVerification.Enabled = false
+	cfg.Hooks.BeforeCompletionDecision.Enabled = false
+}

--- a/internal/runtime/acceptance/engine_test.go
+++ b/internal/runtime/acceptance/engine_test.go
@@ -61,6 +61,30 @@ func TestEngineEvaluateFinalAggregation(t *testing.T) {
 		}
 	})
 
+	t.Run("fail keeps detailed stop reason from gate", func(t *testing.T) {
+		t.Parallel()
+		engine := NewEngine(staticPolicy{
+			verifiers: []verify.FinalVerifier{
+				staticVerifier{
+					name: "build",
+					result: verify.VerificationResult{
+						Name:       "build",
+						Status:     verify.VerificationFail,
+						Reason:     "missing verifier command configuration",
+						ErrorClass: verify.ErrorClassEnvMissing,
+					},
+				},
+			},
+		})
+		decision, err := engine.EvaluateFinal(context.Background(), makeInput())
+		if err != nil {
+			t.Fatalf("EvaluateFinal() error = %v", err)
+		}
+		if decision.StopReason != controlplane.StopReasonVerificationConfigMissing {
+			t.Fatalf("stop_reason = %q, want %q", decision.StopReason, controlplane.StopReasonVerificationConfigMissing)
+		}
+	})
+
 	t.Run("any hard_block -> incomplete", func(t *testing.T) {
 		t.Parallel()
 		engine := NewEngine(staticPolicy{

--- a/internal/runtime/acceptance/engine_test.go
+++ b/internal/runtime/acceptance/engine_test.go
@@ -1,0 +1,176 @@
+package acceptance
+
+import (
+	"context"
+	"testing"
+
+	"neo-code/internal/config"
+	"neo-code/internal/runtime/controlplane"
+	"neo-code/internal/runtime/verify"
+)
+
+type staticPolicy struct {
+	verifiers []verify.FinalVerifier
+}
+
+func (p staticPolicy) ResolveVerifiers(input verify.FinalVerifyInput) []verify.FinalVerifier {
+	_ = input
+	return p.verifiers
+}
+
+type staticVerifier struct {
+	name   string
+	result verify.VerificationResult
+}
+
+func (v staticVerifier) Name() string { return v.name }
+func (v staticVerifier) VerifyFinal(ctx context.Context, input verify.FinalVerifyInput) (verify.VerificationResult, error) {
+	_ = ctx
+	_ = input
+	return v.result, nil
+}
+
+func TestEngineEvaluateFinalAggregation(t *testing.T) {
+	t.Parallel()
+
+	makeInput := func() FinalAcceptanceInput {
+		return FinalAcceptanceInput{
+			CompletionGate: CompletionGateDecision{Passed: true},
+			VerificationInput: verify.FinalVerifyInput{
+				VerificationConfig: verifyEnabledConfig(),
+			},
+		}
+	}
+
+	t.Run("any fail -> failed", func(t *testing.T) {
+		t.Parallel()
+		engine := NewEngine(staticPolicy{
+			verifiers: []verify.FinalVerifier{
+				staticVerifier{name: "test", result: verify.VerificationResult{Name: "test", Status: verify.VerificationFail, ErrorClass: verify.ErrorClassTestFailure}},
+			},
+		})
+		decision, err := engine.EvaluateFinal(context.Background(), makeInput())
+		if err != nil {
+			t.Fatalf("EvaluateFinal() error = %v", err)
+		}
+		if decision.Status != AcceptanceFailed {
+			t.Fatalf("status = %q, want %q", decision.Status, AcceptanceFailed)
+		}
+		if decision.StopReason != controlplane.StopReasonVerificationFailed {
+			t.Fatalf("stop_reason = %q, want %q", decision.StopReason, controlplane.StopReasonVerificationFailed)
+		}
+	})
+
+	t.Run("any hard_block -> incomplete", func(t *testing.T) {
+		t.Parallel()
+		engine := NewEngine(staticPolicy{
+			verifiers: []verify.FinalVerifier{
+				staticVerifier{name: "todo", result: verify.VerificationResult{Name: "todo", Status: verify.VerificationHardBlock, WaitingExternal: true}},
+			},
+		})
+		decision, err := engine.EvaluateFinal(context.Background(), makeInput())
+		if err != nil {
+			t.Fatalf("EvaluateFinal() error = %v", err)
+		}
+		if decision.Status != AcceptanceIncomplete {
+			t.Fatalf("status = %q, want %q", decision.Status, AcceptanceIncomplete)
+		}
+		if decision.StopReason != controlplane.StopReasonTodoWaitingExternal {
+			t.Fatalf("stop_reason = %q, want %q", decision.StopReason, controlplane.StopReasonTodoWaitingExternal)
+		}
+	})
+
+	t.Run("any soft_block -> continue", func(t *testing.T) {
+		t.Parallel()
+		engine := NewEngine(staticPolicy{
+			verifiers: []verify.FinalVerifier{
+				staticVerifier{name: "todo", result: verify.VerificationResult{Name: "todo", Status: verify.VerificationSoftBlock}},
+			},
+		})
+		decision, err := engine.EvaluateFinal(context.Background(), makeInput())
+		if err != nil {
+			t.Fatalf("EvaluateFinal() error = %v", err)
+		}
+		if decision.Status != AcceptanceContinue {
+			t.Fatalf("status = %q, want %q", decision.Status, AcceptanceContinue)
+		}
+	})
+
+	t.Run("all pass -> accepted", func(t *testing.T) {
+		t.Parallel()
+		engine := NewEngine(staticPolicy{
+			verifiers: []verify.FinalVerifier{
+				staticVerifier{name: "todo", result: verify.VerificationResult{Name: "todo", Status: verify.VerificationPass}},
+			},
+		})
+		decision, err := engine.EvaluateFinal(context.Background(), makeInput())
+		if err != nil {
+			t.Fatalf("EvaluateFinal() error = %v", err)
+		}
+		if decision.Status != AcceptanceAccepted {
+			t.Fatalf("status = %q, want %q", decision.Status, AcceptanceAccepted)
+		}
+		if decision.StopReason != controlplane.StopReasonAccepted {
+			t.Fatalf("stop_reason = %q, want %q", decision.StopReason, controlplane.StopReasonAccepted)
+		}
+	})
+}
+
+func TestEngineEvaluateFinalCompletionGateAndRetry(t *testing.T) {
+	t.Parallel()
+
+	engine := NewEngine(staticPolicy{
+		verifiers: []verify.FinalVerifier{
+			staticVerifier{name: "todo", result: verify.VerificationResult{Name: "todo", Status: verify.VerificationPass}},
+		},
+	})
+
+	t.Run("completion gate false -> continue", func(t *testing.T) {
+		t.Parallel()
+		decision, err := engine.EvaluateFinal(context.Background(), FinalAcceptanceInput{
+			CompletionGate: CompletionGateDecision{Passed: false},
+			VerificationInput: verify.FinalVerifyInput{
+				VerificationConfig: verifyEnabledConfig(),
+			},
+		})
+		if err != nil {
+			t.Fatalf("EvaluateFinal() error = %v", err)
+		}
+		if decision.Status != AcceptanceContinue {
+			t.Fatalf("status = %q, want %q", decision.Status, AcceptanceContinue)
+		}
+	})
+
+	t.Run("retry exhausted overrides", func(t *testing.T) {
+		t.Parallel()
+		decision, err := engine.EvaluateFinal(context.Background(), FinalAcceptanceInput{
+			CompletionGate: CompletionGateDecision{Passed: true},
+			VerificationInput: verify.FinalVerifyInput{
+				VerificationConfig: verifyEnabledConfig(),
+				Todos: []verify.TodoSnapshot{
+					{ID: "todo-1", Required: true, RetryCount: 2, RetryLimit: 2},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("EvaluateFinal() error = %v", err)
+		}
+		if decision.Status != AcceptanceFailed {
+			t.Fatalf("status = %q, want %q", decision.Status, AcceptanceFailed)
+		}
+		if decision.StopReason != controlplane.StopReasonRetryExhausted {
+			t.Fatalf("stop_reason = %q, want %q", decision.StopReason, controlplane.StopReasonRetryExhausted)
+		}
+	})
+}
+
+func verifyEnabledConfig() (cfg config.VerificationConfig) {
+	cfg = config.StaticDefaults().Runtime.Verification
+	cfg.Enabled = boolPtr(true)
+	return cfg
+}
+
+func boolPtr(value bool) *bool {
+	v := value
+	return &v
+}

--- a/internal/runtime/acceptance/engine_test.go
+++ b/internal/runtime/acceptance/engine_test.go
@@ -164,6 +164,61 @@ func TestEngineEvaluateFinalCompletionGateAndRetry(t *testing.T) {
 	})
 }
 
+func TestEngineEvaluateFinalHookFailurePolicy(t *testing.T) {
+	t.Parallel()
+
+	engine := NewEngine(staticPolicy{
+		verifiers: []verify.FinalVerifier{
+			staticVerifier{name: "todo", result: verify.VerificationResult{Name: "todo", Status: verify.VerificationPass}},
+		},
+	})
+
+	t.Run("fail_closed returns failed decision", func(t *testing.T) {
+		t.Parallel()
+		cfg := verifyEnabledConfig()
+		cfg.Hooks.BeforeCompletionDecision.Enabled = true
+		cfg.Hooks.BeforeCompletionDecision.FailurePolicy = "fail_closed"
+		decision, err := engine.EvaluateFinal(context.Background(), FinalAcceptanceInput{
+			CompletionGate: CompletionGateDecision{Passed: true},
+			VerificationInput: verify.FinalVerifyInput{
+				VerificationConfig: cfg,
+			},
+			MaxTurnsReached: true,
+			MaxTurnsLimit:   0,
+		})
+		if err != nil {
+			t.Fatalf("EvaluateFinal() error = %v", err)
+		}
+		if decision.Status != AcceptanceFailed {
+			t.Fatalf("status = %q, want %q", decision.Status, AcceptanceFailed)
+		}
+		if decision.StopReason != controlplane.StopReasonVerificationExecutionError {
+			t.Fatalf("stop_reason = %q, want %q", decision.StopReason, controlplane.StopReasonVerificationExecutionError)
+		}
+	})
+
+	t.Run("fail_open ignores hook error", func(t *testing.T) {
+		t.Parallel()
+		cfg := verifyEnabledConfig()
+		cfg.Hooks.BeforeCompletionDecision.Enabled = true
+		cfg.Hooks.BeforeCompletionDecision.FailurePolicy = "fail_open"
+		decision, err := engine.EvaluateFinal(context.Background(), FinalAcceptanceInput{
+			CompletionGate: CompletionGateDecision{Passed: true},
+			VerificationInput: verify.FinalVerifyInput{
+				VerificationConfig: cfg,
+			},
+			MaxTurnsReached: true,
+			MaxTurnsLimit:   0,
+		})
+		if err != nil {
+			t.Fatalf("EvaluateFinal() error = %v", err)
+		}
+		if decision.Status != AcceptanceAccepted {
+			t.Fatalf("status = %q, want %q", decision.Status, AcceptanceAccepted)
+		}
+	})
+}
+
 func verifyEnabledConfig() (cfg config.VerificationConfig) {
 	cfg = config.StaticDefaults().Runtime.Verification
 	cfg.Enabled = boolPtr(true)

--- a/internal/runtime/acceptance/error_class.go
+++ b/internal/runtime/acceptance/error_class.go
@@ -1,0 +1,6 @@
+package acceptance
+
+import "neo-code/internal/runtime/verify"
+
+// ErrorClass 复用 verifier 层统一错误分类枚举。
+type ErrorClass = verify.ErrorClass

--- a/internal/runtime/acceptance/hook.go
+++ b/internal/runtime/acceptance/hook.go
@@ -1,0 +1,25 @@
+package acceptance
+
+import (
+	"context"
+	"time"
+)
+
+// Hook 表示 beforeAcceptFinal 流程中可插拔的内置钩子。
+type Hook interface {
+	Name() string
+	Run(ctx context.Context, input FinalAcceptanceInput) error
+}
+
+// runHookWithTimeout 在限定超时下执行 hook，避免验收链路被单点阻塞。
+func runHookWithTimeout(ctx context.Context, timeoutSec int, hook Hook, input FinalAcceptanceInput) error {
+	if hook == nil {
+		return nil
+	}
+	if timeoutSec <= 0 {
+		timeoutSec = 1
+	}
+	runCtx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSec)*time.Second)
+	defer cancel()
+	return hook.Run(runCtx, input)
+}

--- a/internal/runtime/acceptance/hook_runtime.go
+++ b/internal/runtime/acceptance/hook_runtime.go
@@ -1,0 +1,172 @@
+package acceptance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"neo-code/internal/config"
+	"neo-code/internal/runtime/controlplane"
+	"neo-code/internal/runtime/verify"
+)
+
+type prioritizedHook struct {
+	priority int
+	hook     Hook
+}
+
+// runConfiguredHooks 按 priority 与超时设置执行阶段 hook，确保验收链路可控。
+func runConfiguredHooks(
+	ctx context.Context,
+	spec config.HookSpec,
+	stage string,
+	hooks []prioritizedHook,
+	input FinalAcceptanceInput,
+) error {
+	if !spec.Enabled || len(hooks) == 0 {
+		return nil
+	}
+	selected := make([]prioritizedHook, 0, len(hooks))
+	for _, item := range hooks {
+		if item.hook == nil {
+			continue
+		}
+		// priority 作为最小执行门槛，允许通过配置裁剪低优先级 hook。
+		if spec.Priority > 0 && item.priority < spec.Priority {
+			continue
+		}
+		selected = append(selected, item)
+	}
+	if len(selected) == 0 {
+		return nil
+	}
+	sort.SliceStable(selected, func(i, j int) bool {
+		if selected[i].priority == selected[j].priority {
+			return selected[i].hook.Name() < selected[j].hook.Name()
+		}
+		return selected[i].priority < selected[j].priority
+	})
+	for _, item := range selected {
+		if err := runHookWithTimeout(ctx, spec.TimeoutSec, item.hook, input); err != nil {
+			return fmt.Errorf("%s hook %q failed: %w", stage, item.hook.Name(), err)
+		}
+	}
+	return nil
+}
+
+// isFailOpenPolicy 判断 hook 失败时是否允许继续验收流程。
+func isFailOpenPolicy(policy string) bool {
+	return strings.EqualFold(strings.TrimSpace(policy), hookFailurePolicyFailOpen)
+}
+
+// hookFailureDecision 将 hook 失败统一映射为结构化 failed 决策。
+func hookFailureDecision(stage string, err error) AcceptanceDecision {
+	detail := strings.TrimSpace(err.Error())
+	if detail == "" {
+		detail = "acceptance hook failed"
+	}
+	return AcceptanceDecision{
+		Status:             AcceptanceFailed,
+		StopReason:         controlplane.StopReasonVerificationExecutionError,
+		ErrorClass:         verify.ErrorClassUnknown,
+		UserVisibleSummary: "验收阶段执行失败，任务失败。",
+		InternalSummary:    fmt.Sprintf("%s: %s", stage, detail),
+		HasProgress:        false,
+	}
+}
+
+type verifierSelectionHook struct {
+	verifierCount int
+}
+
+// Name 返回 hook 标识，便于日志与错误定位。
+func (h verifierSelectionHook) Name() string { return "verifier_selection" }
+
+// Run 校验启用 verifier 时至少选择了一个执行器，避免空流水线误判通过。
+func (h verifierSelectionHook) Run(_ context.Context, input FinalAcceptanceInput) error {
+	if !input.VerificationInput.VerificationConfig.EnabledValue() {
+		return nil
+	}
+	if h.verifierCount > 0 {
+		return nil
+	}
+	return errors.New("verification enabled but no verifier selected")
+}
+
+type taskTypeMetadataHook struct{}
+
+// Name 返回 hook 标识，便于日志与错误定位。
+func (taskTypeMetadataHook) Name() string { return "task_type_metadata" }
+
+// Run 校验 task_type 元数据不为空字符串，避免策略映射退化为隐式脏值。
+func (taskTypeMetadataHook) Run(_ context.Context, input FinalAcceptanceInput) error {
+	if len(input.VerificationInput.Metadata) == 0 {
+		return nil
+	}
+	value, exists := input.VerificationInput.Metadata["task_type"]
+	if !exists {
+		return nil
+	}
+	if strings.TrimSpace(fmt.Sprintf("%v", value)) != "" {
+		return nil
+	}
+	return errors.New("task_type metadata is empty")
+}
+
+type verificationResultHook struct {
+	resultCount int
+}
+
+// Name 返回 hook 标识，便于日志与错误定位。
+func (h verificationResultHook) Name() string { return "verification_results" }
+
+// Run 校验 verifier 编排后存在结果输出，避免空结果链路被误判为通过。
+func (h verificationResultHook) Run(_ context.Context, input FinalAcceptanceInput) error {
+	if !input.VerificationInput.VerificationConfig.EnabledValue() {
+		return nil
+	}
+	if h.resultCount > 0 {
+		return nil
+	}
+	return errors.New("verification finished without results")
+}
+
+type maxTurnConsistencyHook struct{}
+
+// Name 返回 hook 标识，便于日志与错误定位。
+func (maxTurnConsistencyHook) Name() string { return "max_turn_consistency" }
+
+// Run 校验 max turn 标志与阈值一致性，避免 stop reason 决策基于不完整事实。
+func (maxTurnConsistencyHook) Run(_ context.Context, input FinalAcceptanceInput) error {
+	if !input.MaxTurnsReached {
+		return nil
+	}
+	if input.MaxTurnsLimit > 0 {
+		return nil
+	}
+	return errors.New("max_turns_reached=true but max_turns_limit is empty")
+}
+
+// beforeVerificationHooks 返回 before_verification 阶段内置 hook 列表。
+func beforeVerificationHooks(verifierCount int) []prioritizedHook {
+	return []prioritizedHook{
+		{priority: 10, hook: verifierSelectionHook{verifierCount: verifierCount}},
+		{priority: 20, hook: taskTypeMetadataHook{}},
+	}
+}
+
+// afterVerificationHooks 返回 after_verification 阶段内置 hook 列表。
+func afterVerificationHooks(resultCount int) []prioritizedHook {
+	return []prioritizedHook{
+		{priority: 20, hook: verificationResultHook{resultCount: resultCount}},
+	}
+}
+
+// beforeCompletionDecisionHooks 返回 before_completion_decision 阶段内置 hook 列表。
+func beforeCompletionDecisionHooks() []prioritizedHook {
+	return []prioritizedHook{
+		{priority: 30, hook: maxTurnConsistencyHook{}},
+	}
+}

--- a/internal/runtime/acceptance/hook_runtime_test.go
+++ b/internal/runtime/acceptance/hook_runtime_test.go
@@ -1,0 +1,172 @@
+package acceptance
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"neo-code/internal/config"
+	"neo-code/internal/runtime/controlplane"
+	"neo-code/internal/runtime/verify"
+)
+
+type namedHook struct {
+	name string
+	run  func(ctx context.Context, input FinalAcceptanceInput) error
+}
+
+func (h namedHook) Name() string { return h.name }
+
+func (h namedHook) Run(ctx context.Context, input FinalAcceptanceInput) error {
+	if h.run == nil {
+		return nil
+	}
+	return h.run(ctx, input)
+}
+
+func TestRunConfiguredHooks(t *testing.T) {
+	t.Parallel()
+
+	makeSpec := func() config.HookSpec {
+		return config.HookSpec{Enabled: true, TimeoutSec: 1}
+	}
+
+	t.Run("disabled or empty short circuit", func(t *testing.T) {
+		t.Parallel()
+		spec := makeSpec()
+		spec.Enabled = false
+		if err := runConfiguredHooks(context.Background(), spec, "before", nil, FinalAcceptanceInput{}); err != nil {
+			t.Fatalf("runConfiguredHooks() error = %v", err)
+		}
+	})
+
+	t.Run("priority filter and stable order", func(t *testing.T) {
+		t.Parallel()
+		executed := make([]string, 0)
+		spec := makeSpec()
+		spec.Priority = 10
+		hooks := []prioritizedHook{
+			{priority: 5, hook: namedHook{name: "skip-low", run: func(context.Context, FinalAcceptanceInput) error { executed = append(executed, "skip-low"); return nil }}},
+			{priority: 10, hook: namedHook{name: "b", run: func(context.Context, FinalAcceptanceInput) error { executed = append(executed, "b"); return nil }}},
+			{priority: 10, hook: namedHook{name: "a", run: func(context.Context, FinalAcceptanceInput) error { executed = append(executed, "a"); return nil }}},
+		}
+		if err := runConfiguredHooks(context.Background(), spec, "before", hooks, FinalAcceptanceInput{}); err != nil {
+			t.Fatalf("runConfiguredHooks() error = %v", err)
+		}
+		if strings.Join(executed, ",") != "a,b" {
+			t.Fatalf("execution order = %v, want [a b]", executed)
+		}
+	})
+
+	t.Run("hook error includes stage and hook name", func(t *testing.T) {
+		t.Parallel()
+		spec := makeSpec()
+		err := runConfiguredHooks(context.Background(), spec, "after", []prioritizedHook{
+			{priority: 10, hook: namedHook{name: "failing", run: func(context.Context, FinalAcceptanceInput) error { return errors.New("boom") }}},
+		}, FinalAcceptanceInput{})
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		if !strings.Contains(err.Error(), "after hook \"failing\" failed") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestHookPolicyAndDecision(t *testing.T) {
+	t.Parallel()
+
+	if !isFailOpenPolicy(" fail_open ") {
+		t.Fatalf("expected fail_open to be true")
+	}
+	if isFailOpenPolicy("fail_closed") {
+		t.Fatalf("expected fail_closed to be false")
+	}
+
+	decision := hookFailureDecision("before", errors.New("x"))
+	if decision.Status != AcceptanceFailed || decision.StopReason != controlplane.StopReasonVerificationExecutionError {
+		t.Fatalf("unexpected decision: %+v", decision)
+	}
+	if !strings.Contains(decision.InternalSummary, "before") {
+		t.Fatalf("unexpected internal summary: %q", decision.InternalSummary)
+	}
+}
+
+func TestRuntimeHooksNameAndRun(t *testing.T) {
+	t.Parallel()
+
+	t.Run("verifier selection", func(t *testing.T) {
+		t.Parallel()
+		hook := verifierSelectionHook{verifierCount: 0}
+		if hook.Name() != "verifier_selection" {
+			t.Fatalf("unexpected name: %q", hook.Name())
+		}
+		input := FinalAcceptanceInput{VerificationInput: verify.FinalVerifyInput{VerificationConfig: config.StaticDefaults().Runtime.Verification}}
+		if err := hook.Run(context.Background(), input); err == nil {
+			t.Fatalf("expected verifier selection error")
+		}
+		hook.verifierCount = 1
+		if err := hook.Run(context.Background(), input); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("task type metadata", func(t *testing.T) {
+		t.Parallel()
+		hook := taskTypeMetadataHook{}
+		if hook.Name() != "task_type_metadata" {
+			t.Fatalf("unexpected name: %q", hook.Name())
+		}
+		if err := hook.Run(context.Background(), FinalAcceptanceInput{}); err != nil {
+			t.Fatalf("unexpected empty metadata error: %v", err)
+		}
+		if err := hook.Run(context.Background(), FinalAcceptanceInput{VerificationInput: verify.FinalVerifyInput{Metadata: map[string]any{"task_type": " "}}}); err == nil {
+			t.Fatalf("expected empty task_type error")
+		}
+	})
+
+	t.Run("verification result hook", func(t *testing.T) {
+		t.Parallel()
+		hook := verificationResultHook{resultCount: 0}
+		if hook.Name() != "verification_results" {
+			t.Fatalf("unexpected name: %q", hook.Name())
+		}
+		input := FinalAcceptanceInput{VerificationInput: verify.FinalVerifyInput{VerificationConfig: config.StaticDefaults().Runtime.Verification}}
+		if err := hook.Run(context.Background(), input); err == nil {
+			t.Fatalf("expected empty results error")
+		}
+		hook.resultCount = 1
+		if err := hook.Run(context.Background(), input); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("max turn consistency hook", func(t *testing.T) {
+		t.Parallel()
+		hook := maxTurnConsistencyHook{}
+		if hook.Name() != "max_turn_consistency" {
+			t.Fatalf("unexpected name: %q", hook.Name())
+		}
+		if err := hook.Run(context.Background(), FinalAcceptanceInput{MaxTurnsReached: true, MaxTurnsLimit: 0}); err == nil {
+			t.Fatalf("expected max turn inconsistency error")
+		}
+		if err := hook.Run(context.Background(), FinalAcceptanceInput{MaxTurnsReached: true, MaxTurnsLimit: 5}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestHookBuilders(t *testing.T) {
+	t.Parallel()
+
+	if hooks := beforeVerificationHooks(1); len(hooks) != 2 {
+		t.Fatalf("beforeVerificationHooks len = %d, want 2", len(hooks))
+	}
+	if hooks := afterVerificationHooks(1); len(hooks) != 1 {
+		t.Fatalf("afterVerificationHooks len = %d, want 1", len(hooks))
+	}
+	if hooks := beforeCompletionDecisionHooks(); len(hooks) != 1 {
+		t.Fatalf("beforeCompletionDecisionHooks len = %d, want 1", len(hooks))
+	}
+}

--- a/internal/runtime/acceptance/hook_runtime_test.go
+++ b/internal/runtime/acceptance/hook_runtime_test.go
@@ -59,6 +59,19 @@ func TestRunConfiguredHooks(t *testing.T) {
 		}
 	})
 
+	t.Run("all hooks filtered or nil returns nil", func(t *testing.T) {
+		t.Parallel()
+		spec := makeSpec()
+		spec.Priority = 100
+		err := runConfiguredHooks(context.Background(), spec, "before", []prioritizedHook{
+			{priority: 10, hook: nil},
+			{priority: 10, hook: namedHook{name: "low"}},
+		}, FinalAcceptanceInput{})
+		if err != nil {
+			t.Fatalf("runConfiguredHooks() error = %v", err)
+		}
+	})
+
 	t.Run("hook error includes stage and hook name", func(t *testing.T) {
 		t.Parallel()
 		spec := makeSpec()
@@ -90,6 +103,11 @@ func TestHookPolicyAndDecision(t *testing.T) {
 	}
 	if !strings.Contains(decision.InternalSummary, "before") {
 		t.Fatalf("unexpected internal summary: %q", decision.InternalSummary)
+	}
+
+	emptyDecision := hookFailureDecision("after", errors.New(""))
+	if !strings.Contains(emptyDecision.InternalSummary, "acceptance hook failed") {
+		t.Fatalf("expected default hook failure detail, got %q", emptyDecision.InternalSummary)
 	}
 }
 

--- a/internal/runtime/acceptance/policy.go
+++ b/internal/runtime/acceptance/policy.go
@@ -1,0 +1,125 @@
+package acceptance
+
+import (
+	"fmt"
+	"strings"
+
+	"neo-code/internal/runtime/verify"
+)
+
+type taskType string
+
+const (
+	taskTypeUnknown    taskType = "unknown"
+	taskTypeCreateFile taskType = "create_file"
+	taskTypeEditCode   taskType = "edit_code"
+	taskTypeFixBug     taskType = "fix_bug"
+	taskTypeRefactor   taskType = "refactor"
+	taskTypeDocs       taskType = "docs"
+	taskTypeConfig     taskType = "config"
+)
+
+// AcceptancePolicy 定义 final 验收时 verifier 选择策略。
+type AcceptancePolicy interface {
+	ResolveVerifiers(input verify.FinalVerifyInput) []verify.FinalVerifier
+}
+
+// DefaultPolicy 按 task_type 与 verification config 解析 verifier 列表。
+type DefaultPolicy struct {
+	Executor verify.CommandExecutor
+}
+
+// ResolveVerifiers 依据 task policy 与配置启停生成 verifier 执行列表。
+func (p DefaultPolicy) ResolveVerifiers(input verify.FinalVerifyInput) []verify.FinalVerifier {
+	task := resolveTaskType(input.Metadata, input.VerificationConfig.DefaultTaskPolicy)
+	names := mappedVerifierNames(task)
+
+	verifiers := make([]verify.FinalVerifier, 0, len(names))
+	seen := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		seen[name] = struct{}{}
+		if !isVerifierEnabled(name, input) {
+			continue
+		}
+		if verifier := p.buildVerifier(name); verifier != nil {
+			verifiers = append(verifiers, verifier)
+		}
+	}
+	return verifiers
+}
+
+// buildVerifier 基于名称构建 verifier 实例。
+func (p DefaultPolicy) buildVerifier(name string) verify.FinalVerifier {
+	switch strings.TrimSpace(name) {
+	case "todo_convergence":
+		return verify.TodoConvergenceVerifier{}
+	case "file_exists":
+		return verify.FileExistsVerifier{}
+	case "content_match":
+		return verify.ContentMatchVerifier{}
+	case "command_success":
+		return verify.CommandSuccessVerifier{VerifierName: "command_success", Executor: p.Executor}
+	case "git_diff":
+		return verify.GitDiffVerifier{Executor: p.Executor}
+	case "build":
+		v := verify.NewBuildVerifier(p.Executor)
+		return v
+	case "test":
+		v := verify.NewTestVerifier(p.Executor)
+		return v
+	case "lint":
+		v := verify.NewLintVerifier(p.Executor)
+		return v
+	case "typecheck":
+		v := verify.NewTypecheckVerifier(p.Executor)
+		return v
+	default:
+		return nil
+	}
+}
+
+// isVerifierEnabled 根据 verification config 判断 verifier 是否生效。
+func isVerifierEnabled(name string, input verify.FinalVerifyInput) bool {
+	cfg, exists := input.VerificationConfig.Verifiers[strings.TrimSpace(name)]
+	if !exists {
+		return name == "todo_convergence"
+	}
+	return cfg.Enabled
+}
+
+// resolveTaskType 根据 metadata 与默认策略解析任务类型。
+func resolveTaskType(metadata map[string]any, fallback string) taskType {
+	raw := strings.ToLower(strings.TrimSpace(fallback))
+	if len(metadata) > 0 {
+		if value, ok := metadata["task_type"]; ok && value != nil {
+			raw = strings.ToLower(strings.TrimSpace(fmt.Sprintf("%v", value)))
+		}
+	}
+	switch taskType(raw) {
+	case taskTypeCreateFile, taskTypeEditCode, taskTypeFixBug, taskTypeRefactor, taskTypeDocs, taskTypeConfig:
+		return taskType(raw)
+	default:
+		return taskTypeUnknown
+	}
+}
+
+// mappedVerifierNames 返回任务类型对应的 verifier 名称集合。
+func mappedVerifierNames(task taskType) []string {
+	switch task {
+	case taskTypeCreateFile, taskTypeDocs:
+		return []string{"todo_convergence", "file_exists", "content_match"}
+	case taskTypeConfig:
+		return []string{"todo_convergence", "file_exists", "content_match", "command_success"}
+	case taskTypeEditCode:
+		return []string{"todo_convergence", "git_diff", "build", "test", "typecheck"}
+	case taskTypeFixBug:
+		return []string{"todo_convergence", "git_diff", "test", "build", "typecheck"}
+	case taskTypeRefactor:
+		return []string{"todo_convergence", "git_diff", "build", "test", "lint", "typecheck"}
+	default:
+		return []string{"todo_convergence"}
+	}
+}

--- a/internal/runtime/acceptance/policy_test.go
+++ b/internal/runtime/acceptance/policy_test.go
@@ -1,0 +1,123 @@
+package acceptance
+
+import (
+	"testing"
+
+	"neo-code/internal/config"
+	"neo-code/internal/runtime/verify"
+)
+
+func TestResolveTaskType(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		metadata map[string]any
+		fallback string
+		want     taskType
+	}{
+		{name: "metadata wins", metadata: map[string]any{"task_type": "fix_bug"}, fallback: "docs", want: taskTypeFixBug},
+		{name: "fallback used", fallback: "refactor", want: taskTypeRefactor},
+		{name: "unknown fallback", fallback: "other", want: taskTypeUnknown},
+		{name: "unknown metadata", metadata: map[string]any{"task_type": 100}, fallback: "docs", want: taskTypeUnknown},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := resolveTaskType(tc.metadata, tc.fallback); got != tc.want {
+				t.Fatalf("resolveTaskType() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMappedVerifierNames(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		task taskType
+		want []string
+	}{
+		{task: taskTypeCreateFile, want: []string{"todo_convergence", "file_exists", "content_match"}},
+		{task: taskTypeDocs, want: []string{"todo_convergence", "file_exists", "content_match"}},
+		{task: taskTypeConfig, want: []string{"todo_convergence", "file_exists", "content_match", "command_success"}},
+		{task: taskTypeEditCode, want: []string{"todo_convergence", "git_diff", "build", "test", "typecheck"}},
+		{task: taskTypeFixBug, want: []string{"todo_convergence", "git_diff", "test", "build", "typecheck"}},
+		{task: taskTypeRefactor, want: []string{"todo_convergence", "git_diff", "build", "test", "lint", "typecheck"}},
+		{task: taskTypeUnknown, want: []string{"todo_convergence"}},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(string(tc.task), func(t *testing.T) {
+			t.Parallel()
+			got := mappedVerifierNames(tc.task)
+			if len(got) != len(tc.want) {
+				t.Fatalf("mappedVerifierNames() len = %d, want %d", len(got), len(tc.want))
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Fatalf("mappedVerifierNames()[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultPolicyResolveVerifiers(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.StaticDefaults().Runtime.Verification
+	cfg.Enabled = boolPtrPolicy(true)
+	cfg.Verifiers["git_diff"] = config.VerifierConfig{Enabled: true}
+	cfg.Verifiers["build"] = config.VerifierConfig{Enabled: true}
+	cfg.Verifiers["test"] = config.VerifierConfig{Enabled: false}
+	cfg.Verifiers["typecheck"] = config.VerifierConfig{Enabled: true}
+
+	verifiers := (DefaultPolicy{}).ResolveVerifiers(verify.FinalVerifyInput{
+		Metadata:           map[string]any{"task_type": "edit_code"},
+		VerificationConfig: cfg,
+	})
+
+	if len(verifiers) != 4 {
+		t.Fatalf("ResolveVerifiers() len = %d, want 4", len(verifiers))
+	}
+
+	names := make([]string, 0, len(verifiers))
+	for _, item := range verifiers {
+		names = append(names, item.Name())
+	}
+	wantNames := []string{"todo_convergence", "git_diff", "build", "typecheck"}
+	for i := range wantNames {
+		if names[i] != wantNames[i] {
+			t.Fatalf("name[%d] = %q, want %q", i, names[i], wantNames[i])
+		}
+	}
+}
+
+func TestDefaultPolicyBuildVerifierAndEnabledFallback(t *testing.T) {
+	t.Parallel()
+
+	policy := DefaultPolicy{}
+	if verifier := policy.buildVerifier("unknown"); verifier != nil {
+		t.Fatalf("buildVerifier(unknown) = %T, want nil", verifier)
+	}
+
+	cfg := config.StaticDefaults().Runtime.Verification
+	cfg.Enabled = boolPtrPolicy(true)
+	delete(cfg.Verifiers, "todo_convergence")
+	delete(cfg.Verifiers, "git_diff")
+	if !isVerifierEnabled("todo_convergence", verify.FinalVerifyInput{VerificationConfig: cfg}) {
+		t.Fatalf("todo_convergence should be enabled by default when config missing")
+	}
+	if isVerifierEnabled("git_diff", verify.FinalVerifyInput{VerificationConfig: cfg}) {
+		t.Fatalf("git_diff should be disabled when config missing")
+	}
+}
+
+func boolPtrPolicy(value bool) *bool {
+	v := value
+	return &v
+}

--- a/internal/runtime/acceptance/stop_reason.go
+++ b/internal/runtime/acceptance/stop_reason.go
@@ -1,0 +1,6 @@
+package acceptance
+
+import "neo-code/internal/runtime/controlplane"
+
+// StopReason 复用控制面统一停止原因枚举，避免 acceptance 层引入平行真源。
+type StopReason = controlplane.StopReason

--- a/internal/runtime/acceptance/types.go
+++ b/internal/runtime/acceptance/types.go
@@ -1,0 +1,45 @@
+package acceptance
+
+import (
+	"neo-code/internal/runtime/controlplane"
+	"neo-code/internal/runtime/verify"
+)
+
+// CompletionGateDecision 表示 completion gate 评估结果。
+type CompletionGateDecision struct {
+	Passed bool   `json:"passed"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// AcceptanceStatus 表示 final 验收的统一决策状态。
+type AcceptanceStatus string
+
+const (
+	AcceptanceAccepted   AcceptanceStatus = "accepted"
+	AcceptanceContinue   AcceptanceStatus = "continue"
+	AcceptanceIncomplete AcceptanceStatus = "incomplete"
+	AcceptanceFailed     AcceptanceStatus = "failed"
+)
+
+// AcceptanceDecision 表示 runtime beforeAcceptFinal 的结构化输出。
+type AcceptanceDecision struct {
+	Status             AcceptanceStatus            `json:"status"`
+	StopReason         controlplane.StopReason     `json:"stop_reason,omitempty"`
+	ErrorClass         verify.ErrorClass           `json:"error_class,omitempty"`
+	UserVisibleSummary string                      `json:"user_visible_summary,omitempty"`
+	InternalSummary    string                      `json:"internal_summary,omitempty"`
+	ContinueHint       string                      `json:"continue_hint,omitempty"`
+	VerifierResults    []verify.VerificationResult `json:"verifier_results,omitempty"`
+	HasProgress        bool                        `json:"has_progress,omitempty"`
+	Retryable          bool                        `json:"retryable,omitempty"`
+	WaitingExternal    bool                        `json:"waiting_external,omitempty"`
+}
+
+// FinalAcceptanceInput 表示 beforeAcceptFinal 需要的输入快照。
+type FinalAcceptanceInput struct {
+	CompletionGate     CompletionGateDecision  `json:"completion_gate"`
+	VerificationInput  verify.FinalVerifyInput `json:"verification_input"`
+	NoProgressExceeded bool                    `json:"no_progress_exceeded,omitempty"`
+	MaxTurnsReached    bool                    `json:"max_turns_reached,omitempty"`
+	MaxTurnsLimit      int                     `json:"max_turns_limit,omitempty"`
+}

--- a/internal/runtime/controlplane/decider.go
+++ b/internal/runtime/controlplane/decider.go
@@ -7,29 +7,38 @@ import (
 	"strings"
 )
 
+// TerminalStatus 表示 runtime run 的唯一终态裁决结果。
+type TerminalStatus string
+
+const (
+	TerminalStatusCompleted  TerminalStatus = "completed"
+	TerminalStatusContinue   TerminalStatus = "continue"
+	TerminalStatusIncomplete TerminalStatus = "incomplete"
+	TerminalStatusFailed     TerminalStatus = "failed"
+)
+
 // StopInput 汇总最终 stop 决议所需的信号。
 type StopInput struct {
-	UserInterrupted bool
-	MaxTurnsReached bool
-	MaxTurnsLimit   int
-	BudgetExceeded  bool
-	FatalError      error
-	Completed       bool
+	PreDecidedReason StopReason
+	PreDecidedDetail string
+
+	UserInterrupted    bool
+	BudgetExceeded     bool
+	MaxTurnsReached    bool
+	MaxTurnsLimit      int
+	RetryExhausted     bool
+	VerificationFailed bool
+	FatalError         error
+	Completed          bool
 }
 
 // DecideStopReason 按固定优先级返回唯一的最终 stop 原因。
 func DecideStopReason(in StopInput) (StopReason, string) {
+	if in.PreDecidedReason != "" {
+		return in.PreDecidedReason, strings.TrimSpace(in.PreDecidedDetail)
+	}
 	if in.UserInterrupted {
 		return StopReasonUserInterrupt, ""
-	}
-	if in.MaxTurnsReached {
-		if in.MaxTurnsLimit > 0 {
-			return StopReasonMaxTurnsReached, fmt.Sprintf("runtime: max turn limit reached (%d)", in.MaxTurnsLimit)
-		}
-		return StopReasonMaxTurnsReached, ""
-	}
-	if in.BudgetExceeded {
-		return StopReasonBudgetExceeded, ""
 	}
 	if in.FatalError != nil {
 		if errors.Is(in.FatalError, context.Canceled) {
@@ -37,8 +46,23 @@ func DecideStopReason(in StopInput) (StopReason, string) {
 		}
 		return StopReasonFatalError, strings.TrimSpace(in.FatalError.Error())
 	}
+	if in.BudgetExceeded {
+		return StopReasonBudgetExceeded, ""
+	}
+	if in.MaxTurnsReached {
+		if in.MaxTurnsLimit > 0 {
+			return StopReasonMaxTurnExceeded, fmt.Sprintf("runtime: max turn limit reached (%d)", in.MaxTurnsLimit)
+		}
+		return StopReasonMaxTurnExceeded, ""
+	}
+	if in.RetryExhausted {
+		return StopReasonRetryExhausted, ""
+	}
+	if in.VerificationFailed {
+		return StopReasonVerificationFailed, ""
+	}
 	if in.Completed {
-		return StopReasonCompleted, ""
+		return StopReasonAccepted, ""
 	}
 	return StopReasonFatalError, "runtime: stop reason undetermined"
 }

--- a/internal/runtime/controlplane/decider_test.go
+++ b/internal/runtime/controlplane/decider_test.go
@@ -99,4 +99,27 @@ func TestDecideStopReasonDetails(t *testing.T) {
 	if detail != "runtime: stop reason undetermined" {
 		t.Fatalf("detail = %q, want undetermined detail", detail)
 	}
+
+	reason, detail = DecideStopReason(StopInput{
+		PreDecidedReason: StopReasonCompatibilityFallback,
+		PreDecidedDetail: "  fallback  ",
+	})
+	if reason != StopReasonCompatibilityFallback || detail != "fallback" {
+		t.Fatalf("pre-decided mismatch, got (%q, %q)", reason, detail)
+	}
+
+	reason, detail = DecideStopReason(StopInput{MaxTurnsReached: true})
+	if reason != StopReasonMaxTurnExceeded || detail != "" {
+		t.Fatalf("max-turn no-limit mismatch, got (%q, %q)", reason, detail)
+	}
+
+	reason, detail = DecideStopReason(StopInput{RetryExhausted: true})
+	if reason != StopReasonRetryExhausted || detail != "" {
+		t.Fatalf("retry exhausted mismatch, got (%q, %q)", reason, detail)
+	}
+
+	reason, detail = DecideStopReason(StopInput{VerificationFailed: true})
+	if reason != StopReasonVerificationFailed || detail != "" {
+		t.Fatalf("verification failed mismatch, got (%q, %q)", reason, detail)
+	}
 }

--- a/internal/runtime/controlplane/decider_test.go
+++ b/internal/runtime/controlplane/decider_test.go
@@ -33,13 +33,13 @@ func TestDecideStopReasonPriority(t *testing.T) {
 			wantReason: StopReasonUserInterrupt,
 		},
 		{
-			name: "max_turns_wins_over_fatal",
+			name: "fatal_wins_over_max_turns",
 			in: StopInput{
 				MaxTurnsReached: true,
 				MaxTurnsLimit:   40,
 				FatalError:      errSample,
 			},
-			wantReason: StopReasonMaxTurnsReached,
+			wantReason: StopReasonFatalError,
 		},
 		{
 			name: "fatal_error_wins_over_completed",
@@ -85,8 +85,8 @@ func TestDecideStopReasonDetails(t *testing.T) {
 		MaxTurnsReached: true,
 		MaxTurnsLimit:   40,
 	})
-	if reason != StopReasonMaxTurnsReached {
-		t.Fatalf("reason = %q, want %q", reason, StopReasonMaxTurnsReached)
+	if reason != StopReasonMaxTurnExceeded {
+		t.Fatalf("reason = %q, want %q", reason, StopReasonMaxTurnExceeded)
 	}
 	if detail != "runtime: max turn limit reached (40)" {
 		t.Fatalf("detail = %q, want max turn detail", detail)

--- a/internal/runtime/controlplane/phase.go
+++ b/internal/runtime/controlplane/phase.go
@@ -26,6 +26,7 @@ var allowedRunStateTransitions = map[RunState]map[RunState]struct{}{
 	},
 	RunStatePlan: {
 		RunStatePlan:              {},
+		RunStateVerify:            {},
 		RunStateExecute:           {},
 		RunStateCompacting:        {},
 		RunStateWaitingPermission: {},

--- a/internal/runtime/controlplane/phase_test.go
+++ b/internal/runtime/controlplane/phase_test.go
@@ -34,7 +34,7 @@ func TestValidateRunStateTransitionMainlineAndGovernanceStates(t *testing.T) {
 func TestValidateRunStateTransitionRejectsInvalidJump(t *testing.T) {
 	t.Parallel()
 
-	if err := ValidateRunStateTransition(RunStatePlan, RunStateVerify); err == nil {
+	if err := ValidateRunStateTransition(RunStateCompacting, RunStateExecute); err == nil {
 		t.Fatalf("expected invalid transition to return error")
 	}
 }

--- a/internal/runtime/controlplane/stop_reason.go
+++ b/internal/runtime/controlplane/stop_reason.go
@@ -4,14 +4,41 @@ package controlplane
 type StopReason string
 
 const (
-	// StopReasonFatalError 表示出现不可恢复错误。
-	StopReasonFatalError StopReason = "STOP_FATAL_ERROR"
-	// StopReasonMaxTurnsReached 表示达到运行轮次上限并主动终止。
-	StopReasonMaxTurnsReached StopReason = "STOP_MAX_TURNS_REACHED"
-	// StopReasonBudgetExceeded 表示预算闭环判定本轮请求无法继续发送。
-	StopReasonBudgetExceeded StopReason = "STOP_BUDGET_EXCEEDED"
-	// StopReasonCompleted 表示运行满足完成条件。
-	StopReasonCompleted StopReason = "STOP_COMPLETED"
 	// StopReasonUserInterrupt 表示运行被用户或上层上下文中断。
-	StopReasonUserInterrupt StopReason = "STOP_USER_INTERRUPT"
+	StopReasonUserInterrupt StopReason = "user_interrupt"
+	// StopReasonFatalError 表示出现不可恢复错误。
+	StopReasonFatalError StopReason = "fatal_error"
+	// StopReasonBudgetExceeded 表示预算闭环判定本轮请求无法继续发送。
+	StopReasonBudgetExceeded StopReason = "budget_exceeded"
+	// StopReasonMaxTurnExceeded 表示达到运行轮次上限并主动终止。
+	StopReasonMaxTurnExceeded StopReason = "max_turn_exceeded"
+	// StopReasonRetryExhausted 表示 todo 重试次数已耗尽。
+	StopReasonRetryExhausted StopReason = "retry_exhausted"
+	// StopReasonVerificationFailed 表示验证器明确失败。
+	StopReasonVerificationFailed StopReason = "verification_failed"
+	// StopReasonAccepted 表示 completion/verification 双门控均通过并完成收尾。
+	StopReasonAccepted StopReason = "accepted"
+	// StopReasonTodoNotConverged 表示 required todo 尚未收敛。
+	StopReasonTodoNotConverged StopReason = "todo_not_converged"
+	// StopReasonTodoWaitingExternal 表示 required todo 等待外部输入。
+	StopReasonTodoWaitingExternal StopReason = "todo_waiting_external"
+	// StopReasonNoProgressAfterFinalIntercept 表示 final 连续拦截但无进展。
+	StopReasonNoProgressAfterFinalIntercept StopReason = "no_progress_after_final_intercept"
+	// StopReasonMaxTurnExceededWithUnconvergedTodos 表示 max turn + todo 未收敛。
+	StopReasonMaxTurnExceededWithUnconvergedTodos StopReason = "max_turn_exceeded_with_unconverged_todos"
+	// StopReasonMaxTurnExceededWithFailedVerification 表示 max turn + verification 未通过。
+	StopReasonMaxTurnExceededWithFailedVerification StopReason = "max_turn_exceeded_with_failed_verification"
+	// StopReasonVerificationConfigMissing 表示 verifier 必需配置缺失。
+	StopReasonVerificationConfigMissing StopReason = "verification_config_missing"
+	// StopReasonVerificationExecutionDenied 表示 verifier 命令被执行策略拒绝。
+	StopReasonVerificationExecutionDenied StopReason = "verification_execution_denied"
+	// StopReasonVerificationExecutionError 表示 verifier 命令执行异常。
+	StopReasonVerificationExecutionError StopReason = "verification_execution_error"
+	// StopReasonCompatibilityFallback 表示走了兼容回退路径。
+	StopReasonCompatibilityFallback StopReason = "compatibility_fallback"
+
+	// StopReasonMaxTurnsReached 兼容旧命名，语义等价于 max_turn_exceeded。
+	StopReasonMaxTurnsReached StopReason = StopReasonMaxTurnExceeded
+	// StopReasonCompleted 兼容旧命名，语义等价于 accepted。
+	StopReasonCompleted StopReason = StopReasonAccepted
 )

--- a/internal/runtime/events.go
+++ b/internal/runtime/events.go
@@ -3,7 +3,9 @@ package runtime
 import (
 	"time"
 
+	"neo-code/internal/runtime/acceptance"
 	"neo-code/internal/runtime/controlplane"
+	"neo-code/internal/runtime/verify"
 )
 
 // EventType 标识 runtime 事件类型。
@@ -55,6 +57,48 @@ type ProgressEvaluatedPayload struct {
 type StopReasonDecidedPayload struct {
 	Reason controlplane.StopReason `json:"reason"`
 	Detail string                  `json:"detail,omitempty"`
+}
+
+// VerificationStartedPayload 描述 final 验收验证开始事件。
+type VerificationStartedPayload struct {
+	CompletionPassed bool `json:"completion_passed"`
+}
+
+// VerificationStageFinishedPayload 描述单个 verifier 阶段完成事件。
+type VerificationStageFinishedPayload struct {
+	Name       string                    `json:"name"`
+	Status     verify.VerificationStatus `json:"status"`
+	Summary    string                    `json:"summary,omitempty"`
+	Reason     string                    `json:"reason,omitempty"`
+	ErrorClass verify.ErrorClass         `json:"error_class,omitempty"`
+}
+
+// VerificationFinishedPayload 描述整体验证流程结束事件。
+type VerificationFinishedPayload struct {
+	AcceptanceStatus acceptance.AcceptanceStatus `json:"acceptance_status"`
+	StopReason       controlplane.StopReason     `json:"stop_reason,omitempty"`
+	ErrorClass       verify.ErrorClass           `json:"error_class,omitempty"`
+}
+
+// VerificationCompletedPayload 描述验证通过并可完成的事件。
+type VerificationCompletedPayload struct {
+	StopReason controlplane.StopReason `json:"stop_reason,omitempty"`
+}
+
+// VerificationFailedPayload 描述验证失败事件。
+type VerificationFailedPayload struct {
+	StopReason controlplane.StopReason `json:"stop_reason,omitempty"`
+	ErrorClass verify.ErrorClass       `json:"error_class,omitempty"`
+}
+
+// AcceptanceDecidedPayload 描述 acceptance engine 决议结果。
+type AcceptanceDecidedPayload struct {
+	Status             acceptance.AcceptanceStatus `json:"status"`
+	StopReason         controlplane.StopReason     `json:"stop_reason,omitempty"`
+	ErrorClass         verify.ErrorClass           `json:"error_class,omitempty"`
+	UserVisibleSummary string                      `json:"user_visible_summary,omitempty"`
+	InternalSummary    string                      `json:"internal_summary,omitempty"`
+	ContinueHint       string                      `json:"continue_hint,omitempty"`
 }
 
 // LedgerReconciledPayload 为账本对账预留负载。
@@ -232,6 +276,18 @@ const (
 	EventProgressEvaluated EventType = "progress_evaluated"
 	// EventStopReasonDecided 表示 stop reason 已决议。
 	EventStopReasonDecided EventType = "stop_reason_decided"
+	// EventVerificationStarted 表示 final 验证流程开始。
+	EventVerificationStarted EventType = "verification_started"
+	// EventVerificationStageFinished 表示单个 verifier 阶段完成。
+	EventVerificationStageFinished EventType = "verification_stage_finished"
+	// EventVerificationFinished 表示 final 验证流程结束。
+	EventVerificationFinished EventType = "verification_finished"
+	// EventVerificationCompleted 表示验证通过并可完成。
+	EventVerificationCompleted EventType = "verification_completed"
+	// EventVerificationFailed 表示验证失败。
+	EventVerificationFailed EventType = "verification_failed"
+	// EventAcceptanceDecided 表示 acceptance 决议已生成。
+	EventAcceptanceDecided EventType = "acceptance_decided"
 	// EventLedgerReconciled 表示本轮 usage 已按新账本语义完成调和。
 	EventLedgerReconciled EventType = "ledger_reconciled"
 	// EventTodoUpdated 表示 todo_write 成功更新。

--- a/internal/runtime/final_acceptance.go
+++ b/internal/runtime/final_acceptance.go
@@ -39,6 +39,10 @@ func (s *Service) beforeAcceptFinal(
 	if maxNoProgress <= 0 {
 		maxNoProgress = 3
 	}
+	noProgressStreak := state.progress.LastScore.NoProgressStreak
+	if noProgressStreak < 0 {
+		noProgressStreak = 0
+	}
 	maxTurnsLimit := state.maxTurnsLimit
 	maxTurnsReached := state.maxTurnsReached
 	if !maxTurnsReached {
@@ -66,19 +70,27 @@ func (s *Service) beforeAcceptFinal(
 				Turn:                 state.turn,
 				MaxTurns:             resolveRuntimeMaxTurns(snapshot.Config.Runtime),
 				MaxTurnsReached:      maxTurnsReached,
-				FinalInterceptStreak: state.finalInterceptStreak,
+				FinalInterceptStreak: noProgressStreak,
 			},
 			Metadata: map[string]any{
 				"task_type": inferTaskType(state),
 			},
 			VerificationConfig: verificationCfg,
 		},
-		NoProgressExceeded: state.finalInterceptStreak >= maxNoProgress,
+		NoProgressExceeded: maxNoProgress > 0 && noProgressStreak >= maxNoProgress,
 		MaxTurnsReached:    maxTurnsReached,
 		MaxTurnsLimit:      maxTurnsLimit,
 	}
 
-	return engine.EvaluateFinal(ctx, input)
+	decision, err := engine.EvaluateFinal(ctx, input)
+	if err != nil {
+		return acceptance.AcceptanceDecision{}, err
+	}
+	// 继续分支复用 runtime progress 结果，避免把“final 被拦截”误判为“无进展”。
+	if decision.Status == acceptance.AcceptanceContinue && hasRuntimeProgress(state) {
+		decision.HasProgress = true
+	}
+	return decision, nil
 }
 
 // recordAcceptanceTerminal 将 acceptance 输出映射为 runtime 唯一终态记录。
@@ -204,4 +216,13 @@ func applyAcceptanceResultProgress(state *runState, decision acceptance.Acceptan
 	default:
 		state.finalInterceptStreak = 0
 	}
+}
+
+// hasRuntimeProgress 判断 runtime 当前快照是否存在业务或探索进展。
+func hasRuntimeProgress(state *runState) bool {
+	if state == nil {
+		return false
+	}
+	score := state.progress.LastScore
+	return score.HasBusinessProgress || score.HasExplorationProgress
 }

--- a/internal/runtime/final_acceptance.go
+++ b/internal/runtime/final_acceptance.go
@@ -1,0 +1,186 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+
+	providertypes "neo-code/internal/provider/types"
+	"neo-code/internal/runtime/acceptance"
+	"neo-code/internal/runtime/controlplane"
+	"neo-code/internal/runtime/verify"
+	agentsession "neo-code/internal/session"
+)
+
+const finalContinueReminder = "There are unfinished required todos or unmet acceptance checks. Continue execution. Do not finalize yet."
+
+// beforeAcceptFinal 在 runtime 接受模型 final 前执行双门控验收。
+func (s *Service) beforeAcceptFinal(
+	ctx context.Context,
+	state *runState,
+	snapshot TurnBudgetSnapshot,
+	assistant providertypes.Message,
+	completionPassed bool,
+) (acceptance.AcceptanceDecision, error) {
+	if state == nil {
+		return acceptance.AcceptanceDecision{}, nil
+	}
+
+	verificationCfg := snapshot.Config.Runtime.Verification.Clone()
+	if !verificationCfg.FinalInterceptValue() {
+		return acceptance.AcceptanceDecision{
+			Status:             acceptance.AcceptanceAccepted,
+			StopReason:         controlplane.StopReasonCompatibilityFallback,
+			UserVisibleSummary: "已通过兼容路径接受 final（final_intercept 关闭）。",
+			InternalSummary:    "verification final intercept disabled, compatibility fallback accepted",
+			HasProgress:        true,
+		}, nil
+	}
+
+	policy := acceptance.DefaultPolicy{
+		Executor: verify.PolicyCommandExecutor{},
+	}
+	engine := acceptance.NewEngine(policy)
+
+	maxNoProgress := verificationCfg.MaxNoProgress
+	if maxNoProgress <= 0 {
+		maxNoProgress = 3
+	}
+	input := acceptance.FinalAcceptanceInput{
+		CompletionGate: acceptance.CompletionGateDecision{
+			Passed: completionPassed,
+			Reason: string(state.completion.CompletionBlockedReason),
+		},
+		VerificationInput: verify.FinalVerifyInput{
+			SessionID:          state.session.ID,
+			RunID:              state.runID,
+			TaskID:             state.taskID,
+			Workdir:            snapshot.Workdir,
+			Messages:           buildVerifyMessages(state.session.Messages),
+			Todos:              buildVerifyTodos(state.session.Todos),
+			LastAssistantFinal: renderPartsForVerification(assistant.Parts),
+			ToolResults:        nil,
+			RuntimeState: verify.RuntimeStateSnapshot{
+				Turn:                 state.turn,
+				MaxTurns:             resolveRuntimeMaxTurns(snapshot.Config.Runtime),
+				MaxTurnsReached:      state.maxTurnsReached,
+				FinalInterceptStreak: state.finalInterceptStreak,
+			},
+			Metadata: map[string]any{
+				"task_type": inferTaskType(state),
+			},
+			VerificationConfig: verificationCfg,
+		},
+		NoProgressExceeded: state.finalInterceptStreak >= maxNoProgress,
+		MaxTurnsReached:    state.maxTurnsReached,
+		MaxTurnsLimit:      state.maxTurnsLimit,
+	}
+
+	return engine.EvaluateFinal(ctx, input)
+}
+
+// recordAcceptanceTerminal 将 acceptance 输出映射为 runtime 唯一终态记录。
+func recordAcceptanceTerminal(state *runState, decision acceptance.AcceptanceDecision) {
+	if state == nil {
+		return
+	}
+	status := acceptance.TerminalStatusFromAcceptance(decision.Status)
+	state.markTerminalDecision(status, decision.StopReason, strings.TrimSpace(decision.InternalSummary))
+}
+
+// buildVerifyTodos 将 session todo 转换为 verifier 快照。
+func buildVerifyTodos(items []agentsession.TodoItem) []verify.TodoSnapshot {
+	if len(items) == 0 {
+		return nil
+	}
+	todos := make([]verify.TodoSnapshot, 0, len(items))
+	for _, item := range items {
+		todos = append(todos, verify.TodoSnapshot{
+			ID:            strings.TrimSpace(item.ID),
+			Content:       strings.TrimSpace(item.Content),
+			Status:        strings.TrimSpace(string(item.Status)),
+			Required:      item.RequiredValue(),
+			BlockedReason: string(item.BlockedReasonValue()),
+			RetryCount:    item.RetryCount,
+			RetryLimit:    item.RetryLimit,
+			FailureReason: strings.TrimSpace(item.FailureReason),
+		})
+	}
+	return todos
+}
+
+// buildVerifyMessages 将会话消息压缩为 verifier 所需最小快照。
+func buildVerifyMessages(messages []providertypes.Message) []verify.MessageLike {
+	if len(messages) == 0 {
+		return nil
+	}
+	out := make([]verify.MessageLike, 0, len(messages))
+	for _, message := range messages {
+		out = append(out, verify.MessageLike{
+			Role:    strings.TrimSpace(message.Role),
+			Content: renderPartsForVerification(message.Parts),
+		})
+	}
+	return out
+}
+
+// renderPartsForVerification 将消息分片合并为 verifier 侧可读文本。
+func renderPartsForVerification(parts []providertypes.ContentPart) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	segments := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part.Kind != providertypes.ContentPartText {
+			continue
+		}
+		text := strings.TrimSpace(part.Text)
+		if text == "" {
+			continue
+		}
+		segments = append(segments, text)
+	}
+	return strings.Join(segments, "\n")
+}
+
+// inferTaskType 基于 task_id 与 task_state 文本推断当前任务类型。
+func inferTaskType(state *runState) string {
+	if state == nil {
+		return "unknown"
+	}
+	corpus := strings.ToLower(strings.TrimSpace(
+		state.taskID + " " + state.session.TaskState.Goal + " " + state.session.TaskState.NextStep,
+	))
+	switch {
+	case strings.Contains(corpus, "fix bug"), strings.Contains(corpus, "bugfix"):
+		return "fix_bug"
+	case strings.Contains(corpus, "refactor"):
+		return "refactor"
+	case strings.Contains(corpus, "edit code"), strings.Contains(corpus, "modify code"), strings.Contains(corpus, "patch"):
+		return "edit_code"
+	case strings.Contains(corpus, "create file"), strings.Contains(corpus, "scaffold"):
+		return "create_file"
+	case strings.Contains(corpus, "docs"), strings.Contains(corpus, "documentation"):
+		return "docs"
+	case strings.Contains(corpus, "config"), strings.Contains(corpus, "yaml"), strings.Contains(corpus, "json"):
+		return "config"
+	default:
+		return "unknown"
+	}
+}
+
+// applyAcceptanceResultProgress 根据 acceptance 输出更新 final 拦截熔断计数器。
+func applyAcceptanceResultProgress(state *runState, decision acceptance.AcceptanceDecision) {
+	if state == nil {
+		return
+	}
+	switch decision.Status {
+	case acceptance.AcceptanceContinue:
+		if decision.HasProgress {
+			state.finalInterceptStreak = 0
+			return
+		}
+		state.finalInterceptStreak++
+	default:
+		state.finalInterceptStreak = 0
+	}
+}

--- a/internal/runtime/final_acceptance.go
+++ b/internal/runtime/final_acceptance.go
@@ -6,7 +6,6 @@ import (
 
 	providertypes "neo-code/internal/provider/types"
 	"neo-code/internal/runtime/acceptance"
-	"neo-code/internal/runtime/controlplane"
 	"neo-code/internal/runtime/verify"
 	agentsession "neo-code/internal/session"
 )
@@ -27,13 +26,8 @@ func (s *Service) beforeAcceptFinal(
 
 	verificationCfg := snapshot.Config.Runtime.Verification.Clone()
 	if !verificationCfg.FinalInterceptValue() {
-		return acceptance.AcceptanceDecision{
-			Status:             acceptance.AcceptanceAccepted,
-			StopReason:         controlplane.StopReasonCompatibilityFallback,
-			UserVisibleSummary: "已通过兼容路径接受 final（final_intercept 关闭）。",
-			InternalSummary:    "verification final intercept disabled, compatibility fallback accepted",
-			HasProgress:        true,
-		}, nil
+		// final_intercept 关闭时仅绕过 verifier，不得绕过 completion gate。
+		verificationCfg.Enabled = boolPtrRuntime(false)
 	}
 
 	policy := acceptance.DefaultPolicy{
@@ -44,6 +38,15 @@ func (s *Service) beforeAcceptFinal(
 	maxNoProgress := verificationCfg.MaxNoProgress
 	if maxNoProgress <= 0 {
 		maxNoProgress = 3
+	}
+	maxTurnsLimit := state.maxTurnsLimit
+	maxTurnsReached := state.maxTurnsReached
+	if !maxTurnsReached {
+		resolvedMaxTurns := resolveRuntimeMaxTurns(snapshot.Config.Runtime)
+		if resolvedMaxTurns > 0 && state.turn+1 >= resolvedMaxTurns {
+			maxTurnsReached = true
+			maxTurnsLimit = resolvedMaxTurns
+		}
 	}
 	input := acceptance.FinalAcceptanceInput{
 		CompletionGate: acceptance.CompletionGateDecision{
@@ -62,7 +65,7 @@ func (s *Service) beforeAcceptFinal(
 			RuntimeState: verify.RuntimeStateSnapshot{
 				Turn:                 state.turn,
 				MaxTurns:             resolveRuntimeMaxTurns(snapshot.Config.Runtime),
-				MaxTurnsReached:      state.maxTurnsReached,
+				MaxTurnsReached:      maxTurnsReached,
 				FinalInterceptStreak: state.finalInterceptStreak,
 			},
 			Metadata: map[string]any{
@@ -71,8 +74,8 @@ func (s *Service) beforeAcceptFinal(
 			VerificationConfig: verificationCfg,
 		},
 		NoProgressExceeded: state.finalInterceptStreak >= maxNoProgress,
-		MaxTurnsReached:    state.maxTurnsReached,
-		MaxTurnsLimit:      state.maxTurnsLimit,
+		MaxTurnsReached:    maxTurnsReached,
+		MaxTurnsLimit:      maxTurnsLimit,
 	}
 
 	return engine.EvaluateFinal(ctx, input)
@@ -151,21 +154,39 @@ func inferTaskType(state *runState) string {
 		state.taskID + " " + state.session.TaskState.Goal + " " + state.session.TaskState.NextStep,
 	))
 	switch {
-	case strings.Contains(corpus, "fix bug"), strings.Contains(corpus, "bugfix"):
+	case containsAny(corpus,
+		"fix bug", "bugfix", "修 bug", "修bug", "修复", "排查", "故障", "报错",
+	):
 		return "fix_bug"
-	case strings.Contains(corpus, "refactor"):
+	case containsAny(corpus, "refactor", "重构", "代码整理", "结构优化"):
 		return "refactor"
-	case strings.Contains(corpus, "edit code"), strings.Contains(corpus, "modify code"), strings.Contains(corpus, "patch"):
+	case containsAny(corpus, "edit code", "modify code", "patch", "修改代码", "改代码", "代码调整", "打补丁"):
 		return "edit_code"
-	case strings.Contains(corpus, "create file"), strings.Contains(corpus, "scaffold"):
+	case containsAny(corpus, "create file", "scaffold", "创建文件", "新建文件", "新增文件", "脚手架"):
 		return "create_file"
-	case strings.Contains(corpus, "docs"), strings.Contains(corpus, "documentation"):
+	case containsAny(corpus, "docs", "documentation", "文档", "readme", "说明文档"):
 		return "docs"
-	case strings.Contains(corpus, "config"), strings.Contains(corpus, "yaml"), strings.Contains(corpus, "json"):
+	case containsAny(corpus, "config", "yaml", "json", "toml", "配置", "yml", "环境变量"):
 		return "config"
 	default:
 		return "unknown"
 	}
+}
+
+// containsAny 判断语料中是否包含任一关键字。
+func containsAny(corpus string, keywords ...string) bool {
+	for _, keyword := range keywords {
+		if strings.Contains(corpus, strings.TrimSpace(keyword)) {
+			return true
+		}
+	}
+	return false
+}
+
+// boolPtrRuntime 返回 bool 指针，便于在运行期快速构造配置快照字段。
+func boolPtrRuntime(value bool) *bool {
+	v := value
+	return &v
 }
 
 // applyAcceptanceResultProgress 根据 acceptance 输出更新 final 拦截熔断计数器。

--- a/internal/runtime/final_acceptance_test.go
+++ b/internal/runtime/final_acceptance_test.go
@@ -6,6 +6,7 @@ import (
 
 	"neo-code/internal/config"
 	providertypes "neo-code/internal/provider/types"
+	"neo-code/internal/runtime/acceptance"
 	agentsession "neo-code/internal/session"
 )
 
@@ -171,6 +172,91 @@ func TestInferTaskTypeSupportsChineseKeywords(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFinalAcceptanceHelperBranches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("beforeAcceptFinal nil state", func(t *testing.T) {
+		t.Parallel()
+		service := &Service{}
+		decision, err := service.beforeAcceptFinal(context.Background(), nil, TurnBudgetSnapshot{}, providertypes.Message{}, true)
+		if err != nil {
+			t.Fatalf("beforeAcceptFinal() error = %v", err)
+		}
+		if decision.Status != "" {
+			t.Fatalf("expected empty decision for nil state, got %+v", decision)
+		}
+	})
+
+	t.Run("maxNoProgress fallback to default", func(t *testing.T) {
+		t.Parallel()
+		service := &Service{}
+		cfg := config.StaticDefaults().Clone()
+		cfg.Runtime.Verification.MaxNoProgress = 0
+		state := newRunState("run-max-no-progress-default", agentsession.New("max-no-progress-default"))
+		state.finalInterceptStreak = 3
+		required := true
+		state.session.Todos = []agentsession.TodoItem{
+			{ID: "todo-1", Content: "pending", Status: agentsession.TodoStatusPending, Required: &required},
+		}
+		decision, err := service.beforeAcceptFinal(context.Background(), &state, TurnBudgetSnapshot{
+			Config:  cfg,
+			Workdir: t.TempDir(),
+		}, providertypes.Message{}, true)
+		if err != nil {
+			t.Fatalf("beforeAcceptFinal() error = %v", err)
+		}
+		if decision.Status != "incomplete" {
+			t.Fatalf("status = %q, want incomplete", decision.Status)
+		}
+	})
+
+	t.Run("recordAcceptanceTerminal nil state no panic", func(t *testing.T) {
+		t.Parallel()
+		recordAcceptanceTerminal(nil, acceptance.AcceptanceDecision{})
+	})
+
+	t.Run("renderPartsForVerification non-text ignored", func(t *testing.T) {
+		t.Parallel()
+		got := renderPartsForVerification([]providertypes.ContentPart{
+			{Kind: providertypes.ContentPartImage, Text: "ignored"},
+			providertypes.NewTextPart(" ok "),
+		})
+		if got != "ok" {
+			t.Fatalf("renderPartsForVerification() = %q, want %q", got, "ok")
+		}
+	})
+
+	t.Run("inferTaskType nil state", func(t *testing.T) {
+		t.Parallel()
+		if got := inferTaskType(nil); got != "unknown" {
+			t.Fatalf("inferTaskType(nil) = %q, want unknown", got)
+		}
+	})
+
+	t.Run("applyAcceptanceResultProgress branches", func(t *testing.T) {
+		t.Parallel()
+		state := newRunState("run-progress", agentsession.New("progress"))
+		state.finalInterceptStreak = 2
+
+		applyAcceptanceResultProgress(&state, acceptance.AcceptanceDecision{Status: acceptance.AcceptanceContinue, HasProgress: true})
+		if state.finalInterceptStreak != 0 {
+			t.Fatalf("streak = %d, want 0 after progress", state.finalInterceptStreak)
+		}
+
+		applyAcceptanceResultProgress(&state, acceptance.AcceptanceDecision{Status: acceptance.AcceptanceContinue, HasProgress: false})
+		if state.finalInterceptStreak != 1 {
+			t.Fatalf("streak = %d, want 1 after continue without progress", state.finalInterceptStreak)
+		}
+
+		applyAcceptanceResultProgress(&state, acceptance.AcceptanceDecision{Status: acceptance.AcceptanceAccepted})
+		if state.finalInterceptStreak != 0 {
+			t.Fatalf("streak = %d, want 0 after non-continue", state.finalInterceptStreak)
+		}
+
+		applyAcceptanceResultProgress(nil, acceptance.AcceptanceDecision{Status: acceptance.AcceptanceContinue})
+	})
 }
 
 func boolPtr(value bool) *bool {

--- a/internal/runtime/final_acceptance_test.go
+++ b/internal/runtime/final_acceptance_test.go
@@ -46,6 +46,34 @@ func TestBeforeAcceptFinalDecisionPaths(t *testing.T) {
 		}
 	})
 
+	t.Run("continue carries runtime progress signal", func(t *testing.T) {
+		t.Parallel()
+		state := newRunState("run-continue-progress", agentsession.New("continue-progress"))
+		state.progress.LastScore.HasBusinessProgress = true
+		required := true
+		state.session.Todos = []agentsession.TodoItem{
+			{
+				ID:       "todo-1",
+				Content:  "do work",
+				Status:   agentsession.TodoStatusPending,
+				Required: &required,
+			},
+		}
+		decision, err := service.beforeAcceptFinal(context.Background(), &state, snapshot, providertypes.Message{
+			Role:  providertypes.RoleAssistant,
+			Parts: []providertypes.ContentPart{providertypes.NewTextPart("done")},
+		}, true)
+		if err != nil {
+			t.Fatalf("beforeAcceptFinal() error = %v", err)
+		}
+		if decision.Status != "continue" {
+			t.Fatalf("status = %q, want continue", decision.Status)
+		}
+		if !decision.HasProgress {
+			t.Fatalf("expected continue decision to carry runtime progress")
+		}
+	})
+
 	t.Run("all converged -> accepted", func(t *testing.T) {
 		t.Parallel()
 		state := newRunState("run-accepted", agentsession.New("accepted"))
@@ -195,7 +223,7 @@ func TestFinalAcceptanceHelperBranches(t *testing.T) {
 		cfg := config.StaticDefaults().Clone()
 		cfg.Runtime.Verification.MaxNoProgress = 0
 		state := newRunState("run-max-no-progress-default", agentsession.New("max-no-progress-default"))
-		state.finalInterceptStreak = 3
+		state.progress.LastScore.NoProgressStreak = 3
 		required := true
 		state.session.Todos = []agentsession.TodoItem{
 			{ID: "todo-1", Content: "pending", Status: agentsession.TodoStatusPending, Required: &required},

--- a/internal/runtime/final_acceptance_test.go
+++ b/internal/runtime/final_acceptance_test.go
@@ -1,0 +1,101 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"neo-code/internal/config"
+	providertypes "neo-code/internal/provider/types"
+	agentsession "neo-code/internal/session"
+)
+
+func TestBeforeAcceptFinalDecisionPaths(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{}
+	baseCfg := config.StaticDefaults().Clone()
+	baseCfg.Runtime.Verification.Enabled = boolPtr(true)
+	baseCfg.Runtime.Verification.FinalIntercept = boolPtr(true)
+	snapshot := TurnBudgetSnapshot{
+		Config:  baseCfg,
+		Workdir: t.TempDir(),
+	}
+
+	t.Run("pending required todo -> continue", func(t *testing.T) {
+		t.Parallel()
+		state := newRunState("run-continue", agentsession.New("continue"))
+		required := true
+		state.session.Todos = []agentsession.TodoItem{
+			{
+				ID:       "todo-1",
+				Content:  "do work",
+				Status:   agentsession.TodoStatusPending,
+				Required: &required,
+			},
+		}
+		decision, err := service.beforeAcceptFinal(context.Background(), &state, snapshot, providertypes.Message{
+			Role:  providertypes.RoleAssistant,
+			Parts: []providertypes.ContentPart{providertypes.NewTextPart("done")},
+		}, true)
+		if err != nil {
+			t.Fatalf("beforeAcceptFinal() error = %v", err)
+		}
+		if decision.Status != "continue" {
+			t.Fatalf("status = %q, want continue", decision.Status)
+		}
+	})
+
+	t.Run("all converged -> accepted", func(t *testing.T) {
+		t.Parallel()
+		state := newRunState("run-accepted", agentsession.New("accepted"))
+		decision, err := service.beforeAcceptFinal(context.Background(), &state, snapshot, providertypes.Message{
+			Role:  providertypes.RoleAssistant,
+			Parts: []providertypes.ContentPart{providertypes.NewTextPart("done")},
+		}, true)
+		if err != nil {
+			t.Fatalf("beforeAcceptFinal() error = %v", err)
+		}
+		if decision.Status != "accepted" {
+			t.Fatalf("status = %q, want accepted", decision.Status)
+		}
+	})
+
+	t.Run("verification disabled -> compatibility fallback", func(t *testing.T) {
+		t.Parallel()
+		state := newRunState("run-fallback", agentsession.New("fallback"))
+		cfg := snapshot.Config
+		cfg.Runtime.Verification.Enabled = boolPtr(false)
+		decision, err := service.beforeAcceptFinal(context.Background(), &state, TurnBudgetSnapshot{
+			Config:  cfg,
+			Workdir: snapshot.Workdir,
+		}, providertypes.Message{}, true)
+		if err != nil {
+			t.Fatalf("beforeAcceptFinal() error = %v", err)
+		}
+		if decision.StopReason != "compatibility_fallback" {
+			t.Fatalf("stop_reason = %q, want compatibility_fallback", decision.StopReason)
+		}
+	})
+
+	t.Run("final intercept disabled -> compatibility fallback", func(t *testing.T) {
+		t.Parallel()
+		state := newRunState("run-no-intercept", agentsession.New("no-intercept"))
+		cfg := snapshot.Config
+		cfg.Runtime.Verification.FinalIntercept = boolPtr(false)
+		decision, err := service.beforeAcceptFinal(context.Background(), &state, TurnBudgetSnapshot{
+			Config:  cfg,
+			Workdir: snapshot.Workdir,
+		}, providertypes.Message{}, true)
+		if err != nil {
+			t.Fatalf("beforeAcceptFinal() error = %v", err)
+		}
+		if decision.StopReason != "compatibility_fallback" {
+			t.Fatalf("stop_reason = %q, want compatibility_fallback", decision.StopReason)
+		}
+	})
+}
+
+func boolPtr(value bool) *bool {
+	v := value
+	return &v
+}

--- a/internal/runtime/final_acceptance_test.go
+++ b/internal/runtime/final_acceptance_test.go
@@ -93,6 +93,84 @@ func TestBeforeAcceptFinalDecisionPaths(t *testing.T) {
 			t.Fatalf("stop_reason = %q, want compatibility_fallback", decision.StopReason)
 		}
 	})
+
+	t.Run("final intercept disabled still respects completion gate", func(t *testing.T) {
+		t.Parallel()
+		state := newRunState("run-no-intercept-completion-gate", agentsession.New("no-intercept-completion-gate"))
+		required := true
+		state.session.Todos = []agentsession.TodoItem{
+			{ID: "todo-1", Content: "待完成", Status: agentsession.TodoStatusPending, Required: &required},
+		}
+		cfg := snapshot.Config
+		cfg.Runtime.Verification.FinalIntercept = boolPtr(false)
+		decision, err := service.beforeAcceptFinal(context.Background(), &state, TurnBudgetSnapshot{
+			Config:  cfg,
+			Workdir: snapshot.Workdir,
+		}, providertypes.Message{}, false)
+		if err != nil {
+			t.Fatalf("beforeAcceptFinal() error = %v", err)
+		}
+		if decision.Status != "continue" {
+			t.Fatalf("status = %q, want continue", decision.Status)
+		}
+	})
+
+	t.Run("last turn continue becomes max-turn incomplete", func(t *testing.T) {
+		t.Parallel()
+		state := newRunState("run-max-turn-incomplete", agentsession.New("max-turn-incomplete"))
+		state.turn = 0
+		required := true
+		state.session.Todos = []agentsession.TodoItem{
+			{ID: "todo-1", Content: "待完成", Status: agentsession.TodoStatusPending, Required: &required},
+		}
+		cfg := snapshot.Config
+		cfg.Runtime.MaxTurns = 1
+		decision, err := service.beforeAcceptFinal(context.Background(), &state, TurnBudgetSnapshot{
+			Config:  cfg,
+			Workdir: snapshot.Workdir,
+		}, providertypes.Message{}, true)
+		if err != nil {
+			t.Fatalf("beforeAcceptFinal() error = %v", err)
+		}
+		if decision.Status != "incomplete" {
+			t.Fatalf("status = %q, want incomplete", decision.Status)
+		}
+		if decision.StopReason != "max_turn_exceeded_with_unconverged_todos" {
+			t.Fatalf("stop_reason = %q, want max_turn_exceeded_with_unconverged_todos", decision.StopReason)
+		}
+	})
+}
+
+func TestInferTaskTypeSupportsChineseKeywords(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		taskID string
+		goal   string
+		want   string
+	}{
+		{name: "fix bug chinese", goal: "修复 provider 报错", want: "fix_bug"},
+		{name: "refactor chinese", goal: "重构 runtime 结构", want: "refactor"},
+		{name: "edit code chinese", goal: "修改代码逻辑", want: "edit_code"},
+		{name: "create file chinese", goal: "创建文件并补充脚手架", want: "create_file"},
+		{name: "docs chinese", goal: "补充文档说明", want: "docs"},
+		{name: "config chinese", goal: "调整配置 yaml", want: "config"},
+		{name: "unknown", goal: "整理需求", want: "unknown"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			session := agentsession.New(tc.name)
+			session.TaskState.Goal = tc.goal
+			state := newRunState("run-"+tc.name, session)
+			state.taskID = tc.taskID
+			if got := inferTaskType(&state); got != tc.want {
+				t.Fatalf("inferTaskType() = %q, want %q", got, tc.want)
+			}
+		})
+	}
 }
 
 func boolPtr(value bool) *bool {

--- a/internal/runtime/run.go
+++ b/internal/runtime/run.go
@@ -280,7 +280,11 @@ func (s *Service) Run(ctx context.Context, input UserInput) (err error) {
 					s.triggerMemoExtraction(state.session.ID, state.session.Messages, state.rememberedThisRun)
 					return nil
 				case acceptance.AcceptanceContinue:
-					if err := s.appendSystemMessageAndSave(ctx, &state, finalContinueReminder); err != nil {
+					reminder := strings.TrimSpace(acceptanceDecision.ContinueHint)
+					if reminder == "" {
+						reminder = finalContinueReminder
+					}
+					if err := s.appendSystemMessageAndSave(ctx, &state, reminder); err != nil {
 						return s.handleRunError(ctx, state.runID, state.session.ID, err)
 					}
 					state.mu.Lock()
@@ -295,6 +299,7 @@ func (s *Service) Run(ctx context.Context, input UserInput) (err error) {
 						snapshot.RepeatCycleStreakLimit,
 					)
 					state.progress = controlplane.EvaluateProgress(state.progress, progressInput)
+					state.finalInterceptStreak = state.progress.LastScore.NoProgressStreak
 					currentScore := state.progress.LastScore
 					state.mu.Unlock()
 					s.emitRunScoped(ctx, EventProgressEvaluated, &state, ProgressEvaluatedPayload{Score: currentScore})

--- a/internal/runtime/run.go
+++ b/internal/runtime/run.go
@@ -16,6 +16,7 @@ import (
 	"neo-code/internal/promptasset"
 	"neo-code/internal/provider"
 	providertypes "neo-code/internal/provider/types"
+	"neo-code/internal/runtime/acceptance"
 	"neo-code/internal/runtime/controlplane"
 	"neo-code/internal/runtime/streaming"
 	agentsession "neo-code/internal/session"
@@ -144,6 +145,7 @@ func (s *Service) Run(ctx context.Context, input UserInput) (err error) {
 			return s.handleRunError(ctx, state.runID, state.session.ID, err)
 		}
 
+	turnAttempt:
 		for {
 			if err := ctx.Err(); err != nil {
 				return s.handleRunError(ctx, state.runID, state.session.ID, err)
@@ -233,28 +235,87 @@ func (s *Service) Run(ctx context.Context, input UserInput) (err error) {
 			state.mu.Unlock()
 
 			if len(turnOutput.assistant.ToolCalls) == 0 {
-				if completed {
+				if err := s.setBaseRunState(ctx, &state, controlplane.RunStateVerify); err != nil {
+					return s.handleRunError(ctx, state.runID, state.session.ID, err)
+				}
+
+				s.emitRunScoped(ctx, EventVerificationStarted, &state, VerificationStartedPayload{
+					CompletionPassed: completed,
+				})
+				acceptanceDecision, err := s.beforeAcceptFinal(ctx, &state, snapshot, turnOutput.assistant, completed)
+				if err != nil {
+					return s.handleRunError(ctx, state.runID, state.session.ID, err)
+				}
+				for _, result := range acceptanceDecision.VerifierResults {
+					s.emitRunScoped(ctx, EventVerificationStageFinished, &state, VerificationStageFinishedPayload{
+						Name:       result.Name,
+						Status:     result.Status,
+						Summary:    result.Summary,
+						Reason:     result.Reason,
+						ErrorClass: result.ErrorClass,
+					})
+				}
+				s.emitRunScoped(ctx, EventVerificationFinished, &state, VerificationFinishedPayload{
+					AcceptanceStatus: acceptanceDecision.Status,
+					StopReason:       acceptanceDecision.StopReason,
+					ErrorClass:       acceptanceDecision.ErrorClass,
+				})
+				s.emitRunScoped(ctx, EventAcceptanceDecided, &state, AcceptanceDecidedPayload{
+					Status:             acceptanceDecision.Status,
+					StopReason:         acceptanceDecision.StopReason,
+					ErrorClass:         acceptanceDecision.ErrorClass,
+					UserVisibleSummary: acceptanceDecision.UserVisibleSummary,
+					InternalSummary:    acceptanceDecision.InternalSummary,
+					ContinueHint:       acceptanceDecision.ContinueHint,
+				})
+				applyAcceptanceResultProgress(&state, acceptanceDecision)
+
+				switch acceptanceDecision.Status {
+				case acceptance.AcceptanceAccepted:
+					s.emitRunScoped(ctx, EventVerificationCompleted, &state, VerificationCompletedPayload{
+						StopReason: acceptanceDecision.StopReason,
+					})
+					recordAcceptanceTerminal(&state, acceptanceDecision)
 					s.emitRunScoped(ctx, EventAgentDone, &state, turnOutput.assistant)
 					s.triggerMemoExtraction(state.session.ID, state.session.Messages, state.rememberedThisRun)
 					return nil
+				case acceptance.AcceptanceContinue:
+					if err := s.appendSystemMessageAndSave(ctx, &state, finalContinueReminder); err != nil {
+						return s.handleRunError(ctx, state.runID, state.session.ID, err)
+					}
+					state.mu.Lock()
+					progressInput := collectProgressInput(
+						controlplane.RunStateVerify,
+						state.session.TaskState.Clone(),
+						state.session.TaskState.Clone(),
+						cloneTodosForPersistence(state.session.Todos),
+						cloneTodosForPersistence(state.session.Todos),
+						toolExecutionSummary{},
+						snapshot.NoProgressStreakLimit,
+						snapshot.RepeatCycleStreakLimit,
+					)
+					state.progress = controlplane.EvaluateProgress(state.progress, progressInput)
+					currentScore := state.progress.LastScore
+					state.mu.Unlock()
+					s.emitRunScoped(ctx, EventProgressEvaluated, &state, ProgressEvaluatedPayload{Score: currentScore})
+					break turnAttempt
+				case acceptance.AcceptanceIncomplete:
+					recordAcceptanceTerminal(&state, acceptanceDecision)
+					s.emitRunScoped(ctx, EventAgentDone, &state, turnOutput.assistant)
+					return nil
+				case acceptance.AcceptanceFailed:
+					s.emitRunScoped(ctx, EventVerificationFailed, &state, VerificationFailedPayload{
+						StopReason: acceptanceDecision.StopReason,
+						ErrorClass: acceptanceDecision.ErrorClass,
+					})
+					recordAcceptanceTerminal(&state, acceptanceDecision)
+					s.emitRunScoped(ctx, EventAgentDone, &state, turnOutput.assistant)
+					return nil
+				default:
+					recordAcceptanceTerminal(&state, acceptanceDecision)
+					s.emitRunScoped(ctx, EventAgentDone, &state, turnOutput.assistant)
+					return nil
 				}
-				state.mu.Lock()
-				progressInput := collectProgressInput(
-					controlplane.RunStatePlan,
-					state.session.TaskState.Clone(),
-					state.session.TaskState.Clone(),
-					cloneTodosForPersistence(state.session.Todos),
-					cloneTodosForPersistence(state.session.Todos),
-					toolExecutionSummary{},
-					snapshot.NoProgressStreakLimit,
-					snapshot.RepeatCycleStreakLimit,
-				)
-				state.progress = controlplane.EvaluateProgress(state.progress, progressInput)
-				currentScore := state.progress.LastScore
-				state.mu.Unlock()
-
-				s.emitRunScoped(ctx, EventProgressEvaluated, &state, ProgressEvaluatedPayload{Score: currentScore})
-				break
 			}
 
 			beforeTask := state.session.TaskState.Clone()

--- a/internal/runtime/run_lifecycle.go
+++ b/internal/runtime/run_lifecycle.go
@@ -143,7 +143,10 @@ func (s *Service) emitRunTermination(ctx context.Context, input UserInput, state
 	}
 
 	in := controlplane.StopInput{}
-	if state != nil && state.maxTurnsReached {
+	if state != nil && state.terminalSet {
+		in.PreDecidedReason = state.terminalStopReason
+		in.PreDecidedDetail = state.terminalStopDetail
+	} else if state != nil && state.maxTurnsReached {
 		in.MaxTurnsReached = true
 		in.MaxTurnsLimit = state.maxTurnsLimit
 	} else if state != nil && state.budgetExceeded {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -5404,7 +5404,7 @@ func TestAgentDoneEventCarriesRunScopedEnvelope(t *testing.T) {
 	if doneEvent.Turn == turnUnspecified {
 		t.Fatalf("expected run-scoped turn, got %d", doneEvent.Turn)
 	}
-	if doneEvent.Phase != string(controlplane.RunStatePlan) {
-		t.Fatalf("expected phase=%q, got %q", controlplane.RunStatePlan, doneEvent.Phase)
+	if doneEvent.Phase != string(controlplane.RunStateVerify) {
+		t.Fatalf("expected phase=%q, got %q", controlplane.RunStateVerify, doneEvent.Phase)
 	}
 }

--- a/internal/runtime/session_mutation.go
+++ b/internal/runtime/session_mutation.go
@@ -75,6 +75,30 @@ func (s *Service) appendAssistantMessageAndSave(
 	return nil
 }
 
+// appendSystemMessageAndSave 将系统提醒消息追加到会话并持久化。
+func (s *Service) appendSystemMessageAndSave(ctx context.Context, state *runState, text string) error {
+	if state == nil {
+		return nil
+	}
+	message := providertypes.Message{
+		Role: providertypes.RoleSystem,
+		Parts: []providertypes.ContentPart{
+			providertypes.NewTextPart(strings.TrimSpace(text)),
+		},
+	}
+	state.session.Messages = append(state.session.Messages, message)
+	state.touchSession()
+	return s.sessionStore.AppendMessages(ctx, agentsession.AppendMessagesInput{
+		SessionID:       state.session.ID,
+		Messages:        []providertypes.Message{message},
+		UpdatedAt:       state.session.UpdatedAt,
+		Provider:        state.session.Provider,
+		Model:           state.session.Model,
+		Workdir:         state.session.Workdir,
+		HasUnknownUsage: state.session.HasUnknownUsage,
+	})
+}
+
 // appendToolMessageAndSave 将工具原始结果写回会话，持久化时仅追加一条 tool message。
 func (s *Service) appendToolMessageAndSave(
 	ctx context.Context,

--- a/internal/runtime/state.go
+++ b/internal/runtime/state.go
@@ -30,6 +30,11 @@ type runState struct {
 	budgetExceeded          bool
 	maxTurnsReached         bool
 	maxTurnsLimit           int
+	finalInterceptStreak    int
+	terminalStatus          controlplane.TerminalStatus
+	terminalStopReason      controlplane.StopReason
+	terminalStopDetail      string
+	terminalSet             bool
 	hasUnknownUsage         bool
 	completion              controlplane.CompletionState
 	progress                controlplane.ProgressState
@@ -90,4 +95,15 @@ func (s *runState) markSkillMissingReported(skillID string) bool {
 	}
 	s.reportedMissingSkills[normalized] = struct{}{}
 	return true
+}
+
+// markTerminalDecision 记录本次运行的唯一终态裁决结果，供统一 stop reason 发射使用。
+func (s *runState) markTerminalDecision(status controlplane.TerminalStatus, reason controlplane.StopReason, detail string) {
+	if s == nil {
+		return
+	}
+	s.terminalStatus = status
+	s.terminalStopReason = reason
+	s.terminalStopDetail = detail
+	s.terminalSet = true
 }

--- a/internal/runtime/turn_control.go
+++ b/internal/runtime/turn_control.go
@@ -189,6 +189,9 @@ func computeSubgoalFingerprint(
 // hasPendingAgentTodos 判断当前 session 中是否仍存在未闭合 todo。
 func hasPendingAgentTodos(items []agentsession.TodoItem) bool {
 	for _, item := range items {
+		if !item.RequiredValue() {
+			continue
+		}
 		if item.Status.IsTerminal() {
 			continue
 		}

--- a/internal/runtime/turn_control_test.go
+++ b/internal/runtime/turn_control_test.go
@@ -107,13 +107,14 @@ func TestTransitionRunPhaseInvalidTransitionReturnsError(t *testing.T) {
 
 	service := &Service{events: make(chan RuntimeEvent, 4)}
 	state := newRunState("run-invalid-phase", newRuntimeSession("session-invalid-phase"))
-	state.lifecycle = controlplane.RunStatePlan
+	state.lifecycle = controlplane.RunStateCompacting
+	state.baseLifecycle = controlplane.RunStateCompacting
 
-	err := service.setBaseRunState(context.Background(), &state, controlplane.RunStateVerify)
+	err := service.setBaseRunState(context.Background(), &state, controlplane.RunStateExecute)
 	if err == nil {
 		t.Fatalf("expected invalid transition to return error")
 	}
-	if state.lifecycle != controlplane.RunStatePlan {
+	if state.lifecycle != controlplane.RunStateCompacting {
 		t.Fatalf("expected lifecycle to remain unchanged, got %q", state.lifecycle)
 	}
 	if events := collectRuntimeEvents(service.Events()); len(events) != 0 {

--- a/internal/runtime/verify/build.go
+++ b/internal/runtime/verify/build.go
@@ -1,0 +1,20 @@
+package verify
+
+const (
+	buildVerifierName = "build"
+)
+
+// BuildVerifier 复用命令执行 verifier，承载 build 验证语义。
+type BuildVerifier struct {
+	CommandSuccessVerifier
+}
+
+// NewBuildVerifier 创建 build verifier。
+func NewBuildVerifier(executor CommandExecutor) BuildVerifier {
+	return BuildVerifier{
+		CommandSuccessVerifier: CommandSuccessVerifier{
+			VerifierName: buildVerifierName,
+			Executor:     executor,
+		},
+	}
+}

--- a/internal/runtime/verify/command_success.go
+++ b/internal/runtime/verify/command_success.go
@@ -41,12 +41,25 @@ func (v CommandSuccessVerifier) VerifyFinal(ctx context.Context, input FinalVeri
 	command := strings.TrimSpace(cfg.Command)
 	if command == "" {
 		if cfg.Required {
+			status := VerificationSoftBlock
+			summary := "verification command is required but missing"
+			reason := "missing verifier command configuration"
+			errorClass := ErrorClassEnvMissing
+			if cfg.FailClosed {
+				status = VerificationFail
+			}
+			if cfg.FailOpen {
+				status = VerificationPass
+				summary = "verification command missing but ignored by fail_open policy"
+				reason = "optionalized by fail_open policy"
+				errorClass = ""
+			}
 			return VerificationResult{
 				Name:       name,
-				Status:     VerificationSoftBlock,
-				Summary:    "verification command is required but missing",
-				Reason:     "missing verifier command configuration",
-				ErrorClass: ErrorClassEnvMissing,
+				Status:     status,
+				Summary:    summary,
+				Reason:     reason,
+				ErrorClass: errorClass,
 			}, nil
 		}
 		return VerificationResult{

--- a/internal/runtime/verify/command_success.go
+++ b/internal/runtime/verify/command_success.go
@@ -1,0 +1,162 @@
+package verify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	commandSuccessVerifierName = "command_success"
+)
+
+// CommandSuccessVerifier 负责执行配置命令并基于退出码做验证。
+type CommandSuccessVerifier struct {
+	VerifierName string
+	Executor     CommandExecutor
+}
+
+// Name 返回 verifier 名称。
+func (v CommandSuccessVerifier) Name() string {
+	normalized := strings.TrimSpace(v.VerifierName)
+	if normalized == "" {
+		return commandSuccessVerifierName
+	}
+	return normalized
+}
+
+// VerifyFinal 执行命令并返回 pass/fail/soft_block 结果。
+func (v CommandSuccessVerifier) VerifyFinal(ctx context.Context, input FinalVerifyInput) (VerificationResult, error) {
+	name := v.Name()
+	executor := v.Executor
+	if executor == nil {
+		executor = PolicyCommandExecutor{}
+	}
+
+	cfg, exists := input.VerificationConfig.Verifiers[name]
+	if !exists {
+		cfg = input.VerificationConfig.Verifiers[commandSuccessVerifierName]
+	}
+	command := strings.TrimSpace(cfg.Command)
+	if command == "" {
+		if cfg.Required {
+			return VerificationResult{
+				Name:       name,
+				Status:     VerificationSoftBlock,
+				Summary:    "verification command is required but missing",
+				Reason:     "missing verifier command configuration",
+				ErrorClass: ErrorClassEnvMissing,
+			}, nil
+		}
+		return VerificationResult{
+			Name:    name,
+			Status:  VerificationPass,
+			Summary: "verification command is not configured, skip",
+			Reason:  "optional verifier skipped",
+		}, nil
+	}
+
+	result, err := executor.Execute(ctx, CommandExecutionRequest{
+		Command:       command,
+		Workdir:       input.Workdir,
+		TimeoutSec:    cfg.TimeoutSec,
+		OutputCapByte: cfg.OutputCapBytes,
+		Policy:        input.VerificationConfig.ExecutionPolicy,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrVerificationExecutionDenied):
+			return VerificationResult{
+				Name:       name,
+				Status:     VerificationFail,
+				Summary:    err.Error(),
+				Reason:     "verification command denied by execution policy",
+				ErrorClass: ErrorClassPermissionDenied,
+				Evidence: map[string]any{
+					"command": command,
+				},
+			}, nil
+		default:
+			errorClass := classifyCommandExecutionError(err)
+			return VerificationResult{
+				Name:       name,
+				Status:     VerificationFail,
+				Summary:    err.Error(),
+				Reason:     "verification command execution failed",
+				ErrorClass: errorClass,
+				Retryable:  errorClass == ErrorClassTimeout,
+				Evidence: map[string]any{
+					"command": command,
+				},
+			}, nil
+		}
+	}
+
+	if result.ExitCode == 0 {
+		return VerificationResult{
+			Name:     name,
+			Status:   VerificationPass,
+			Summary:  "verification command succeeded",
+			Reason:   "command exit code is 0",
+			Evidence: commandEvidence(command, result),
+		}, nil
+	}
+	return VerificationResult{
+		Name:       name,
+		Status:     VerificationFail,
+		Summary:    fmt.Sprintf("verification command failed with exit code %d", result.ExitCode),
+		Reason:     "command exit code is non-zero",
+		ErrorClass: classifyCommandFailure(name, result),
+		Retryable:  true,
+		Evidence:   commandEvidence(command, result),
+	}, nil
+}
+
+// commandEvidence 将命令执行结果收敛为可观测证据。
+func commandEvidence(command string, result CommandExecutionResult) map[string]any {
+	return map[string]any{
+		"command":      command,
+		"command_name": result.CommandName,
+		"exit_code":    result.ExitCode,
+		"timed_out":    result.TimedOut,
+		"truncated":    result.Truncated,
+		"duration_ms":  result.DurationMS,
+		"stdout":       strings.TrimSpace(result.Stdout),
+		"stderr":       strings.TrimSpace(result.Stderr),
+	}
+}
+
+// classifyCommandExecutionError 将命令执行错误映射为统一 ErrorClass。
+func classifyCommandExecutionError(err error) ErrorClass {
+	normalized := strings.ToLower(strings.TrimSpace(err.Error()))
+	switch {
+	case strings.Contains(normalized, "timeout"):
+		return ErrorClassTimeout
+	case strings.Contains(normalized, "not found"):
+		return ErrorClassCommandNotFound
+	case strings.Contains(normalized, "permission"):
+		return ErrorClassPermissionDenied
+	default:
+		return ErrorClassUnknown
+	}
+}
+
+// classifyCommandFailure 将命令失败按 verifier 语义映射到稳定错误分类。
+func classifyCommandFailure(verifierName string, result CommandExecutionResult) ErrorClass {
+	if result.TimedOut {
+		return ErrorClassTimeout
+	}
+	switch strings.ToLower(strings.TrimSpace(verifierName)) {
+	case "build":
+		return ErrorClassCompileError
+	case "test":
+		return ErrorClassTestFailure
+	case "lint":
+		return ErrorClassLintFailure
+	case "typecheck":
+		return ErrorClassTypeError
+	default:
+		return ErrorClassUnknown
+	}
+}

--- a/internal/runtime/verify/command_success_test.go
+++ b/internal/runtime/verify/command_success_test.go
@@ -1,0 +1,242 @@
+package verify
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"neo-code/internal/config"
+)
+
+type stubCommandExecutor struct {
+	result   CommandExecutionResult
+	err      error
+	requests []CommandExecutionRequest
+}
+
+func (s *stubCommandExecutor) Execute(ctx context.Context, req CommandExecutionRequest) (CommandExecutionResult, error) {
+	_ = ctx
+	s.requests = append(s.requests, req)
+	if s.err != nil {
+		return CommandExecutionResult{}, s.err
+	}
+	return s.result, nil
+}
+
+func verifyConfigForCommandTests() config.VerificationConfig {
+	cfg := config.StaticDefaults().Runtime.Verification
+	cfg.Enabled = boolPtrVerify(true)
+	return cfg
+}
+
+func boolPtrVerify(value bool) *bool {
+	v := value
+	return &v
+}
+
+func TestCommandSuccessVerifierName(t *testing.T) {
+	t.Parallel()
+
+	if got := (CommandSuccessVerifier{}).Name(); got != commandSuccessVerifierName {
+		t.Fatalf("Name() = %q, want %q", got, commandSuccessVerifierName)
+	}
+	if got := (CommandSuccessVerifier{VerifierName: "  build  "}).Name(); got != "build" {
+		t.Fatalf("Name() = %q, want build", got)
+	}
+}
+
+func TestCommandSuccessVerifierVerifyFinalMissingCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("required missing command returns soft_block", func(t *testing.T) {
+		t.Parallel()
+		cfg := verifyConfigForCommandTests()
+		verifierCfg := cfg.Verifiers[commandSuccessVerifierName]
+		verifierCfg.Required = true
+		verifierCfg.Command = ""
+		cfg.Verifiers[commandSuccessVerifierName] = verifierCfg
+
+		result, err := (CommandSuccessVerifier{}).VerifyFinal(context.Background(), FinalVerifyInput{VerificationConfig: cfg})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationSoftBlock {
+			t.Fatalf("status = %q, want %q", result.Status, VerificationSoftBlock)
+		}
+		if result.ErrorClass != ErrorClassEnvMissing {
+			t.Fatalf("error_class = %q, want %q", result.ErrorClass, ErrorClassEnvMissing)
+		}
+	})
+
+	t.Run("optional missing command returns pass", func(t *testing.T) {
+		t.Parallel()
+		cfg := verifyConfigForCommandTests()
+		verifierCfg := cfg.Verifiers[commandSuccessVerifierName]
+		verifierCfg.Required = false
+		verifierCfg.Command = ""
+		cfg.Verifiers[commandSuccessVerifierName] = verifierCfg
+
+		result, err := (CommandSuccessVerifier{}).VerifyFinal(context.Background(), FinalVerifyInput{VerificationConfig: cfg})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationPass {
+			t.Fatalf("status = %q, want %q", result.Status, VerificationPass)
+		}
+	})
+}
+
+func TestCommandSuccessVerifierVerifyFinalExecutionOutcomes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("denied error maps to permission denied", func(t *testing.T) {
+		t.Parallel()
+		executor := &stubCommandExecutor{err: ErrVerificationExecutionDenied}
+		cfg := verifyConfigForCommandTests()
+		verifierCfg := cfg.Verifiers[commandSuccessVerifierName]
+		verifierCfg.Command = "go test ./..."
+		cfg.Verifiers[commandSuccessVerifierName] = verifierCfg
+
+		result, err := (CommandSuccessVerifier{Executor: executor}).VerifyFinal(context.Background(), FinalVerifyInput{VerificationConfig: cfg})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationFail || result.ErrorClass != ErrorClassPermissionDenied {
+			t.Fatalf("unexpected result: %+v", result)
+		}
+	})
+
+	t.Run("timeout execution error is retryable", func(t *testing.T) {
+		t.Parallel()
+		executor := &stubCommandExecutor{err: errors.New("command timeout exceeded")}
+		cfg := verifyConfigForCommandTests()
+		verifierCfg := cfg.Verifiers[commandSuccessVerifierName]
+		verifierCfg.Command = "go test ./..."
+		cfg.Verifiers[commandSuccessVerifierName] = verifierCfg
+
+		result, err := (CommandSuccessVerifier{Executor: executor}).VerifyFinal(context.Background(), FinalVerifyInput{VerificationConfig: cfg})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.ErrorClass != ErrorClassTimeout || !result.Retryable {
+			t.Fatalf("unexpected timeout mapping: %+v", result)
+		}
+	})
+
+	t.Run("exit code zero returns pass", func(t *testing.T) {
+		t.Parallel()
+		executor := &stubCommandExecutor{result: CommandExecutionResult{CommandName: "go", ExitCode: 0, Stdout: " ok ", Stderr: " "}}
+		cfg := verifyConfigForCommandTests()
+		verifierCfg := cfg.Verifiers[commandSuccessVerifierName]
+		verifierCfg.Command = "go test ./..."
+		verifierCfg.TimeoutSec = 30
+		verifierCfg.OutputCapBytes = 2048
+		cfg.Verifiers[commandSuccessVerifierName] = verifierCfg
+
+		result, err := (CommandSuccessVerifier{Executor: executor}).VerifyFinal(context.Background(), FinalVerifyInput{Workdir: "/workspace", VerificationConfig: cfg})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationPass {
+			t.Fatalf("status = %q, want %q", result.Status, VerificationPass)
+		}
+		if len(executor.requests) != 1 {
+			t.Fatalf("expected one execute call, got %d", len(executor.requests))
+		}
+		if executor.requests[0].Command != "go test ./..." || executor.requests[0].Workdir != "/workspace" {
+			t.Fatalf("unexpected request: %+v", executor.requests[0])
+		}
+		if got := result.Evidence["stdout"]; got != "ok" {
+			t.Fatalf("stdout evidence = %v, want ok", got)
+		}
+	})
+
+	t.Run("named verifier falls back to command_success config", func(t *testing.T) {
+		t.Parallel()
+		executor := &stubCommandExecutor{result: CommandExecutionResult{ExitCode: 0}}
+		cfg := verifyConfigForCommandTests()
+		verifierCfg := cfg.Verifiers[commandSuccessVerifierName]
+		verifierCfg.Command = "go version"
+		cfg.Verifiers[commandSuccessVerifierName] = verifierCfg
+
+		result, err := (CommandSuccessVerifier{VerifierName: "custom", Executor: executor}).VerifyFinal(context.Background(), FinalVerifyInput{VerificationConfig: cfg})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Name != "custom" || result.Status != VerificationPass {
+			t.Fatalf("unexpected result: %+v", result)
+		}
+		if len(executor.requests) != 1 || executor.requests[0].Command != "go version" {
+			t.Fatalf("unexpected request: %+v", executor.requests)
+		}
+	})
+
+	t.Run("non-zero exit maps verifier-specific error class", func(t *testing.T) {
+		t.Parallel()
+		executor := &stubCommandExecutor{result: CommandExecutionResult{ExitCode: 2}}
+		cfg := verifyConfigForCommandTests()
+		cfg.Verifiers["build"] = config.VerifierConfig{Enabled: true, Command: "go build ./..."}
+
+		result, err := (CommandSuccessVerifier{VerifierName: "build", Executor: executor}).VerifyFinal(context.Background(), FinalVerifyInput{VerificationConfig: cfg})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationFail || result.ErrorClass != ErrorClassCompileError {
+			t.Fatalf("unexpected failure mapping: %+v", result)
+		}
+	})
+}
+
+func TestClassifyCommandExecutionError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want ErrorClass
+	}{
+		{name: "timeout", err: errors.New("timeout"), want: ErrorClassTimeout},
+		{name: "not found", err: errors.New("binary not found"), want: ErrorClassCommandNotFound},
+		{name: "permission", err: errors.New("permission denied"), want: ErrorClassPermissionDenied},
+		{name: "unknown", err: errors.New("other"), want: ErrorClassUnknown},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := classifyCommandExecutionError(tc.err); got != tc.want {
+				t.Fatalf("classifyCommandExecutionError() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyCommandFailure(t *testing.T) {
+	t.Parallel()
+
+	if got := classifyCommandFailure("any", CommandExecutionResult{TimedOut: true}); got != ErrorClassTimeout {
+		t.Fatalf("timed out class = %q, want %q", got, ErrorClassTimeout)
+	}
+
+	cases := []struct {
+		name string
+		want ErrorClass
+	}{
+		{name: "build", want: ErrorClassCompileError},
+		{name: "test", want: ErrorClassTestFailure},
+		{name: "lint", want: ErrorClassLintFailure},
+		{name: "typecheck", want: ErrorClassTypeError},
+		{name: "other", want: ErrorClassUnknown},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := classifyCommandFailure(tc.name, CommandExecutionResult{}); got != tc.want {
+				t.Fatalf("classifyCommandFailure() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/verify/command_success_test.go
+++ b/internal/runtime/verify/command_success_test.go
@@ -54,6 +54,7 @@ func TestCommandSuccessVerifierVerifyFinalMissingCommand(t *testing.T) {
 		verifierCfg := cfg.Verifiers[commandSuccessVerifierName]
 		verifierCfg.Required = true
 		verifierCfg.Command = ""
+		verifierCfg.FailClosed = false
 		cfg.Verifiers[commandSuccessVerifierName] = verifierCfg
 
 		result, err := (CommandSuccessVerifier{}).VerifyFinal(context.Background(), FinalVerifyInput{VerificationConfig: cfg})
@@ -65,6 +66,43 @@ func TestCommandSuccessVerifierVerifyFinalMissingCommand(t *testing.T) {
 		}
 		if result.ErrorClass != ErrorClassEnvMissing {
 			t.Fatalf("error_class = %q, want %q", result.ErrorClass, ErrorClassEnvMissing)
+		}
+	})
+
+	t.Run("required missing command with fail_closed returns fail", func(t *testing.T) {
+		t.Parallel()
+		cfg := verifyConfigForCommandTests()
+		verifierCfg := cfg.Verifiers[commandSuccessVerifierName]
+		verifierCfg.Required = true
+		verifierCfg.Command = ""
+		verifierCfg.FailClosed = true
+		cfg.Verifiers[commandSuccessVerifierName] = verifierCfg
+
+		result, err := (CommandSuccessVerifier{}).VerifyFinal(context.Background(), FinalVerifyInput{VerificationConfig: cfg})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationFail {
+			t.Fatalf("status = %q, want %q", result.Status, VerificationFail)
+		}
+	})
+
+	t.Run("required missing command with fail_open returns pass", func(t *testing.T) {
+		t.Parallel()
+		cfg := verifyConfigForCommandTests()
+		verifierCfg := cfg.Verifiers[commandSuccessVerifierName]
+		verifierCfg.Required = true
+		verifierCfg.Command = ""
+		verifierCfg.FailOpen = true
+		verifierCfg.FailClosed = false
+		cfg.Verifiers[commandSuccessVerifierName] = verifierCfg
+
+		result, err := (CommandSuccessVerifier{}).VerifyFinal(context.Background(), FinalVerifyInput{VerificationConfig: cfg})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationPass {
+			t.Fatalf("status = %q, want %q", result.Status, VerificationPass)
 		}
 	})
 

--- a/internal/runtime/verify/content_match.go
+++ b/internal/runtime/verify/content_match.go
@@ -3,7 +3,6 @@ package verify
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"strings"
 )
 
@@ -25,54 +24,44 @@ func (ContentMatchVerifier) VerifyFinal(_ context.Context, input FinalVerifyInpu
 	required := exists && cfg.Required
 	rules := metadataStringMapSlice(input.Metadata, "content_match")
 	if len(rules) == 0 {
-		if required {
-			return VerificationResult{
-				Name:    contentMatchVerifierName,
-				Status:  VerificationSoftBlock,
-				Summary: "content_match is required but missing",
-				Reason:  "missing content_match metadata",
-			}, nil
-		}
-		return VerificationResult{
-			Name:    contentMatchVerifierName,
-			Status:  VerificationPass,
-			Summary: "no content_match rule configured, skip content check",
-			Reason:  "optional verifier skipped",
-		}, nil
+		return verifierMetadataResult(
+			contentMatchVerifierName,
+			required,
+			"content_match",
+			"no content_match rule configured, skip content check",
+		), nil
 	}
 
 	missingFiles := make([]string, 0)
+	deniedPaths := make([]string, 0)
 	missingTokens := make(map[string][]string)
 	for rawPath, expectedTokens := range rules {
-		path := strings.TrimSpace(rawPath)
-		if path == "" {
+		absPath, err := resolvePathWithinWorkdir(input.Workdir, rawPath)
+		if err != nil {
+			deniedPaths = append(deniedPaths, rawPath)
 			continue
-		}
-		absPath := path
-		if !filepath.IsAbs(absPath) {
-			absPath = filepath.Join(strings.TrimSpace(input.Workdir), path)
 		}
 		contentBytes, err := os.ReadFile(absPath)
 		if err != nil {
-			missingFiles = append(missingFiles, path)
+			missingFiles = append(missingFiles, rawPath)
 			continue
 		}
-		content := string(contentBytes)
-		for _, token := range expectedTokens {
-			normalized := strings.TrimSpace(token)
-			if normalized == "" {
-				continue
-			}
-			if !strings.Contains(content, normalized) {
-				missingTokens[path] = append(missingTokens[path], normalized)
-			}
-		}
+		collectMissingTokens(missingTokens, rawPath, string(contentBytes), expectedTokens)
 	}
 
 	evidence := map[string]any{
 		"rules":          rules,
 		"missing_files":  missingFiles,
 		"missing_tokens": missingTokens,
+		"denied_paths":   deniedPaths,
+	}
+	if len(deniedPaths) > 0 {
+		return verificationDeniedResult(
+			contentMatchVerifierName,
+			"content rules contain paths outside workdir",
+			"content path denied by workdir policy",
+			evidence,
+		), nil
 	}
 	if len(missingFiles) == 0 && len(missingTokens) == 0 {
 		return VerificationResult{
@@ -91,4 +80,13 @@ func (ContentMatchVerifier) VerifyFinal(_ context.Context, input FinalVerifyInpu
 		ErrorClass: ErrorClassUnknown,
 		Evidence:   evidence,
 	}, nil
+}
+
+// collectMissingTokens 收敛文件缺失关键字，保持 token 去空白后的匹配语义不变。
+func collectMissingTokens(missingTokens map[string][]string, path string, content string, expectedTokens []string) {
+	for _, token := range compactStrings(expectedTokens) {
+		if !strings.Contains(content, token) {
+			missingTokens[path] = append(missingTokens[path], token)
+		}
+	}
 }

--- a/internal/runtime/verify/content_match.go
+++ b/internal/runtime/verify/content_match.go
@@ -1,0 +1,94 @@
+package verify
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	contentMatchVerifierName = "content_match"
+)
+
+// ContentMatchVerifier 校验预期文件内容是否命中要求。
+type ContentMatchVerifier struct{}
+
+// Name 返回 verifier 名称。
+func (ContentMatchVerifier) Name() string {
+	return contentMatchVerifierName
+}
+
+// VerifyFinal 校验 metadata.content_match 声明的路径与关键内容约束。
+func (ContentMatchVerifier) VerifyFinal(_ context.Context, input FinalVerifyInput) (VerificationResult, error) {
+	cfg, exists := input.VerificationConfig.Verifiers[contentMatchVerifierName]
+	required := exists && cfg.Required
+	rules := metadataStringMapSlice(input.Metadata, "content_match")
+	if len(rules) == 0 {
+		if required {
+			return VerificationResult{
+				Name:    contentMatchVerifierName,
+				Status:  VerificationSoftBlock,
+				Summary: "content_match is required but missing",
+				Reason:  "missing content_match metadata",
+			}, nil
+		}
+		return VerificationResult{
+			Name:    contentMatchVerifierName,
+			Status:  VerificationPass,
+			Summary: "no content_match rule configured, skip content check",
+			Reason:  "optional verifier skipped",
+		}, nil
+	}
+
+	missingFiles := make([]string, 0)
+	missingTokens := make(map[string][]string)
+	for rawPath, expectedTokens := range rules {
+		path := strings.TrimSpace(rawPath)
+		if path == "" {
+			continue
+		}
+		absPath := path
+		if !filepath.IsAbs(absPath) {
+			absPath = filepath.Join(strings.TrimSpace(input.Workdir), path)
+		}
+		contentBytes, err := os.ReadFile(absPath)
+		if err != nil {
+			missingFiles = append(missingFiles, path)
+			continue
+		}
+		content := string(contentBytes)
+		for _, token := range expectedTokens {
+			normalized := strings.TrimSpace(token)
+			if normalized == "" {
+				continue
+			}
+			if !strings.Contains(content, normalized) {
+				missingTokens[path] = append(missingTokens[path], normalized)
+			}
+		}
+	}
+
+	evidence := map[string]any{
+		"rules":          rules,
+		"missing_files":  missingFiles,
+		"missing_tokens": missingTokens,
+	}
+	if len(missingFiles) == 0 && len(missingTokens) == 0 {
+		return VerificationResult{
+			Name:     contentMatchVerifierName,
+			Status:   VerificationPass,
+			Summary:  "all expected content rules matched",
+			Reason:   "content match check passed",
+			Evidence: evidence,
+		}, nil
+	}
+	return VerificationResult{
+		Name:       contentMatchVerifierName,
+		Status:     VerificationFail,
+		Summary:    "content rule mismatch detected",
+		Reason:     "content match check failed",
+		ErrorClass: ErrorClassUnknown,
+		Evidence:   evidence,
+	}, nil
+}

--- a/internal/runtime/verify/content_match_test.go
+++ b/internal/runtime/verify/content_match_test.go
@@ -1,0 +1,57 @@
+package verify
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestContentMatchVerifierPathTraversalDenied(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workdir := filepath.Join(root, "work")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	outside := filepath.Join(root, "secret.txt")
+	if err := os.WriteFile(outside, []byte("token"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	verifier := ContentMatchVerifier{}
+	result, err := verifier.VerifyFinal(context.Background(), FinalVerifyInput{
+		Workdir: workdir,
+		Metadata: map[string]any{
+			"content_match": map[string][]string{"../secret.txt": {"token"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("VerifyFinal() error = %v", err)
+	}
+	assertVerifierStatus(t, result, VerificationFail)
+	assertPermissionDeniedClass(t, result)
+}
+
+func TestContentMatchVerifierSuccessWithinWorkdir(t *testing.T) {
+	t.Parallel()
+
+	workdir := t.TempDir()
+	file := filepath.Join(workdir, "a.txt")
+	if err := os.WriteFile(file, []byte("hello world"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	verifier := ContentMatchVerifier{}
+	result, err := verifier.VerifyFinal(context.Background(), FinalVerifyInput{
+		Workdir: workdir,
+		Metadata: map[string]any{
+			"content_match": map[string][]string{"a.txt": {"hello"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("VerifyFinal() error = %v", err)
+	}
+	assertVerifierStatus(t, result, VerificationPass)
+}

--- a/internal/runtime/verify/execution_policy.go
+++ b/internal/runtime/verify/execution_policy.go
@@ -30,6 +30,12 @@ var readonlyGitSubcommands = map[string]struct{}{
 	"ls-files":  {},
 }
 
+const (
+	defaultVerificationTimeoutSec = 120
+	defaultVerificationOutputCap  = 128 * 1024
+	shellMetacharacters           = ";|&`$<>()\n\r"
+)
+
 // CommandExecutionRequest 描述一次 verifier 命令执行请求。
 type CommandExecutionRequest struct {
 	Command       string
@@ -71,20 +77,8 @@ func (PolicyCommandExecutor) Execute(ctx context.Context, req CommandExecutionRe
 		return CommandExecutionResult{}, fmt.Errorf("%w: %s", ErrVerificationExecutionDenied, reason)
 	}
 
-	timeoutSec := req.TimeoutSec
-	if timeoutSec <= 0 {
-		timeoutSec = req.Policy.DefaultTimeout
-	}
-	if timeoutSec <= 0 {
-		timeoutSec = 120
-	}
-	outputCap := req.OutputCapByte
-	if outputCap <= 0 {
-		outputCap = req.Policy.DefaultOutputCap
-	}
-	if outputCap <= 0 {
-		outputCap = 128 * 1024
-	}
+	timeoutSec := firstPositive(req.TimeoutSec, req.Policy.DefaultTimeout, defaultVerificationTimeoutSec)
+	outputCap := firstPositive(req.OutputCapByte, req.Policy.DefaultOutputCap, defaultVerificationOutputCap)
 
 	runCtx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSec)*time.Second)
 	defer cancel()
@@ -133,26 +127,15 @@ func (PolicyCommandExecutor) Execute(ctx context.Context, req CommandExecutionRe
 
 // isCommandAllowed 判断命令是否符合 verification non-interactive 白名单策略。
 func isCommandAllowed(commandName string, raw string, policy config.VerificationExecutionPolicyConfig) (bool, string) {
-	denied := make(map[string]struct{}, len(policy.DeniedCommands))
-	for _, item := range policy.DeniedCommands {
-		normalized := strings.ToLower(strings.TrimSpace(item))
-		if normalized == "" {
-			continue
-		}
-		denied[normalized] = struct{}{}
+	if hasShellMetacharacter(raw) {
+		return false, "shell metacharacter is not allowed in verification command"
 	}
-	if _, blocked := denied[commandName]; blocked {
+
+	if _, blocked := normalizedCommandSet(policy.DeniedCommands)[commandName]; blocked {
 		return false, fmt.Sprintf("command %q is denied by verification policy", commandName)
 	}
 
-	allowed := make(map[string]struct{}, len(policy.AllowedCommands))
-	for _, item := range policy.AllowedCommands {
-		normalized := strings.ToLower(strings.TrimSpace(item))
-		if normalized == "" {
-			continue
-		}
-		allowed[normalized] = struct{}{}
-	}
+	allowed := normalizedCommandSet(policy.AllowedCommands)
 	if len(allowed) > 0 {
 		if _, ok := allowed[commandName]; !ok {
 			return false, fmt.Sprintf("command %q is not in allowed_commands", commandName)
@@ -171,6 +154,11 @@ func isCommandAllowed(commandName string, raw string, policy config.Verification
 	return true, ""
 }
 
+// hasShellMetacharacter 判断命令文本是否包含会触发 shell 解释的高风险元字符。
+func hasShellMetacharacter(command string) bool {
+	return strings.ContainsAny(command, shellMetacharacters)
+}
+
 // shellCommand 按平台构建执行命令，统一以非交互 shell 运行 verifier 指令。
 func shellCommand(ctx context.Context, command string) *exec.Cmd {
 	if runtime.GOOS == "windows" {
@@ -181,23 +169,50 @@ func shellCommand(ctx context.Context, command string) *exec.Cmd {
 
 // commandHead 返回命令首个 token（小写）。
 func commandHead(command string) string {
-	fields := strings.Fields(strings.TrimSpace(command))
+	fields := commandFields(command)
 	if len(fields) == 0 {
 		return ""
 	}
-	return strings.ToLower(strings.TrimSpace(fields[0]))
+	return fields[0]
 }
 
 // gitSubcommand 提取 git 命令的二级子命令（小写）。
 func gitSubcommand(command string) string {
+	fields := commandFields(command)
+	if len(fields) < 2 || fields[0] != "git" {
+		return ""
+	}
+	return fields[1]
+}
+
+// normalizedCommandSet 将命令列表规整为小写集合，便于白名单/拒绝名单判断。
+func normalizedCommandSet(commands []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(commands))
+	for _, command := range commands {
+		if normalized := commandHead(command); normalized != "" {
+			set[normalized] = struct{}{}
+		}
+	}
+	return set
+}
+
+// commandFields 返回规整后的命令 token 序列。
+func commandFields(command string) []string {
 	fields := strings.Fields(strings.TrimSpace(command))
-	if len(fields) < 2 {
-		return ""
+	for i, field := range fields {
+		fields[i] = strings.ToLower(strings.TrimSpace(field))
 	}
-	if strings.ToLower(strings.TrimSpace(fields[0])) != "git" {
-		return ""
+	return fields
+}
+
+// firstPositive 返回首个大于 0 的值，否则回退到最后一个默认值。
+func firstPositive(values ...int) int {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
 	}
-	return strings.ToLower(strings.TrimSpace(fields[1]))
+	return 0
 }
 
 type cappedBuffer struct {
@@ -209,7 +224,7 @@ type cappedBuffer struct {
 // newCappedBuffer 创建带大小上限的输出缓冲区，避免 verifier 命令输出无限膨胀。
 func newCappedBuffer(limit int) *cappedBuffer {
 	if limit <= 0 {
-		limit = 128 * 1024
+		limit = defaultVerificationOutputCap
 	}
 	return &cappedBuffer{limit: limit}
 }

--- a/internal/runtime/verify/execution_policy.go
+++ b/internal/runtime/verify/execution_policy.go
@@ -150,6 +150,9 @@ func isCommandAllowed(commandName string, raw string, policy config.Verification
 		if _, ok := readonlyGitSubcommands[sub]; !ok {
 			return false, fmt.Sprintf("git subcommand %q is not read-only", sub)
 		}
+		if denied, reason := hasDangerousGitArguments(raw); denied {
+			return false, reason
+		}
 	}
 	return true, ""
 }
@@ -183,6 +186,32 @@ func gitSubcommand(command string) string {
 		return ""
 	}
 	return fields[1]
+}
+
+// hasDangerousGitArguments 校验只读 git 子命令是否携带可能产生写入副作用的参数。
+func hasDangerousGitArguments(command string) (bool, string) {
+	fields := commandFields(command)
+	if len(fields) < 2 || fields[0] != "git" {
+		return false, ""
+	}
+	args := fields[2:]
+	for _, arg := range args {
+		switch {
+		case arg == "-o" || arg == "--output" || strings.HasPrefix(arg, "--output="):
+			return true, "git output redirection flags are not allowed"
+		case arg == "-c" || strings.HasPrefix(arg, "-c"):
+			return true, "git -c config override is not allowed"
+		case arg == "--config-env" || strings.HasPrefix(arg, "--config-env="):
+			return true, "git --config-env is not allowed"
+		case arg == "--git-dir" || strings.HasPrefix(arg, "--git-dir="):
+			return true, "git --git-dir is not allowed"
+		case arg == "--work-tree" || strings.HasPrefix(arg, "--work-tree="):
+			return true, "git --work-tree is not allowed"
+		case arg == "--ext-diff" || arg == "--external-diff":
+			return true, "git external diff hooks are not allowed"
+		}
+	}
+	return false, ""
 }
 
 // normalizedCommandSet 将命令列表规整为小写集合，便于白名单/拒绝名单判断。

--- a/internal/runtime/verify/execution_policy.go
+++ b/internal/runtime/verify/execution_policy.go
@@ -1,0 +1,250 @@
+package verify
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"neo-code/internal/config"
+)
+
+var (
+	// ErrVerificationExecutionDenied 表示 verifier 命令被执行策略拒绝。
+	ErrVerificationExecutionDenied = errors.New("verification execution denied")
+	// ErrVerificationExecutionError 表示 verifier 命令执行过程中发生系统错误。
+	ErrVerificationExecutionError = errors.New("verification execution error")
+)
+
+var readonlyGitSubcommands = map[string]struct{}{
+	"diff":      {},
+	"status":    {},
+	"show":      {},
+	"log":       {},
+	"rev-parse": {},
+	"ls-files":  {},
+}
+
+// CommandExecutionRequest 描述一次 verifier 命令执行请求。
+type CommandExecutionRequest struct {
+	Command       string
+	Workdir       string
+	TimeoutSec    int
+	OutputCapByte int
+	Policy        config.VerificationExecutionPolicyConfig
+}
+
+// CommandExecutionResult 描述 verifier 命令执行结果。
+type CommandExecutionResult struct {
+	ExitCode    int
+	Stdout      string
+	Stderr      string
+	TimedOut    bool
+	Truncated   bool
+	DurationMS  int64
+	CommandName string
+}
+
+// CommandExecutor 约束 verifier 命令执行能力，便于测试替换。
+type CommandExecutor interface {
+	Execute(ctx context.Context, req CommandExecutionRequest) (CommandExecutionResult, error)
+}
+
+// PolicyCommandExecutor 在 runtime 进程内执行 non-interactive verifier 命令。
+type PolicyCommandExecutor struct{}
+
+// Execute 在白名单策略下执行 verifier 命令并返回结构化结果。
+func (PolicyCommandExecutor) Execute(ctx context.Context, req CommandExecutionRequest) (CommandExecutionResult, error) {
+	normalizedCommand := strings.TrimSpace(req.Command)
+	commandName := commandHead(normalizedCommand)
+	if normalizedCommand == "" || commandName == "" {
+		return CommandExecutionResult{}, fmt.Errorf("%w: empty command", ErrVerificationExecutionDenied)
+	}
+
+	allowed, reason := isCommandAllowed(commandName, normalizedCommand, req.Policy)
+	if !allowed {
+		return CommandExecutionResult{}, fmt.Errorf("%w: %s", ErrVerificationExecutionDenied, reason)
+	}
+
+	timeoutSec := req.TimeoutSec
+	if timeoutSec <= 0 {
+		timeoutSec = req.Policy.DefaultTimeout
+	}
+	if timeoutSec <= 0 {
+		timeoutSec = 120
+	}
+	outputCap := req.OutputCapByte
+	if outputCap <= 0 {
+		outputCap = req.Policy.DefaultOutputCap
+	}
+	if outputCap <= 0 {
+		outputCap = 128 * 1024
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSec)*time.Second)
+	defer cancel()
+
+	cmd := shellCommand(runCtx, normalizedCommand)
+	if workdir := strings.TrimSpace(req.Workdir); workdir != "" {
+		cmd.Dir = workdir
+	}
+	cmd.Env = append(os.Environ(),
+		"CI=1",
+		"GIT_TERMINAL_PROMPT=0",
+	)
+
+	stdout := newCappedBuffer(outputCap)
+	stderr := newCappedBuffer(outputCap)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	start := time.Now()
+	runErr := cmd.Run()
+	duration := time.Since(start)
+	result := CommandExecutionResult{
+		ExitCode:    0,
+		Stdout:      stdout.String(),
+		Stderr:      stderr.String(),
+		Truncated:   stdout.Truncated() || stderr.Truncated(),
+		DurationMS:  duration.Milliseconds(),
+		CommandName: commandName,
+	}
+	if runErr == nil {
+		return result, nil
+	}
+
+	if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+		result.TimedOut = true
+		return result, fmt.Errorf("%w: command timeout", ErrVerificationExecutionError)
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		result.ExitCode = exitErr.ExitCode()
+		return result, nil
+	}
+	return result, fmt.Errorf("%w: %v", ErrVerificationExecutionError, runErr)
+}
+
+// isCommandAllowed 判断命令是否符合 verification non-interactive 白名单策略。
+func isCommandAllowed(commandName string, raw string, policy config.VerificationExecutionPolicyConfig) (bool, string) {
+	denied := make(map[string]struct{}, len(policy.DeniedCommands))
+	for _, item := range policy.DeniedCommands {
+		normalized := strings.ToLower(strings.TrimSpace(item))
+		if normalized == "" {
+			continue
+		}
+		denied[normalized] = struct{}{}
+	}
+	if _, blocked := denied[commandName]; blocked {
+		return false, fmt.Sprintf("command %q is denied by verification policy", commandName)
+	}
+
+	allowed := make(map[string]struct{}, len(policy.AllowedCommands))
+	for _, item := range policy.AllowedCommands {
+		normalized := strings.ToLower(strings.TrimSpace(item))
+		if normalized == "" {
+			continue
+		}
+		allowed[normalized] = struct{}{}
+	}
+	if len(allowed) > 0 {
+		if _, ok := allowed[commandName]; !ok {
+			return false, fmt.Sprintf("command %q is not in allowed_commands", commandName)
+		}
+	}
+
+	if commandName == "git" {
+		sub := gitSubcommand(raw)
+		if sub == "" {
+			return false, "git subcommand is required"
+		}
+		if _, ok := readonlyGitSubcommands[sub]; !ok {
+			return false, fmt.Sprintf("git subcommand %q is not read-only", sub)
+		}
+	}
+	return true, ""
+}
+
+// shellCommand 按平台构建执行命令，统一以非交互 shell 运行 verifier 指令。
+func shellCommand(ctx context.Context, command string) *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.CommandContext(ctx, "powershell", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command)
+	}
+	return exec.CommandContext(ctx, "sh", "-lc", command)
+}
+
+// commandHead 返回命令首个 token（小写）。
+func commandHead(command string) string {
+	fields := strings.Fields(strings.TrimSpace(command))
+	if len(fields) == 0 {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(fields[0]))
+}
+
+// gitSubcommand 提取 git 命令的二级子命令（小写）。
+func gitSubcommand(command string) string {
+	fields := strings.Fields(strings.TrimSpace(command))
+	if len(fields) < 2 {
+		return ""
+	}
+	if strings.ToLower(strings.TrimSpace(fields[0])) != "git" {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(fields[1]))
+}
+
+type cappedBuffer struct {
+	limit     int
+	buffer    bytes.Buffer
+	truncated bool
+}
+
+// newCappedBuffer 创建带大小上限的输出缓冲区，避免 verifier 命令输出无限膨胀。
+func newCappedBuffer(limit int) *cappedBuffer {
+	if limit <= 0 {
+		limit = 128 * 1024
+	}
+	return &cappedBuffer{limit: limit}
+}
+
+// Write 实现 io.Writer，仅保留上限范围内的输出。
+func (b *cappedBuffer) Write(p []byte) (int, error) {
+	if b == nil {
+		return len(p), nil
+	}
+	if b.buffer.Len() >= b.limit {
+		b.truncated = true
+		return len(p), nil
+	}
+	remain := b.limit - b.buffer.Len()
+	if len(p) > remain {
+		b.truncated = true
+		_, _ = b.buffer.Write(p[:remain])
+		return len(p), nil
+	}
+	_, _ = b.buffer.Write(p)
+	return len(p), nil
+}
+
+// String 返回当前缓冲区文本。
+func (b *cappedBuffer) String() string {
+	if b == nil {
+		return ""
+	}
+	return b.buffer.String()
+}
+
+// Truncated 返回输出是否发生截断。
+func (b *cappedBuffer) Truncated() bool {
+	if b == nil {
+		return false
+	}
+	return b.truncated
+}

--- a/internal/runtime/verify/execution_policy_additional_test.go
+++ b/internal/runtime/verify/execution_policy_additional_test.go
@@ -1,0 +1,162 @@
+package verify
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"neo-code/internal/config"
+)
+
+func TestPolicyCommandExecutorExecuteBranches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty command denied", func(t *testing.T) {
+		t.Parallel()
+		_, err := PolicyCommandExecutor{}.Execute(context.Background(), CommandExecutionRequest{Command: "  "})
+		if err == nil || !errors.Is(err, ErrVerificationExecutionDenied) {
+			t.Fatalf("expected ErrVerificationExecutionDenied, got %v", err)
+		}
+	})
+
+	t.Run("invalid workdir returns execution error", func(t *testing.T) {
+		t.Parallel()
+		policy := config.StaticDefaults().Runtime.Verification.ExecutionPolicy
+		result, err := PolicyCommandExecutor{}.Execute(context.Background(), CommandExecutionRequest{
+			Command: "go version",
+			Workdir: "/path/not/exist",
+			Policy:  policy,
+		})
+		if err == nil || !errors.Is(err, ErrVerificationExecutionError) {
+			t.Fatalf("expected ErrVerificationExecutionError, got result=%+v err=%v", result, err)
+		}
+	})
+
+	t.Run("command timeout", func(t *testing.T) {
+		t.Parallel()
+		policy := config.VerificationExecutionPolicyConfig{
+			Mode:             "non_interactive",
+			AllowedCommands:  []string{"sh"},
+			DefaultTimeout:   1,
+			DefaultOutputCap: 1024,
+		}
+		result, err := PolicyCommandExecutor{}.Execute(context.Background(), CommandExecutionRequest{
+			Command: "sh -c 'sleep 2'",
+			Policy:  policy,
+		})
+		if err == nil || !errors.Is(err, ErrVerificationExecutionError) {
+			t.Fatalf("expected timeout execution error, got result=%+v err=%v", result, err)
+		}
+		if !result.TimedOut {
+			t.Fatalf("result.TimedOut = false, want true")
+		}
+	})
+
+	t.Run("non-zero exit code", func(t *testing.T) {
+		t.Parallel()
+		policy := config.VerificationExecutionPolicyConfig{
+			Mode:             "non_interactive",
+			AllowedCommands:  []string{"sh"},
+			DefaultTimeout:   5,
+			DefaultOutputCap: 1024,
+		}
+		result, err := PolicyCommandExecutor{}.Execute(context.Background(), CommandExecutionRequest{
+			Command: "sh -c 'exit 7'",
+			Policy:  policy,
+		})
+		if err != nil {
+			t.Fatalf("expected nil err for exit status, got %v", err)
+		}
+		if result.ExitCode != 7 {
+			t.Fatalf("exit code = %d, want 7", result.ExitCode)
+		}
+	})
+}
+
+func TestExecutionPolicyHelpers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("isCommandAllowed branches", func(t *testing.T) {
+		t.Parallel()
+		policy := config.VerificationExecutionPolicyConfig{
+			Mode:            "non_interactive",
+			AllowedCommands: []string{"go", "git"},
+			DeniedCommands:  []string{"rm"},
+		}
+		if ok, _ := isCommandAllowed("go", "go test ./...", policy); !ok {
+			t.Fatalf("go should be allowed")
+		}
+		if ok, reason := isCommandAllowed("rm", "rm -rf .", policy); ok || reason == "" {
+			t.Fatalf("rm should be denied")
+		}
+		if ok, _ := isCommandAllowed("go", "go test ./... && echo x", policy); ok {
+			t.Fatalf("metacharacter command should be denied")
+		}
+		if ok, _ := isCommandAllowed("python", "python -V", policy); ok {
+			t.Fatalf("python should not pass allow list")
+		}
+		if ok, _ := isCommandAllowed("git", "git", policy); ok {
+			t.Fatalf("git without subcommand should be denied")
+		}
+		if ok, _ := isCommandAllowed("git", "git checkout .", policy); ok {
+			t.Fatalf("git write subcommand should be denied")
+		}
+	})
+
+	t.Run("basic parser helpers", func(t *testing.T) {
+		t.Parallel()
+		if commandHead("  ") != "" {
+			t.Fatalf("commandHead blank should be empty")
+		}
+		if commandHead("Go Test") != "go" {
+			t.Fatalf("commandHead lower-case mismatch")
+		}
+		if gitSubcommand("git status") != "status" {
+			t.Fatalf("gitSubcommand mismatch")
+		}
+		if gitSubcommand("go test") != "" {
+			t.Fatalf("gitSubcommand should be empty for non-git")
+		}
+		set := normalizedCommandSet([]string{" Go  ", "", "GIT status"})
+		if _, ok := set["go"]; !ok {
+			t.Fatalf("normalized set should include go")
+		}
+		if _, ok := set["git"]; !ok {
+			t.Fatalf("normalized set should include git")
+		}
+		if got := firstPositive(-1, 0, 9, 10); got != 9 {
+			t.Fatalf("firstPositive() = %d, want 9", got)
+		}
+		if got := firstPositive(-1, 0); got != 0 {
+			t.Fatalf("firstPositive() = %d, want 0", got)
+		}
+	})
+
+	t.Run("cappedBuffer branches", func(t *testing.T) {
+		t.Parallel()
+		buffer := newCappedBuffer(3)
+		if _, err := buffer.Write([]byte("abc")); err != nil {
+			t.Fatalf("Write() error = %v", err)
+		}
+		if _, err := buffer.Write([]byte("def")); err != nil {
+			t.Fatalf("Write() overflow error = %v", err)
+		}
+		if !buffer.Truncated() {
+			t.Fatalf("buffer should be truncated")
+		}
+		if buffer.String() != "abc" {
+			t.Fatalf("buffer content = %q, want %q", buffer.String(), "abc")
+		}
+
+		var nilBuffer *cappedBuffer
+		if _, err := nilBuffer.Write([]byte("x")); err != nil {
+			t.Fatalf("nil buffer Write() error = %v", err)
+		}
+		if nilBuffer.String() != "" {
+			t.Fatalf("nil buffer String() should be empty")
+		}
+		if nilBuffer.Truncated() {
+			t.Fatalf("nil buffer Truncated() should be false")
+		}
+	})
+}

--- a/internal/runtime/verify/execution_policy_additional_test.go
+++ b/internal/runtime/verify/execution_policy_additional_test.go
@@ -3,6 +3,7 @@ package verify
 import (
 	"context"
 	"errors"
+	"runtime"
 	"testing"
 
 	"neo-code/internal/config"
@@ -34,14 +35,20 @@ func TestPolicyCommandExecutorExecuteBranches(t *testing.T) {
 
 	t.Run("command timeout", func(t *testing.T) {
 		t.Parallel()
+		timeoutCommand := "sh -c 'sleep 2'"
+		allowedCommand := "sh"
+		if runtime.GOOS == "windows" {
+			timeoutCommand = "powershell -NoLogo -NoProfile -NonInteractive -Command Start-Sleep -Seconds 2"
+			allowedCommand = "powershell"
+		}
 		policy := config.VerificationExecutionPolicyConfig{
 			Mode:             "non_interactive",
-			AllowedCommands:  []string{"sh"},
+			AllowedCommands:  []string{allowedCommand},
 			DefaultTimeout:   1,
 			DefaultOutputCap: 1024,
 		}
 		result, err := PolicyCommandExecutor{}.Execute(context.Background(), CommandExecutionRequest{
-			Command: "sh -c 'sleep 2'",
+			Command: timeoutCommand,
 			Policy:  policy,
 		})
 		if err == nil || !errors.Is(err, ErrVerificationExecutionError) {
@@ -54,21 +61,27 @@ func TestPolicyCommandExecutorExecuteBranches(t *testing.T) {
 
 	t.Run("non-zero exit code", func(t *testing.T) {
 		t.Parallel()
+		failCommand := "sh -c 'exit 7'"
+		allowedCommand := "sh"
+		if runtime.GOOS == "windows" {
+			failCommand = "go tool definitely-not-a-real-tool"
+			allowedCommand = "go"
+		}
 		policy := config.VerificationExecutionPolicyConfig{
 			Mode:             "non_interactive",
-			AllowedCommands:  []string{"sh"},
+			AllowedCommands:  []string{allowedCommand},
 			DefaultTimeout:   5,
 			DefaultOutputCap: 1024,
 		}
 		result, err := PolicyCommandExecutor{}.Execute(context.Background(), CommandExecutionRequest{
-			Command: "sh -c 'exit 7'",
+			Command: failCommand,
 			Policy:  policy,
 		})
 		if err != nil {
 			t.Fatalf("expected nil err for exit status, got %v", err)
 		}
-		if result.ExitCode != 7 {
-			t.Fatalf("exit code = %d, want 7", result.ExitCode)
+		if result.ExitCode == 0 {
+			t.Fatalf("exit code = %d, want non-zero", result.ExitCode)
 		}
 	})
 }
@@ -101,6 +114,15 @@ func TestExecutionPolicyHelpers(t *testing.T) {
 		if ok, _ := isCommandAllowed("git", "git checkout .", policy); ok {
 			t.Fatalf("git write subcommand should be denied")
 		}
+		if ok, _ := isCommandAllowed("git", "git diff --output=../leak.txt", policy); ok {
+			t.Fatalf("git output flag should be denied")
+		}
+		if ok, _ := isCommandAllowed("git", "git show -o ../leak.txt", policy); ok {
+			t.Fatalf("git short output flag should be denied")
+		}
+		if ok, _ := isCommandAllowed("git", "git diff -c core.pager=cat", policy); ok {
+			t.Fatalf("git -c override should be denied")
+		}
 	})
 
 	t.Run("basic parser helpers", func(t *testing.T) {
@@ -116,6 +138,12 @@ func TestExecutionPolicyHelpers(t *testing.T) {
 		}
 		if gitSubcommand("go test") != "" {
 			t.Fatalf("gitSubcommand should be empty for non-git")
+		}
+		if denied, _ := hasDangerousGitArguments("git diff --output=tmp.txt"); !denied {
+			t.Fatalf("expected dangerous git output argument to be denied")
+		}
+		if denied, _ := hasDangerousGitArguments("git status"); denied {
+			t.Fatalf("git status should not be denied by dangerous argument checker")
 		}
 		set := normalizedCommandSet([]string{" Go  ", "", "GIT status"})
 		if _, ok := set["go"]; !ok {

--- a/internal/runtime/verify/execution_policy_test.go
+++ b/internal/runtime/verify/execution_policy_test.go
@@ -8,14 +8,31 @@ import (
 	"neo-code/internal/config"
 )
 
+func defaultExecutionPolicy() config.VerificationExecutionPolicyConfig {
+	return config.StaticDefaults().Runtime.Verification.ExecutionPolicy
+}
+
+func assertExecutionDenied(t *testing.T, command string) {
+	t.Helper()
+
+	_, err := PolicyCommandExecutor{}.Execute(context.Background(), CommandExecutionRequest{
+		Command: command,
+		Policy:  defaultExecutionPolicy(),
+	})
+	if err == nil {
+		t.Fatal("expected command to be denied")
+	}
+	if !errors.Is(err, ErrVerificationExecutionDenied) {
+		t.Fatalf("error = %v, want ErrVerificationExecutionDenied", err)
+	}
+}
+
 func TestPolicyCommandExecutorAllowsWhitelistedCommand(t *testing.T) {
 	t.Parallel()
 
-	executor := PolicyCommandExecutor{}
-	policy := config.StaticDefaults().Runtime.Verification.ExecutionPolicy
-	result, err := executor.Execute(context.Background(), CommandExecutionRequest{
+	result, err := PolicyCommandExecutor{}.Execute(context.Background(), CommandExecutionRequest{
 		Command: "go version",
-		Policy:  policy,
+		Policy:  defaultExecutionPolicy(),
 	})
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
@@ -28,33 +45,28 @@ func TestPolicyCommandExecutorAllowsWhitelistedCommand(t *testing.T) {
 func TestPolicyCommandExecutorRejectsDeniedCommand(t *testing.T) {
 	t.Parallel()
 
-	executor := PolicyCommandExecutor{}
-	policy := config.StaticDefaults().Runtime.Verification.ExecutionPolicy
-	_, err := executor.Execute(context.Background(), CommandExecutionRequest{
-		Command: "rm -rf .",
-		Policy:  policy,
-	})
-	if err == nil {
-		t.Fatal("expected denied command error")
-	}
-	if !errors.Is(err, ErrVerificationExecutionDenied) {
-		t.Fatalf("error = %v, want ErrVerificationExecutionDenied", err)
-	}
+	assertExecutionDenied(t, "rm -rf .")
 }
 
 func TestPolicyCommandExecutorRejectsGitWriteSubcommand(t *testing.T) {
 	t.Parallel()
 
-	executor := PolicyCommandExecutor{}
-	policy := config.StaticDefaults().Runtime.Verification.ExecutionPolicy
-	_, err := executor.Execute(context.Background(), CommandExecutionRequest{
-		Command: "git checkout .",
-		Policy:  policy,
-	})
-	if err == nil {
-		t.Fatal("expected git write command to be denied")
+	assertExecutionDenied(t, "git checkout .")
+}
+
+func TestPolicyCommandExecutorRejectsShellMetacharacter(t *testing.T) {
+	t.Parallel()
+
+	testCases := []string{
+		"go test ./...; rm -rf .",
+		"git diff && git checkout .",
+		"echo $HOME",
 	}
-	if !errors.Is(err, ErrVerificationExecutionDenied) {
-		t.Fatalf("error = %v, want ErrVerificationExecutionDenied", err)
+	for _, command := range testCases {
+		command := command
+		t.Run(command, func(t *testing.T) {
+			t.Parallel()
+			assertExecutionDenied(t, command)
+		})
 	}
 }

--- a/internal/runtime/verify/execution_policy_test.go
+++ b/internal/runtime/verify/execution_policy_test.go
@@ -1,0 +1,60 @@
+package verify
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"neo-code/internal/config"
+)
+
+func TestPolicyCommandExecutorAllowsWhitelistedCommand(t *testing.T) {
+	t.Parallel()
+
+	executor := PolicyCommandExecutor{}
+	policy := config.StaticDefaults().Runtime.Verification.ExecutionPolicy
+	result, err := executor.Execute(context.Background(), CommandExecutionRequest{
+		Command: "go version",
+		Policy:  policy,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit_code = %d, want 0", result.ExitCode)
+	}
+}
+
+func TestPolicyCommandExecutorRejectsDeniedCommand(t *testing.T) {
+	t.Parallel()
+
+	executor := PolicyCommandExecutor{}
+	policy := config.StaticDefaults().Runtime.Verification.ExecutionPolicy
+	_, err := executor.Execute(context.Background(), CommandExecutionRequest{
+		Command: "rm -rf .",
+		Policy:  policy,
+	})
+	if err == nil {
+		t.Fatal("expected denied command error")
+	}
+	if !errors.Is(err, ErrVerificationExecutionDenied) {
+		t.Fatalf("error = %v, want ErrVerificationExecutionDenied", err)
+	}
+}
+
+func TestPolicyCommandExecutorRejectsGitWriteSubcommand(t *testing.T) {
+	t.Parallel()
+
+	executor := PolicyCommandExecutor{}
+	policy := config.StaticDefaults().Runtime.Verification.ExecutionPolicy
+	_, err := executor.Execute(context.Background(), CommandExecutionRequest{
+		Command: "git checkout .",
+		Policy:  policy,
+	})
+	if err == nil {
+		t.Fatal("expected git write command to be denied")
+	}
+	if !errors.Is(err, ErrVerificationExecutionDenied) {
+		t.Fatalf("error = %v, want ErrVerificationExecutionDenied", err)
+	}
+}

--- a/internal/runtime/verify/file_content_additional_test.go
+++ b/internal/runtime/verify/file_content_additional_test.go
@@ -1,0 +1,160 @@
+package verify
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"neo-code/internal/config"
+)
+
+func TestFileExistsVerifierAdditionalBranches(t *testing.T) {
+	t.Parallel()
+
+	v := FileExistsVerifier{}
+
+	t.Run("missing metadata optional and required", func(t *testing.T) {
+		t.Parallel()
+		optional, err := v.VerifyFinal(context.Background(), FinalVerifyInput{})
+		if err != nil {
+			t.Fatalf("VerifyFinal() optional error = %v", err)
+		}
+		if optional.Status != VerificationPass {
+			t.Fatalf("optional status = %q, want pass", optional.Status)
+		}
+
+		cfg := defaultVerificationConfigForTest()
+		cfg.Verifiers[fileExistsVerifierName] = verifierConfigForTest(true)
+		required, err := v.VerifyFinal(context.Background(), FinalVerifyInput{VerificationConfig: cfg})
+		if err != nil {
+			t.Fatalf("VerifyFinal() required error = %v", err)
+		}
+		if required.Status != VerificationSoftBlock {
+			t.Fatalf("required status = %q, want soft_block", required.Status)
+		}
+	})
+
+	t.Run("missing empty dir denied branches", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		workdir := filepath.Join(root, "work")
+		if err := os.MkdirAll(workdir, 0o755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+		dirPath := filepath.Join(workdir, "d")
+		if err := os.MkdirAll(dirPath, 0o755); err != nil {
+			t.Fatalf("MkdirAll(dir) error = %v", err)
+		}
+		emptyPath := filepath.Join(workdir, "empty.txt")
+		if err := os.WriteFile(emptyPath, nil, 0o644); err != nil {
+			t.Fatalf("WriteFile(empty) error = %v", err)
+		}
+
+		result, err := v.VerifyFinal(context.Background(), FinalVerifyInput{
+			Workdir: workdir,
+			Metadata: map[string]any{
+				"expected_files": []string{"missing.txt", "empty.txt", "d", "../outside"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationFail {
+			t.Fatalf("status = %q, want fail", result.Status)
+		}
+		if result.ErrorClass != ErrorClassPermissionDenied {
+			t.Fatalf("error class = %q, want permission_denied", result.ErrorClass)
+		}
+	})
+
+	t.Run("missing and empty without denied should be unknown fail", func(t *testing.T) {
+		t.Parallel()
+		workdir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(workdir, "empty.txt"), nil, 0o644); err != nil {
+			t.Fatalf("WriteFile(empty) error = %v", err)
+		}
+		result, err := v.VerifyFinal(context.Background(), FinalVerifyInput{
+			Workdir: workdir,
+			Metadata: map[string]any{
+				"expected_files": []string{"missing.txt", "empty.txt"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationFail || result.ErrorClass != ErrorClassUnknown {
+			t.Fatalf("unexpected result: %+v", result)
+		}
+	})
+}
+
+func TestContentMatchVerifierAdditionalBranches(t *testing.T) {
+	t.Parallel()
+
+	v := ContentMatchVerifier{}
+
+	t.Run("missing metadata optional and required", func(t *testing.T) {
+		t.Parallel()
+		optional, err := v.VerifyFinal(context.Background(), FinalVerifyInput{})
+		if err != nil {
+			t.Fatalf("VerifyFinal() optional error = %v", err)
+		}
+		if optional.Status != VerificationPass {
+			t.Fatalf("optional status = %q, want pass", optional.Status)
+		}
+
+		cfg := defaultVerificationConfigForTest()
+		cfg.Verifiers[contentMatchVerifierName] = verifierConfigForTest(true)
+		required, err := v.VerifyFinal(context.Background(), FinalVerifyInput{VerificationConfig: cfg})
+		if err != nil {
+			t.Fatalf("VerifyFinal() required error = %v", err)
+		}
+		if required.Status != VerificationSoftBlock {
+			t.Fatalf("required status = %q, want soft_block", required.Status)
+		}
+	})
+
+	t.Run("missing file and token mismatch", func(t *testing.T) {
+		t.Parallel()
+		workdir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(workdir, "a.txt"), []byte("hello"), 0o644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+
+		result, err := v.VerifyFinal(context.Background(), FinalVerifyInput{
+			Workdir: workdir,
+			Metadata: map[string]any{
+				"content_match": map[string][]string{
+					"a.txt":       []string{"hello", "world"},
+					"missing.txt": []string{"x"},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationFail {
+			t.Fatalf("status = %q, want fail", result.Status)
+		}
+	})
+
+	t.Run("collectMissingTokens compacts blanks", func(t *testing.T) {
+		t.Parallel()
+		missing := map[string][]string{}
+		collectMissingTokens(missing, "a.txt", "hello", []string{" hello ", "", "world"})
+		if len(missing["a.txt"]) != 1 || missing["a.txt"][0] != "world" {
+			t.Fatalf("missing tokens = %#v", missing)
+		}
+	})
+}
+
+func defaultVerificationConfigForTest() config.VerificationConfig {
+	cfg := config.VerificationConfig{}
+	cfg.Verifiers = map[string]config.VerifierConfig{}
+	return cfg
+}
+
+func verifierConfigForTest(required bool) config.VerifierConfig {
+	return config.VerifierConfig{Required: required}
+}

--- a/internal/runtime/verify/file_content_additional_test.go
+++ b/internal/runtime/verify/file_content_additional_test.go
@@ -87,6 +87,39 @@ func TestFileExistsVerifierAdditionalBranches(t *testing.T) {
 			t.Fatalf("unexpected result: %+v", result)
 		}
 	})
+
+	t.Run("symlink escaping workdir should be denied", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		workdir := filepath.Join(root, "work")
+		outside := filepath.Join(root, "outside")
+		if err := os.MkdirAll(workdir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(workdir) error = %v", err)
+		}
+		if err := os.MkdirAll(outside, 0o755); err != nil {
+			t.Fatalf("MkdirAll(outside) error = %v", err)
+		}
+		outsideFile := filepath.Join(outside, "secret.txt")
+		if err := os.WriteFile(outsideFile, []byte("secret"), 0o644); err != nil {
+			t.Fatalf("WriteFile(outside) error = %v", err)
+		}
+		if err := os.Symlink(outsideFile, filepath.Join(workdir, "link.txt")); err != nil {
+			t.Skipf("symlink is not available on this platform: %v", err)
+		}
+
+		result, err := v.VerifyFinal(context.Background(), FinalVerifyInput{
+			Workdir: workdir,
+			Metadata: map[string]any{
+				"expected_files": []string{"link.txt"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationFail || result.ErrorClass != ErrorClassPermissionDenied {
+			t.Fatalf("unexpected symlink denied result: %+v", result)
+		}
+	})
 }
 
 func TestContentMatchVerifierAdditionalBranches(t *testing.T) {
@@ -145,6 +178,41 @@ func TestContentMatchVerifierAdditionalBranches(t *testing.T) {
 		collectMissingTokens(missing, "a.txt", "hello", []string{" hello ", "", "world"})
 		if len(missing["a.txt"]) != 1 || missing["a.txt"][0] != "world" {
 			t.Fatalf("missing tokens = %#v", missing)
+		}
+	})
+
+	t.Run("symlink escaping workdir should be denied", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		workdir := filepath.Join(root, "work")
+		outside := filepath.Join(root, "outside")
+		if err := os.MkdirAll(workdir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(workdir) error = %v", err)
+		}
+		if err := os.MkdirAll(outside, 0o755); err != nil {
+			t.Fatalf("MkdirAll(outside) error = %v", err)
+		}
+		outsideFile := filepath.Join(outside, "secret.txt")
+		if err := os.WriteFile(outsideFile, []byte("secret-token"), 0o644); err != nil {
+			t.Fatalf("WriteFile(outside) error = %v", err)
+		}
+		if err := os.Symlink(outsideFile, filepath.Join(workdir, "link.txt")); err != nil {
+			t.Skipf("symlink is not available on this platform: %v", err)
+		}
+
+		result, err := v.VerifyFinal(context.Background(), FinalVerifyInput{
+			Workdir: workdir,
+			Metadata: map[string]any{
+				"content_match": map[string][]string{
+					"link.txt": []string{"secret-token"},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationFail || result.ErrorClass != ErrorClassPermissionDenied {
+			t.Fatalf("unexpected symlink denied result: %+v", result)
 		}
 	})
 }

--- a/internal/runtime/verify/file_exists.go
+++ b/internal/runtime/verify/file_exists.go
@@ -3,8 +3,6 @@ package verify
 import (
 	"context"
 	"os"
-	"path/filepath"
-	"strings"
 )
 
 const (
@@ -25,33 +23,23 @@ func (FileExistsVerifier) VerifyFinal(_ context.Context, input FinalVerifyInput)
 	required := exists && cfg.Required
 	paths := metadataStringSlice(input.Metadata, "expected_files")
 	if len(paths) == 0 {
-		if required {
-			return VerificationResult{
-				Name:    fileExistsVerifierName,
-				Status:  VerificationSoftBlock,
-				Summary: "expected_files is required but missing",
-				Reason:  "missing expected_files metadata",
-			}, nil
-		}
-		return VerificationResult{
-			Name:    fileExistsVerifierName,
-			Status:  VerificationPass,
-			Summary: "no expected files configured, skip file existence check",
-			Reason:  "optional verifier skipped",
-		}, nil
+		return verifierMetadataResult(
+			fileExistsVerifierName,
+			required,
+			"expected_files",
+			"no expected files configured, skip file existence check",
+		), nil
 	}
 
 	missing := make([]string, 0)
 	empty := make([]string, 0)
 	dirs := make([]string, 0)
-	for _, raw := range paths {
-		path := strings.TrimSpace(raw)
-		if path == "" {
+	denied := make([]string, 0)
+	for _, path := range paths {
+		absPath, err := resolvePathWithinWorkdir(input.Workdir, path)
+		if err != nil {
+			denied = append(denied, path)
 			continue
-		}
-		absPath := path
-		if !filepath.IsAbs(absPath) {
-			absPath = filepath.Join(strings.TrimSpace(input.Workdir), path)
 		}
 		info, err := os.Stat(absPath)
 		if err != nil {
@@ -72,6 +60,15 @@ func (FileExistsVerifier) VerifyFinal(_ context.Context, input FinalVerifyInput)
 		"missing_files":   missing,
 		"empty_files":     empty,
 		"directory_paths": dirs,
+		"denied_paths":    denied,
+	}
+	if len(denied) > 0 {
+		return verificationDeniedResult(
+			fileExistsVerifierName,
+			"expected files contain paths outside workdir",
+			"file existence path denied by workdir policy",
+			evidence,
+		), nil
 	}
 	if len(missing) == 0 && len(empty) == 0 && len(dirs) == 0 {
 		return VerificationResult{

--- a/internal/runtime/verify/file_exists.go
+++ b/internal/runtime/verify/file_exists.go
@@ -1,0 +1,93 @@
+package verify
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	fileExistsVerifierName = "file_exists"
+)
+
+// FileExistsVerifier 校验预期文件是否存在且可用。
+type FileExistsVerifier struct{}
+
+// Name 返回 verifier 名称。
+func (FileExistsVerifier) Name() string {
+	return fileExistsVerifierName
+}
+
+// VerifyFinal 校验 metadata 声明的 expected_files 是否存在并且非空文件。
+func (FileExistsVerifier) VerifyFinal(_ context.Context, input FinalVerifyInput) (VerificationResult, error) {
+	cfg, exists := input.VerificationConfig.Verifiers[fileExistsVerifierName]
+	required := exists && cfg.Required
+	paths := metadataStringSlice(input.Metadata, "expected_files")
+	if len(paths) == 0 {
+		if required {
+			return VerificationResult{
+				Name:    fileExistsVerifierName,
+				Status:  VerificationSoftBlock,
+				Summary: "expected_files is required but missing",
+				Reason:  "missing expected_files metadata",
+			}, nil
+		}
+		return VerificationResult{
+			Name:    fileExistsVerifierName,
+			Status:  VerificationPass,
+			Summary: "no expected files configured, skip file existence check",
+			Reason:  "optional verifier skipped",
+		}, nil
+	}
+
+	missing := make([]string, 0)
+	empty := make([]string, 0)
+	dirs := make([]string, 0)
+	for _, raw := range paths {
+		path := strings.TrimSpace(raw)
+		if path == "" {
+			continue
+		}
+		absPath := path
+		if !filepath.IsAbs(absPath) {
+			absPath = filepath.Join(strings.TrimSpace(input.Workdir), path)
+		}
+		info, err := os.Stat(absPath)
+		if err != nil {
+			missing = append(missing, path)
+			continue
+		}
+		if info.IsDir() {
+			dirs = append(dirs, path)
+			continue
+		}
+		if info.Size() <= 0 {
+			empty = append(empty, path)
+		}
+	}
+
+	evidence := map[string]any{
+		"expected_files":  paths,
+		"missing_files":   missing,
+		"empty_files":     empty,
+		"directory_paths": dirs,
+	}
+	if len(missing) == 0 && len(empty) == 0 && len(dirs) == 0 {
+		return VerificationResult{
+			Name:     fileExistsVerifierName,
+			Status:   VerificationPass,
+			Summary:  "all expected files exist and are non-empty",
+			Reason:   "file existence check passed",
+			Evidence: evidence,
+		}, nil
+	}
+	return VerificationResult{
+		Name:       fileExistsVerifierName,
+		Status:     VerificationFail,
+		Summary:    "expected files are missing or invalid",
+		Reason:     "file existence check failed",
+		ErrorClass: ErrorClassUnknown,
+		Evidence:   evidence,
+	}, nil
+}

--- a/internal/runtime/verify/file_exists_test.go
+++ b/internal/runtime/verify/file_exists_test.go
@@ -1,0 +1,66 @@
+package verify
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func assertVerifierStatus(t *testing.T, result VerificationResult, want VerificationStatus) {
+	t.Helper()
+	if result.Status != want {
+		t.Fatalf("status = %q, want %q", result.Status, want)
+	}
+}
+
+func assertPermissionDeniedClass(t *testing.T, result VerificationResult) {
+	t.Helper()
+	if result.ErrorClass != ErrorClassPermissionDenied {
+		t.Fatalf("error_class = %q, want %q", result.ErrorClass, ErrorClassPermissionDenied)
+	}
+}
+
+func TestFileExistsVerifierPathTraversalDenied(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workdir := filepath.Join(root, "work")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	outside := filepath.Join(root, "secret.txt")
+	if err := os.WriteFile(outside, []byte("secret"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	verifier := FileExistsVerifier{}
+	result, err := verifier.VerifyFinal(context.Background(), FinalVerifyInput{
+		Workdir:  workdir,
+		Metadata: map[string]any{"expected_files": []string{"../secret.txt"}},
+	})
+	if err != nil {
+		t.Fatalf("VerifyFinal() error = %v", err)
+	}
+	assertVerifierStatus(t, result, VerificationFail)
+	assertPermissionDeniedClass(t, result)
+}
+
+func TestFileExistsVerifierSuccessWithinWorkdir(t *testing.T) {
+	t.Parallel()
+
+	workdir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workdir, "a.txt"), []byte("ok"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	verifier := FileExistsVerifier{}
+	result, err := verifier.VerifyFinal(context.Background(), FinalVerifyInput{
+		Workdir:  workdir,
+		Metadata: map[string]any{"expected_files": []string{"a.txt"}},
+	})
+	if err != nil {
+		t.Fatalf("VerifyFinal() error = %v", err)
+	}
+	assertVerifierStatus(t, result, VerificationPass)
+}

--- a/internal/runtime/verify/git_diff.go
+++ b/internal/runtime/verify/git_diff.go
@@ -1,0 +1,98 @@
+package verify
+
+import (
+	"context"
+	"strings"
+)
+
+const (
+	gitDiffVerifierName = "git_diff"
+)
+
+// GitDiffVerifier 校验工作区是否存在有效 diff。
+type GitDiffVerifier struct {
+	Executor CommandExecutor
+}
+
+// Name 返回 verifier 名称。
+func (v GitDiffVerifier) Name() string {
+	return gitDiffVerifierName
+}
+
+// VerifyFinal 执行 git diff 检查，确保 edit/fix/refactor 任务有真实改动。
+func (v GitDiffVerifier) VerifyFinal(ctx context.Context, input FinalVerifyInput) (VerificationResult, error) {
+	executor := v.Executor
+	if executor == nil {
+		executor = PolicyCommandExecutor{}
+	}
+	cfg := input.VerificationConfig.Verifiers[gitDiffVerifierName]
+	command := strings.TrimSpace(cfg.Command)
+	if command == "" {
+		command = "git diff --name-only"
+	}
+
+	result, err := executor.Execute(ctx, CommandExecutionRequest{
+		Command:       command,
+		Workdir:       input.Workdir,
+		TimeoutSec:    cfg.TimeoutSec,
+		OutputCapByte: cfg.OutputCapBytes,
+		Policy:        input.VerificationConfig.ExecutionPolicy,
+	})
+	if err != nil {
+		return VerificationResult{
+			Name:       gitDiffVerifierName,
+			Status:     VerificationFail,
+			Summary:    err.Error(),
+			Reason:     "git diff command execution failed",
+			ErrorClass: classifyCommandExecutionError(err),
+			Evidence: map[string]any{
+				"command": command,
+			},
+		}, nil
+	}
+	if result.ExitCode != 0 {
+		return VerificationResult{
+			Name:       gitDiffVerifierName,
+			Status:     VerificationFail,
+			Summary:    "git diff command returned non-zero",
+			Reason:     "git diff command failed",
+			ErrorClass: ErrorClassUnknown,
+			Evidence:   commandEvidence(command, result),
+		}, nil
+	}
+
+	lines := nonEmptyLines(result.Stdout)
+	if len(lines) == 0 {
+		return VerificationResult{
+			Name:     gitDiffVerifierName,
+			Status:   VerificationFail,
+			Summary:  "git diff is empty",
+			Reason:   "no changed files detected",
+			Evidence: commandEvidence(command, result),
+		}, nil
+	}
+	evidence := commandEvidence(command, result)
+	evidence["changed_files"] = lines
+	evidence["changed_files_count"] = len(lines)
+	return VerificationResult{
+		Name:     gitDiffVerifierName,
+		Status:   VerificationPass,
+		Summary:  "git diff contains changed files",
+		Reason:   "workspace change detected",
+		Evidence: evidence,
+	}, nil
+}
+
+// nonEmptyLines 返回文本中的非空行列表。
+func nonEmptyLines(text string) []string {
+	raw := strings.Split(text, "\n")
+	lines := make([]string, 0, len(raw))
+	for _, item := range raw {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		lines = append(lines, item)
+	}
+	return lines
+}

--- a/internal/runtime/verify/git_diff_test.go
+++ b/internal/runtime/verify/git_diff_test.go
@@ -89,6 +89,25 @@ func TestGitDiffVerifierVerifyFinal(t *testing.T) {
 			t.Fatalf("changed_files = %#v, want %#v", files, []string{"a.go", "b.go"})
 		}
 	})
+
+	t.Run("uses default command when verifier command empty", func(t *testing.T) {
+		t.Parallel()
+		cfg := verifyConfigForGitDiffTests()
+		verifierCfg := cfg.Verifiers[gitDiffVerifierName]
+		verifierCfg.Command = "   "
+		cfg.Verifiers[gitDiffVerifierName] = verifierCfg
+
+		result, err := (GitDiffVerifier{}).VerifyFinal(context.Background(), FinalVerifyInput{
+			Workdir:            t.TempDir(),
+			VerificationConfig: cfg,
+		})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationFail && result.Status != VerificationPass {
+			t.Fatalf("unexpected status %q", result.Status)
+		}
+	})
 }
 
 func TestGitDiffVerifierName(t *testing.T) {

--- a/internal/runtime/verify/git_diff_test.go
+++ b/internal/runtime/verify/git_diff_test.go
@@ -1,0 +1,109 @@
+package verify
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"neo-code/internal/config"
+)
+
+func verifyConfigForGitDiffTests() config.VerificationConfig {
+	cfg := config.StaticDefaults().Runtime.Verification
+	cfg.Enabled = boolPtrVerify(true)
+	return cfg
+}
+
+func TestGitDiffVerifierVerifyFinal(t *testing.T) {
+	t.Parallel()
+
+	t.Run("execution error returns fail", func(t *testing.T) {
+		t.Parallel()
+		executor := &stubCommandExecutor{err: errors.New("permission denied")}
+		cfg := verifyConfigForGitDiffTests()
+
+		result, err := (GitDiffVerifier{Executor: executor}).VerifyFinal(context.Background(), FinalVerifyInput{VerificationConfig: cfg})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationFail || result.ErrorClass != ErrorClassPermissionDenied {
+			t.Fatalf("unexpected result: %+v", result)
+		}
+	})
+
+	t.Run("non zero exit code returns fail", func(t *testing.T) {
+		t.Parallel()
+		executor := &stubCommandExecutor{result: CommandExecutionResult{ExitCode: 1}}
+		cfg := verifyConfigForGitDiffTests()
+
+		result, err := (GitDiffVerifier{Executor: executor}).VerifyFinal(context.Background(), FinalVerifyInput{VerificationConfig: cfg})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationFail {
+			t.Fatalf("status = %q, want %q", result.Status, VerificationFail)
+		}
+	})
+
+	t.Run("empty output returns fail", func(t *testing.T) {
+		t.Parallel()
+		executor := &stubCommandExecutor{result: CommandExecutionResult{ExitCode: 0, Stdout: "\n\t "}}
+		cfg := verifyConfigForGitDiffTests()
+
+		result, err := (GitDiffVerifier{Executor: executor}).VerifyFinal(context.Background(), FinalVerifyInput{VerificationConfig: cfg})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationFail {
+			t.Fatalf("status = %q, want %q", result.Status, VerificationFail)
+		}
+	})
+
+	t.Run("changed files returns pass and evidence", func(t *testing.T) {
+		t.Parallel()
+		executor := &stubCommandExecutor{result: CommandExecutionResult{ExitCode: 0, Stdout: "a.go\n b.go \n\n"}}
+		cfg := verifyConfigForGitDiffTests()
+		verifierCfg := cfg.Verifiers[gitDiffVerifierName]
+		verifierCfg.Command = "git diff --name-only"
+		cfg.Verifiers[gitDiffVerifierName] = verifierCfg
+
+		result, err := (GitDiffVerifier{Executor: executor}).VerifyFinal(context.Background(), FinalVerifyInput{Workdir: "/workspace", VerificationConfig: cfg})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationPass {
+			t.Fatalf("status = %q, want %q", result.Status, VerificationPass)
+		}
+		if len(executor.requests) != 1 {
+			t.Fatalf("expected one execute call, got %d", len(executor.requests))
+		}
+		if executor.requests[0].Command != "git diff --name-only" || executor.requests[0].Workdir != "/workspace" {
+			t.Fatalf("unexpected request: %+v", executor.requests[0])
+		}
+		files, ok := result.Evidence["changed_files"].([]string)
+		if !ok {
+			t.Fatalf("changed_files should be []string, got %T", result.Evidence["changed_files"])
+		}
+		if !reflect.DeepEqual(files, []string{"a.go", "b.go"}) {
+			t.Fatalf("changed_files = %#v, want %#v", files, []string{"a.go", "b.go"})
+		}
+	})
+}
+
+func TestGitDiffVerifierName(t *testing.T) {
+	t.Parallel()
+	if got := (GitDiffVerifier{}).Name(); got != gitDiffVerifierName {
+		t.Fatalf("Name() = %q, want %q", got, gitDiffVerifierName)
+	}
+}
+
+func TestNonEmptyLines(t *testing.T) {
+	t.Parallel()
+
+	got := nonEmptyLines("a\n\n b \n\t\n c")
+	want := []string{"a", "b", "c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("nonEmptyLines() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/runtime/verify/helpers.go
+++ b/internal/runtime/verify/helpers.go
@@ -2,6 +2,7 @@ package verify
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -146,12 +147,37 @@ func resolvePathWithinWorkdir(workdir string, rawPath string) (string, error) {
 		return "", fmt.Errorf("resolve path: %w", err)
 	}
 
-	rel, err := filepath.Rel(workdirAbs, resolvedPath)
-	if err != nil {
-		return "", fmt.Errorf("check path relation: %w", err)
-	}
-	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	if err := ensurePathWithinBase(workdirAbs, resolvedPath); err != nil {
 		return "", fmt.Errorf("path %q is outside workdir", rawPath)
 	}
+
+	// 对已存在路径追加真实路径校验，防止通过符号链接逃逸 workdir。
+	workdirReal, err := filepath.EvalSymlinks(workdirAbs)
+	if err != nil {
+		workdirReal = workdirAbs
+	}
+	resolvedReal, err := filepath.EvalSymlinks(resolvedPath)
+	switch {
+	case err == nil:
+		if err := ensurePathWithinBase(workdirReal, resolvedReal); err != nil {
+			return "", fmt.Errorf("path %q resolves outside workdir", rawPath)
+		}
+	case os.IsNotExist(err):
+		// 目标不存在时由上层 verifier 按 missing 处理；此处只做已存在路径的边界约束。
+	default:
+		return "", fmt.Errorf("resolve symlink path: %w", err)
+	}
 	return resolvedPath, nil
+}
+
+// ensurePathWithinBase 校验目标路径仍位于基准目录内，避免路径穿越或边界越权。
+func ensurePathWithinBase(base string, target string) error {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return fmt.Errorf("check path relation: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("outside base path")
+	}
+	return nil
 }

--- a/internal/runtime/verify/helpers.go
+++ b/internal/runtime/verify/helpers.go
@@ -2,8 +2,39 @@ package verify
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 )
+
+// verifierMetadataResult 统一生成 metadata 缺失时的 required/optional 结果。
+func verifierMetadataResult(name string, required bool, metadataKey string, skipSummary string) VerificationResult {
+	if !required {
+		return VerificationResult{
+			Name:    name,
+			Status:  VerificationPass,
+			Summary: skipSummary,
+			Reason:  "optional verifier skipped",
+		}
+	}
+	return VerificationResult{
+		Name:    name,
+		Status:  VerificationSoftBlock,
+		Summary: fmt.Sprintf("%s is required but missing", metadataKey),
+		Reason:  fmt.Sprintf("missing %s metadata", metadataKey),
+	}
+}
+
+// verificationDeniedResult 统一生成路径越界等安全拒绝结果。
+func verificationDeniedResult(name string, summary string, reason string, evidence map[string]any) VerificationResult {
+	return VerificationResult{
+		Name:       name,
+		Status:     VerificationFail,
+		Summary:    summary,
+		Reason:     reason,
+		ErrorClass: ErrorClassPermissionDenied,
+		Evidence:   evidence,
+	}
+}
 
 // metadataStringSlice 从 metadata 中解析字符串列表。
 func metadataStringSlice(metadata map[string]any, key string) []string {
@@ -16,13 +47,7 @@ func metadataStringSlice(metadata map[string]any, key string) []string {
 	}
 	switch typed := raw.(type) {
 	case []string:
-		out := make([]string, 0, len(typed))
-		for _, item := range typed {
-			if normalized := strings.TrimSpace(item); normalized != "" {
-				out = append(out, normalized)
-			}
-		}
-		return out
+		return compactStrings(typed)
 	case []any:
 		out := make([]string, 0, len(typed))
 		for _, item := range typed {
@@ -84,4 +109,49 @@ func metadataStringMapSlice(metadata map[string]any, key string) map[string][]st
 		return nil
 	}
 	return normalized
+}
+
+// compactStrings 会去除空白与空字符串，返回紧凑切片。
+func compactStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if normalized := strings.TrimSpace(value); normalized != "" {
+			out = append(out, normalized)
+		}
+	}
+	return out
+}
+
+// resolvePathWithinWorkdir 将 verifier 输入路径解析为绝对路径，并确保路径仍位于 workdir 内部。
+func resolvePathWithinWorkdir(workdir string, rawPath string) (string, error) {
+	normalizedWorkdir := strings.TrimSpace(workdir)
+	if normalizedWorkdir == "" {
+		return "", fmt.Errorf("workdir is required")
+	}
+	workdirAbs, err := filepath.Abs(filepath.Clean(normalizedWorkdir))
+	if err != nil {
+		return "", fmt.Errorf("resolve workdir: %w", err)
+	}
+
+	normalizedPath := strings.TrimSpace(rawPath)
+	if normalizedPath == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	resolvedPath := normalizedPath
+	if !filepath.IsAbs(resolvedPath) {
+		resolvedPath = filepath.Join(workdirAbs, resolvedPath)
+	}
+	resolvedPath, err = filepath.Abs(filepath.Clean(resolvedPath))
+	if err != nil {
+		return "", fmt.Errorf("resolve path: %w", err)
+	}
+
+	rel, err := filepath.Rel(workdirAbs, resolvedPath)
+	if err != nil {
+		return "", fmt.Errorf("check path relation: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q is outside workdir", rawPath)
+	}
+	return resolvedPath, nil
 }

--- a/internal/runtime/verify/helpers.go
+++ b/internal/runtime/verify/helpers.go
@@ -1,0 +1,87 @@
+package verify
+
+import (
+	"fmt"
+	"strings"
+)
+
+// metadataStringSlice 从 metadata 中解析字符串列表。
+func metadataStringSlice(metadata map[string]any, key string) []string {
+	if len(metadata) == 0 {
+		return nil
+	}
+	raw, ok := metadata[key]
+	if !ok || raw == nil {
+		return nil
+	}
+	switch typed := raw.(type) {
+	case []string:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if normalized := strings.TrimSpace(item); normalized != "" {
+				out = append(out, normalized)
+			}
+		}
+		return out
+	case []any:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if normalized := strings.TrimSpace(fmt.Sprintf("%v", item)); normalized != "" {
+				out = append(out, normalized)
+			}
+		}
+		return out
+	case string:
+		trimmed := strings.TrimSpace(typed)
+		if trimmed == "" {
+			return nil
+		}
+		return []string{trimmed}
+	default:
+		return nil
+	}
+}
+
+// metadataStringMapSlice 从 metadata 中解析 map[string][]string。
+func metadataStringMapSlice(metadata map[string]any, key string) map[string][]string {
+	if len(metadata) == 0 {
+		return nil
+	}
+	raw, ok := metadata[key]
+	if !ok || raw == nil {
+		return nil
+	}
+	normalized := make(map[string][]string)
+	switch typed := raw.(type) {
+	case map[string][]string:
+		for path, values := range typed {
+			path = strings.TrimSpace(path)
+			if path == "" {
+				continue
+			}
+			for _, value := range values {
+				value = strings.TrimSpace(value)
+				if value == "" {
+					continue
+				}
+				normalized[path] = append(normalized[path], value)
+			}
+		}
+	case map[string]any:
+		for path, value := range typed {
+			path = strings.TrimSpace(path)
+			if path == "" {
+				continue
+			}
+			values := metadataStringSlice(map[string]any{"value": value}, "value")
+			if len(values) == 0 {
+				continue
+			}
+			normalized[path] = values
+		}
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
+}

--- a/internal/runtime/verify/helpers_test.go
+++ b/internal/runtime/verify/helpers_test.go
@@ -1,0 +1,123 @@
+package verify
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestVerifierMetadataResult(t *testing.T) {
+	t.Parallel()
+
+	optional := verifierMetadataResult("file_exists", false, "expected_files", "skip")
+	if optional.Status != VerificationPass || optional.Summary != "skip" {
+		t.Fatalf("unexpected optional result: %+v", optional)
+	}
+
+	required := verifierMetadataResult("file_exists", true, "expected_files", "skip")
+	if required.Status != VerificationSoftBlock || !strings.Contains(required.Summary, "expected_files") {
+		t.Fatalf("unexpected required result: %+v", required)
+	}
+}
+
+func TestVerificationDeniedResult(t *testing.T) {
+	t.Parallel()
+
+	result := verificationDeniedResult("file_exists", "denied", "policy", map[string]any{"a": 1})
+	if result.Status != VerificationFail || result.ErrorClass != ErrorClassPermissionDenied {
+		t.Fatalf("unexpected denied result: %+v", result)
+	}
+}
+
+func TestMetadataStringSlice(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		meta map[string]any
+		key  string
+		want []string
+	}{
+		{name: "empty", meta: nil, key: "k", want: nil},
+		{name: "string slice", meta: map[string]any{"k": []string{" a ", "", "b"}}, key: "k", want: []string{"a", "b"}},
+		{name: "any slice", meta: map[string]any{"k": []any{" a ", 2, ""}}, key: "k", want: []string{"a", "2"}},
+		{name: "single string", meta: map[string]any{"k": "  a  "}, key: "k", want: []string{"a"}},
+		{name: "unsupported", meta: map[string]any{"k": 1}, key: "k", want: nil},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := metadataStringSlice(tc.meta, tc.key)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("metadataStringSlice() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMetadataStringMapSlice(t *testing.T) {
+	t.Parallel()
+
+	t.Run("map string slices", func(t *testing.T) {
+		t.Parallel()
+		got := metadataStringMapSlice(map[string]any{
+			"rules": map[string][]string{" a.txt ": []string{" x ", ""}},
+		}, "rules")
+		want := map[string][]string{"a.txt": []string{"x"}}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("metadataStringMapSlice() = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("map any", func(t *testing.T) {
+		t.Parallel()
+		got := metadataStringMapSlice(map[string]any{
+			"rules": map[string]any{"a.txt": []any{" x ", 2}, " ": "ignored"},
+		}, "rules")
+		want := map[string][]string{"a.txt": []string{"x", "2"}}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("metadataStringMapSlice() = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("invalid returns nil", func(t *testing.T) {
+		t.Parallel()
+		if got := metadataStringMapSlice(map[string]any{"rules": "bad"}, "rules"); got != nil {
+			t.Fatalf("expected nil, got %#v", got)
+		}
+	})
+}
+
+func TestResolvePathWithinWorkdir(t *testing.T) {
+	t.Parallel()
+
+	workdir := t.TempDir()
+	child, err := resolvePathWithinWorkdir(workdir, "a/b.txt")
+	if err != nil {
+		t.Fatalf("resolvePathWithinWorkdir() error = %v", err)
+	}
+	if !strings.HasPrefix(child, workdir) {
+		t.Fatalf("resolved path %q should be in workdir %q", child, workdir)
+	}
+
+	absChild, err := resolvePathWithinWorkdir(workdir, filepath.Join(workdir, "a.txt"))
+	if err != nil {
+		t.Fatalf("resolvePathWithinWorkdir(abs) error = %v", err)
+	}
+	if !strings.HasPrefix(absChild, workdir) {
+		t.Fatalf("resolved abs path %q should be in workdir %q", absChild, workdir)
+	}
+
+	if _, err := resolvePathWithinWorkdir("", "a.txt"); err == nil {
+		t.Fatalf("expected empty workdir error")
+	}
+	if _, err := resolvePathWithinWorkdir(workdir, ""); err == nil {
+		t.Fatalf("expected empty path error")
+	}
+	if _, err := resolvePathWithinWorkdir(workdir, "../outside.txt"); err == nil {
+		t.Fatalf("expected traversal error")
+	}
+}

--- a/internal/runtime/verify/helpers_test.go
+++ b/internal/runtime/verify/helpers_test.go
@@ -1,6 +1,7 @@
 package verify
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -119,5 +120,31 @@ func TestResolvePathWithinWorkdir(t *testing.T) {
 	}
 	if _, err := resolvePathWithinWorkdir(workdir, "../outside.txt"); err == nil {
 		t.Fatalf("expected traversal error")
+	}
+}
+
+func TestResolvePathWithinWorkdirRejectsSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workdir := filepath.Join(root, "work")
+	outsideDir := filepath.Join(root, "outside")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workdir) error = %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(outside) error = %v", err)
+	}
+	outsideFile := filepath.Join(outsideDir, "secret.txt")
+	if err := os.WriteFile(outsideFile, []byte("secret"), 0o644); err != nil {
+		t.Fatalf("WriteFile(outside) error = %v", err)
+	}
+	linkPath := filepath.Join(workdir, "link.txt")
+	if err := os.Symlink(outsideFile, linkPath); err != nil {
+		t.Skipf("symlink is not available on this platform: %v", err)
+	}
+
+	if _, err := resolvePathWithinWorkdir(workdir, "link.txt"); err == nil {
+		t.Fatalf("expected symlink escape to be denied")
 	}
 }

--- a/internal/runtime/verify/lint.go
+++ b/internal/runtime/verify/lint.go
@@ -1,0 +1,20 @@
+package verify
+
+const (
+	lintVerifierName = "lint"
+)
+
+// LintVerifier 复用命令执行 verifier，承载 lint 验证语义。
+type LintVerifier struct {
+	CommandSuccessVerifier
+}
+
+// NewLintVerifier 创建 lint verifier。
+func NewLintVerifier(executor CommandExecutor) LintVerifier {
+	return LintVerifier{
+		CommandSuccessVerifier: CommandSuccessVerifier{
+			VerifierName: lintVerifierName,
+			Executor:     executor,
+		},
+	}
+}

--- a/internal/runtime/verify/orchestrator.go
+++ b/internal/runtime/verify/orchestrator.go
@@ -2,7 +2,9 @@ package verify
 
 import (
 	"context"
+	"strings"
 
+	"neo-code/internal/config"
 	"neo-code/internal/runtime/controlplane"
 )
 
@@ -19,10 +21,12 @@ func (o Orchestrator) RunFinalVerification(ctx context.Context, input FinalVerif
 		if verifier == nil {
 			continue
 		}
+		verifierName := strings.TrimSpace(verifier.Name())
+		verifierCfg, hasCfg := input.VerificationConfig.Verifiers[verifierName]
 		result, err := verifier.VerifyFinal(ctx, input)
 		if err != nil {
 			result = VerificationResult{
-				Name:       verifier.Name(),
+				Name:       verifierName,
 				Status:     VerificationFail,
 				Summary:    err.Error(),
 				Reason:     "verifier execution error",
@@ -30,6 +34,12 @@ func (o Orchestrator) RunFinalVerification(ctx context.Context, input FinalVerif
 			}
 		}
 		result = NormalizeResult(result)
+		if result.Name == "" {
+			result.Name = verifierName
+		}
+		if hasCfg {
+			result = applyVerifierFailurePolicy(result, verifierCfg)
+		}
 		if result.WaitingExternal {
 			waitingExternal = true
 		}
@@ -45,7 +55,7 @@ func (o Orchestrator) RunFinalVerification(ctx context.Context, input FinalVerif
 		switch result.Status {
 		case VerificationFail:
 			decision.Passed = false
-			decision.Reason = controlplane.StopReasonVerificationFailed
+			decision.Reason = stopReasonForVerificationFailure(result)
 			return decision, nil
 		case VerificationHardBlock:
 			decision.Passed = false
@@ -62,4 +72,64 @@ func (o Orchestrator) RunFinalVerification(ctx context.Context, input FinalVerif
 		}
 	}
 	return decision, nil
+}
+
+// applyVerifierFailurePolicy 根据 fail_open/fail_closed 配置归一化 verifier 失败语义。
+func applyVerifierFailurePolicy(result VerificationResult, cfg config.VerifierConfig) VerificationResult {
+	if cfg.FailClosed && result.Status == VerificationSoftBlock && result.ErrorClass == ErrorClassEnvMissing {
+		evidence := result.Evidence
+		if evidence == nil {
+			evidence = make(map[string]any)
+		}
+		evidence["fail_closed_applied"] = true
+		evidence["original_status"] = string(VerificationSoftBlock)
+		result.Status = VerificationFail
+		if result.ErrorClass == "" {
+			result.ErrorClass = ErrorClassUnknown
+		}
+		result.Evidence = evidence
+	}
+	if !cfg.FailOpen {
+		return result
+	}
+	if result.Status != VerificationFail {
+		return result
+	}
+	evidence := result.Evidence
+	if evidence == nil {
+		evidence = make(map[string]any)
+	}
+	evidence["fail_open_applied"] = true
+	evidence["original_status"] = string(VerificationFail)
+	result.Status = VerificationPass
+	result.ErrorClass = ""
+	result.Retryable = false
+	result.WaitingExternal = false
+	result.Summary = "verifier failure ignored by fail_open policy"
+	result.Reason = "fail_open policy downgraded verifier failure"
+	result.Evidence = evidence
+	return result
+}
+
+// stopReasonForVerificationFailure 将 verifier 失败映射到细粒度 stop reason。
+func stopReasonForVerificationFailure(result VerificationResult) controlplane.StopReason {
+	normalizedSummary := strings.ToLower(strings.TrimSpace(result.Summary))
+	normalizedReason := strings.ToLower(strings.TrimSpace(result.Reason))
+	switch {
+	case strings.Contains(normalizedReason, "missing verifier command configuration"),
+		strings.Contains(normalizedSummary, "required but missing"),
+		result.ErrorClass == ErrorClassEnvMissing:
+		return controlplane.StopReasonVerificationConfigMissing
+	case strings.Contains(normalizedReason, "denied"),
+		strings.Contains(normalizedSummary, "denied"),
+		result.ErrorClass == ErrorClassPermissionDenied:
+		return controlplane.StopReasonVerificationExecutionDenied
+	case strings.Contains(normalizedReason, "execution"),
+		strings.Contains(normalizedSummary, "execution"),
+		result.ErrorClass == ErrorClassTimeout,
+		result.ErrorClass == ErrorClassCommandNotFound:
+		return controlplane.StopReasonVerificationExecutionError
+	default:
+		return controlplane.StopReasonVerificationFailed
+	}
 }

--- a/internal/runtime/verify/orchestrator.go
+++ b/internal/runtime/verify/orchestrator.go
@@ -1,0 +1,65 @@
+package verify
+
+import (
+	"context"
+
+	"neo-code/internal/runtime/controlplane"
+)
+
+// Orchestrator 按固定顺序执行 verifier 并收敛 verification gate。
+type Orchestrator struct {
+	Verifiers []FinalVerifier
+}
+
+// RunFinalVerification 执行 verifier 列表并生成统一 gate 决议。
+func (o Orchestrator) RunFinalVerification(ctx context.Context, input FinalVerifyInput) (VerificationGateDecision, error) {
+	results := make([]VerificationResult, 0, len(o.Verifiers))
+	waitingExternal := false
+	for _, verifier := range o.Verifiers {
+		if verifier == nil {
+			continue
+		}
+		result, err := verifier.VerifyFinal(ctx, input)
+		if err != nil {
+			result = VerificationResult{
+				Name:       verifier.Name(),
+				Status:     VerificationFail,
+				Summary:    err.Error(),
+				Reason:     "verifier execution error",
+				ErrorClass: ErrorClassUnknown,
+			}
+		}
+		result = NormalizeResult(result)
+		if result.WaitingExternal {
+			waitingExternal = true
+		}
+		results = append(results, result)
+	}
+
+	decision := VerificationGateDecision{
+		Passed:  true,
+		Reason:  controlplane.StopReasonAccepted,
+		Results: results,
+	}
+	for _, result := range results {
+		switch result.Status {
+		case VerificationFail:
+			decision.Passed = false
+			decision.Reason = controlplane.StopReasonVerificationFailed
+			return decision, nil
+		case VerificationHardBlock:
+			decision.Passed = false
+			if waitingExternal {
+				decision.Reason = controlplane.StopReasonTodoWaitingExternal
+			} else {
+				decision.Reason = controlplane.StopReasonTodoNotConverged
+			}
+		case VerificationSoftBlock:
+			decision.Passed = false
+			if decision.Reason == controlplane.StopReasonAccepted {
+				decision.Reason = controlplane.StopReasonTodoNotConverged
+			}
+		}
+	}
+	return decision, nil
+}

--- a/internal/runtime/verify/orchestrator_test.go
+++ b/internal/runtime/verify/orchestrator_test.go
@@ -78,6 +78,19 @@ func TestOrchestratorRunFinalVerification(t *testing.T) {
 		}
 	})
 
+	t.Run("hard block without waiting external maps to todo_not_converged", func(t *testing.T) {
+		t.Parallel()
+		decision, err := (Orchestrator{Verifiers: []FinalVerifier{
+			stubFinalVerifier{name: "todo", result: VerificationResult{Name: "todo", Status: VerificationHardBlock}},
+		}}).RunFinalVerification(context.Background(), FinalVerifyInput{})
+		if err != nil {
+			t.Fatalf("RunFinalVerification() error = %v", err)
+		}
+		if decision.Passed || decision.Reason != controlplane.StopReasonTodoNotConverged {
+			t.Fatalf("unexpected decision: %+v", decision)
+		}
+	})
+
 	t.Run("soft block keeps todo_not_converged", func(t *testing.T) {
 		t.Parallel()
 		decision, err := (Orchestrator{Verifiers: []FinalVerifier{

--- a/internal/runtime/verify/orchestrator_test.go
+++ b/internal/runtime/verify/orchestrator_test.go
@@ -1,0 +1,106 @@
+package verify
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"neo-code/internal/runtime/controlplane"
+)
+
+type stubFinalVerifier struct {
+	name   string
+	result VerificationResult
+	err    error
+}
+
+func (s stubFinalVerifier) Name() string {
+	return s.name
+}
+
+func (s stubFinalVerifier) VerifyFinal(ctx context.Context, input FinalVerifyInput) (VerificationResult, error) {
+	_ = ctx
+	_ = input
+	if s.err != nil {
+		return VerificationResult{}, s.err
+	}
+	return s.result, nil
+}
+
+func TestOrchestratorRunFinalVerification(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty verifier list passes", func(t *testing.T) {
+		t.Parallel()
+		decision, err := (Orchestrator{}).RunFinalVerification(context.Background(), FinalVerifyInput{})
+		if err != nil {
+			t.Fatalf("RunFinalVerification() error = %v", err)
+		}
+		if !decision.Passed || decision.Reason != controlplane.StopReasonAccepted {
+			t.Fatalf("unexpected decision: %+v", decision)
+		}
+	})
+
+	t.Run("nil verifier is ignored", func(t *testing.T) {
+		t.Parallel()
+		decision, err := (Orchestrator{Verifiers: []FinalVerifier{nil}}).RunFinalVerification(context.Background(), FinalVerifyInput{})
+		if err != nil {
+			t.Fatalf("RunFinalVerification() error = %v", err)
+		}
+		if len(decision.Results) != 0 {
+			t.Fatalf("results length = %d, want 0", len(decision.Results))
+		}
+	})
+
+	t.Run("verifier error converts to fail decision", func(t *testing.T) {
+		t.Parallel()
+		decision, err := (Orchestrator{Verifiers: []FinalVerifier{
+			stubFinalVerifier{name: "todo", err: errors.New("boom")},
+		}}).RunFinalVerification(context.Background(), FinalVerifyInput{})
+		if err != nil {
+			t.Fatalf("RunFinalVerification() error = %v", err)
+		}
+		if decision.Passed || decision.Reason != controlplane.StopReasonVerificationFailed {
+			t.Fatalf("unexpected decision: %+v", decision)
+		}
+	})
+
+	t.Run("hard block with waiting external maps to waiting_external reason", func(t *testing.T) {
+		t.Parallel()
+		decision, err := (Orchestrator{Verifiers: []FinalVerifier{
+			stubFinalVerifier{name: "todo", result: VerificationResult{Name: "todo", Status: VerificationHardBlock, WaitingExternal: true}},
+		}}).RunFinalVerification(context.Background(), FinalVerifyInput{})
+		if err != nil {
+			t.Fatalf("RunFinalVerification() error = %v", err)
+		}
+		if decision.Passed || decision.Reason != controlplane.StopReasonTodoWaitingExternal {
+			t.Fatalf("unexpected decision: %+v", decision)
+		}
+	})
+
+	t.Run("soft block keeps todo_not_converged", func(t *testing.T) {
+		t.Parallel()
+		decision, err := (Orchestrator{Verifiers: []FinalVerifier{
+			stubFinalVerifier{name: "todo", result: VerificationResult{Name: "todo", Status: VerificationSoftBlock}},
+		}}).RunFinalVerification(context.Background(), FinalVerifyInput{})
+		if err != nil {
+			t.Fatalf("RunFinalVerification() error = %v", err)
+		}
+		if decision.Passed || decision.Reason != controlplane.StopReasonTodoNotConverged {
+			t.Fatalf("unexpected decision: %+v", decision)
+		}
+	})
+
+	t.Run("normalize empty status to fail", func(t *testing.T) {
+		t.Parallel()
+		decision, err := (Orchestrator{Verifiers: []FinalVerifier{
+			stubFinalVerifier{name: "empty", result: VerificationResult{Name: "empty"}},
+		}}).RunFinalVerification(context.Background(), FinalVerifyInput{})
+		if err != nil {
+			t.Fatalf("RunFinalVerification() error = %v", err)
+		}
+		if decision.Passed || decision.Reason != controlplane.StopReasonVerificationFailed {
+			t.Fatalf("unexpected decision: %+v", decision)
+		}
+	})
+}

--- a/internal/runtime/verify/orchestrator_test.go
+++ b/internal/runtime/verify/orchestrator_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"neo-code/internal/config"
 	"neo-code/internal/runtime/controlplane"
 )
 
@@ -60,7 +61,7 @@ func TestOrchestratorRunFinalVerification(t *testing.T) {
 		if err != nil {
 			t.Fatalf("RunFinalVerification() error = %v", err)
 		}
-		if decision.Passed || decision.Reason != controlplane.StopReasonVerificationFailed {
+		if decision.Passed || decision.Reason != controlplane.StopReasonVerificationExecutionError {
 			t.Fatalf("unexpected decision: %+v", decision)
 		}
 	})
@@ -114,6 +115,93 @@ func TestOrchestratorRunFinalVerification(t *testing.T) {
 		}
 		if decision.Passed || decision.Reason != controlplane.StopReasonVerificationFailed {
 			t.Fatalf("unexpected decision: %+v", decision)
+		}
+	})
+
+	t.Run("fail_open downgrades verifier fail", func(t *testing.T) {
+		t.Parallel()
+		input := FinalVerifyInput{
+			VerificationConfig: config.VerificationConfig{
+				Verifiers: map[string]config.VerifierConfig{
+					"todo": {FailOpen: true},
+				},
+			},
+		}
+		decision, err := (Orchestrator{Verifiers: []FinalVerifier{
+			stubFinalVerifier{name: "todo", result: VerificationResult{Name: "todo", Status: VerificationFail}},
+		}}).RunFinalVerification(context.Background(), input)
+		if err != nil {
+			t.Fatalf("RunFinalVerification() error = %v", err)
+		}
+		if !decision.Passed || decision.Reason != controlplane.StopReasonAccepted {
+			t.Fatalf("unexpected decision: %+v", decision)
+		}
+	})
+
+	t.Run("fail_closed escalates soft_block to fail", func(t *testing.T) {
+		t.Parallel()
+		input := FinalVerifyInput{
+			VerificationConfig: config.VerificationConfig{
+				Verifiers: map[string]config.VerifierConfig{
+					"todo": {FailClosed: true},
+				},
+			},
+		}
+		decision, err := (Orchestrator{Verifiers: []FinalVerifier{
+			stubFinalVerifier{
+				name: "todo",
+				result: VerificationResult{
+					Name:       "todo",
+					Status:     VerificationSoftBlock,
+					ErrorClass: ErrorClassEnvMissing,
+				},
+			},
+		}}).RunFinalVerification(context.Background(), input)
+		if err != nil {
+			t.Fatalf("RunFinalVerification() error = %v", err)
+		}
+		if decision.Passed || decision.Reason != controlplane.StopReasonVerificationConfigMissing {
+			t.Fatalf("unexpected decision: %+v", decision)
+		}
+	})
+
+	t.Run("fail reason maps to detailed stop reason", func(t *testing.T) {
+		t.Parallel()
+		testCases := []struct {
+			name   string
+			result VerificationResult
+			want   controlplane.StopReason
+		}{
+			{
+				name:   "config missing",
+				result: VerificationResult{Name: "build", Status: VerificationFail, Reason: "missing verifier command configuration", ErrorClass: ErrorClassEnvMissing},
+				want:   controlplane.StopReasonVerificationConfigMissing,
+			},
+			{
+				name:   "execution denied",
+				result: VerificationResult{Name: "test", Status: VerificationFail, Reason: "verification command denied by execution policy", ErrorClass: ErrorClassPermissionDenied},
+				want:   controlplane.StopReasonVerificationExecutionDenied,
+			},
+			{
+				name:   "execution error",
+				result: VerificationResult{Name: "lint", Status: VerificationFail, Reason: "verification command execution failed", ErrorClass: ErrorClassTimeout},
+				want:   controlplane.StopReasonVerificationExecutionError,
+			},
+		}
+		for _, tc := range testCases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				decision, err := (Orchestrator{Verifiers: []FinalVerifier{
+					stubFinalVerifier{name: tc.result.Name, result: tc.result},
+				}}).RunFinalVerification(context.Background(), FinalVerifyInput{})
+				if err != nil {
+					t.Fatalf("RunFinalVerification() error = %v", err)
+				}
+				if decision.Reason != tc.want {
+					t.Fatalf("reason = %q, want %q", decision.Reason, tc.want)
+				}
+			})
 		}
 	})
 }

--- a/internal/runtime/verify/test.go
+++ b/internal/runtime/verify/test.go
@@ -1,0 +1,20 @@
+package verify
+
+const (
+	testVerifierName = "test"
+)
+
+// TestVerifier 复用命令执行 verifier，承载测试验证语义。
+type TestVerifier struct {
+	CommandSuccessVerifier
+}
+
+// NewTestVerifier 创建 test verifier。
+func NewTestVerifier(executor CommandExecutor) TestVerifier {
+	return TestVerifier{
+		CommandSuccessVerifier: CommandSuccessVerifier{
+			VerifierName: testVerifierName,
+			Executor:     executor,
+		},
+	}
+}

--- a/internal/runtime/verify/todo_convergence.go
+++ b/internal/runtime/verify/todo_convergence.go
@@ -1,0 +1,96 @@
+package verify
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+const (
+	todoConvergenceVerifierName = "todo_convergence"
+)
+
+var waitingExternalBlockedReasons = map[string]struct{}{
+	"permission_wait":        {},
+	"user_input_wait":        {},
+	"external_resource_wait": {},
+}
+
+// TodoConvergenceVerifier 检查 required todo 是否已经全部收敛到终态。
+type TodoConvergenceVerifier struct{}
+
+// Name 返回 verifier 名称。
+func (TodoConvergenceVerifier) Name() string {
+	return todoConvergenceVerifierName
+}
+
+// VerifyFinal 对 required todo 进行终态收敛验证。
+func (TodoConvergenceVerifier) VerifyFinal(_ context.Context, input FinalVerifyInput) (VerificationResult, error) {
+	totalRequired := 0
+	terminalCount := 0
+	pendingIDs := make([]string, 0)
+	inProgressIDs := make([]string, 0)
+	blockedIDs := make([]string, 0)
+	waitingExternalIDs := make([]string, 0)
+
+	for _, todo := range input.Todos {
+		if !todo.Required {
+			continue
+		}
+		totalRequired++
+		switch strings.ToLower(strings.TrimSpace(todo.Status)) {
+		case "completed", "failed", "canceled":
+			terminalCount++
+		case "pending":
+			pendingIDs = append(pendingIDs, strings.TrimSpace(todo.ID))
+		case "in_progress":
+			inProgressIDs = append(inProgressIDs, strings.TrimSpace(todo.ID))
+		case "blocked":
+			blockedIDs = append(blockedIDs, strings.TrimSpace(todo.ID))
+			reason := strings.ToLower(strings.TrimSpace(todo.BlockedReason))
+			if _, ok := waitingExternalBlockedReasons[reason]; ok {
+				waitingExternalIDs = append(waitingExternalIDs, strings.TrimSpace(todo.ID))
+			}
+		default:
+			pendingIDs = append(pendingIDs, strings.TrimSpace(todo.ID))
+		}
+	}
+
+	evidence := map[string]any{
+		"total_required_todos": totalRequired,
+		"terminal_count":       terminalCount,
+		"pending_ids":          pendingIDs,
+		"in_progress_ids":      inProgressIDs,
+		"blocked_ids":          blockedIDs,
+		"waiting_external_ids": waitingExternalIDs,
+	}
+
+	if totalRequired == 0 || terminalCount == totalRequired {
+		return VerificationResult{
+			Name:     todoConvergenceVerifierName,
+			Status:   VerificationPass,
+			Summary:  "required todos are converged",
+			Reason:   "all required todos are terminal",
+			Evidence: evidence,
+		}, nil
+	}
+
+	if len(waitingExternalIDs) > 0 {
+		return VerificationResult{
+			Name:            todoConvergenceVerifierName,
+			Status:          VerificationHardBlock,
+			Summary:         fmt.Sprintf("%d required todo(s) wait for external input", len(waitingExternalIDs)),
+			Reason:          "required todos are blocked by external dependency",
+			WaitingExternal: true,
+			Evidence:        evidence,
+		}, nil
+	}
+
+	return VerificationResult{
+		Name:     todoConvergenceVerifierName,
+		Status:   VerificationSoftBlock,
+		Summary:  fmt.Sprintf("required todos not converged: terminal=%d/%d", terminalCount, totalRequired),
+		Reason:   "required todos are still pending, in progress, or internally blocked",
+		Evidence: evidence,
+	}, nil
+}

--- a/internal/runtime/verify/todo_convergence_test.go
+++ b/internal/runtime/verify/todo_convergence_test.go
@@ -1,0 +1,78 @@
+package verify
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTodoConvergenceVerifierStates(t *testing.T) {
+	t.Parallel()
+
+	verifier := TodoConvergenceVerifier{}
+
+	t.Run("all terminal required todos pass", func(t *testing.T) {
+		t.Parallel()
+		result, err := verifier.VerifyFinal(context.Background(), FinalVerifyInput{
+			Todos: []TodoSnapshot{
+				{ID: "t1", Status: "completed", Required: true},
+				{ID: "t2", Status: "failed", Required: true},
+				{ID: "t3", Status: "canceled", Required: true},
+			},
+		})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationPass {
+			t.Fatalf("status = %q, want %q", result.Status, VerificationPass)
+		}
+	})
+
+	t.Run("pending and in_progress are soft_block", func(t *testing.T) {
+		t.Parallel()
+		result, err := verifier.VerifyFinal(context.Background(), FinalVerifyInput{
+			Todos: []TodoSnapshot{
+				{ID: "t1", Status: "pending", Required: true},
+				{ID: "t2", Status: "in_progress", Required: true},
+			},
+		})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationSoftBlock {
+			t.Fatalf("status = %q, want %q", result.Status, VerificationSoftBlock)
+		}
+	})
+
+	t.Run("blocked waiting external is hard_block", func(t *testing.T) {
+		t.Parallel()
+		result, err := verifier.VerifyFinal(context.Background(), FinalVerifyInput{
+			Todos: []TodoSnapshot{
+				{ID: "t1", Status: "blocked", Required: true, BlockedReason: "user_input_wait"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationHardBlock {
+			t.Fatalf("status = %q, want %q", result.Status, VerificationHardBlock)
+		}
+		if !result.WaitingExternal {
+			t.Fatalf("expected WaitingExternal=true")
+		}
+	})
+
+	t.Run("optional todo is ignored", func(t *testing.T) {
+		t.Parallel()
+		result, err := verifier.VerifyFinal(context.Background(), FinalVerifyInput{
+			Todos: []TodoSnapshot{
+				{ID: "t1", Status: "pending", Required: false},
+			},
+		})
+		if err != nil {
+			t.Fatalf("VerifyFinal() error = %v", err)
+		}
+		if result.Status != VerificationPass {
+			t.Fatalf("status = %q, want %q", result.Status, VerificationPass)
+		}
+	})
+}

--- a/internal/runtime/verify/typecheck.go
+++ b/internal/runtime/verify/typecheck.go
@@ -1,0 +1,20 @@
+package verify
+
+const (
+	typecheckVerifierName = "typecheck"
+)
+
+// TypecheckVerifier 复用命令执行 verifier，承载类型检查验证语义。
+type TypecheckVerifier struct {
+	CommandSuccessVerifier
+}
+
+// NewTypecheckVerifier 创建 typecheck verifier。
+func NewTypecheckVerifier(executor CommandExecutor) TypecheckVerifier {
+	return TypecheckVerifier{
+		CommandSuccessVerifier: CommandSuccessVerifier{
+			VerifierName: typecheckVerifierName,
+			Executor:     executor,
+		},
+	}
+}

--- a/internal/runtime/verify/types.go
+++ b/internal/runtime/verify/types.go
@@ -1,0 +1,114 @@
+package verify
+
+import (
+	"neo-code/internal/config"
+	"neo-code/internal/runtime/controlplane"
+)
+
+// VerificationStatus 表示单个 verifier 的结构化结果状态。
+type VerificationStatus string
+
+const (
+	// VerificationPass 表示验证通过。
+	VerificationPass VerificationStatus = "pass"
+	// VerificationSoftBlock 表示当前不能收尾，但仍可继续推进。
+	VerificationSoftBlock VerificationStatus = "soft_block"
+	// VerificationHardBlock 表示当前不能收尾且需要外部条件才能继续。
+	VerificationHardBlock VerificationStatus = "hard_block"
+	// VerificationFail 表示验证明确失败。
+	VerificationFail VerificationStatus = "fail"
+)
+
+// ErrorClass 表示验证失败的稳定错误分类。
+type ErrorClass string
+
+const (
+	ErrorClassCompileError     ErrorClass = "compile_error"
+	ErrorClassTestFailure      ErrorClass = "test_failure"
+	ErrorClassLintFailure      ErrorClass = "lint_failure"
+	ErrorClassTypeError        ErrorClass = "type_error"
+	ErrorClassTimeout          ErrorClass = "timeout"
+	ErrorClassPermissionDenied ErrorClass = "permission_denied"
+	ErrorClassEnvMissing       ErrorClass = "env_missing"
+	ErrorClassCommandNotFound  ErrorClass = "command_not_found"
+	ErrorClassUnknown          ErrorClass = "unknown"
+)
+
+// VerificationResult 表示单个 verifier 的输出。
+type VerificationResult struct {
+	Name            string             `json:"name"`
+	Status          VerificationStatus `json:"status"`
+	Summary         string             `json:"summary,omitempty"`
+	Reason          string             `json:"reason,omitempty"`
+	ErrorClass      ErrorClass         `json:"error_class,omitempty"`
+	Retryable       bool               `json:"retryable,omitempty"`
+	WaitingExternal bool               `json:"waiting_external,omitempty"`
+	Evidence        map[string]any     `json:"evidence,omitempty"`
+}
+
+// MessageLike 表示 verifier 所需的消息快照。
+type MessageLike struct {
+	Role    string `json:"role,omitempty"`
+	Content string `json:"content,omitempty"`
+}
+
+// ToolResultLike 表示 verifier 可读取的工具结果快照。
+type ToolResultLike struct {
+	Name    string         `json:"name,omitempty"`
+	Content string         `json:"content,omitempty"`
+	IsError bool           `json:"is_error,omitempty"`
+	Facts   map[string]any `json:"facts,omitempty"`
+}
+
+// TodoSnapshot 表示 verifier 所需的 todo 快照。
+type TodoSnapshot struct {
+	ID            string `json:"id"`
+	Content       string `json:"content,omitempty"`
+	Status        string `json:"status,omitempty"`
+	Required      bool   `json:"required"`
+	BlockedReason string `json:"blocked_reason,omitempty"`
+	RetryCount    int    `json:"retry_count,omitempty"`
+	RetryLimit    int    `json:"retry_limit,omitempty"`
+	FailureReason string `json:"failure_reason,omitempty"`
+}
+
+// RuntimeStateSnapshot 表示 verifier 所需的 runtime 控制面快照。
+type RuntimeStateSnapshot struct {
+	Turn                 int  `json:"turn,omitempty"`
+	MaxTurns             int  `json:"max_turns,omitempty"`
+	MaxTurnsReached      bool `json:"max_turns_reached,omitempty"`
+	FinalInterceptStreak int  `json:"final_intercept_streak,omitempty"`
+}
+
+// FinalVerifyInput 表示一次 final 验证请求的完整输入。
+type FinalVerifyInput struct {
+	SessionID          string                    `json:"session_id,omitempty"`
+	RunID              string                    `json:"run_id,omitempty"`
+	TaskID             string                    `json:"task_id,omitempty"`
+	Workdir            string                    `json:"workdir,omitempty"`
+	Messages           []MessageLike             `json:"messages,omitempty"`
+	Todos              []TodoSnapshot            `json:"todos,omitempty"`
+	LastAssistantFinal string                    `json:"last_assistant_final,omitempty"`
+	ToolResults        []ToolResultLike          `json:"tool_results,omitempty"`
+	RuntimeState       RuntimeStateSnapshot      `json:"runtime_state,omitempty"`
+	Metadata           map[string]any            `json:"metadata,omitempty"`
+	VerificationConfig config.VerificationConfig `json:"verification_config,omitempty"`
+}
+
+// VerificationGateDecision 表示聚合后的 verification gate 决议。
+type VerificationGateDecision struct {
+	Passed  bool                    `json:"passed"`
+	Reason  controlplane.StopReason `json:"reason"`
+	Results []VerificationResult    `json:"results,omitempty"`
+}
+
+// NormalizeResult 规整 verifier 输出，确保状态与错误分类始终可消费。
+func NormalizeResult(result VerificationResult) VerificationResult {
+	if result.Status == "" {
+		result.Status = VerificationFail
+	}
+	if result.ErrorClass == "" {
+		result.ErrorClass = ErrorClassUnknown
+	}
+	return result
+}

--- a/internal/runtime/verify/verifier.go
+++ b/internal/runtime/verify/verifier.go
@@ -1,0 +1,9 @@
+package verify
+
+import "context"
+
+// FinalVerifier 定义 final 验收阶段 verifier 的统一契约。
+type FinalVerifier interface {
+	Name() string
+	VerifyFinal(ctx context.Context, input FinalVerifyInput) (VerificationResult, error)
+}

--- a/internal/runtime/verify/verifier_names_test.go
+++ b/internal/runtime/verify/verifier_names_test.go
@@ -1,0 +1,30 @@
+package verify
+
+import "testing"
+
+func TestVerifierNamesAndConstructors(t *testing.T) {
+	t.Parallel()
+
+	if got := (FileExistsVerifier{}).Name(); got != fileExistsVerifierName {
+		t.Fatalf("FileExistsVerifier.Name() = %q, want %q", got, fileExistsVerifierName)
+	}
+	if got := (ContentMatchVerifier{}).Name(); got != contentMatchVerifierName {
+		t.Fatalf("ContentMatchVerifier.Name() = %q, want %q", got, contentMatchVerifierName)
+	}
+	if got := (TodoConvergenceVerifier{}).Name(); got != todoConvergenceVerifierName {
+		t.Fatalf("TodoConvergenceVerifier.Name() = %q, want %q", got, todoConvergenceVerifierName)
+	}
+
+	if got := NewBuildVerifier(nil).Name(); got != buildVerifierName {
+		t.Fatalf("NewBuildVerifier().Name() = %q, want %q", got, buildVerifierName)
+	}
+	if got := NewTestVerifier(nil).Name(); got != testVerifierName {
+		t.Fatalf("NewTestVerifier().Name() = %q, want %q", got, testVerifierName)
+	}
+	if got := NewLintVerifier(nil).Name(); got != lintVerifierName {
+		t.Fatalf("NewLintVerifier().Name() = %q, want %q", got, lintVerifierName)
+	}
+	if got := NewTypecheckVerifier(nil).Name(); got != typecheckVerifierName {
+		t.Fatalf("NewTypecheckVerifier().Name() = %q, want %q", got, typecheckVerifierName)
+	}
+}

--- a/internal/session/todo.go
+++ b/internal/session/todo.go
@@ -9,7 +9,7 @@ import (
 )
 
 // CurrentTodoVersion 表示当前 Todo 结构版本。
-const CurrentTodoVersion = 4
+const CurrentTodoVersion = 5
 
 // TodoStatus 表示 Todo 项的状态枚举。
 type TodoStatus string
@@ -27,6 +27,22 @@ const (
 	TodoStatusFailed TodoStatus = "failed"
 	// TodoStatusCanceled 表示已取消。
 	TodoStatusCanceled TodoStatus = "canceled"
+)
+
+// TodoBlockedReason 表示 blocked todo 的结构化阻塞原因。
+type TodoBlockedReason string
+
+const (
+	// TodoBlockedReasonInternalDependency 表示被内部依赖阻塞。
+	TodoBlockedReasonInternalDependency TodoBlockedReason = "internal_dependency"
+	// TodoBlockedReasonPermissionWait 表示等待权限审批。
+	TodoBlockedReasonPermissionWait TodoBlockedReason = "permission_wait"
+	// TodoBlockedReasonUserInputWait 表示等待用户补充输入。
+	TodoBlockedReasonUserInputWait TodoBlockedReason = "user_input_wait"
+	// TodoBlockedReasonExternalResourceWait 表示等待外部资源就绪。
+	TodoBlockedReasonExternalResourceWait TodoBlockedReason = "external_resource_wait"
+	// TodoBlockedReasonUnknown 表示未知阻塞原因或旧数据缺省值。
+	TodoBlockedReasonUnknown TodoBlockedReason = "unknown"
 )
 
 const (
@@ -47,29 +63,33 @@ const (
 
 // TodoItem 表示会话级结构化待办项。
 type TodoItem struct {
-	ID            string     `json:"id"`
-	Content       string     `json:"content"`
-	Status        TodoStatus `json:"status"`
-	Dependencies  []string   `json:"dependencies,omitempty"`
-	Priority      int        `json:"priority,omitempty"`
-	Executor      string     `json:"executor,omitempty"`
-	OwnerType     string     `json:"owner_type,omitempty"`
-	OwnerID       string     `json:"owner_id,omitempty"`
-	Acceptance    []string   `json:"acceptance,omitempty"`
-	Artifacts     []string   `json:"artifacts,omitempty"`
-	FailureReason string     `json:"failure_reason,omitempty"`
-	RetryCount    int        `json:"retry_count,omitempty"`
-	RetryLimit    int        `json:"retry_limit,omitempty"`
-	NextRetryAt   time.Time  `json:"next_retry_at,omitempty"`
-	Revision      int64      `json:"revision"`
-	CreatedAt     time.Time  `json:"created_at"`
-	UpdatedAt     time.Time  `json:"updated_at"`
+	ID            string            `json:"id"`
+	Content       string            `json:"content"`
+	Status        TodoStatus        `json:"status"`
+	Required      *bool             `json:"required,omitempty"`
+	BlockedReason TodoBlockedReason `json:"blocked_reason,omitempty"`
+	Dependencies  []string          `json:"dependencies,omitempty"`
+	Priority      int               `json:"priority,omitempty"`
+	Executor      string            `json:"executor,omitempty"`
+	OwnerType     string            `json:"owner_type,omitempty"`
+	OwnerID       string            `json:"owner_id,omitempty"`
+	Acceptance    []string          `json:"acceptance,omitempty"`
+	Artifacts     []string          `json:"artifacts,omitempty"`
+	FailureReason string            `json:"failure_reason,omitempty"`
+	RetryCount    int               `json:"retry_count,omitempty"`
+	RetryLimit    int               `json:"retry_limit,omitempty"`
+	NextRetryAt   time.Time         `json:"next_retry_at,omitempty"`
+	Revision      int64             `json:"revision"`
+	CreatedAt     time.Time         `json:"created_at"`
+	UpdatedAt     time.Time         `json:"updated_at"`
 }
 
 // TodoPatch 表示对 Todo 可选字段的更新补丁。
 type TodoPatch struct {
 	Content       *string
 	Status        *TodoStatus
+	Required      *bool
+	BlockedReason *TodoBlockedReason
 	Dependencies  *[]string
 	Priority      *int
 	Executor      *string
@@ -88,7 +108,28 @@ func (i TodoItem) Clone() TodoItem {
 	i.Dependencies = append([]string(nil), i.Dependencies...)
 	i.Acceptance = append([]string(nil), i.Acceptance...)
 	i.Artifacts = append([]string(nil), i.Artifacts...)
+	if i.Required != nil {
+		required := *i.Required
+		i.Required = &required
+	}
 	return i
+}
+
+// RequiredValue 返回 todo 是否为 required，兼容旧数据缺省值 true。
+func (i TodoItem) RequiredValue() bool {
+	if i.Required == nil {
+		return true
+	}
+	return *i.Required
+}
+
+// BlockedReasonValue 返回 todo 阻塞原因，兼容旧数据缺省值 unknown。
+func (i TodoItem) BlockedReasonValue() TodoBlockedReason {
+	normalized := normalizeTodoBlockedReason(i.BlockedReason)
+	if normalized == "" {
+		return TodoBlockedReasonUnknown
+	}
+	return normalized
 }
 
 // Valid 判断当前状态值是否为受支持状态。
@@ -265,11 +306,13 @@ func (s *Session) UpdateTodo(id string, patch TodoPatch, expectedRevision int64)
 func (s *Session) ClaimTodo(id string, ownerType string, ownerID string, expectedRevision int64) error {
 	status := TodoStatusInProgress
 	failureReason := ""
+	blockedReason := TodoBlockedReasonUnknown
 	nextRetryAt := time.Time{}
 	patch := TodoPatch{
 		Status:        &status,
 		OwnerType:     &ownerType,
 		OwnerID:       &ownerID,
+		BlockedReason: &blockedReason,
 		FailureReason: &failureReason,
 		NextRetryAt:   &nextRetryAt,
 	}
@@ -280,11 +323,13 @@ func (s *Session) ClaimTodo(id string, ownerType string, ownerID string, expecte
 func (s *Session) CompleteTodo(id string, artifacts []string, expectedRevision int64) error {
 	status := TodoStatusCompleted
 	failureReason := ""
+	blockedReason := TodoBlockedReasonUnknown
 	retryCount := 0
 	nextRetryAt := time.Time{}
 	patch := TodoPatch{
 		Status:        &status,
 		Artifacts:     &artifacts,
+		BlockedReason: &blockedReason,
 		FailureReason: &failureReason,
 		RetryCount:    &retryCount,
 		NextRetryAt:   &nextRetryAt,
@@ -295,9 +340,11 @@ func (s *Session) CompleteTodo(id string, artifacts []string, expectedRevision i
 // FailTodo 将 Todo 标记为失败并记录失败原因。
 func (s *Session) FailTodo(id string, reason string, expectedRevision int64) error {
 	status := TodoStatusFailed
+	blockedReason := TodoBlockedReasonUnknown
 	nextRetryAt := time.Time{}
 	patch := TodoPatch{
 		Status:        &status,
+		BlockedReason: &blockedReason,
 		FailureReason: &reason,
 		NextRetryAt:   &nextRetryAt,
 	}
@@ -410,6 +457,11 @@ func normalizeTodoItem(item TodoItem) (TodoItem, error) {
 	if item.Executor == "" {
 		item.Executor = TodoExecutorAgent
 	}
+	item.BlockedReason = normalizeTodoBlockedReason(item.BlockedReason)
+	if item.Required != nil {
+		required := *item.Required
+		item.Required = &required
+	}
 	item.OwnerType = normalizeTodoOwnerType(item.OwnerType)
 	item.OwnerID = strings.TrimSpace(item.OwnerID)
 	item.Acceptance = normalizeTodoTextList(item.Acceptance)
@@ -438,6 +490,8 @@ func normalizeTodoItem(item TodoItem) (TodoItem, error) {
 		return TodoItem{}, fmt.Errorf("session: todo %q content is empty", item.ID)
 	case !item.Status.Valid():
 		return TodoItem{}, fmt.Errorf("session: invalid todo status %q", item.Status)
+	case !isValidTodoBlockedReason(item.BlockedReason):
+		return TodoItem{}, fmt.Errorf("session: invalid todo blocked_reason %q", item.BlockedReason)
 	case !isValidTodoExecutor(item.Executor):
 		return TodoItem{}, fmt.Errorf("session: invalid todo executor %q", item.Executor)
 	case !isValidTodoOwnerType(item.OwnerType):
@@ -446,6 +500,13 @@ func normalizeTodoItem(item TodoItem) (TodoItem, error) {
 
 	if item.Status != TodoStatusFailed && item.Status != TodoStatusPending && item.Status != TodoStatusBlocked {
 		item.FailureReason = ""
+	}
+	if item.Status != TodoStatusBlocked {
+		item.BlockedReason = TodoBlockedReasonUnknown
+	}
+	if item.Required == nil {
+		defaultRequired := true
+		item.Required = &defaultRequired
 	}
 	if item.Status != TodoStatusPending && item.Status != TodoStatusFailed {
 		item.NextRetryAt = time.Time{}
@@ -541,6 +602,14 @@ func applyTodoPatch(item TodoItem, patch TodoPatch) (TodoItem, error) {
 	if patch.Dependencies != nil {
 		next.Dependencies = normalizeTodoDependencies(*patch.Dependencies)
 	}
+	if patch.Required != nil {
+		required := *patch.Required
+		next.Required = &required
+	}
+	if patch.BlockedReason != nil {
+		reason := normalizeTodoBlockedReason(*patch.BlockedReason)
+		next.BlockedReason = reason
+	}
 	if patch.Priority != nil {
 		next.Priority = *patch.Priority
 	}
@@ -587,6 +656,29 @@ func applyTodoPatch(item TodoItem, patch TodoPatch) (TodoItem, error) {
 		return TodoItem{}, err
 	}
 	return normalized, nil
+}
+
+// normalizeTodoBlockedReason 规整 blocked_reason 字段并提供 unknown 缺省语义。
+func normalizeTodoBlockedReason(reason TodoBlockedReason) TodoBlockedReason {
+	normalized := strings.ToLower(strings.TrimSpace(string(reason)))
+	if normalized == "" {
+		return TodoBlockedReasonUnknown
+	}
+	return TodoBlockedReason(normalized)
+}
+
+// isValidTodoBlockedReason 判断 blocked_reason 是否受支持。
+func isValidTodoBlockedReason(reason TodoBlockedReason) bool {
+	switch normalizeTodoBlockedReason(reason) {
+	case TodoBlockedReasonInternalDependency,
+		TodoBlockedReasonPermissionWait,
+		TodoBlockedReasonUserInputWait,
+		TodoBlockedReasonExternalResourceWait,
+		TodoBlockedReasonUnknown:
+		return true
+	default:
+		return false
+	}
 }
 
 // normalizeTodoOwnerType 规范化 owner_type 字段。

--- a/internal/session/todo_compatibility_test.go
+++ b/internal/session/todo_compatibility_test.go
@@ -1,0 +1,67 @@
+package session
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTodoCompatibilityDefaultsForLegacyFields(t *testing.T) {
+	t.Parallel()
+
+	var todos []TodoItem
+	if err := json.Unmarshal([]byte(`[
+		{"id":"todo-1","content":"legacy","status":"blocked"},
+		{"id":"todo-2","content":"legacy2","status":"pending"}
+	]`), &todos); err != nil {
+		t.Fatalf("unmarshal todos: %v", err)
+	}
+
+	normalized, err := normalizeAndValidateTodos(todos)
+	if err != nil {
+		t.Fatalf("normalizeAndValidateTodos() error = %v", err)
+	}
+	if len(normalized) != 2 {
+		t.Fatalf("normalized len = %d, want 2", len(normalized))
+	}
+	if !normalized[0].RequiredValue() || !normalized[1].RequiredValue() {
+		t.Fatalf("legacy missing required should default to true, got %+v", normalized)
+	}
+	if normalized[0].BlockedReasonValue() != TodoBlockedReasonUnknown {
+		t.Fatalf("legacy missing blocked_reason should default unknown, got %q", normalized[0].BlockedReasonValue())
+	}
+}
+
+func TestTodoOptionalAndBlockedReasonPatch(t *testing.T) {
+	t.Parallel()
+
+	session := New("compat")
+	if err := session.AddTodo(TodoItem{
+		ID:      "todo-1",
+		Content: "optional task",
+	}); err != nil {
+		t.Fatalf("AddTodo() error = %v", err)
+	}
+	item, ok := session.FindTodo("todo-1")
+	if !ok {
+		t.Fatalf("FindTodo() not found")
+	}
+
+	required := false
+	blocked := TodoBlockedReasonUserInputWait
+	status := TodoStatusBlocked
+	if err := session.UpdateTodo("todo-1", TodoPatch{
+		Required:      &required,
+		BlockedReason: &blocked,
+		Status:        &status,
+	}, item.Revision); err != nil {
+		t.Fatalf("UpdateTodo() error = %v", err)
+	}
+
+	updated, _ := session.FindTodo("todo-1")
+	if updated.RequiredValue() {
+		t.Fatalf("expected optional todo (required=false), got %+v", updated)
+	}
+	if updated.BlockedReasonValue() != TodoBlockedReasonUserInputWait {
+		t.Fatalf("blocked_reason = %q, want %q", updated.BlockedReasonValue(), TodoBlockedReasonUserInputWait)
+	}
+}

--- a/internal/tools/todo/common.go
+++ b/internal/tools/todo/common.go
@@ -58,16 +58,18 @@ type writeInput struct {
 }
 
 type todoPatchInput struct {
-	Content       *string                  `json:"content,omitempty"`
-	Status        *agentsession.TodoStatus `json:"status,omitempty"`
-	Dependencies  *[]string                `json:"dependencies,omitempty"`
-	Priority      *int                     `json:"priority,omitempty"`
-	Executor      *string                  `json:"executor,omitempty"`
-	OwnerType     *string                  `json:"owner_type,omitempty"`
-	OwnerID       *string                  `json:"owner_id,omitempty"`
-	Acceptance    *[]string                `json:"acceptance,omitempty"`
-	Artifacts     *[]string                `json:"artifacts,omitempty"`
-	FailureReason *string                  `json:"failure_reason,omitempty"`
+	Content       *string                         `json:"content,omitempty"`
+	Status        *agentsession.TodoStatus        `json:"status,omitempty"`
+	Required      *bool                           `json:"required,omitempty"`
+	BlockedReason *agentsession.TodoBlockedReason `json:"blocked_reason,omitempty"`
+	Dependencies  *[]string                       `json:"dependencies,omitempty"`
+	Priority      *int                            `json:"priority,omitempty"`
+	Executor      *string                         `json:"executor,omitempty"`
+	OwnerType     *string                         `json:"owner_type,omitempty"`
+	OwnerID       *string                         `json:"owner_id,omitempty"`
+	Acceptance    *[]string                       `json:"acceptance,omitempty"`
+	Artifacts     *[]string                       `json:"artifacts,omitempty"`
+	FailureReason *string                         `json:"failure_reason,omitempty"`
 }
 
 func (p *todoPatchInput) toSessionPatch() agentsession.TodoPatch {
@@ -77,6 +79,8 @@ func (p *todoPatchInput) toSessionPatch() agentsession.TodoPatch {
 	return agentsession.TodoPatch{
 		Content:       p.Content,
 		Status:        p.Status,
+		Required:      p.Required,
+		BlockedReason: p.BlockedReason,
 		Dependencies:  p.Dependencies,
 		Priority:      p.Priority,
 		Executor:      p.Executor,
@@ -172,6 +176,7 @@ func normalizeWriteInputObject(payload map[string]any) {
 func normalizeTodoPatchObject(payload map[string]any) {
 	normalizeStringField(payload, "content")
 	normalizeStringField(payload, "status")
+	normalizeStringField(payload, "blocked_reason")
 	normalizeStringField(payload, "executor")
 	normalizeStringField(payload, "owner_type")
 	normalizeStringField(payload, "owner_id")
@@ -186,6 +191,7 @@ func normalizeTodoItemObject(payload map[string]any) {
 	normalizeStringField(payload, "id")
 	normalizeStringField(payload, "content")
 	normalizeStringField(payload, "status")
+	normalizeStringField(payload, "blocked_reason")
 	normalizeStringField(payload, "executor")
 	normalizeStringField(payload, "owner_type")
 	normalizeStringField(payload, "owner_id")
@@ -381,6 +387,7 @@ func ensureTodoWriteItemLength(field string, item agentsession.TodoItem) error {
 	}{
 		{field: field + ".id", value: item.ID},
 		{field: field + ".content", value: item.Content},
+		{field: field + ".blocked_reason", value: string(item.BlockedReason)},
 		{field: field + ".executor", value: item.Executor},
 		{field: field + ".owner_type", value: item.OwnerType},
 		{field: field + ".owner_id", value: item.OwnerID},
@@ -407,6 +414,11 @@ func ensureTodoWriteItemLength(field string, item agentsession.TodoItem) error {
 func ensureTodoWritePatchLength(patch todoPatchInput) error {
 	if patch.Content != nil {
 		if err := ensureTodoWriteTextLength("patch.content", *patch.Content); err != nil {
+			return err
+		}
+	}
+	if patch.BlockedReason != nil {
+		if err := ensureTodoWriteTextLength("patch.blocked_reason", string(*patch.BlockedReason)); err != nil {
 			return err
 		}
 	}

--- a/internal/tools/todo/write.go
+++ b/internal/tools/todo/write.go
@@ -38,6 +38,13 @@ func (t *Tool) Schema() map[string]any {
 		string(agentsession.TodoStatusFailed),
 		string(agentsession.TodoStatusCanceled),
 	}
+	blockedReasonEnum := []string{
+		string(agentsession.TodoBlockedReasonInternalDependency),
+		string(agentsession.TodoBlockedReasonPermissionWait),
+		string(agentsession.TodoBlockedReasonUserInputWait),
+		string(agentsession.TodoBlockedReasonExternalResourceWait),
+		string(agentsession.TodoBlockedReasonUnknown),
+	}
 
 	todoItemSchema := map[string]any{
 		"type": "object",
@@ -51,6 +58,13 @@ func (t *Tool) Schema() map[string]any {
 			"status": map[string]any{
 				"type": "string",
 				"enum": statusEnum,
+			},
+			"required": map[string]any{
+				"type": "boolean",
+			},
+			"blocked_reason": map[string]any{
+				"type": "string",
+				"enum": blockedReasonEnum,
 			},
 			"dependencies": map[string]any{
 				"type": "array",
@@ -133,6 +147,13 @@ func (t *Tool) Schema() map[string]any {
 					"status": map[string]any{
 						"type": "string",
 						"enum": statusEnum,
+					},
+					"required": map[string]any{
+						"type": "boolean",
+					},
+					"blocked_reason": map[string]any{
+						"type": "string",
+						"enum": blockedReasonEnum,
 					},
 					"dependencies": map[string]any{
 						"type": "array",

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -1506,14 +1506,49 @@ func runtimeEventStopReasonDecidedHandler(a *App, event tuiservices.RuntimeEvent
 
 	reason := strings.ToLower(strings.TrimSpace(string(payload.Reason)))
 	switch reason {
+	case "stop_completed":
+		reason = strings.ToLower(string(tuiservices.StopReasonAccepted))
+	case "stop_user_interrupt":
+		reason = strings.ToLower(string(tuiservices.StopReasonUserInterrupt))
+	case "stop_fatal_error":
+		reason = strings.ToLower(string(tuiservices.StopReasonFatalError))
+	case "stop_max_turns_reached":
+		reason = strings.ToLower(string(tuiservices.StopReasonMaxTurnExceeded))
+	case "stop_budget_exceeded":
+		reason = strings.ToLower(string(tuiservices.StopReasonBudgetExceeded))
+	}
+	switch reason {
 	case strings.ToLower(string(tuiservices.StopReasonCompleted)):
 		if strings.TrimSpace(a.state.ExecutionError) == "" {
 			a.state.StatusText = statusReady
 		}
+	case strings.ToLower(string(tuiservices.StopReasonTodoNotConverged)),
+		strings.ToLower(string(tuiservices.StopReasonTodoWaitingExternal)),
+		strings.ToLower(string(tuiservices.StopReasonNoProgressAfterFinalIntercept)),
+		strings.ToLower(string(tuiservices.StopReasonMaxTurnExceededWithUnconvergedTodos)),
+		strings.ToLower(string(tuiservices.StopReasonMaxTurnExceededWithFailedVerification)):
+		detail := strings.TrimSpace(payload.Detail)
+		if detail == "" {
+			detail = "Task is incomplete"
+		}
+		a.state.ExecutionError = ""
+		a.state.StatusText = detail
+		a.appendActivity("run", "Run incomplete", detail, false)
 	case strings.ToLower(string(tuiservices.StopReasonUserInterrupt)):
 		a.state.ExecutionError = ""
 		a.state.StatusText = statusCanceled
 		a.appendActivity("run", "Canceled current run", "", false)
+	case strings.ToLower(string(tuiservices.StopReasonRetryExhausted)),
+		strings.ToLower(string(tuiservices.StopReasonVerificationFailed)),
+		strings.ToLower(string(tuiservices.StopReasonVerificationExecutionDenied)),
+		strings.ToLower(string(tuiservices.StopReasonVerificationExecutionError)):
+		detail := strings.TrimSpace(payload.Detail)
+		if detail == "" {
+			detail = "Verification failed"
+		}
+		a.state.ExecutionError = detail
+		a.state.StatusText = detail
+		a.appendActivity("run", "Verification failed", detail, true)
 	case strings.ToLower(string(tuiservices.StopReasonBudgetExceeded)):
 		detail := strings.TrimSpace(payload.Detail)
 		if detail == "" {

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -1467,6 +1467,12 @@ var runtimeEventHandlerRegistry = map[tuiservices.EventType]func(*App, tuiservic
 	tuiservices.EventCompactError:                             runtimeEventCompactErrorHandler,
 	tuiservices.EventTokenUsage:                               runtimeEventTokenUsageHandler,
 	tuiservices.EventPhaseChanged:                             runtimeEventPhaseChangedHandler,
+	tuiservices.EventVerificationStarted:                      runtimeEventVerificationStartedHandler,
+	tuiservices.EventVerificationStageFinished:                runtimeEventVerificationStageFinishedHandler,
+	tuiservices.EventVerificationFinished:                     runtimeEventVerificationFinishedHandler,
+	tuiservices.EventVerificationCompleted:                    runtimeEventVerificationCompletedHandler,
+	tuiservices.EventVerificationFailed:                       runtimeEventVerificationFailedHandler,
+	tuiservices.EventAcceptanceDecided:                        runtimeEventAcceptanceDecidedHandler,
 	tuiservices.EventStopReasonDecided:                        runtimeEventStopReasonDecidedHandler,
 	tuiservices.EventTodoUpdated:                              runtimeEventTodoUpdatedHandler,
 	tuiservices.EventTodoConflict:                             runtimeEventTodoConflictHandler,
@@ -1488,6 +1494,112 @@ func runtimeEventPhaseChangedHandler(a *App, event tuiservices.RuntimeEvent) boo
 	case "verify":
 		a.setRunProgress(0.82, "Verifying")
 	}
+	return false
+}
+
+// runtimeEventVerificationStartedHandler 处理验证流程开始事件并更新运行进度提示。
+func runtimeEventVerificationStartedHandler(a *App, event tuiservices.RuntimeEvent) bool {
+	payload, ok := event.Payload.(tuiservices.VerificationStartedPayload)
+	if !ok {
+		return false
+	}
+	progress := 0.84
+	if payload.CompletionPassed {
+		progress = 0.88
+	}
+	a.setRunProgress(progress, "Verifying acceptance")
+	a.appendActivity("verify", "Verification started", fmt.Sprintf("completion_passed=%t", payload.CompletionPassed), false)
+	return false
+}
+
+// runtimeEventVerificationStageFinishedHandler 处理单个 verifier 阶段完成事件。
+func runtimeEventVerificationStageFinishedHandler(a *App, event tuiservices.RuntimeEvent) bool {
+	payload, ok := event.Payload.(tuiservices.VerificationStageFinishedPayload)
+	if !ok {
+		return false
+	}
+	status := strings.ToLower(strings.TrimSpace(payload.Status))
+	detail := strings.TrimSpace(payload.Summary)
+	if detail == "" {
+		detail = strings.TrimSpace(payload.Reason)
+	}
+	if detail == "" {
+		detail = "no summary"
+	}
+	title := "Verifier stage finished"
+	if name := strings.TrimSpace(payload.Name); name != "" {
+		title = "Verifier stage: " + name
+	}
+	isError := status == "fail" || status == "hard_block"
+	a.appendActivity("verify", title, detail, isError)
+	return false
+}
+
+// runtimeEventVerificationFinishedHandler 处理验证总流程结束事件。
+func runtimeEventVerificationFinishedHandler(a *App, event tuiservices.RuntimeEvent) bool {
+	payload, ok := event.Payload.(tuiservices.VerificationFinishedPayload)
+	if !ok {
+		return false
+	}
+	a.setRunProgress(0.92, "Verification finished")
+	detail := fmt.Sprintf("acceptance=%s stop_reason=%s", payload.AcceptanceStatus, payload.StopReason)
+	a.appendActivity("verify", "Verification finished", detail, false)
+	return false
+}
+
+// runtimeEventVerificationCompletedHandler 处理验证通过事件。
+func runtimeEventVerificationCompletedHandler(a *App, event tuiservices.RuntimeEvent) bool {
+	payload, ok := event.Payload.(tuiservices.VerificationCompletedPayload)
+	if !ok {
+		return false
+	}
+	detail := strings.TrimSpace(string(payload.StopReason))
+	if detail == "" {
+		detail = "accepted"
+	}
+	a.appendActivity("verify", "Verification completed", detail, false)
+	return false
+}
+
+// runtimeEventVerificationFailedHandler 处理验证失败事件。
+func runtimeEventVerificationFailedHandler(a *App, event tuiservices.RuntimeEvent) bool {
+	payload, ok := event.Payload.(tuiservices.VerificationFailedPayload)
+	if !ok {
+		return false
+	}
+	detail := strings.TrimSpace(string(payload.StopReason))
+	if detail == "" {
+		detail = "verification_failed"
+	}
+	if class := strings.TrimSpace(string(payload.ErrorClass)); class != "" {
+		detail = detail + " (" + class + ")"
+	}
+	a.appendActivity("verify", "Verification failed", detail, true)
+	return false
+}
+
+// runtimeEventAcceptanceDecidedHandler 处理 acceptance 决策事件并记录可观测日志。
+func runtimeEventAcceptanceDecidedHandler(a *App, event tuiservices.RuntimeEvent) bool {
+	payload, ok := event.Payload.(tuiservices.AcceptanceDecidedPayload)
+	if !ok {
+		return false
+	}
+	status := strings.TrimSpace(payload.Status)
+	if status == "" {
+		status = "unknown"
+	}
+	detail := strings.TrimSpace(payload.UserVisibleSummary)
+	if detail == "" {
+		detail = strings.TrimSpace(payload.InternalSummary)
+	}
+	if detail == "" {
+		detail = strings.TrimSpace(payload.ContinueHint)
+	}
+	if detail == "" {
+		detail = "acceptance decision generated"
+	}
+	isError := strings.EqualFold(status, "failed")
+	a.appendActivity("acceptance", "Acceptance decided ("+status+")", detail, isError)
 	return false
 }
 
@@ -1522,6 +1634,14 @@ func runtimeEventStopReasonDecidedHandler(a *App, event tuiservices.RuntimeEvent
 		if strings.TrimSpace(a.state.ExecutionError) == "" {
 			a.state.StatusText = statusReady
 		}
+	case strings.ToLower(string(tuiservices.StopReasonCompatibilityFallback)):
+		detail := strings.TrimSpace(payload.Detail)
+		if detail == "" {
+			detail = "Completed via compatibility fallback"
+		}
+		a.state.ExecutionError = ""
+		a.state.StatusText = detail
+		a.appendActivity("run", "Run completed (compatibility fallback)", detail, false)
 	case strings.ToLower(string(tuiservices.StopReasonTodoNotConverged)),
 		strings.ToLower(string(tuiservices.StopReasonTodoWaitingExternal)),
 		strings.ToLower(string(tuiservices.StopReasonNoProgressAfterFinalIntercept)),

--- a/internal/tui/core/app/update_runtime_events_test.go
+++ b/internal/tui/core/app/update_runtime_events_test.go
@@ -293,6 +293,102 @@ func TestRuntimeEventMultimodalHandlers(t *testing.T) {
 	}
 }
 
+func TestRuntimeEventVerificationAndAcceptanceHandlers(t *testing.T) {
+	t.Parallel()
+
+	app, _ := newTestApp(t)
+
+	if handled := runtimeEventVerificationStartedHandler(&app, agentruntime.RuntimeEvent{Payload: "bad"}); handled {
+		t.Fatalf("expected invalid verification_started payload to return false")
+	}
+	runtimeEventVerificationStartedHandler(&app, agentruntime.RuntimeEvent{
+		Payload: agentruntime.VerificationStartedPayload{CompletionPassed: false},
+	})
+	if !app.runProgressKnown || app.runProgressValue != 0.84 || app.runProgressLabel != "Verifying acceptance" {
+		t.Fatalf("unexpected progress after verification_started: known=%v value=%v label=%q", app.runProgressKnown, app.runProgressValue, app.runProgressLabel)
+	}
+	if len(app.activities) == 0 || app.activities[len(app.activities)-1].Title != "Verification started" {
+		t.Fatalf("expected verification started activity, got %+v", app.activities)
+	}
+
+	runtimeEventVerificationStartedHandler(&app, agentruntime.RuntimeEvent{
+		Payload: agentruntime.VerificationStartedPayload{CompletionPassed: true},
+	})
+	if app.runProgressValue != 0.88 {
+		t.Fatalf("progress value = %v, want 0.88 when completion passed", app.runProgressValue)
+	}
+
+	if handled := runtimeEventVerificationStageFinishedHandler(&app, agentruntime.RuntimeEvent{Payload: 1}); handled {
+		t.Fatalf("expected invalid stage payload to return false")
+	}
+	runtimeEventVerificationStageFinishedHandler(&app, agentruntime.RuntimeEvent{
+		Payload: agentruntime.VerificationStageFinishedPayload{
+			Name:    "git_diff",
+			Status:  "fail",
+			Summary: "",
+			Reason:  "",
+		},
+	})
+	stage := app.activities[len(app.activities)-1]
+	if stage.Title != "Verifier stage: git_diff" || stage.Detail != "no summary" || !stage.IsError {
+		t.Fatalf("unexpected stage activity: %+v", stage)
+	}
+
+	if handled := runtimeEventVerificationFinishedHandler(&app, agentruntime.RuntimeEvent{Payload: true}); handled {
+		t.Fatalf("expected invalid verification_finished payload to return false")
+	}
+	runtimeEventVerificationFinishedHandler(&app, agentruntime.RuntimeEvent{
+		Payload: agentruntime.VerificationFinishedPayload{
+			AcceptanceStatus: "accepted",
+			StopReason:       agentruntime.StopReasonAccepted,
+		},
+	})
+	if app.runProgressValue != 0.92 || app.runProgressLabel != "Verification finished" {
+		t.Fatalf("unexpected progress after verification_finished: value=%v label=%q", app.runProgressValue, app.runProgressLabel)
+	}
+
+	if handled := runtimeEventVerificationCompletedHandler(&app, agentruntime.RuntimeEvent{Payload: 1}); handled {
+		t.Fatalf("expected invalid verification_completed payload to return false")
+	}
+	runtimeEventVerificationCompletedHandler(&app, agentruntime.RuntimeEvent{
+		Payload: agentruntime.VerificationCompletedPayload{},
+	})
+	completed := app.activities[len(app.activities)-1]
+	if completed.Title != "Verification completed" || completed.Detail != "accepted" || completed.IsError {
+		t.Fatalf("unexpected completed activity: %+v", completed)
+	}
+
+	if handled := runtimeEventVerificationFailedHandler(&app, agentruntime.RuntimeEvent{Payload: 1}); handled {
+		t.Fatalf("expected invalid verification_failed payload to return false")
+	}
+	runtimeEventVerificationFailedHandler(&app, agentruntime.RuntimeEvent{
+		Payload: agentruntime.VerificationFailedPayload{
+			StopReason: agentruntime.StopReasonVerificationFailed,
+			ErrorClass: "test_failure",
+		},
+	})
+	failed := app.activities[len(app.activities)-1]
+	if failed.Title != "Verification failed" || !strings.Contains(failed.Detail, "test_failure") || !failed.IsError {
+		t.Fatalf("unexpected failed activity: %+v", failed)
+	}
+
+	if handled := runtimeEventAcceptanceDecidedHandler(&app, agentruntime.RuntimeEvent{Payload: nil}); handled {
+		t.Fatalf("expected invalid acceptance payload to return false")
+	}
+	runtimeEventAcceptanceDecidedHandler(&app, agentruntime.RuntimeEvent{
+		Payload: agentruntime.AcceptanceDecidedPayload{
+			Status:             "failed",
+			UserVisibleSummary: "",
+			InternalSummary:    "",
+			ContinueHint:       "provide missing files",
+		},
+	})
+	acceptance := app.activities[len(app.activities)-1]
+	if acceptance.Title != "Acceptance decided (failed)" || acceptance.Detail != "provide missing files" || !acceptance.IsError {
+		t.Fatalf("unexpected acceptance activity: %+v", acceptance)
+	}
+}
+
 func TestHandleRuntimeEventRoutesByRegistryWithoutBindingTransientSession(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/core/app/update_runtime_events_test.go
+++ b/internal/tui/core/app/update_runtime_events_test.go
@@ -140,6 +140,13 @@ func TestRuntimeEventStopReasonDecidedHandlerBranches(t *testing.T) {
 	}
 
 	runtimeEventStopReasonDecidedHandler(&app, agentruntime.RuntimeEvent{
+		Payload: agentruntime.StopReasonDecidedPayload{Reason: agentruntime.StopReasonCompatibilityFallback},
+	})
+	if app.state.ExecutionError != "" || app.state.StatusText != "Completed via compatibility fallback" {
+		t.Fatalf("expected compatibility fallback to be non-error, got status=%q err=%q", app.state.StatusText, app.state.ExecutionError)
+	}
+
+	runtimeEventStopReasonDecidedHandler(&app, agentruntime.RuntimeEvent{
 		Payload: agentruntime.StopReasonDecidedPayload{Reason: agentruntime.StopReason("STOP_UNKNOWN")},
 	})
 	if !strings.Contains(app.state.ExecutionError, "unknown stop reason") {
@@ -170,6 +177,24 @@ func TestRuntimeEventHandlerRegistryContainsRenamedEvents(t *testing.T) {
 	}
 	if _, ok := runtimeEventHandlerRegistry[agentruntime.EventSkillMissing]; !ok {
 		t.Fatalf("expected skill_missing handler to be registered")
+	}
+	if _, ok := runtimeEventHandlerRegistry[agentruntime.EventVerificationStarted]; !ok {
+		t.Fatalf("expected verification_started handler to be registered")
+	}
+	if _, ok := runtimeEventHandlerRegistry[agentruntime.EventVerificationStageFinished]; !ok {
+		t.Fatalf("expected verification_stage_finished handler to be registered")
+	}
+	if _, ok := runtimeEventHandlerRegistry[agentruntime.EventVerificationFinished]; !ok {
+		t.Fatalf("expected verification_finished handler to be registered")
+	}
+	if _, ok := runtimeEventHandlerRegistry[agentruntime.EventVerificationCompleted]; !ok {
+		t.Fatalf("expected verification_completed handler to be registered")
+	}
+	if _, ok := runtimeEventHandlerRegistry[agentruntime.EventVerificationFailed]; !ok {
+		t.Fatalf("expected verification_failed handler to be registered")
+	}
+	if _, ok := runtimeEventHandlerRegistry[agentruntime.EventAcceptanceDecided]; !ok {
+		t.Fatalf("expected acceptance_decided handler to be registered")
 	}
 }
 

--- a/internal/tui/services/gateway_stream_client.go
+++ b/internal/tui/services/gateway_stream_client.go
@@ -215,6 +215,18 @@ func restoreRuntimePayload(eventType EventType, payload any) (any, error) {
 		return decodeRuntimePayload[PhaseChangedPayload](payload)
 	case EventStopReasonDecided:
 		return decodeStopReasonPayload(payload)
+	case EventVerificationStarted:
+		return decodeRuntimePayload[VerificationStartedPayload](payload)
+	case EventVerificationStageFinished:
+		return decodeRuntimePayload[VerificationStageFinishedPayload](payload)
+	case EventVerificationFinished:
+		return decodeRuntimePayload[VerificationFinishedPayload](payload)
+	case EventVerificationCompleted:
+		return decodeRuntimePayload[VerificationCompletedPayload](payload)
+	case EventVerificationFailed:
+		return decodeRuntimePayload[VerificationFailedPayload](payload)
+	case EventAcceptanceDecided:
+		return decodeRuntimePayload[AcceptanceDecidedPayload](payload)
 	case EventInputNormalized:
 		return decodeRuntimePayload[InputNormalizedPayload](payload)
 	case EventAssetSaved:
@@ -242,8 +254,27 @@ func decodeStopReasonPayload(payload any) (StopReasonDecidedPayload, error) {
 	if err != nil {
 		return StopReasonDecidedPayload{}, err
 	}
-	decoded.Reason = StopReason(strings.TrimSpace(string(decoded.Reason)))
+	decoded.Reason = normalizeStopReasonCompatibility(decoded.Reason)
 	return decoded, nil
+}
+
+// normalizeStopReasonCompatibility 统一兼容 runtime 新旧 stop reason 枚举值。
+func normalizeStopReasonCompatibility(reason StopReason) StopReason {
+	normalized := strings.ToLower(strings.TrimSpace(string(reason)))
+	switch normalized {
+	case "stop_completed":
+		return StopReasonAccepted
+	case "stop_user_interrupt":
+		return StopReasonUserInterrupt
+	case "stop_fatal_error":
+		return StopReasonFatalError
+	case "stop_max_turns_reached":
+		return StopReasonMaxTurnExceeded
+	case "stop_budget_exceeded":
+		return StopReasonBudgetExceeded
+	default:
+		return StopReason(normalized)
+	}
 }
 
 // decodeStringPayload 兼容字符串类事件 payload 解码。

--- a/internal/tui/services/runtime_contract.go
+++ b/internal/tui/services/runtime_contract.go
@@ -185,22 +185,91 @@ type PhaseChangedPayload struct {
 type StopReason string
 
 const (
-	// StopReasonCompleted 表示 runtime 当前协议中的正常完成原因。
-	StopReasonCompleted StopReason = "STOP_COMPLETED"
 	// StopReasonUserInterrupt 表示 runtime 当前协议中的用户中断原因。
-	StopReasonUserInterrupt StopReason = "STOP_USER_INTERRUPT"
+	StopReasonUserInterrupt StopReason = "user_interrupt"
 	// StopReasonFatalError 表示 runtime 当前协议中的不可恢复错误原因。
-	StopReasonFatalError StopReason = "STOP_FATAL_ERROR"
-	// StopReasonMaxTurnsReached 表示 runtime 达到最大轮次上限后的受控停止原因。
-	StopReasonMaxTurnsReached StopReason = "STOP_MAX_TURNS_REACHED"
+	StopReasonFatalError StopReason = "fatal_error"
 	// StopReasonBudgetExceeded 表示 runtime 当前协议中的预算超限停止原因。
-	StopReasonBudgetExceeded StopReason = "STOP_BUDGET_EXCEEDED"
+	StopReasonBudgetExceeded StopReason = "budget_exceeded"
+	// StopReasonMaxTurnExceeded 表示 runtime 达到最大轮次上限后的受控停止原因。
+	StopReasonMaxTurnExceeded StopReason = "max_turn_exceeded"
+	// StopReasonRetryExhausted 表示 todo 重试耗尽。
+	StopReasonRetryExhausted StopReason = "retry_exhausted"
+	// StopReasonVerificationFailed 表示验证失败。
+	StopReasonVerificationFailed StopReason = "verification_failed"
+	// StopReasonAccepted 表示双门控通过并被 acceptance 接受。
+	StopReasonAccepted StopReason = "accepted"
+	// StopReasonTodoNotConverged 表示 required todo 未收敛。
+	StopReasonTodoNotConverged StopReason = "todo_not_converged"
+	// StopReasonTodoWaitingExternal 表示 todo 等待外部输入。
+	StopReasonTodoWaitingExternal StopReason = "todo_waiting_external"
+	// StopReasonNoProgressAfterFinalIntercept 表示 final 被拦截后长期无进展。
+	StopReasonNoProgressAfterFinalIntercept StopReason = "no_progress_after_final_intercept"
+	// StopReasonMaxTurnExceededWithUnconvergedTodos 表示 max turn + todo 未收敛。
+	StopReasonMaxTurnExceededWithUnconvergedTodos StopReason = "max_turn_exceeded_with_unconverged_todos"
+	// StopReasonMaxTurnExceededWithFailedVerification 表示 max turn + verification 失败。
+	StopReasonMaxTurnExceededWithFailedVerification StopReason = "max_turn_exceeded_with_failed_verification"
+	// StopReasonVerificationConfigMissing 表示 verification 必需配置缺失。
+	StopReasonVerificationConfigMissing StopReason = "verification_config_missing"
+	// StopReasonVerificationExecutionDenied 表示 verification 命令被策略拒绝。
+	StopReasonVerificationExecutionDenied StopReason = "verification_execution_denied"
+	// StopReasonVerificationExecutionError 表示 verification 命令执行异常。
+	StopReasonVerificationExecutionError StopReason = "verification_execution_error"
+	// StopReasonCompatibilityFallback 表示走兼容回退路径。
+	StopReasonCompatibilityFallback StopReason = "compatibility_fallback"
+
+	// StopReasonCompleted 兼容旧命名，等价 accepted。
+	StopReasonCompleted StopReason = StopReasonAccepted
+	// StopReasonMaxTurnsReached 兼容旧命名，等价 max_turn_exceeded。
+	StopReasonMaxTurnsReached StopReason = StopReasonMaxTurnExceeded
 )
 
 // StopReasonDecidedPayload 描述停止原因决策结果。
 type StopReasonDecidedPayload struct {
 	Reason StopReason `json:"reason"`
 	Detail string     `json:"detail,omitempty"`
+}
+
+// VerificationStartedPayload 描述 final 验证阶段开始。
+type VerificationStartedPayload struct {
+	CompletionPassed bool `json:"completion_passed"`
+}
+
+// VerificationStageFinishedPayload 描述单个 verifier 阶段结果。
+type VerificationStageFinishedPayload struct {
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Summary    string `json:"summary,omitempty"`
+	Reason     string `json:"reason,omitempty"`
+	ErrorClass string `json:"error_class,omitempty"`
+}
+
+// VerificationFinishedPayload 描述验证流程结束结果。
+type VerificationFinishedPayload struct {
+	AcceptanceStatus string     `json:"acceptance_status"`
+	StopReason       StopReason `json:"stop_reason,omitempty"`
+	ErrorClass       string     `json:"error_class,omitempty"`
+}
+
+// VerificationCompletedPayload 描述验证通过并可完成。
+type VerificationCompletedPayload struct {
+	StopReason StopReason `json:"stop_reason,omitempty"`
+}
+
+// VerificationFailedPayload 描述验证失败信息。
+type VerificationFailedPayload struct {
+	StopReason StopReason `json:"stop_reason,omitempty"`
+	ErrorClass string     `json:"error_class,omitempty"`
+}
+
+// AcceptanceDecidedPayload 描述 acceptance 引擎输出。
+type AcceptanceDecidedPayload struct {
+	Status             string     `json:"status"`
+	StopReason         StopReason `json:"stop_reason,omitempty"`
+	ErrorClass         string     `json:"error_class,omitempty"`
+	UserVisibleSummary string     `json:"user_visible_summary,omitempty"`
+	InternalSummary    string     `json:"internal_summary,omitempty"`
+	ContinueHint       string     `json:"continue_hint,omitempty"`
 }
 
 // TokenUsagePayload 描述 runtime 当前 token_usage 事件载荷。
@@ -243,32 +312,38 @@ type AssetSaveFailedPayload struct {
 }
 
 const (
-	EventUserMessage         EventType = "user_message"
-	EventAgentChunk          EventType = "agent_chunk"
-	EventAgentDone           EventType = "agent_done"
-	EventToolStart           EventType = "tool_start"
-	EventToolResult          EventType = "tool_result"
-	EventToolChunk           EventType = "tool_chunk"
-	EventRunCanceled         EventType = "run_canceled"
-	EventError               EventType = "error"
-	EventToolCallThinking    EventType = "tool_call_thinking"
-	EventProviderRetry       EventType = "provider_retry"
-	EventPermissionRequested EventType = "permission_requested"
-	EventPermissionResolved  EventType = "permission_resolved"
-	EventCompactStart        EventType = "compact_start"
-	EventCompactApplied      EventType = "compact_applied"
-	EventCompactError        EventType = "compact_error"
-	EventTokenUsage          EventType = "token_usage"
-	EventSkillActivated      EventType = "skill_activated"
-	EventSkillDeactivated    EventType = "skill_deactivated"
-	EventSkillMissing        EventType = "skill_missing"
-	EventPhaseChanged        EventType = "phase_changed"
-	EventProgressEvaluated   EventType = "progress_evaluated"
-	EventStopReasonDecided   EventType = "stop_reason_decided"
-	EventTodoUpdated         EventType = "todo_updated"
-	EventTodoConflict        EventType = "todo_conflict"
-	EventTodoSummaryInjected EventType = "todo_summary_injected"
-	EventInputNormalized     EventType = "input_normalized"
-	EventAssetSaved          EventType = "asset_saved"
-	EventAssetSaveFailed     EventType = "asset_save_failed"
+	EventUserMessage               EventType = "user_message"
+	EventAgentChunk                EventType = "agent_chunk"
+	EventAgentDone                 EventType = "agent_done"
+	EventToolStart                 EventType = "tool_start"
+	EventToolResult                EventType = "tool_result"
+	EventToolChunk                 EventType = "tool_chunk"
+	EventRunCanceled               EventType = "run_canceled"
+	EventError                     EventType = "error"
+	EventToolCallThinking          EventType = "tool_call_thinking"
+	EventProviderRetry             EventType = "provider_retry"
+	EventPermissionRequested       EventType = "permission_requested"
+	EventPermissionResolved        EventType = "permission_resolved"
+	EventCompactStart              EventType = "compact_start"
+	EventCompactApplied            EventType = "compact_applied"
+	EventCompactError              EventType = "compact_error"
+	EventTokenUsage                EventType = "token_usage"
+	EventSkillActivated            EventType = "skill_activated"
+	EventSkillDeactivated          EventType = "skill_deactivated"
+	EventSkillMissing              EventType = "skill_missing"
+	EventPhaseChanged              EventType = "phase_changed"
+	EventProgressEvaluated         EventType = "progress_evaluated"
+	EventStopReasonDecided         EventType = "stop_reason_decided"
+	EventVerificationStarted       EventType = "verification_started"
+	EventVerificationStageFinished EventType = "verification_stage_finished"
+	EventVerificationFinished      EventType = "verification_finished"
+	EventVerificationCompleted     EventType = "verification_completed"
+	EventVerificationFailed        EventType = "verification_failed"
+	EventAcceptanceDecided         EventType = "acceptance_decided"
+	EventTodoUpdated               EventType = "todo_updated"
+	EventTodoConflict              EventType = "todo_conflict"
+	EventTodoSummaryInjected       EventType = "todo_summary_injected"
+	EventInputNormalized           EventType = "input_normalized"
+	EventAssetSaved                EventType = "asset_saved"
+	EventAssetSaveFailed           EventType = "asset_save_failed"
 )


### PR DESCRIPTION
## 背景
当前 runtime 仍存在“模型发出 final 即可结束”的路径，缺少统一的验收与完成判定闭环。
本 PR 将主链路升级为 `completion gate + verification gate` 双门控，并收敛为单一终态裁决输出。

## 目标
- 在模型 final 前强制执行 `beforeAcceptFinal`。
- 统一终态决策：`accepted / continue / incomplete / failed`。
- 统一 stop reason / verification / acceptance 事件协议。
- 首阶段落地 Todo 收敛与可扩展 verifier 引擎。

## 变更范围
### 1) Runtime Finalization / Hook
- 新增 `internal/runtime/final_acceptance.go`，引入 `beforeAcceptFinal`。
- `internal/runtime/run.go` 改造 final 分支：先验证再决定终态，不再直接 completed。
- `continue` 分支注入 reminder，失败/未完成分支统一收口并落盘。

### 2) Acceptance 层（唯一收口表达）
- 新增 `internal/runtime/acceptance/*`：
  - `types.go`：AcceptanceStatus/Decision/Input。
  - `engine.go`：聚合规则（fail > hard_block > soft_block > pass）。
  - `policy.go`：task type 到 verifier 映射。
  - `decider.go`：acceptance -> terminal status 映射。
  - `stop_reason.go` / `error_class.go`：复用统一枚举。

### 3) Verifier 引擎
- 新增 `internal/runtime/verify/*`：
  - `orchestrator.go`、`types.go`、`verifier.go`。
  - P0: `todo_convergence`。
  - P1: `file_exists` / `content_match` / `command_success` / `git_diff` / `build` / `test` / `lint` / `typecheck`。
  - `execution_policy.go`：非交互执行、白名单/拒绝名单、只读 git 子命令限制。

### 4) Controlplane 收敛
- `internal/runtime/controlplane/stop_reason.go`：扩展并统一 stop reason 集合。
- `internal/runtime/controlplane/decider.go`：固定优先级并支持 pre-decided 输入。
- `internal/runtime/controlplane/phase.go`：verify phase 升级为流水线节点（支持 `plan -> verify`）。

### 5) 配置与兼容
- 新增 `internal/config/verification.go`。
- `internal/config/runtime.go` 接入 verification 配置。
- 修复开关语义：`runtime.verification.enabled/final_intercept` 改为可区分“未配置 vs 显式 false”（避免默认值覆盖显式关闭）。
- 兼容路径使用 `compatibility_fallback` 并在事件/摘要中显式标注。

### 6) Todo 迁移兼容
- `internal/session/todo.go` 增加 `required`、`blocked_reason`，并确保旧会话默认值兼容。
- `internal/tools/todo/*` 对齐 schema 与 patch 映射。

### 7) TUI / 协议适配
- `internal/runtime/events.go` 新增：
  - `verification_started`
  - `verification_stage_finished`
  - `verification_finished`
  - `verification_completed`
  - `verification_failed`
  - `acceptance_decided`
- `internal/tui/services/runtime_contract.go`、`gateway_stream_client.go`、`internal/tui/core/app/update.go` 同步枚举与 payload，兼容旧 reason 形式。

### 8) 文档
新增 7 篇设计与迁移文档：
- `docs/task-acceptance-design.md`
- `docs/verifier-engine-design.md`
- `docs/runtime-finalization-flow.md`
- `docs/verifier-configuration-and-policy.md`
- `docs/todo-schema-migration.md`
- `docs/stop-reason-and-decision-priority.md`
- `docs/compatibility-fallback-lifecycle.md`

## 关键行为变化
- provider/model 的 final signal 不再直接触发 completed。
- completed 的唯一条件：completion gate 与 verification gate 同时通过。
- stop reason 与终态输出由统一裁决层产出，事件/UI/持久化消费同源结果。

## 测试
新增/更新重点测试：
- `internal/runtime/final_acceptance_test.go`
- `internal/runtime/acceptance/engine_test.go`
- `internal/runtime/verify/todo_convergence_test.go`
- `internal/runtime/verify/execution_policy_test.go`
- `internal/session/todo_compatibility_test.go`
- `internal/config/runtime_test.go`（含显式 false 配置回归）
- controlplane/runtime/tui 对应回归用例同步更新

本地回归（关键包）通过：
- `go test ./internal/runtime/... -count=1`
- `go test ./internal/session ./internal/tools/todo ./internal/tui/services ./internal/tui/core/app -run "ModelScope|StopReason|OpenResource" -count=1`
- `go test ./internal/config -run "TestRuntimeConfigVerificationDefaultsApplied|TestRuntimeConfigVerificationExplicitFalsePreserved" -count=1`

说明：Windows 环境存在仓库既有并发临时目录/clipboard/backpressure 相关偶发测试不稳定，已独立复核本 PR 关联关键用例通过。

## 风险与回滚
- 风险：终态判断链路从“完成即停”变为“验收后停”，若外部配置错误可能导致 continue/incomplete 变多。
- 缓解：保留短期 `compatibility_fallback`，并通过统一 stop reason + 事件可观测。
- 回滚：可通过 `runtime.verification.enabled=false` 快速切回兼容路径（同时保留结构化事件标记）。
