### PR TITLE
fix: terminate final-acceptance loop when completion gate is blocked

### DIFF
--- a/internal/runtime/acceptance/engine.go
+++ b/internal/runtime/acceptance/engine.go
@@ -24,66 +24,66 @@ func NewEngine(policy AcceptancePolicy) *Engine {
 
 // EvaluateFinal 执行 final 验收并输出结构化决策。
 func (e *Engine) EvaluateFinal(ctx context.Context, input FinalAcceptanceInput) (AcceptanceDecision, error) {
+	var decision AcceptanceDecision
 	if !input.CompletionGate.Passed {
-		return AcceptanceDecision{
+		decision = AcceptanceDecision{
 			Status:             AcceptanceContinue,
 			StopReason:         controlplane.StopReasonTodoNotConverged,
 			UserVisibleSummary: "当前回合尚未达到可收尾条件，继续执行。",
 			InternalSummary:    "completion gate did not pass",
 			ContinueHint:       "There are unfinished required todos or unmet acceptance checks. Continue execution. Do not finalize yet.",
 			HasProgress:        false,
-		}, nil
-	}
-
-	verificationCfg := input.VerificationInput.VerificationConfig
-	hookCfg := verificationCfg.Hooks
-	verifierEnabled := verificationCfg.EnabledValue()
-
-	var decision AcceptanceDecision
-	if verifierEnabled {
-		verifiers := e.policy.ResolveVerifiers(input.VerificationInput)
-		if hookDecision, failed := runHookStage(
-			ctx,
-			hookCfg.BeforeVerification,
-			hookStageBeforeVerification,
-			beforeVerificationHooks(len(verifiers)),
-			input,
-		); failed {
-			return hookDecision, nil
 		}
-
-		orch := verify.Orchestrator{Verifiers: verifiers}
-		gateDecision, err := orch.RunFinalVerification(ctx, input.VerificationInput)
-		if err != nil {
-			return AcceptanceDecision{}, err
-		}
-		if hookDecision, failed := runHookStage(
-			ctx,
-			hookCfg.AfterVerification,
-			hookStageAfterVerification,
-			afterVerificationHooks(len(gateDecision.Results)),
-			input,
-		); failed {
-			return hookDecision, nil
-		}
-		decision = aggregateVerificationDecision(gateDecision)
 	} else {
-		decision = AcceptanceDecision{
-			Status:             AcceptanceAccepted,
-			StopReason:         controlplane.StopReasonCompatibilityFallback,
-			UserVisibleSummary: "已通过兼容路径接受 final（验证引擎关闭）。",
-			InternalSummary:    "verification disabled, compatibility fallback accepted",
-			HasProgress:        true,
+		verificationCfg := input.VerificationInput.VerificationConfig
+		hookCfg := verificationCfg.Hooks
+		verifierEnabled := verificationCfg.EnabledValue()
+
+		if verifierEnabled {
+			verifiers := e.policy.ResolveVerifiers(input.VerificationInput)
+			if hookDecision, failed := runHookStage(
+				ctx,
+				hookCfg.BeforeVerification,
+				hookStageBeforeVerification,
+				beforeVerificationHooks(len(verifiers)),
+				input,
+			); failed {
+				return hookDecision, nil
+			}
+
+			orch := verify.Orchestrator{Verifiers: verifiers}
+			gateDecision, err := orch.RunFinalVerification(ctx, input.VerificationInput)
+			if err != nil {
+				return AcceptanceDecision{}, err
+			}
+			if hookDecision, failed := runHookStage(
+				ctx,
+				hookCfg.AfterVerification,
+				hookStageAfterVerification,
+				afterVerificationHooks(len(gateDecision.Results)),
+				input,
+			); failed {
+				return hookDecision, nil
+			}
+			decision = aggregateVerificationDecision(gateDecision)
+		} else {
+			decision = AcceptanceDecision{
+				Status:             AcceptanceAccepted,
+				StopReason:         controlplane.StopReasonCompatibilityFallback,
+				UserVisibleSummary: "已通过兼容路径接受 final（验证引擎关闭）。",
+				InternalSummary:    "verification disabled, compatibility fallback accepted",
+				HasProgress:        true,
+			}
 		}
-	}
-	if hookDecision, failed := runHookStage(
-		ctx,
-		hookCfg.BeforeCompletionDecision,
-		hookStageBeforeCompletionDecision,
-		beforeCompletionDecisionHooks(),
-		input,
-	); failed {
-		return hookDecision, nil
+		if hookDecision, failed := runHookStage(
+			ctx,
+			hookCfg.BeforeCompletionDecision,
+			hookStageBeforeCompletionDecision,
+			beforeCompletionDecisionHooks(),
+			input,
+		); failed {
+			return hookDecision, nil
+		}
 	}
 	if input.NoProgressExceeded && decision.Status == AcceptanceContinue {
 		decision.Status = AcceptanceIncomplete

--- a/internal/runtime/acceptance/engine_test.go
+++ b/internal/runtime/acceptance/engine_test.go
@@ -165,6 +165,47 @@ func TestEngineEvaluateFinalCompletionGateAndRetry(t *testing.T) {
 		}
 	})
 
+	t.Run("completion gate false with no-progress exceeded -> incomplete", func(t *testing.T) {
+		t.Parallel()
+		decision, err := engine.EvaluateFinal(context.Background(), FinalAcceptanceInput{
+			CompletionGate:     CompletionGateDecision{Passed: false},
+			NoProgressExceeded: true,
+			VerificationInput: verify.FinalVerifyInput{
+				VerificationConfig: verifyEnabledConfig(),
+			},
+		})
+		if err != nil {
+			t.Fatalf("EvaluateFinal() error = %v", err)
+		}
+		if decision.Status != AcceptanceIncomplete {
+			t.Fatalf("status = %q, want %q", decision.Status, AcceptanceIncomplete)
+		}
+		if decision.StopReason != controlplane.StopReasonNoProgressAfterFinalIntercept {
+			t.Fatalf("stop_reason = %q, want %q", decision.StopReason, controlplane.StopReasonNoProgressAfterFinalIntercept)
+		}
+	})
+
+	t.Run("completion gate false with max turns reached -> incomplete", func(t *testing.T) {
+		t.Parallel()
+		decision, err := engine.EvaluateFinal(context.Background(), FinalAcceptanceInput{
+			CompletionGate:  CompletionGateDecision{Passed: false},
+			MaxTurnsReached: true,
+			MaxTurnsLimit:   7,
+			VerificationInput: verify.FinalVerifyInput{
+				VerificationConfig: verifyEnabledConfig(),
+			},
+		})
+		if err != nil {
+			t.Fatalf("EvaluateFinal() error = %v", err)
+		}
+		if decision.Status != AcceptanceIncomplete {
+			t.Fatalf("status = %q, want %q", decision.Status, AcceptanceIncomplete)
+		}
+		if decision.StopReason != controlplane.StopReasonMaxTurnExceededWithUnconvergedTodos {
+			t.Fatalf("stop_reason = %q, want %q", decision.StopReason, controlplane.StopReasonMaxTurnExceededWithUnconvergedTodos)
+		}
+	})
+
 	t.Run("retry exhausted overrides", func(t *testing.T) {
 		t.Parallel()
 		decision, err := engine.EvaluateFinal(context.Background(), FinalAcceptanceInput{
@@ -173,6 +214,28 @@ func TestEngineEvaluateFinalCompletionGateAndRetry(t *testing.T) {
 				VerificationConfig: verifyEnabledConfig(),
 				Todos: []verify.TodoSnapshot{
 					{ID: "todo-1", Required: true, RetryCount: 2, RetryLimit: 2},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("EvaluateFinal() error = %v", err)
+		}
+		if decision.Status != AcceptanceFailed {
+			t.Fatalf("status = %q, want %q", decision.Status, AcceptanceFailed)
+		}
+		if decision.StopReason != controlplane.StopReasonRetryExhausted {
+			t.Fatalf("stop_reason = %q, want %q", decision.StopReason, controlplane.StopReasonRetryExhausted)
+		}
+	})
+
+	t.Run("completion gate false and retry exhausted -> failed", func(t *testing.T) {
+		t.Parallel()
+		decision, err := engine.EvaluateFinal(context.Background(), FinalAcceptanceInput{
+			CompletionGate: CompletionGateDecision{Passed: false},
+			VerificationInput: verify.FinalVerifyInput{
+				VerificationConfig: verifyEnabledConfig(),
+				Todos: []verify.TodoSnapshot{
+					{ID: "todo-1", Required: true, RetryCount: 1, RetryLimit: 1},
 				},
 			},
 		})

--- a/internal/runtime/final_acceptance_test.go
+++ b/internal/runtime/final_acceptance_test.go
@@ -46,6 +46,25 @@ func TestBeforeAcceptFinalDecisionPaths(t *testing.T) {
 		}
 	})
 
+	t.Run("completion gate false with no progress exceeded -> incomplete", func(t *testing.T) {
+		t.Parallel()
+		state := newRunState("run-continue-no-progress", agentsession.New("continue-no-progress"))
+		state.progress.LastScore.NoProgressStreak = snapshot.Config.Runtime.Verification.MaxNoProgress
+		decision, err := service.beforeAcceptFinal(context.Background(), &state, snapshot, providertypes.Message{
+			Role:  providertypes.RoleAssistant,
+			Parts: []providertypes.ContentPart{providertypes.NewTextPart("done")},
+		}, false)
+		if err != nil {
+			t.Fatalf("beforeAcceptFinal() error = %v", err)
+		}
+		if decision.Status != "incomplete" {
+			t.Fatalf("status = %q, want incomplete", decision.Status)
+		}
+		if decision.StopReason != "no_progress_after_final_intercept" {
+			t.Fatalf("stop_reason = %q, want no_progress_after_final_intercept", decision.StopReason)
+		}
+	})
+
 	t.Run("continue carries runtime progress signal", func(t *testing.T) {
 		t.Parallel()
 		state := newRunState("run-continue-progress", agentsession.New("continue-progress"))


### PR DESCRIPTION
## 背景
当 completion gate 未通过时，acceptance engine 会立即返回 continue，导致后续 no-progress/max-turn/retry 收敛逻辑失效，运行可能长期空转（持续注入 continue reminder）。

## 变更
- 调整 `internal/runtime/acceptance/engine.go`：
  - 取消 completion gate 未通过时的早返回。
  - 先生成 continue 决策，再统一进入 no-progress / max-turn / retry_exhausted 收敛分支。
  - 保持 completion gate 通过时原有 verifier + hook 行为不变。
- 新增/补强回归测试：
  - `internal/runtime/acceptance/engine_test.go`
    - completion gate=false + no_progress_exceeded => incomplete
    - completion gate=false + max_turns_reached => incomplete
    - completion gate=false + retry_exhausted => failed
  - `internal/runtime/final_acceptance_test.go`
    - beforeAcceptFinal 在 completion gate=false 且 no progress 超阈值时返回 incomplete

## 验证
- `go test ./internal/runtime/acceptance ./internal/runtime -run "TestEngineEvaluateFinal|TestBeforeAcceptFinalDecisionPaths"` ✅
- `go test ./...` ⚠️ 当前仓库存在与本改动无关的既有失败：
  - `internal/gateway/launcher`（绝对路径断言）
  - `internal/tui/core/app`（TempDir 清理）
