### PR TITLE
fix(tui): 调整界面大小，增加面板搜索，对齐输入格式，调整md渲染

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ Gateway 转发与自动拉起说明：
 - `/provider`：打开 provider 选择器
 - `/model`：打开 model 选择器
 - `/compact`：压缩当前会话上下文
-- `/status`：查看当前会话与运行状态
 - `/cwd [path]`：查看或设置当前会话工作区
 - `/memo`：查看记忆索引
 - `/remember <text>`：保存记忆

--- a/internal/tui/components/components_test.go
+++ b/internal/tui/components/components_test.go
@@ -102,8 +102,8 @@ func TestCodeBlockHelpers(t *testing.T) {
 
 func TestRenderCommandMenuRow(t *testing.T) {
 	row := RenderCommandMenuRow(CommandMenuRowData{
-		Title:            "/status",
-		Description:      "show status",
+		Title:            "/help",
+		Description:      "show help",
 		Highlight:        true,
 		Selected:         false,
 		Width:            30,
@@ -111,7 +111,7 @@ func TestRenderCommandMenuRow(t *testing.T) {
 		UsageMatchStyle:  lipgloss.NewStyle().Bold(true),
 		DescriptionStyle: lipgloss.NewStyle(),
 	})
-	if !strings.Contains(row, "/status") || !strings.Contains(row, "show status") {
+	if !strings.Contains(row, "/help") || !strings.Contains(row, "show help") {
 		t.Fatalf("unexpected command menu row: %q", row)
 	}
 }

--- a/internal/tui/core/app/commands.go
+++ b/internal/tui/core/app/commands.go
@@ -22,7 +22,6 @@ const (
 	slashCommandExit        = "/exit"
 	slashCommandClear       = "/clear"
 	slashCommandCompact     = "/compact"
-	slashCommandStatus      = "/status"
 	slashCommandProvider    = "/provider"
 	slashCommandProviderAdd = "/provider add"
 	slashCommandModelPick   = "/model"
@@ -38,7 +37,6 @@ const (
 	slashUsageExit        = "/exit"
 	slashUsageClear       = "/clear"
 	slashUsageCompact     = "/compact"
-	slashUsageStatus      = "/status"
 	slashUsageProvider    = "/provider"
 	slashUsageProviderAdd = "/provider add"
 	slashUsageModel       = "/model"
@@ -128,7 +126,6 @@ var builtinSlashCommands = []slashCommand{
 	{Usage: slashUsageHelp, Description: "Show slash command help"},
 	{Usage: slashUsageClear, Description: "Clear the current draft transcript"},
 	{Usage: slashUsageCompact, Description: "Compact the current session context"},
-	{Usage: slashUsageStatus, Description: "Show current session and agent status"},
 	{Usage: slashUsageWorkdir, Description: "Show or set current session workspace root (/cwd [path])"},
 	{Usage: slashUsageMemo, Description: "Show persistent memo index"},
 	{Usage: slashUsageRemember, Description: "Save a persistent memo (/remember <text>)"},
@@ -150,7 +147,8 @@ func newSelectionPicker(items []list.Item) list.Model {
 	picker.Title = ""
 	picker.SetShowHelp(false)
 	picker.SetShowStatusBar(false)
-	picker.SetFilteringEnabled(false)
+	picker.SetShowFilter(true)
+	picker.SetFilteringEnabled(true)
 	picker.DisableQuitKeybindings()
 	return picker
 }
@@ -217,8 +215,16 @@ func mapModelItems(models []providertypes.ModelDescriptor) []selectionItem {
 }
 
 func replacePickerItems(current *list.Model, items []selectionItem) {
+	filterValue := current.FilterValue()
+	filterState := current.FilterState()
 	next := newSelectionPickerItems(items)
 	next.SetSize(current.Width(), current.Height())
+	if filterState != list.Unfiltered {
+		next.SetFilterText(filterValue)
+	}
+	if filterState == list.Filtering {
+		next.SetFilterState(list.Filtering)
+	}
 	*current = next
 }
 
@@ -282,6 +288,9 @@ func (a *App) openPicker(mode pickerMode, statusText string, picker *list.Model,
 	a.state.ActivePicker = mode
 	a.state.StatusText = statusText
 	a.input.Blur()
+	picker.ResetFilter()
+	picker.SetFilterText("")
+	picker.SetFilterState(list.Filtering)
 	selectPickerItemByID(picker, selectedID)
 }
 
@@ -393,17 +402,11 @@ func executeLocalCommand(ctx context.Context, configManager *config.Manager, pro
 	switch strings.ToLower(fields[0]) {
 	case slashCommandHelp:
 		return slashHelpText(), nil
-	case slashCommandStatus:
-		return executeStatusCommand(snapshot), nil
 	case slashCommandProvider:
 		return executeProviderCommand(ctx, providerSvc, strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(raw), slashCommandProvider)))
 	default:
 		return "", fmt.Errorf("unknown command %q", fields[0])
 	}
-}
-
-func executeStatusCommand(snapshot tuistatus.Snapshot) string {
-	return tuistatus.Format(snapshot, draftSessionTitle)
 }
 
 func executeProviderCommand(ctx context.Context, providerSvc ProviderController, value string) (string, error) {

--- a/internal/tui/core/app/commands_test.go
+++ b/internal/tui/core/app/commands_test.go
@@ -10,7 +10,6 @@ import (
 
 	configstate "neo-code/internal/config/state"
 	providertypes "neo-code/internal/provider/types"
-	tuistatus "neo-code/internal/tui/core/status"
 )
 
 func TestBuiltinSlashCommands(t *testing.T) {
@@ -22,6 +21,7 @@ func TestBuiltinSlashCommands(t *testing.T) {
 	foundTodo := false
 	foundSkills := false
 	foundSkillUse := false
+	foundStatus := false
 	for _, cmd := range builtinSlashCommands {
 		if cmd.Usage == slashUsageHelp {
 			found = true
@@ -34,6 +34,9 @@ func TestBuiltinSlashCommands(t *testing.T) {
 		}
 		if cmd.Usage == slashUsageSkillUse {
 			foundSkillUse = true
+		}
+		if strings.EqualFold(cmd.Usage, "/status") {
+			foundStatus = true
 		}
 	}
 	if !found {
@@ -48,6 +51,9 @@ func TestBuiltinSlashCommands(t *testing.T) {
 	if !foundSkillUse {
 		t.Error("expected to find /skill use command")
 	}
+	if foundStatus {
+		t.Error("did not expect /status command in builtin slash commands")
+	}
 }
 
 func TestNewSelectionPicker(t *testing.T) {
@@ -55,7 +61,12 @@ func TestNewSelectionPicker(t *testing.T) {
 		selectionItem{id: "1", name: "Item 1", description: "Desc 1"},
 	}
 	picker := newSelectionPicker(items)
-	_ = picker
+	if !picker.FilteringEnabled() {
+		t.Fatalf("expected selection picker filtering to be enabled")
+	}
+	if !picker.ShowFilter() {
+		t.Fatalf("expected selection picker to show search filter")
+	}
 }
 
 func TestNewSelectionPickerItems(t *testing.T) {
@@ -64,6 +75,47 @@ func TestNewSelectionPickerItems(t *testing.T) {
 	}
 	picker := newSelectionPickerItems(items)
 	_ = picker
+}
+
+func TestReplacePickerItemsKeepsFilterEditingState(t *testing.T) {
+	current := newSelectionPickerItems([]selectionItem{
+		{id: "m-1", name: "model-one", description: "first"},
+	})
+	current.SetSize(48, 12)
+	current.SetFilterText("model")
+	current.SetFilterState(list.Filtering)
+
+	replacePickerItems(&current, []selectionItem{
+		{id: "m-2", name: "model-two", description: "second"},
+	})
+
+	if !current.SettingFilter() {
+		t.Fatalf("expected picker to keep filtering state after replace")
+	}
+	if current.FilterValue() != "model" {
+		t.Fatalf("expected picker to keep filter text, got %q", current.FilterValue())
+	}
+}
+
+func TestReplacePickerItemsKeepsFilteringStateWithEmptyQuery(t *testing.T) {
+	current := newSelectionPickerItems([]selectionItem{
+		{id: "m-1", name: "model-one", description: "first"},
+	})
+	current.SetSize(48, 12)
+	current.SetFilterText("")
+	current.SetFilterState(list.Filtering)
+
+	replacePickerItems(&current, []selectionItem{
+		{id: "m-2", name: "model-two", description: "second"},
+		{id: "m-3", name: "model-three", description: "third"},
+	})
+
+	if !current.SettingFilter() {
+		t.Fatalf("expected picker to stay in filtering state")
+	}
+	if got := len(current.VisibleItems()); got != 2 {
+		t.Fatalf("expected visible items to be preserved under empty filter, got %d", got)
+	}
 }
 
 func TestNewCommandMenuModel(t *testing.T) {
@@ -199,7 +251,7 @@ func TestExecuteLocalCommandErrors(t *testing.T) {
 	}
 }
 
-func TestExecuteLocalCommandHelpAndStatus(t *testing.T) {
+func TestExecuteLocalCommandHelpAndStatusRemoved(t *testing.T) {
 	app, _ := newTestApp(t)
 	snapshot := app.currentStatusSnapshot()
 
@@ -211,12 +263,8 @@ func TestExecuteLocalCommandHelpAndStatus(t *testing.T) {
 		t.Fatalf("expected help output, got %q", helpText)
 	}
 
-	statusText, err := executeLocalCommand(context.Background(), app.configManager, app.providerSvc, snapshot, "/status")
-	if err != nil {
-		t.Fatalf("executeLocalCommand(/status) error = %v", err)
-	}
-	if !strings.Contains(statusText, "Status:") {
-		t.Fatalf("expected status output, got %q", statusText)
+	if _, err := executeLocalCommand(context.Background(), app.configManager, app.providerSvc, snapshot, "/status"); err == nil {
+		t.Fatalf("expected /status to be removed")
 	}
 }
 
@@ -298,19 +346,6 @@ func TestRunModelCatalogRefreshCmd(t *testing.T) {
 	}
 }
 
-func TestExecuteStatusCommandFormatting(t *testing.T) {
-	snapshot := tuistatus.Snapshot{
-		ActiveSessionTitle: "Draft",
-		CurrentProvider:    "test-provider",
-		CurrentModel:       "test-model",
-		CurrentWorkdir:     "/tmp",
-	}
-	output := executeStatusCommand(snapshot)
-	if !strings.Contains(output, "Status:") {
-		t.Fatalf("expected Status header, got %q", output)
-	}
-}
-
 func TestRefreshHelpPicker(t *testing.T) {
 	app, _ := newTestApp(t)
 	app.refreshHelpPicker()
@@ -321,11 +356,18 @@ func TestRefreshHelpPicker(t *testing.T) {
 
 func TestOpenHelpPicker(t *testing.T) {
 	app, _ := newTestApp(t)
+	app.helpPicker.SetFilterText("model")
 	app.openHelpPicker()
 	if app.state.ActivePicker != pickerHelp {
 		t.Fatalf("expected help picker to open")
 	}
 	if app.state.StatusText != statusChooseHelp {
 		t.Fatalf("expected help picker status, got %q", app.state.StatusText)
+	}
+	if app.helpPicker.FilterValue() != "" {
+		t.Fatalf("expected help picker filter to be reset, got %q", app.helpPicker.FilterValue())
+	}
+	if !app.helpPicker.SettingFilter() {
+		t.Fatalf("expected help picker search box to be focused")
 	}
 }

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -819,13 +819,13 @@ func (a App) updatePicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	switch a.state.ActivePicker {
 	case pickerProvider:
-		a.providerPicker, cmd = a.providerPicker.Update(msg)
+		a.providerPicker, cmd = updateListPickerModel(a.providerPicker, msg)
 	case pickerModel:
-		a.modelPicker, cmd = a.modelPicker.Update(msg)
+		a.modelPicker, cmd = updateListPickerModel(a.modelPicker, msg)
 	case pickerSession:
-		a.sessionPicker, cmd = a.sessionPicker.Update(msg)
+		a.sessionPicker, cmd = updateListPickerModel(a.sessionPicker, msg)
 	case pickerHelp:
-		a.helpPicker, cmd = a.helpPicker.Update(msg)
+		a.helpPicker, cmd = updateListPickerModel(a.helpPicker, msg)
 	case pickerFile:
 		a.fileBrowser, cmd = a.fileBrowser.Update(msg)
 		if didSelect, path := a.fileBrowser.DidSelectFile(msg); didSelect {
@@ -856,6 +856,50 @@ func (a App) updatePicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return a.handleModelScopeGuideInput(msg)
 	}
 	return a, cmd
+}
+
+func updateListPickerModel(picker list.Model, msg tea.KeyMsg) (list.Model, tea.Cmd) {
+	if picker.SettingFilter() {
+		switch msg.Type {
+		case tea.KeyUp:
+			picker.CursorUp()
+			return picker, nil
+		case tea.KeyDown:
+			picker.CursorDown()
+			return picker, nil
+		case tea.KeyPgUp:
+			picker.PrevPage()
+			return picker, nil
+		case tea.KeyPgDown:
+			picker.NextPage()
+			return picker, nil
+		case tea.KeyHome:
+			picker.GoToStart()
+			return picker, nil
+		case tea.KeyEnd:
+			picker.GoToEnd()
+			return picker, nil
+		}
+	}
+
+	next, cmd := picker.Update(msg)
+	if !next.SettingFilter() || !isPickerFilterEditKey(msg) {
+		return next, cmd
+	}
+
+	filterValue := next.FilterValue()
+	next.SetFilterText(filterValue)
+	next.SetFilterState(list.Filtering)
+	return next, nil
+}
+
+func isPickerFilterEditKey(msg tea.KeyMsg) bool {
+	switch msg.Type {
+	case tea.KeyRunes, tea.KeyBackspace, tea.KeyDelete:
+		return true
+	default:
+		return false
+	}
 }
 
 // maybeStartModelScopeGuideFromProvider 在选择 modelscope 且未配置 token 时进入半引导流程。

--- a/internal/tui/core/app/update_test.go
+++ b/internal/tui/core/app/update_test.go
@@ -1148,6 +1148,9 @@ func TestViewSmallWindow(t *testing.T) {
 	if !strings.Contains(view, "Window too small") {
 		t.Fatalf("expected small window warning, got %q", view)
 	}
+	if !strings.Contains(view, "60x30") {
+		t.Fatalf("expected 60x30 minimum size hint, got %q", view)
+	}
 }
 
 func TestComputeLayoutStackedAndWide(t *testing.T) {
@@ -1672,6 +1675,79 @@ func TestUpdatePickerSessionEnterWhileBusyRejectsSwitch(t *testing.T) {
 	}
 }
 
+func TestUpdatePickerModelFilterAppliesImmediately(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.modelPicker.SetItems([]list.Item{
+		selectionItem{id: "alpha", name: "alpha-model", description: "a"},
+		selectionItem{id: "beta", name: "beta-model", description: "b"},
+	})
+	app.openPicker(pickerModel, statusChooseModel, &app.modelPicker, "alpha")
+
+	model, cmd := app.updatePicker(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("z")})
+	app = model.(App)
+	if cmd != nil {
+		t.Fatalf("expected inline filter update to return nil cmd")
+	}
+	if app.modelPicker.FilterValue() != "z" {
+		t.Fatalf("expected filter text to update, got %q", app.modelPicker.FilterValue())
+	}
+	if got := len(app.modelPicker.VisibleItems()); got != 0 {
+		t.Fatalf("expected 0 matched items after filtering, got %d", got)
+	}
+}
+
+func TestUpdatePickerModelAllowsArrowNavigationWhileFiltering(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.modelPicker.SetItems([]list.Item{
+		selectionItem{id: "m1", name: "model-one", description: "first"},
+		selectionItem{id: "m2", name: "model-two", description: "second"},
+	})
+	app.openPicker(pickerModel, statusChooseModel, &app.modelPicker, "m1")
+
+	model, cmd := app.updatePicker(tea.KeyMsg{Type: tea.KeyDown})
+	app = model.(App)
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for arrow navigation while filtering")
+	}
+	selected, ok := app.modelPicker.SelectedItem().(selectionItem)
+	if !ok {
+		t.Fatalf("expected selected model item type, got %T", app.modelPicker.SelectedItem())
+	}
+	if selected.id != "m2" {
+		t.Fatalf("expected selection to move to m2, got %q", selected.id)
+	}
+}
+
+func TestUpdatePickerModelFilterUsesFuzzyMatching(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.modelPicker.SetItems([]list.Item{
+		selectionItem{id: "qwen", name: "qwen-turbo", description: "fast"},
+		selectionItem{id: "glm", name: "glm-5.1", description: "alt"},
+	})
+	app.openPicker(pickerModel, statusChooseModel, &app.modelPicker, "qwen")
+
+	model, _ := app.updatePicker(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	app = model.(App)
+	model, _ = app.updatePicker(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("t")})
+	app = model.(App)
+	model, _ = app.updatePicker(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	app = model.(App)
+
+	if app.modelPicker.FilterValue() != "qtr" {
+		t.Fatalf("expected filter text qtr, got %q", app.modelPicker.FilterValue())
+	}
+	if got := len(app.modelPicker.VisibleItems()); got != 1 {
+		t.Fatalf("expected fuzzy filter to keep one item, got %d", got)
+	}
+	selected, ok := app.modelPicker.SelectedItem().(selectionItem)
+	if !ok {
+		t.Fatalf("expected selected model item type, got %T", app.modelPicker.SelectedItem())
+	}
+	if selected.id != "qwen" {
+		t.Fatalf("expected fuzzy match to select qwen, got %q", selected.id)
+	}
+}
+
 func TestActivateSessionByIDNotFound(t *testing.T) {
 	app, _ := newTestApp(t)
 	app.state.Sessions = []agentsession.Summary{{ID: "s1", Title: "one"}}
@@ -2018,9 +2094,10 @@ func TestUpdatePickerHelpSelectionOpensModelPicker(t *testing.T) {
 
 func TestUpdatePickerHelpSelectionRunsSlashCommand(t *testing.T) {
 	app, _ := newTestApp(t)
+	app.state.CurrentWorkdir = t.TempDir()
 	app.refreshHelpPicker()
 	app.openHelpPicker()
-	selectPickerItemByID(&app.helpPicker, slashCommandStatus)
+	selectPickerItemByID(&app.helpPicker, slashUsageWorkdir)
 
 	model, cmd := app.updatePicker(tea.KeyMsg{Type: tea.KeyEnter})
 	if model == nil {
@@ -2028,7 +2105,7 @@ func TestUpdatePickerHelpSelectionRunsSlashCommand(t *testing.T) {
 	}
 	app = model.(App)
 	if app.state.ActivePicker != pickerNone {
-		t.Fatalf("expected help picker to close after selecting /status")
+		t.Fatalf("expected help picker to close after selecting /cwd")
 	}
 	if cmd == nil {
 		t.Fatalf("expected local slash command cmd")
@@ -2038,8 +2115,11 @@ func TestUpdatePickerHelpSelectionRunsSlashCommand(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected localCommandResultMsg, got %T", msg)
 	}
-	if !strings.Contains(result.Notice, "Status:") {
-		t.Fatalf("expected status output in slash result, got %q", result.Notice)
+	if result.Err == nil {
+		t.Fatalf("expected local slash command result error for /cwd")
+	}
+	if !strings.Contains(strings.ToLower(result.Err.Error()), "unknown command") {
+		t.Fatalf("expected unknown command error, got %v", result.Err)
 	}
 }
 
@@ -2096,19 +2176,6 @@ func TestRunSlashCommandSelectionWorkspaceAndLocal(t *testing.T) {
 	localCmd := app.runSlashCommandSelection("/cwd")
 	if localCmd == nil {
 		t.Fatalf("expected local slash cmd for /cwd")
-	}
-
-	statusCmd := app.runSlashCommandSelection(slashCommandStatus)
-	if statusCmd == nil {
-		t.Fatalf("expected local slash cmd for status")
-	}
-	statusMsg := statusCmd()
-	statusResult, ok := statusMsg.(localCommandResultMsg)
-	if !ok {
-		t.Fatalf("expected localCommandResultMsg, got %T", statusMsg)
-	}
-	if !strings.Contains(statusResult.Notice, "Status:") {
-		t.Fatalf("expected status output in local command result")
 	}
 }
 

--- a/internal/tui/core/app/view.go
+++ b/internal/tui/core/app/view.go
@@ -22,6 +22,8 @@ type layout struct {
 const headerBarHeight = 2
 const transcriptScrollbarWidth = 3
 const startupCommandMenuMinReservedHeight = 8
+const minWindowWidth = 60
+const minWindowHeight = 30
 
 const (
 	pickerPanelHorizontalInset = 8
@@ -45,8 +47,13 @@ type pickerLayoutSpec struct {
 func (a App) View() string {
 	docWidth := max(0, a.width-a.styles.doc.GetHorizontalFrameSize())
 	docHeight := max(0, a.height-a.styles.doc.GetVerticalFrameSize())
-	if docWidth < 73 || docHeight < 36 {
-		return strings.TrimRight(a.styles.doc.Render(lipgloss.Place(docWidth, docHeight, lipgloss.Left, lipgloss.Top, "Window too small.\nPlease resize to at least 73x36.")), "\n")
+	if docWidth < minWindowWidth || docHeight < minWindowHeight {
+		hint := fmt.Sprintf(
+			"Window too small.\nPlease resize to at least %dx%d.",
+			minWindowWidth,
+			minWindowHeight,
+		)
+		return strings.TrimRight(a.styles.doc.Render(lipgloss.Place(docWidth, docHeight, lipgloss.Left, lipgloss.Top, hint)), "\n")
 	}
 
 	lay := a.computeLayout()
@@ -613,15 +620,7 @@ func (a App) renderMessageBlockWithCopy(message providertypes.Message, width int
 		return "", nil
 	}
 
-	var (
-		contentBlock string
-		copyButtons  []copyCodeButtonBinding
-	)
-	if message.Role == roleUser {
-		contentBlock = bodyStyle.Render(wrapPlain(content, max(16, maxMessageWidth-2)))
-	} else {
-		contentBlock, copyButtons = a.renderMessageContentWithCopy(content, maxMessageWidth-2, bodyStyle, startCopyID)
-	}
+	contentBlock, copyButtons := a.renderMessageContentWithCopy(content, maxMessageWidth-2, bodyStyle, startCopyID)
 	if message.Role == roleAssistant && !includeTag {
 		return contentBlock, copyButtons
 	}

--- a/internal/tui/core/app/view_test.go
+++ b/internal/tui/core/app/view_test.go
@@ -591,6 +591,9 @@ func TestViewSmallWindowHint(t *testing.T) {
 	if !strings.Contains(view, "Window too small.") {
 		t.Fatalf("expected small-window hint, got %q", view)
 	}
+	if !strings.Contains(view, "Please resize to at least 60x30.") {
+		t.Fatalf("expected 60x30 size hint, got %q", view)
+	}
 }
 
 func TestViewNormalIncludesHeaderAndBody(t *testing.T) {

--- a/internal/tui/core/commands/parser.go
+++ b/internal/tui/core/commands/parser.go
@@ -1,6 +1,10 @@
 package commands
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/sahilm/fuzzy"
+)
 
 // SlashCommand 描述单个 slash 命令定义。
 type SlashCommand struct {
@@ -24,13 +28,47 @@ func MatchSlashCommands(input string, slashPrefix string, commands []SlashComman
 	if IsCompleteSlashCommand(query, commands) {
 		return nil
 	}
-	out := make([]CommandSuggestion, 0, len(commands))
-	for _, command := range commands {
-		normalized := strings.ToLower(command.Usage)
-		match := query == slashPrefix || strings.HasPrefix(normalized, query)
-		if query == slashPrefix || match || strings.Contains(normalized, query) {
-			out = append(out, CommandSuggestion{Command: command, Match: match})
+
+	if query == slashPrefix {
+		out := make([]CommandSuggestion, 0, len(commands))
+		for _, command := range commands {
+			out = append(out, CommandSuggestion{Command: command, Match: true})
 		}
+		return out
+	}
+
+	needle := strings.TrimPrefix(query, slashPrefix)
+	if needle == "" {
+		return nil
+	}
+
+	targets := make([]string, 0, len(commands))
+	indexes := make([]int, 0, len(commands))
+	for idx, command := range commands {
+		normalized := strings.ToLower(strings.TrimSpace(command.Usage))
+		if normalized == "" {
+			continue
+		}
+		targets = append(targets, strings.TrimPrefix(normalized, slashPrefix))
+		indexes = append(indexes, idx)
+	}
+
+	if len(targets) == 0 {
+		return nil
+	}
+
+	matches := fuzzy.Find(needle, targets)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	out := make([]CommandSuggestion, 0, len(matches))
+	for _, match := range matches {
+		command := commands[indexes[match.Index]]
+		out = append(out, CommandSuggestion{
+			Command: command,
+			Match:   true,
+		})
 	}
 	return out
 }

--- a/internal/tui/core/commands/parser_test.go
+++ b/internal/tui/core/commands/parser_test.go
@@ -20,6 +20,14 @@ func TestMatchSlashCommands(t *testing.T) {
 	if complete := MatchSlashCommands("/help", "/", commands); complete != nil {
 		t.Fatalf("expected nil suggestion when command is complete, got %+v", complete)
 	}
+
+	fuzzy := MatchSlashCommands("/mdl", "/", commands)
+	if len(fuzzy) != 1 {
+		t.Fatalf("expected one fuzzy suggestion for /mdl, got %d", len(fuzzy))
+	}
+	if fuzzy[0].Command.Usage != "/model" {
+		t.Fatalf("expected /model for fuzzy query /mdl, got %+v", fuzzy[0])
+	}
 }
 
 func TestIsCompleteSlashCommand(t *testing.T) {

--- a/internal/tui/infra/markdown_renderer.go
+++ b/internal/tui/infra/markdown_renderer.go
@@ -47,6 +47,100 @@ func resolveStyleWithoutHeadingHashes(style string) (ansi.StyleConfig, bool) {
 	cfg.H5.StylePrimitive.Suffix = ""
 	cfg.H6.StylePrimitive.Prefix = ""
 	cfg.H6.StylePrimitive.Suffix = ""
+	stripNonCodeHighlightBackgrounds(&cfg)
 
 	return cfg, true
+}
+
+func stripNonCodeHighlightBackgrounds(cfg *ansi.StyleConfig) {
+	if cfg == nil {
+		return
+	}
+
+	clearBlockHighlights(&cfg.Document)
+	clearBlockHighlights(&cfg.BlockQuote)
+	clearBlockHighlights(&cfg.Paragraph)
+	clearBlockHighlights(&cfg.List.StyleBlock)
+	clearBlockHighlights(&cfg.Heading)
+	clearBlockHighlights(&cfg.H1)
+	clearBlockHighlights(&cfg.H2)
+	clearBlockHighlights(&cfg.H3)
+	clearBlockHighlights(&cfg.H4)
+	clearBlockHighlights(&cfg.H5)
+	clearBlockHighlights(&cfg.H6)
+	clearPrimitiveHighlights(&cfg.Text)
+	clearPrimitiveHighlights(&cfg.Strikethrough)
+	clearPrimitiveHighlights(&cfg.Emph)
+	clearPrimitiveHighlights(&cfg.Strong)
+	clearPrimitiveHighlights(&cfg.HorizontalRule)
+	clearPrimitiveHighlights(&cfg.Item)
+	clearPrimitiveHighlights(&cfg.Enumeration)
+	clearPrimitiveHighlights(&cfg.Task.StylePrimitive)
+	clearPrimitiveHighlights(&cfg.Link)
+	clearPrimitiveHighlights(&cfg.LinkText)
+	clearPrimitiveHighlights(&cfg.Image)
+	clearPrimitiveHighlights(&cfg.ImageText)
+	clearBlockHighlights(&cfg.DefinitionList)
+	clearPrimitiveHighlights(&cfg.DefinitionTerm)
+	clearPrimitiveHighlights(&cfg.DefinitionDescription)
+	clearBlockHighlights(&cfg.HTMLBlock)
+	clearBlockHighlights(&cfg.HTMLSpan)
+	clearBlockHighlights(&cfg.Table.StyleBlock)
+
+	// Keep neutral code backgrounds for readability, but drop token-level color blocks.
+	if cfg.CodeBlock.Chroma != nil {
+		clearChromaTokenHighlights(cfg.CodeBlock.Chroma)
+	}
+}
+
+func clearBlockHighlights(block *ansi.StyleBlock) {
+	if block == nil {
+		return
+	}
+	clearPrimitiveHighlights(&block.StylePrimitive)
+}
+
+func clearPrimitiveHighlights(primitive *ansi.StylePrimitive) {
+	if primitive == nil {
+		return
+	}
+	primitive.BackgroundColor = nil
+	primitive.Inverse = nil
+}
+
+func clearChromaTokenHighlights(chroma *ansi.Chroma) {
+	if chroma == nil {
+		return
+	}
+
+	clearPrimitiveHighlights(&chroma.Text)
+	clearPrimitiveHighlights(&chroma.Error)
+	clearPrimitiveHighlights(&chroma.Comment)
+	clearPrimitiveHighlights(&chroma.CommentPreproc)
+	clearPrimitiveHighlights(&chroma.Keyword)
+	clearPrimitiveHighlights(&chroma.KeywordReserved)
+	clearPrimitiveHighlights(&chroma.KeywordNamespace)
+	clearPrimitiveHighlights(&chroma.KeywordType)
+	clearPrimitiveHighlights(&chroma.Operator)
+	clearPrimitiveHighlights(&chroma.Punctuation)
+	clearPrimitiveHighlights(&chroma.Name)
+	clearPrimitiveHighlights(&chroma.NameBuiltin)
+	clearPrimitiveHighlights(&chroma.NameTag)
+	clearPrimitiveHighlights(&chroma.NameAttribute)
+	clearPrimitiveHighlights(&chroma.NameClass)
+	clearPrimitiveHighlights(&chroma.NameConstant)
+	clearPrimitiveHighlights(&chroma.NameDecorator)
+	clearPrimitiveHighlights(&chroma.NameException)
+	clearPrimitiveHighlights(&chroma.NameFunction)
+	clearPrimitiveHighlights(&chroma.NameOther)
+	clearPrimitiveHighlights(&chroma.Literal)
+	clearPrimitiveHighlights(&chroma.LiteralNumber)
+	clearPrimitiveHighlights(&chroma.LiteralDate)
+	clearPrimitiveHighlights(&chroma.LiteralString)
+	clearPrimitiveHighlights(&chroma.LiteralStringEscape)
+	clearPrimitiveHighlights(&chroma.GenericDeleted)
+	clearPrimitiveHighlights(&chroma.GenericEmph)
+	clearPrimitiveHighlights(&chroma.GenericInserted)
+	clearPrimitiveHighlights(&chroma.GenericStrong)
+	clearPrimitiveHighlights(&chroma.GenericSubheading)
 }

--- a/internal/tui/infra/markdown_renderer_test.go
+++ b/internal/tui/infra/markdown_renderer_test.go
@@ -1,0 +1,76 @@
+package infra
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/glamour/ansi"
+)
+
+func TestStripNonCodeHighlightBackgrounds(t *testing.T) {
+	red := "#ff0000"
+	orange := "#ff9900"
+	gray := "#333333"
+	dark := "#202020"
+	inverse := true
+
+	cfg := ansi.StyleConfig{
+		Text: ansi.StylePrimitive{
+			BackgroundColor: &red,
+			Inverse:         &inverse,
+		},
+		Emph: ansi.StylePrimitive{
+			BackgroundColor: &orange,
+		},
+		Code: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				BackgroundColor: &gray,
+			},
+		},
+		CodeBlock: ansi.StyleCodeBlock{
+			StyleBlock: ansi.StyleBlock{
+				StylePrimitive: ansi.StylePrimitive{
+					BackgroundColor: &dark,
+				},
+			},
+			Chroma: &ansi.Chroma{
+				LiteralString: ansi.StylePrimitive{
+					BackgroundColor: &orange,
+				},
+				GenericDeleted: ansi.StylePrimitive{
+					BackgroundColor: &red,
+					Inverse:         &inverse,
+				},
+				Background: ansi.StylePrimitive{
+					BackgroundColor: &gray,
+				},
+			},
+		},
+	}
+
+	stripNonCodeHighlightBackgrounds(&cfg)
+
+	if cfg.Text.BackgroundColor != nil || cfg.Text.Inverse != nil {
+		t.Fatalf("expected text highlight background/inverse to be cleared")
+	}
+	if cfg.Emph.BackgroundColor != nil {
+		t.Fatalf("expected emphasis highlight background to be cleared")
+	}
+	if cfg.Code.BackgroundColor == nil {
+		t.Fatalf("expected inline code gray background to be preserved")
+	}
+	if cfg.CodeBlock.BackgroundColor == nil {
+		t.Fatalf("expected code block gray background to be preserved")
+	}
+	if cfg.CodeBlock.Chroma == nil {
+		t.Fatalf("expected chroma config to remain present")
+	}
+	if cfg.CodeBlock.Chroma.LiteralString.BackgroundColor != nil {
+		t.Fatalf("expected chroma token background to be cleared")
+	}
+	if cfg.CodeBlock.Chroma.GenericDeleted.BackgroundColor != nil || cfg.CodeBlock.Chroma.GenericDeleted.Inverse != nil {
+		t.Fatalf("expected chroma deleted token highlight to be cleared")
+	}
+	if cfg.CodeBlock.Chroma.Background.BackgroundColor == nil {
+		t.Fatalf("expected neutral chroma background to be preserved")
+	}
+}

--- a/internal/tui/services/file_service.go
+++ b/internal/tui/services/file_service.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sahilm/fuzzy"
+
 	tuiinfra "neo-code/internal/tui/infra"
 )
 
@@ -17,24 +19,31 @@ func SuggestFileMatches(query string, candidates []string, limit int) []string {
 	if len(candidates) == 0 || limit <= 0 {
 		return nil
 	}
-	prefixMatches := make([]string, 0, limit)
-	containsMatches := make([]string, 0, limit)
-	for _, candidate := range candidates {
-		lower := strings.ToLower(candidate)
-		switch {
-		case query == "" || strings.HasPrefix(lower, query):
-			prefixMatches = append(prefixMatches, candidate)
-		case strings.Contains(lower, query):
-			containsMatches = append(containsMatches, candidate)
-		}
-		if len(prefixMatches)+len(containsMatches) >= limit {
-			break
-		}
+
+	query = strings.ToLower(strings.TrimSpace(query))
+	if query == "" {
+		end := min(len(candidates), limit)
+		out := make([]string, 0, end)
+		out = append(out, candidates[:end]...)
+		return out
 	}
 
-	out := append(prefixMatches, containsMatches...)
-	if len(out) > limit {
-		out = out[:limit]
+	targets := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		targets = append(targets, strings.ToLower(candidate))
+	}
+
+	matches := fuzzy.Find(query, targets)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, min(limit, len(matches)))
+	for _, match := range matches {
+		out = append(out, candidates[match.Index])
+		if len(out) >= limit {
+			break
+		}
 	}
 	return out
 }

--- a/internal/tui/services/services_test.go
+++ b/internal/tui/services/services_test.go
@@ -276,7 +276,7 @@ func TestFileServices(t *testing.T) {
 		t.Fatalf("expected 2 matches, got %d (%v)", len(matches), matches)
 	}
 	if matches[0] != "internal/tui/update.go" {
-		t.Fatalf("expected prefix match first, got %v", matches)
+		t.Fatalf("expected best fuzzy match first, got %v", matches)
 	}
 
 	root := t.TempDir()
@@ -311,13 +311,16 @@ func TestSuggestFileMatchesBranches(t *testing.T) {
 		t.Fatalf("expected contains-match branch, got %v", got)
 	}
 	if got := SuggestFileMatches("", candidates, 2); len(got) != 2 {
-		t.Fatalf("expected empty query to return prefix-priority items, got %v", got)
+		t.Fatalf("expected empty query to return first items, got %v", got)
 	}
 	if got := SuggestFileMatches("any", candidates, 0); got != nil {
 		t.Fatalf("expected zero limit to return nil, got %v", got)
 	}
 	if got := SuggestFileMatches("any", nil, 2); got != nil {
 		t.Fatalf("expected nil candidates to return nil, got %v", got)
+	}
+	if got := SuggestFileMatches("itup", candidates, 2); len(got) == 0 || got[0] != "internal/tui/update.go" {
+		t.Fatalf("expected fuzzy abbreviation match for itup, got %v", got)
 	}
 }
 

--- a/www/guide/quick-start.md
+++ b/www/guide/quick-start.md
@@ -29,7 +29,6 @@ go run ./cmd/neocode
 | `/help` | 查看 Slash 命令帮助 |
 | `/clear` | 清空当前草稿会话展示 |
 | `/compact` | 压缩当前会话上下文 |
-| `/status` | 查看当前会话与运行状态 |
 | `/provider` | 打开 Provider 选择器 |
 | `/provider add` | 添加自定义 Provider |
 | `/model` | 打开 Model 选择器 |


### PR DESCRIPTION
## 变更概述
本次改动聚焦 TUI 体验一致性与可用性优化，主要包含四个方向：
- 调整界面尺寸与窗口适配阈值
- 增加各类面板搜索能力并统一为模糊匹配
- 统一输入与消息渲染格式，修复对齐/缩进不一致
- 调整 Markdown 渲染，去除异常高亮背景并保留可读性

## 主要改动

### 1) 界面大小与窗口适配
- 启动/主界面最小窗口要求统一回 `60x30`
- 小窗口提示文案与实际阈值保持一致
- 同步更新相关测试断言，避免 CI 因尺寸提示不一致失败

### 2) 面板搜索能力增强
- 为 `/provider`、`/model`、`/session`、`/help` picker 统一启用搜索框
- 打开 picker 时默认进入可过滤状态，支持直接输入搜索
- 修复 `/model` 在异步刷新后搜索状态丢失的问题
- 修复“输入后不即时过滤”和“过滤时上下键无法移动”问题
- 统一搜索体验为模糊匹配（fuzzy），包括：
  - picker 搜索
  - slash 命令建议
  - 文件建议列表

### 3) 输入/消息格式对齐
- 统一用户与 AI 消息的渲染路径，修复缩进和对齐不一致
- 调整部分列表/面板渲染细节，提升不同终端下显示一致性

### 4) Markdown 渲染优化
- 去除非代码内容中的彩色背景高亮块，避免异常橙色/色块渲染
- 保留代码块灰底等中性背景，保证可读性
- 清理 token 级别不必要背景色，降低主题差异带来的视觉噪音

## 命令行为变更
- 移除 `/status` 命令及其帮助入口
- 同步更新相关测试和文档（README、quick-start）

## 测试与验证
已完成并通过：
- `go test ./internal/tui/core/app -count=1`
- `go test ./internal/tui/core/commands -count=1`
- `go test ./internal/tui/services -count=1`
- `go test ./internal/tui/... -count=1`

## 影响范围
- `internal/tui/core/app/*`
- `internal/tui/core/commands/*`
- `internal/tui/services/*`
- `internal/tui/infra/markdown_renderer*`
- `README.md`
- `www/guide/quick-start.md`

## 风险与兼容性说明
- 搜索结果排序可能因 fuzzy 打分与此前前缀/包含策略不同而变化（属预期优化）
- `/status` 被移除后，依赖该命令的使用习惯需切换到现有状态展示路径（header/picker/activity）
