### PR TITLE
feat(tui): add full-access mode with risk prompt and auto approvals

### DIFF
--- a/internal/tui/core/app/app.go
+++ b/internal/tui/core/app/app.go
@@ -122,6 +122,7 @@ type appRuntimeState struct {
 	runProgressLabel        string
 	lastUserMessageRunID    string
 	pendingPermission       *permissionPromptState
+	pendingAutoPermission   *autoPermissionApprovalState
 	pendingFullAccessPrompt *fullAccessPromptState
 	fullAccessModeEnabled   bool
 	pendingImageAttachments []pendingImageAttachment

--- a/internal/tui/core/app/app.go
+++ b/internal/tui/core/app/app.go
@@ -122,6 +122,8 @@ type appRuntimeState struct {
 	runProgressLabel        string
 	lastUserMessageRunID    string
 	pendingPermission       *permissionPromptState
+	pendingFullAccessPrompt *fullAccessPromptState
+	fullAccessModeEnabled   bool
 	pendingImageAttachments []pendingImageAttachment
 	providerAddForm         *providerAddFormState
 	modelScopeGuide         *modelScopeGuideState

--- a/internal/tui/core/app/commands.go
+++ b/internal/tui/core/app/commands.go
@@ -100,6 +100,10 @@ const (
 	statusPermissionRequired   = "Permission required: choose a decision and press Enter"
 	statusPermissionSubmitting = "Submitting permission decision"
 	statusPermissionSubmitted  = "Permission decision submitted"
+	statusFullAccessPrompt     = "Full access risk prompt: press Y/N"
+	statusFullAccessEnabled    = "Full access mode enabled: tool approvals are auto-approved"
+	statusFullAccessDisabled   = "Full access mode disabled"
+	statusFullAccessCanceled   = "Full access enable canceled"
 
 	focusLabelSessions   = "Sessions"
 	focusLabelTranscript = "Transcript"

--- a/internal/tui/core/app/full_access_prompt.go
+++ b/internal/tui/core/app/full_access_prompt.go
@@ -1,0 +1,92 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// fullAccessPromptOption 描述 Full Access 风险确认弹窗中的一个选项。
+type fullAccessPromptOption struct {
+	Label  string
+	Hint   string
+	Enable bool
+}
+
+var fullAccessPromptOptions = []fullAccessPromptOption{
+	{
+		Label:  "Yes",
+		Hint:   "Enable full access and auto-approve all tool requests",
+		Enable: true,
+	},
+	{
+		Label:  "No",
+		Hint:   "Keep normal approval flow",
+		Enable: false,
+	},
+}
+
+// fullAccessPromptState 保存 Full Access 风险确认弹窗状态。
+type fullAccessPromptState struct {
+	Selected int
+}
+
+// normalizeFullAccessPromptSelection 将选项下标收敛到合法范围，避免越界读取。
+func normalizeFullAccessPromptSelection(selected int) int {
+	if len(fullAccessPromptOptions) == 0 {
+		return 0
+	}
+	if selected < 0 {
+		return len(fullAccessPromptOptions) - 1
+	}
+	if selected >= len(fullAccessPromptOptions) {
+		return 0
+	}
+	return selected
+}
+
+// fullAccessPromptOptionAt 返回指定下标对应的 Full Access 风险确认选项。
+func fullAccessPromptOptionAt(selected int) fullAccessPromptOption {
+	index := normalizeFullAccessPromptSelection(selected)
+	return fullAccessPromptOptions[index]
+}
+
+// parseFullAccessPromptShortcut 将 y/n 快捷输入映射为启用或取消动作。
+func parseFullAccessPromptShortcut(input string) (bool, bool) {
+	switch strings.ToLower(strings.TrimSpace(input)) {
+	case "y", "yes", "enable":
+		return true, true
+	case "n", "no", "cancel":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+// formatFullAccessPromptLines 构造 Full Access 风险确认弹窗文案。
+func formatFullAccessPromptLines(state fullAccessPromptState) []string {
+	normalizedIdx := normalizeFullAccessPromptSelection(state.Selected)
+	lines := []string{
+		"Enable Full Access Mode?",
+		"Risk: all tool permission requests will be auto-approved for this session.",
+		"Press Y/N to approve, or use Up/Down + Enter.",
+	}
+
+	for index, item := range fullAccessPromptOptions {
+		prefix := "  "
+		if normalizedIdx == index {
+			prefix = "> "
+		}
+		lines = append(lines, fmt.Sprintf("%s%s  - %s", prefix, item.Label, item.Hint))
+	}
+	return lines
+}
+
+// renderFullAccessPrompt 渲染 Full Access 风险确认弹窗。
+func (a App) renderFullAccessPrompt() string {
+	if a.pendingFullAccessPrompt == nil {
+		return a.input.View()
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, formatFullAccessPromptLines(*a.pendingFullAccessPrompt)...)
+}

--- a/internal/tui/core/app/full_access_prompt_test.go
+++ b/internal/tui/core/app/full_access_prompt_test.go
@@ -23,8 +23,10 @@ func TestParseFullAccessPromptShortcut(t *testing.T) {
 	}{
 		{input: "y", want: true},
 		{input: "yes", want: true},
+		{input: " enable ", want: true},
 		{input: "n", want: false},
 		{input: "no", want: false},
+		{input: "CaNcEl", want: false},
 	}
 	for _, tt := range tests {
 		got, ok := parseFullAccessPromptShortcut(tt.input)
@@ -61,6 +63,40 @@ func TestRenderFullAccessPrompt(t *testing.T) {
 	rendered := app.renderFullAccessPrompt()
 	if !strings.Contains(rendered, "Enable Full Access Mode?") {
 		t.Fatalf("expected full access prompt content, got %q", rendered)
+	}
+}
+
+func TestNormalizeFullAccessPromptSelectionWithEmptyOptions(t *testing.T) {
+	original := fullAccessPromptOptions
+	fullAccessPromptOptions = nil
+	defer func() {
+		fullAccessPromptOptions = original
+	}()
+
+	if got := normalizeFullAccessPromptSelection(5); got != 0 {
+		t.Fatalf("expected empty options normalize to 0, got %d", got)
+	}
+}
+
+func TestFullAccessPromptOptionAtUsesNormalizedSelection(t *testing.T) {
+	option := fullAccessPromptOptionAt(-1)
+	if option.Label != "No" || option.Enable {
+		t.Fatalf("expected wrapped option to select No(false), got %+v", option)
+	}
+}
+
+func TestRenderFullAccessPromptFallsBackToInputView(t *testing.T) {
+	input := textarea.New()
+	input.SetValue("fallback-input")
+	app := App{
+		appComponents: appComponents{
+			input: input,
+		},
+	}
+
+	rendered := app.renderFullAccessPrompt()
+	if !strings.Contains(rendered, "fallback-input") {
+		t.Fatalf("expected input view when prompt is nil, got %q", rendered)
 	}
 }
 

--- a/internal/tui/core/app/full_access_prompt_test.go
+++ b/internal/tui/core/app/full_access_prompt_test.go
@@ -1,0 +1,92 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/textarea"
+)
+
+func TestNormalizeFullAccessPromptSelectionWrap(t *testing.T) {
+	if got := normalizeFullAccessPromptSelection(-1); got != len(fullAccessPromptOptions)-1 {
+		t.Fatalf("expected -1 to wrap to last index, got %d", got)
+	}
+	if got := normalizeFullAccessPromptSelection(len(fullAccessPromptOptions)); got != 0 {
+		t.Fatalf("expected overflow index to wrap to 0, got %d", got)
+	}
+}
+
+func TestParseFullAccessPromptShortcut(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{input: "y", want: true},
+		{input: "yes", want: true},
+		{input: "n", want: false},
+		{input: "no", want: false},
+	}
+	for _, tt := range tests {
+		got, ok := parseFullAccessPromptShortcut(tt.input)
+		if !ok || got != tt.want {
+			t.Fatalf("parseFullAccessPromptShortcut(%q)=(%v,%v), want (%v,true)", tt.input, got, ok, tt.want)
+		}
+	}
+	if _, ok := parseFullAccessPromptShortcut("unknown"); ok {
+		t.Fatal("expected unknown shortcut to fail")
+	}
+}
+
+func TestFormatFullAccessPromptLines(t *testing.T) {
+	lines := formatFullAccessPromptLines(fullAccessPromptState{Selected: 1})
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "Enable Full Access Mode?") {
+		t.Fatalf("expected header in full access prompt, got %q", joined)
+	}
+	if !strings.Contains(joined, "> No") {
+		t.Fatalf("expected selected option marker, got %q", joined)
+	}
+}
+
+func TestRenderFullAccessPrompt(t *testing.T) {
+	app := App{
+		appComponents: appComponents{input: textarea.New()},
+		appRuntimeState: appRuntimeState{
+			pendingFullAccessPrompt: &fullAccessPromptState{Selected: 0},
+			layoutCached:            true,
+			cachedWidth:             128,
+			cachedHeight:            40,
+		},
+	}
+	rendered := app.renderFullAccessPrompt()
+	if !strings.Contains(rendered, "Enable Full Access Mode?") {
+		t.Fatalf("expected full access prompt content, got %q", rendered)
+	}
+}
+
+func TestRenderPromptWithPendingFullAccessPrompt(t *testing.T) {
+	input := textarea.New()
+	input.SetValue("normal message")
+	app := App{
+		appComponents: appComponents{
+			input: input,
+		},
+		styles: newStyles(),
+		appRuntimeState: appRuntimeState{
+			pendingFullAccessPrompt: &fullAccessPromptState{Selected: 0},
+			layoutCached:            true,
+			cachedWidth:             128,
+			cachedHeight:            40,
+		},
+	}
+	rendered := app.renderPrompt(80)
+	if !strings.Contains(rendered, "Enable Full Access Mode?") {
+		t.Fatalf("expected full access prompt rendering branch, got %q", rendered)
+	}
+
+	app.pendingFullAccessPrompt = nil
+	rendered = app.renderPrompt(80)
+	if !strings.Contains(rendered, "normal message") {
+		t.Fatalf("expected normal input rendering branch, got %q", rendered)
+	}
+}

--- a/internal/tui/core/app/keymap.go
+++ b/internal/tui/core/app/keymap.go
@@ -3,24 +3,25 @@ package tui
 import "github.com/charmbracelet/bubbles/key"
 
 type keyMap struct {
-	Send          key.Binding
-	Newline       key.Binding
-	CancelAgent   key.Binding
-	NewSession    key.Binding
-	OpenWorkspace key.Binding
-	NextPanel     key.Binding
-	PrevPanel     key.Binding
-	FocusInput    key.Binding
-	ToggleHelp    key.Binding
-	Quit          key.Binding
-	ScrollUp      key.Binding
-	ScrollDown    key.Binding
-	PageUp        key.Binding
-	PageDown      key.Binding
-	Top           key.Binding
-	Bottom        key.Binding
-	PasteImage    key.Binding
-	LogViewer     key.Binding
+	Send             key.Binding
+	Newline          key.Binding
+	CancelAgent      key.Binding
+	NewSession       key.Binding
+	OpenWorkspace    key.Binding
+	ToggleFullAccess key.Binding
+	NextPanel        key.Binding
+	PrevPanel        key.Binding
+	FocusInput       key.Binding
+	ToggleHelp       key.Binding
+	Quit             key.Binding
+	ScrollUp         key.Binding
+	ScrollDown       key.Binding
+	PageUp           key.Binding
+	PageDown         key.Binding
+	Top              key.Binding
+	Bottom           key.Binding
+	PasteImage       key.Binding
+	LogViewer        key.Binding
 }
 
 func newKeyMap() keyMap {
@@ -44,6 +45,10 @@ func newKeyMap() keyMap {
 		OpenWorkspace: key.NewBinding(
 			key.WithKeys("ctrl+o"),
 			key.WithHelp("Ctrl+O", "Workspace"),
+		),
+		ToggleFullAccess: key.NewBinding(
+			key.WithKeys("ctrl+f"),
+			key.WithHelp("Ctrl+F", "Full access"),
 		),
 		NextPanel: key.NewBinding(
 			key.WithKeys("tab"),
@@ -107,7 +112,7 @@ func (k keyMap) ShortHelp() []key.Binding {
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Send, k.Newline, k.CancelAgent, k.NewSession},
-		{k.OpenWorkspace},
+		{k.OpenWorkspace, k.ToggleFullAccess},
 		{k.FocusInput, k.NextPanel, k.PrevPanel},
 		{k.ToggleHelp, k.Quit, k.PasteImage, k.ScrollUp},
 		{k.PageUp, k.PageDown, k.Top, k.Bottom},

--- a/internal/tui/core/app/keymap_test.go
+++ b/internal/tui/core/app/keymap_test.go
@@ -43,3 +43,16 @@ func TestFullHelpIncludesOpenWorkspace(t *testing.T) {
 	}
 	t.Fatalf("expected full help to include open workspace binding")
 }
+
+func TestFullHelpIncludesToggleFullAccess(t *testing.T) {
+	keys := newKeyMap()
+	help := keys.FullHelp()
+	for _, row := range help {
+		for _, binding := range row {
+			if binding.Help().Key == keys.ToggleFullAccess.Help().Key {
+				return
+			}
+		}
+	}
+	t.Fatalf("expected full help to include full access toggle binding")
+}

--- a/internal/tui/core/app/permission_prompt.go
+++ b/internal/tui/core/app/permission_prompt.go
@@ -42,6 +42,11 @@ type permissionPromptState struct {
 	Submitting bool
 }
 
+// autoPermissionApprovalState 记录 Full Access 自动审批中的请求，用于回执失败后的状态恢复。
+type autoPermissionApprovalState struct {
+	Request tuiservices.PermissionRequestPayload
+}
+
 // normalizePermissionPromptSelection 保证选项下标始终落在有效范围。
 func normalizePermissionPromptSelection(selected int) int {
 	if len(permissionPromptOptions) == 0 {

--- a/internal/tui/core/app/startup_view.go
+++ b/internal/tui/core/app/startup_view.go
@@ -24,12 +24,13 @@ type startupQuickActionItem struct {
 var startupQuickActions = []startupQuickActionItem{
 	{Key: "Ctrl+N", Label: "New Chat            "},
 	{Key: "     /", Label: "Open Command Palette"},
+	{Key: "Ctrl+F", Label: "Full Access Mode    "},
 	{Key: "Ctrl+L", Label: "Open Log Viewer     "},
 	{Key: "Ctrl+U", Label: "Exit NeoCode        "},
 }
 
 func (a App) shouldRenderStartupScreen() bool {
-	if a.state.ActivePicker != pickerNone || a.logViewerVisible || a.pendingPermission != nil {
+	if a.state.ActivePicker != pickerNone || a.logViewerVisible || a.pendingPermission != nil || a.pendingFullAccessPrompt != nil {
 		return false
 	}
 	if a.state.IsAgentRunning || a.state.IsCompacting {

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -152,6 +152,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.state.CurrentTool = ""
 		a.state.ActiveRunID = ""
 		a.pendingPermission = nil
+		a.pendingAutoPermission = nil
 		a.clearRunProgress()
 		a.state.IsCompacting = false
 		if strings.TrimSpace(a.state.StatusText) == "" {
@@ -163,6 +164,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.state.IsAgentRunning = false
 			a.state.ActiveRunID = ""
 			a.pendingPermission = nil
+			a.pendingAutoPermission = nil
 			a.clearRunProgress()
 			a.state.StreamingReply = false
 			a.state.CurrentTool = ""
@@ -181,20 +183,10 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.syncTodosFromRun()
 		return a, batchUpdateCmds()
 	case permissionResolutionFinishedMsg:
-		if a.pendingPermission != nil && a.pendingPermission.Request.RequestID == typed.RequestID {
-			if typed.Err != nil {
-				a.pendingPermission.Submitting = false
-				a.state.ExecutionError = typed.Err.Error()
-				a.state.StatusText = typed.Err.Error()
-				a.appendActivity("permission", "Permission decision submit failed", typed.Err.Error(), true)
-			} else {
-				a.pendingPermission = nil
-				a.state.ExecutionError = ""
-				a.state.StatusText = statusPermissionSubmitted
-				a.appendActivity("permission", "Permission decision submitted", string(typed.Decision), false)
-				a.refreshPermissionPromptLayout()
-			}
+		if a.handleAutoPermissionResolutionFinished(typed) {
+			return a, batchUpdateCmds()
 		}
+		a.handlePermissionResolutionFinished(typed)
 		return a, batchUpdateCmds()
 	case modelCatalogRefreshMsg:
 		if strings.EqualFold(a.modelRefreshID, typed.ProviderID) {
@@ -692,22 +684,11 @@ func (a *App) submitPermissionDecision(decision tuiservices.PermissionResolution
 // toggleFullAccessMode 处理 Full Access 模式的启停切换；启用前必须经过风险确认。
 func (a *App) toggleFullAccessMode() tea.Cmd {
 	if a.fullAccessModeEnabled {
-		a.fullAccessModeEnabled = false
-		a.pendingFullAccessPrompt = nil
-		a.state.StatusText = statusFullAccessDisabled
-		a.state.ExecutionError = ""
-		a.appendActivity("permission", "Full access mode disabled", "", false)
-		a.refreshPermissionPromptLayout()
+		a.disableFullAccessMode()
 		return nil
 	}
 
-	a.pendingFullAccessPrompt = &fullAccessPromptState{Selected: 0}
-	a.focus = panelInput
-	a.applyFocus()
-	a.state.StatusText = statusFullAccessPrompt
-	a.state.ExecutionError = ""
-	a.appendActivity("permission", "Full access risk prompt opened", "Press Y to enable, N to cancel", false)
-	a.refreshPermissionPromptLayout()
+	a.openFullAccessPrompt()
 	return nil
 }
 
@@ -762,6 +743,76 @@ func (a *App) applyFullAccessPromptSelection(enable bool) tea.Cmd {
 		return a.submitPermissionDecision(tuiservices.DecisionAllowSession)
 	}
 	return nil
+}
+
+// openFullAccessPrompt 打开 Full Access 风险确认弹窗，并将输入焦点收敛回输入区。
+func (a *App) openFullAccessPrompt() {
+	a.pendingFullAccessPrompt = &fullAccessPromptState{Selected: 0}
+	a.focus = panelInput
+	a.applyFocus()
+	a.state.StatusText = statusFullAccessPrompt
+	a.state.ExecutionError = ""
+	a.appendActivity("permission", "Full access risk prompt opened", "Press Y to enable, N to cancel", false)
+	a.refreshPermissionPromptLayout()
+}
+
+// disableFullAccessMode 关闭 Full Access 模式并刷新提示区布局。
+func (a *App) disableFullAccessMode() {
+	a.fullAccessModeEnabled = false
+	a.pendingFullAccessPrompt = nil
+	a.state.StatusText = statusFullAccessDisabled
+	a.state.ExecutionError = ""
+	a.appendActivity("permission", "Full access mode disabled", "", false)
+	a.refreshPermissionPromptLayout()
+}
+
+// handleAutoPermissionResolutionFinished 处理 Full Access 自动审批回执，并在失败时回退到手动审批。
+func (a *App) handleAutoPermissionResolutionFinished(msg permissionResolutionFinishedMsg) bool {
+	if a.pendingAutoPermission == nil || a.pendingAutoPermission.Request.RequestID != msg.RequestID {
+		return false
+	}
+
+	request := a.pendingAutoPermission.Request
+	a.pendingAutoPermission = nil
+	if msg.Err != nil {
+		a.pendingPermission = &permissionPromptState{
+			Request:  request,
+			Selected: normalizePermissionPromptSelection(1),
+		}
+		a.focus = panelInput
+		a.applyFocus()
+		a.state.ExecutionError = msg.Err.Error()
+		a.state.StatusText = statusPermissionRequired
+		a.appendActivity("permission", "Full access auto-approval failed", msg.Err.Error(), true)
+		a.refreshPermissionPromptLayout()
+		return true
+	}
+
+	a.state.ExecutionError = ""
+	a.state.StatusText = statusPermissionSubmitted
+	a.appendActivity("permission", "Full access auto-approval submitted", string(msg.Decision), false)
+	return true
+}
+
+// handlePermissionResolutionFinished 更新手动审批提交流程的成功或失败状态。
+func (a *App) handlePermissionResolutionFinished(msg permissionResolutionFinishedMsg) {
+	if a.pendingPermission == nil || a.pendingPermission.Request.RequestID != msg.RequestID {
+		return
+	}
+
+	if msg.Err != nil {
+		a.pendingPermission.Submitting = false
+		a.state.ExecutionError = msg.Err.Error()
+		a.state.StatusText = msg.Err.Error()
+		a.appendActivity("permission", "Permission decision submit failed", msg.Err.Error(), true)
+		return
+	}
+
+	a.pendingPermission = nil
+	a.state.ExecutionError = ""
+	a.state.StatusText = statusPermissionSubmitted
+	a.appendActivity("permission", "Permission decision submitted", string(msg.Decision), false)
+	a.refreshPermissionPromptLayout()
 }
 
 func (a App) now() time.Time {
@@ -1379,6 +1430,7 @@ func (a *App) resetSessionRuntimeState() {
 	a.state.RunContext = tuistate.ContextWindowState{}
 	a.state.TokenUsage = tuistate.TokenUsageState{}
 	a.pendingPermission = nil
+	a.pendingAutoPermission = nil
 	a.clearRunProgress()
 }
 
@@ -1711,6 +1763,7 @@ func runtimeEventStopReasonDecidedHandler(a *App, event tuiservices.RuntimeEvent
 	a.state.CurrentTool = ""
 	a.state.ActiveRunID = ""
 	a.pendingPermission = nil
+	a.pendingAutoPermission = nil
 	a.clearRunProgress()
 
 	reason := strings.ToLower(strings.TrimSpace(string(payload.Reason)))
@@ -2180,6 +2233,7 @@ func runtimeEventAgentDoneHandler(a *App, event tuiservices.RuntimeEvent) bool {
 	a.state.CurrentTool = ""
 	a.state.ActiveRunID = ""
 	a.pendingPermission = nil
+	a.pendingAutoPermission = nil
 	a.clearRunProgress()
 	if strings.TrimSpace(a.state.ExecutionError) == "" {
 		a.state.StatusText = statusReady
@@ -2200,6 +2254,7 @@ func runtimeEventRunCanceledHandler(a *App, event tuiservices.RuntimeEvent) bool
 	a.state.CurrentTool = ""
 	a.state.ActiveRunID = ""
 	a.pendingPermission = nil
+	a.pendingAutoPermission = nil
 	a.state.ExecutionError = ""
 	a.state.StatusText = statusCanceled
 	a.clearRunProgress()
@@ -2215,6 +2270,7 @@ func runtimeEventErrorHandler(a *App, event tuiservices.RuntimeEvent) bool {
 	a.state.CurrentTool = ""
 	a.state.ActiveRunID = ""
 	a.pendingPermission = nil
+	a.pendingAutoPermission = nil
 	a.clearRunProgress()
 	if payload, ok := event.Payload.(string); ok {
 		a.state.ExecutionError = payload
@@ -2238,22 +2294,8 @@ func runtimeEventPermissionRequestHandler(a *App, event tuiservices.RuntimeEvent
 	if !ok {
 		return false
 	}
-	if a.fullAccessModeEnabled {
-		requestID := strings.TrimSpace(payload.RequestID)
-		if requestID != "" {
-			a.pendingPermission = nil
-			a.state.StatusText = statusPermissionSubmitting
-			a.state.ExecutionError = ""
-			a.deferredEventCmd = runResolvePermission(a.runtime, requestID, tuiservices.DecisionAllowSession)
-			a.appendActivity(
-				"permission",
-				"Full access auto-approved permission",
-				fmt.Sprintf("%s -> %s", fallbackText(payload.ToolName, "tool"), fallbackText(payload.Target, "(empty target)")),
-				false,
-			)
-			a.refreshPermissionPromptLayout()
-			return false
-		}
+	if a.beginAutoPermissionApproval(payload) {
+		return false
 	}
 
 	if a.pendingPermission != nil {
@@ -2282,11 +2324,37 @@ func runtimeEventPermissionRequestHandler(a *App, event tuiservices.RuntimeEvent
 	a.appendActivity(
 		"permission",
 		"Permission request",
-		fmt.Sprintf("%s -> %s", fallbackText(payload.ToolName, "tool"), fallbackText(payload.Target, "(empty target)")),
+		permissionRequestActivityDetail(payload),
 		false,
 	)
 	a.refreshPermissionPromptLayout()
 	return false
+}
+
+// beginAutoPermissionApproval 在 Full Access 模式下直接提交 session 级审批，并记录回执所需状态。
+func (a *App) beginAutoPermissionApproval(payload tuiservices.PermissionRequestPayload) bool {
+	if !a.fullAccessModeEnabled {
+		return false
+	}
+
+	requestID := strings.TrimSpace(payload.RequestID)
+	if requestID == "" {
+		return false
+	}
+
+	a.pendingPermission = nil
+	a.pendingAutoPermission = &autoPermissionApprovalState{Request: payload}
+	a.state.StatusText = statusPermissionSubmitting
+	a.state.ExecutionError = ""
+	a.deferredEventCmd = runResolvePermission(a.runtime, requestID, tuiservices.DecisionAllowSession)
+	a.appendActivity("permission", "Full access auto-approved permission", permissionRequestActivityDetail(payload), false)
+	a.refreshPermissionPromptLayout()
+	return true
+}
+
+// permissionRequestActivityDetail 统一格式化权限请求相关活动明细，避免各分支重复拼接。
+func permissionRequestActivityDetail(payload tuiservices.PermissionRequestPayload) string {
+	return fmt.Sprintf("%s -> %s", fallbackText(payload.ToolName, "tool"), fallbackText(payload.Target, "(empty target)"))
 }
 
 func runtimeEventPermissionResolvedHandler(a *App, event tuiservices.RuntimeEvent) bool {
@@ -2297,6 +2365,9 @@ func runtimeEventPermissionResolvedHandler(a *App, event tuiservices.RuntimeEven
 
 	if a.pendingPermission != nil && a.pendingPermission.Request.RequestID == payload.RequestID {
 		a.pendingPermission = nil
+	}
+	if a.pendingAutoPermission != nil && a.pendingAutoPermission.Request.RequestID == payload.RequestID {
+		a.pendingAutoPermission = nil
 	}
 	a.state.StatusText = fmt.Sprintf("Permission %s", fallbackText(payload.ResolvedAs, "resolved"))
 	a.appendActivity(
@@ -3356,6 +3427,7 @@ func (a *App) startDraftSession() {
 	a.state.RunContext = tuistate.ContextWindowState{}
 	a.state.TokenUsage = tuistate.TokenUsageState{}
 	a.pendingPermission = nil
+	a.pendingAutoPermission = nil
 	a.clearRunProgress()
 	a.input.Reset()
 	a.state.InputText = ""

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -311,6 +311,20 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.applyComponentLayout(true)
 			return a, batchUpdateCmds()
 		}
+		if a.pendingFullAccessPrompt != nil {
+			if cmd, handled := a.updatePendingFullAccessPromptInput(typed); handled {
+				if cmd != nil {
+					cmds = append(cmds, cmd)
+				}
+				return a, batchUpdateCmds()
+			}
+		}
+		if key.Matches(typed, a.keys.ToggleFullAccess) {
+			if cmd := a.toggleFullAccessMode(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+			return a, batchUpdateCmds()
+		}
 		if a.state.IsAgentRunning && key.Matches(typed, a.keys.CancelAgent) {
 			if a.runtime.CancelActiveRun() {
 				a.state.StatusText = statusCanceling
@@ -449,6 +463,14 @@ func (a App) updateInputPanel(msg tea.Msg, typed tea.KeyMsg, cmds []tea.Cmd) (te
 
 	if a.pendingPermission != nil {
 		if cmd, handled := a.updatePendingPermissionInput(typed); handled {
+			if cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+			return a, batchUpdateCmds()
+		}
+	}
+	if a.pendingFullAccessPrompt != nil {
+		if cmd, handled := a.updatePendingFullAccessPromptInput(typed); handled {
 			if cmd != nil {
 				cmds = append(cmds, cmd)
 			}
@@ -665,6 +687,81 @@ func (a *App) submitPermissionDecision(decision tuiservices.PermissionResolution
 	a.appendActivity("permission", "Submitting permission decision", string(decision), false)
 
 	return runResolvePermission(a.runtime, requestID, decision)
+}
+
+// toggleFullAccessMode 处理 Full Access 模式的启停切换；启用前必须经过风险确认。
+func (a *App) toggleFullAccessMode() tea.Cmd {
+	if a.fullAccessModeEnabled {
+		a.fullAccessModeEnabled = false
+		a.pendingFullAccessPrompt = nil
+		a.state.StatusText = statusFullAccessDisabled
+		a.state.ExecutionError = ""
+		a.appendActivity("permission", "Full access mode disabled", "", false)
+		a.refreshPermissionPromptLayout()
+		return nil
+	}
+
+	a.pendingFullAccessPrompt = &fullAccessPromptState{Selected: 0}
+	a.focus = panelInput
+	a.applyFocus()
+	a.state.StatusText = statusFullAccessPrompt
+	a.state.ExecutionError = ""
+	a.appendActivity("permission", "Full access risk prompt opened", "Press Y to enable, N to cancel", false)
+	a.refreshPermissionPromptLayout()
+	return nil
+}
+
+// updatePendingFullAccessPromptInput 处理 Full Access 风险确认弹窗的键盘交互。
+func (a *App) updatePendingFullAccessPromptInput(typed tea.KeyMsg) (tea.Cmd, bool) {
+	if a.pendingFullAccessPrompt == nil {
+		return nil, false
+	}
+
+	switch {
+	case key.Matches(typed, a.keys.ScrollUp):
+		a.pendingFullAccessPrompt.Selected = normalizeFullAccessPromptSelection(a.pendingFullAccessPrompt.Selected - 1)
+		a.state.StatusText = statusFullAccessPrompt
+		return nil, true
+	case key.Matches(typed, a.keys.ScrollDown):
+		a.pendingFullAccessPrompt.Selected = normalizeFullAccessPromptSelection(a.pendingFullAccessPrompt.Selected + 1)
+		a.state.StatusText = statusFullAccessPrompt
+		return nil, true
+	case key.Matches(typed, a.keys.Send):
+		option := fullAccessPromptOptionAt(a.pendingFullAccessPrompt.Selected)
+		return a.applyFullAccessPromptSelection(option.Enable), true
+	case key.Matches(typed, a.keys.FocusInput):
+		return a.applyFullAccessPromptSelection(false), true
+	}
+
+	if typed.Type == tea.KeyRunes && len(typed.Runes) > 0 {
+		if enable, ok := parseFullAccessPromptShortcut(string(typed.Runes)); ok {
+			return a.applyFullAccessPromptSelection(enable), true
+		}
+	}
+	return nil, true
+}
+
+// applyFullAccessPromptSelection 根据风险确认结果更新 Full Access 模式，并按需自动处理待审批请求。
+func (a *App) applyFullAccessPromptSelection(enable bool) tea.Cmd {
+	a.pendingFullAccessPrompt = nil
+	if !enable {
+		a.state.StatusText = statusFullAccessCanceled
+		a.state.ExecutionError = ""
+		a.appendActivity("permission", "Full access enable canceled", "", false)
+		a.refreshPermissionPromptLayout()
+		return nil
+	}
+
+	a.fullAccessModeEnabled = true
+	a.state.StatusText = statusFullAccessEnabled
+	a.state.ExecutionError = ""
+	a.appendActivity("permission", "Full access mode enabled", "All upcoming tool requests will be auto-approved", false)
+	a.refreshPermissionPromptLayout()
+
+	if a.pendingPermission != nil && !a.pendingPermission.Submitting {
+		return a.submitPermissionDecision(tuiservices.DecisionAllowSession)
+	}
+	return nil
 }
 
 func (a App) now() time.Time {
@@ -2140,6 +2237,23 @@ func runtimeEventPermissionRequestHandler(a *App, event tuiservices.RuntimeEvent
 	payload, ok := parsePermissionRequestPayload(event.Payload)
 	if !ok {
 		return false
+	}
+	if a.fullAccessModeEnabled {
+		requestID := strings.TrimSpace(payload.RequestID)
+		if requestID != "" {
+			a.pendingPermission = nil
+			a.state.StatusText = statusPermissionSubmitting
+			a.state.ExecutionError = ""
+			a.deferredEventCmd = runResolvePermission(a.runtime, requestID, tuiservices.DecisionAllowSession)
+			a.appendActivity(
+				"permission",
+				"Full access auto-approved permission",
+				fmt.Sprintf("%s -> %s", fallbackText(payload.ToolName, "tool"), fallbackText(payload.Target, "(empty target)")),
+				false,
+			)
+			a.refreshPermissionPromptLayout()
+			return false
+		}
 	}
 
 	if a.pendingPermission != nil {

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -312,9 +312,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		if key.Matches(typed, a.keys.ToggleFullAccess) {
-			if cmd := a.toggleFullAccessMode(); cmd != nil {
-				cmds = append(cmds, cmd)
-			}
+			a.toggleFullAccessMode()
 			return a, batchUpdateCmds()
 		}
 		if a.state.IsAgentRunning && key.Matches(typed, a.keys.CancelAgent) {
@@ -461,15 +459,6 @@ func (a App) updateInputPanel(msg tea.Msg, typed tea.KeyMsg, cmds []tea.Cmd) (te
 			return a, batchUpdateCmds()
 		}
 	}
-	if a.pendingFullAccessPrompt != nil {
-		if cmd, handled := a.updatePendingFullAccessPromptInput(typed); handled {
-			if cmd != nil {
-				cmds = append(cmds, cmd)
-			}
-			return a, batchUpdateCmds()
-		}
-	}
-
 	if key.Matches(typed, a.keys.Send) {
 		if a.shouldTreatEnterAsNewline(typed, now) {
 			a.growComposerForNewline()
@@ -682,14 +671,13 @@ func (a *App) submitPermissionDecision(decision tuiservices.PermissionResolution
 }
 
 // toggleFullAccessMode 处理 Full Access 模式的启停切换；启用前必须经过风险确认。
-func (a *App) toggleFullAccessMode() tea.Cmd {
+func (a *App) toggleFullAccessMode() {
 	if a.fullAccessModeEnabled {
 		a.disableFullAccessMode()
-		return nil
+		return
 	}
 
 	a.openFullAccessPrompt()
-	return nil
 }
 
 // updatePendingFullAccessPromptInput 处理 Full Access 风险确认弹窗的键盘交互。

--- a/internal/tui/core/app/update_full_access_test.go
+++ b/internal/tui/core/app/update_full_access_test.go
@@ -1,12 +1,27 @@
 package tui
 
 import (
+	"errors"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	agentruntime "neo-code/internal/tui/services"
 )
+
+func expectPermissionResolutionFinishedMsg(t *testing.T, cmd tea.Cmd) permissionResolutionFinishedMsg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatalf("expected non-nil command")
+	}
+
+	msg := cmd()
+	done, ok := msg.(permissionResolutionFinishedMsg)
+	if !ok {
+		t.Fatalf("expected permissionResolutionFinishedMsg, got %T", msg)
+	}
+	return done
+}
 
 func TestToggleFullAccessModeOpensPromptAndDisables(t *testing.T) {
 	app := newPermissionTestApp(&permissionTestRuntime{})
@@ -55,11 +70,7 @@ func TestUpdatePendingFullAccessPromptInputEnableAutoApprovesPendingPermission(t
 		t.Fatalf("expected full access prompt to be cleared after approval")
 	}
 
-	msg := cmd()
-	done, ok := msg.(permissionResolutionFinishedMsg)
-	if !ok {
-		t.Fatalf("expected permissionResolutionFinishedMsg, got %T", msg)
-	}
+	done := expectPermissionResolutionFinishedMsg(t, cmd)
 	if done.RequestID != "perm-full-access" || done.Decision != string(agentruntime.DecisionAllowSession) {
 		t.Fatalf("unexpected auto-approval payload: %+v", done)
 	}
@@ -87,19 +98,52 @@ func TestRuntimePermissionRequestHandlerAutoApprovesWhenFullAccessEnabled(t *tes
 	if app.pendingPermission != nil {
 		t.Fatalf("expected no pending permission prompt in full access mode")
 	}
+	if app.pendingAutoPermission == nil || app.pendingAutoPermission.Request.RequestID != "perm-auto" {
+		t.Fatalf("expected full access mode to track pending auto-approval request")
+	}
 	if app.deferredEventCmd == nil {
 		t.Fatalf("expected full access mode to schedule auto-approval command")
 	}
 
-	msg := app.deferredEventCmd()
-	done, ok := msg.(permissionResolutionFinishedMsg)
-	if !ok {
-		t.Fatalf("expected permissionResolutionFinishedMsg, got %T", msg)
-	}
+	done := expectPermissionResolutionFinishedMsg(t, app.deferredEventCmd)
 	if done.RequestID != "perm-auto" || done.Decision != string(agentruntime.DecisionAllowSession) {
 		t.Fatalf("unexpected auto-approval payload: %+v", done)
 	}
 	if runtime.lastResolved.RequestID != "perm-auto" || runtime.lastResolved.Decision != agentruntime.DecisionAllowSession {
 		t.Fatalf("unexpected runtime resolve input: %+v", runtime.lastResolved)
+	}
+}
+
+func TestUpdatePermissionResolutionFinishedMessageRestoresPromptAfterFullAccessAutoApproveFailure(t *testing.T) {
+	app := newPermissionTestApp(&permissionTestRuntime{})
+	app.pendingAutoPermission = &autoPermissionApprovalState{
+		Request: agentruntime.PermissionRequestPayload{
+			RequestID: "perm-auto-fail",
+			ToolName:  "bash",
+			Target:    "rm -rf /tmp/x",
+		},
+	}
+	app.fullAccessModeEnabled = true
+
+	model, _ := app.Update(permissionResolutionFinishedMsg{
+		RequestID: "perm-auto-fail",
+		Decision:  string(agentruntime.DecisionAllowSession),
+		Err:       errors.New("submit failed"),
+	})
+	next := model.(App)
+	if next.pendingAutoPermission != nil {
+		t.Fatalf("expected pending auto-approval state to be cleared after callback")
+	}
+	if next.pendingPermission == nil || next.pendingPermission.Request.RequestID != "perm-auto-fail" {
+		t.Fatalf("expected failed auto-approval to restore manual permission prompt")
+	}
+	if next.pendingPermission.Submitting {
+		t.Fatalf("expected restored permission prompt to be interactive")
+	}
+	if next.state.StatusText != statusPermissionRequired {
+		t.Fatalf("expected permission required status after fallback, got %q", next.state.StatusText)
+	}
+	if next.state.ExecutionError == "" {
+		t.Fatalf("expected execution error to be preserved for failed auto-approval")
 	}
 }

--- a/internal/tui/core/app/update_full_access_test.go
+++ b/internal/tui/core/app/update_full_access_test.go
@@ -50,6 +50,26 @@ func TestToggleFullAccessModeOpensPromptAndDisables(t *testing.T) {
 	}
 }
 
+func TestUpdateConsumesPendingFullAccessPromptAndBatchesResolveCmd(t *testing.T) {
+	runtime := &permissionTestRuntime{}
+	app := newPermissionTestApp(runtime)
+	app.pendingFullAccessPrompt = &fullAccessPromptState{Selected: 0}
+	app.pendingPermission = &permissionPromptState{
+		Request:  agentruntime.PermissionRequestPayload{RequestID: "perm-from-update"},
+		Selected: 0,
+	}
+
+	model, cmd := app.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := model.(App)
+	if next.pendingFullAccessPrompt != nil {
+		t.Fatalf("expected pending full access prompt to be cleared")
+	}
+	done := expectPermissionResolutionFinishedMsg(t, cmd)
+	if done.RequestID != "perm-from-update" || done.Decision != string(agentruntime.DecisionAllowSession) {
+		t.Fatalf("unexpected batched permission resolution message: %+v", done)
+	}
+}
+
 func TestUpdatePendingFullAccessPromptInputEnableAutoApprovesPendingPermission(t *testing.T) {
 	runtime := &permissionTestRuntime{}
 	app := newPermissionTestApp(runtime)
@@ -145,5 +165,191 @@ func TestUpdatePermissionResolutionFinishedMessageRestoresPromptAfterFullAccessA
 	}
 	if next.state.ExecutionError == "" {
 		t.Fatalf("expected execution error to be preserved for failed auto-approval")
+	}
+}
+
+func TestUpdatePendingFullAccessPromptInputGuardAndNavigation(t *testing.T) {
+	app := newPermissionTestApp(&permissionTestRuntime{})
+	if cmd, handled := app.updatePendingFullAccessPromptInput(tea.KeyMsg{Type: tea.KeyEnter}); handled || cmd != nil {
+		t.Fatalf("expected nil prompt state to return not handled")
+	}
+
+	app.pendingFullAccessPrompt = &fullAccessPromptState{Selected: 0}
+	cmd, handled := app.updatePendingFullAccessPromptInput(tea.KeyMsg{Type: tea.KeyDown})
+	if !handled || cmd != nil {
+		t.Fatalf("expected down key to be handled without cmd")
+	}
+	if app.pendingFullAccessPrompt.Selected != 1 {
+		t.Fatalf("expected selection moved to 1, got %d", app.pendingFullAccessPrompt.Selected)
+	}
+	if app.state.StatusText != statusFullAccessPrompt {
+		t.Fatalf("expected status full access prompt after navigation, got %q", app.state.StatusText)
+	}
+
+	cmd, handled = app.updatePendingFullAccessPromptInput(tea.KeyMsg{Type: tea.KeyUp})
+	if !handled || cmd != nil {
+		t.Fatalf("expected up key to be handled without cmd")
+	}
+	if app.pendingFullAccessPrompt.Selected != 0 {
+		t.Fatalf("expected selection moved back to 0, got %d", app.pendingFullAccessPrompt.Selected)
+	}
+}
+
+func TestUpdatePendingFullAccessPromptInputCancelPaths(t *testing.T) {
+	app := newPermissionTestApp(&permissionTestRuntime{})
+	app.pendingFullAccessPrompt = &fullAccessPromptState{Selected: 1}
+
+	cmd, handled := app.updatePendingFullAccessPromptInput(tea.KeyMsg{Type: tea.KeyEnter})
+	if !handled || cmd != nil {
+		t.Fatalf("expected enter on No option to cancel without cmd")
+	}
+	if app.pendingFullAccessPrompt != nil {
+		t.Fatalf("expected prompt cleared after cancel")
+	}
+	if app.fullAccessModeEnabled {
+		t.Fatalf("expected cancel to keep full access disabled")
+	}
+	if app.state.StatusText != statusFullAccessCanceled {
+		t.Fatalf("expected canceled status, got %q", app.state.StatusText)
+	}
+
+	app.pendingFullAccessPrompt = &fullAccessPromptState{Selected: 0}
+	cmd, handled = app.updatePendingFullAccessPromptInput(tea.KeyMsg{Type: tea.KeyEsc})
+	if !handled || cmd != nil {
+		t.Fatalf("expected esc to cancel prompt")
+	}
+	if app.state.StatusText != statusFullAccessCanceled {
+		t.Fatalf("expected canceled status from esc, got %q", app.state.StatusText)
+	}
+
+	app.pendingFullAccessPrompt = &fullAccessPromptState{Selected: 0}
+	cmd, handled = app.updatePendingFullAccessPromptInput(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if !handled || cmd != nil {
+		t.Fatalf("expected n shortcut to cancel prompt")
+	}
+
+	app.pendingFullAccessPrompt = &fullAccessPromptState{Selected: 0}
+	cmd, handled = app.updatePendingFullAccessPromptInput(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if !handled || cmd != nil {
+		t.Fatalf("expected unknown key to be consumed without command")
+	}
+}
+
+func TestUpdatePendingFullAccessPromptInputEnterEnablePath(t *testing.T) {
+	app := newPermissionTestApp(&permissionTestRuntime{})
+	app.pendingFullAccessPrompt = &fullAccessPromptState{Selected: 0}
+
+	cmd, handled := app.updatePendingFullAccessPromptInput(tea.KeyMsg{Type: tea.KeyEnter})
+	if !handled {
+		t.Fatalf("expected enter to be handled")
+	}
+	if cmd != nil {
+		t.Fatalf("expected no command without pending permission request")
+	}
+	if !app.fullAccessModeEnabled {
+		t.Fatalf("expected full access mode to be enabled")
+	}
+	if app.state.StatusText != statusFullAccessEnabled {
+		t.Fatalf("expected enabled status, got %q", app.state.StatusText)
+	}
+}
+
+func TestApplyFullAccessPromptSelectionWithSubmittingPermissionDoesNotResubmit(t *testing.T) {
+	app := newPermissionTestApp(&permissionTestRuntime{})
+	app.pendingFullAccessPrompt = &fullAccessPromptState{Selected: 0}
+	app.pendingPermission = &permissionPromptState{
+		Request:    agentruntime.PermissionRequestPayload{RequestID: "perm-submitting"},
+		Selected:   0,
+		Submitting: true,
+	}
+
+	cmd := app.applyFullAccessPromptSelection(true)
+	if cmd != nil {
+		t.Fatalf("expected no command when pending permission is already submitting")
+	}
+	if !app.fullAccessModeEnabled {
+		t.Fatalf("expected full access mode enabled")
+	}
+}
+
+func TestHandleAutoPermissionResolutionFinishedGuardsAndSuccess(t *testing.T) {
+	app := newPermissionTestApp(&permissionTestRuntime{})
+	if handled := app.handleAutoPermissionResolutionFinished(permissionResolutionFinishedMsg{RequestID: "none"}); handled {
+		t.Fatalf("expected no handling without pending auto permission")
+	}
+
+	app.pendingAutoPermission = &autoPermissionApprovalState{
+		Request: agentruntime.PermissionRequestPayload{RequestID: "perm-auto"},
+	}
+	if handled := app.handleAutoPermissionResolutionFinished(permissionResolutionFinishedMsg{RequestID: "perm-other"}); handled {
+		t.Fatalf("expected mismatched request id to be ignored")
+	}
+
+	handled := app.handleAutoPermissionResolutionFinished(permissionResolutionFinishedMsg{
+		RequestID: "perm-auto",
+		Decision:  string(agentruntime.DecisionAllowSession),
+	})
+	if !handled {
+		t.Fatalf("expected matching auto permission callback to be handled")
+	}
+	if app.pendingAutoPermission != nil {
+		t.Fatalf("expected pending auto permission to be cleared")
+	}
+	if app.state.StatusText != statusPermissionSubmitted {
+		t.Fatalf("expected submitted status after success, got %q", app.state.StatusText)
+	}
+}
+
+func TestBeginAutoPermissionApprovalGuards(t *testing.T) {
+	app := newPermissionTestApp(&permissionTestRuntime{})
+	if started := app.beginAutoPermissionApproval(agentruntime.PermissionRequestPayload{RequestID: "perm"}); started {
+		t.Fatalf("expected disabled full access mode to skip auto approval")
+	}
+
+	app.fullAccessModeEnabled = true
+	if started := app.beginAutoPermissionApproval(agentruntime.PermissionRequestPayload{RequestID: "   "}); started {
+		t.Fatalf("expected empty request id to skip auto approval")
+	}
+}
+
+func TestRuntimeEventPermissionResolvedHandlerClearsPendingAutoPermission(t *testing.T) {
+	app := newPermissionTestApp(&permissionTestRuntime{})
+	app.pendingAutoPermission = &autoPermissionApprovalState{
+		Request: agentruntime.PermissionRequestPayload{RequestID: "perm-auto-clear"},
+	}
+	event := agentruntime.RuntimeEvent{
+		Type: agentruntime.EventPermissionResolved,
+		Payload: agentruntime.PermissionResolvedPayload{
+			RequestID: "perm-auto-clear",
+		},
+	}
+	if dirty := runtimeEventPermissionResolvedHandler(app, event); dirty {
+		t.Fatalf("permission resolved should not mark transcript dirty")
+	}
+	if app.pendingAutoPermission != nil {
+		t.Fatalf("expected resolved event to clear pending auto permission")
+	}
+}
+
+func TestRuntimeEventPermissionResolvedHandlerGuardPaths(t *testing.T) {
+	app := newPermissionTestApp(&permissionTestRuntime{})
+	if dirty := runtimeEventPermissionResolvedHandler(app, agentruntime.RuntimeEvent{
+		Type:    agentruntime.EventPermissionResolved,
+		Payload: "invalid",
+	}); dirty {
+		t.Fatalf("invalid payload should not mark transcript dirty")
+	}
+
+	app.pendingAutoPermission = &autoPermissionApprovalState{
+		Request: agentruntime.PermissionRequestPayload{RequestID: "perm-auto-keep"},
+	}
+	runtimeEventPermissionResolvedHandler(app, agentruntime.RuntimeEvent{
+		Type: agentruntime.EventPermissionResolved,
+		Payload: agentruntime.PermissionResolvedPayload{
+			RequestID: "other-id",
+		},
+	})
+	if app.pendingAutoPermission == nil {
+		t.Fatalf("mismatched request id should keep pending auto permission")
 	}
 }

--- a/internal/tui/core/app/update_full_access_test.go
+++ b/internal/tui/core/app/update_full_access_test.go
@@ -1,0 +1,105 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	agentruntime "neo-code/internal/tui/services"
+)
+
+func TestToggleFullAccessModeOpensPromptAndDisables(t *testing.T) {
+	app := newPermissionTestApp(&permissionTestRuntime{})
+
+	model, _ := app.Update(tea.KeyMsg{Type: tea.KeyCtrlF})
+	next := model.(App)
+	if next.pendingFullAccessPrompt == nil {
+		t.Fatalf("expected ctrl+f to open full access risk prompt")
+	}
+	if next.state.StatusText != statusFullAccessPrompt {
+		t.Fatalf("expected full access prompt status, got %q", next.state.StatusText)
+	}
+
+	next.fullAccessModeEnabled = true
+	next.pendingFullAccessPrompt = nil
+	model, _ = next.Update(tea.KeyMsg{Type: tea.KeyCtrlF})
+	disabled := model.(App)
+	if disabled.fullAccessModeEnabled {
+		t.Fatalf("expected ctrl+f to disable full access mode")
+	}
+	if disabled.pendingFullAccessPrompt != nil {
+		t.Fatalf("expected disable path to close full access prompt")
+	}
+	if disabled.state.StatusText != statusFullAccessDisabled {
+		t.Fatalf("expected full access disabled status, got %q", disabled.state.StatusText)
+	}
+}
+
+func TestUpdatePendingFullAccessPromptInputEnableAutoApprovesPendingPermission(t *testing.T) {
+	runtime := &permissionTestRuntime{}
+	app := newPermissionTestApp(runtime)
+	app.pendingFullAccessPrompt = &fullAccessPromptState{Selected: 0}
+	app.pendingPermission = &permissionPromptState{
+		Request:  agentruntime.PermissionRequestPayload{RequestID: "perm-full-access"},
+		Selected: 0,
+	}
+
+	cmd, handled := app.updatePendingFullAccessPromptInput(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if !handled || cmd == nil {
+		t.Fatalf("expected y shortcut to enable full access and submit permission")
+	}
+	if !app.fullAccessModeEnabled {
+		t.Fatalf("expected full access mode enabled after approval")
+	}
+	if app.pendingFullAccessPrompt != nil {
+		t.Fatalf("expected full access prompt to be cleared after approval")
+	}
+
+	msg := cmd()
+	done, ok := msg.(permissionResolutionFinishedMsg)
+	if !ok {
+		t.Fatalf("expected permissionResolutionFinishedMsg, got %T", msg)
+	}
+	if done.RequestID != "perm-full-access" || done.Decision != string(agentruntime.DecisionAllowSession) {
+		t.Fatalf("unexpected auto-approval payload: %+v", done)
+	}
+	if runtime.lastResolved.Decision != agentruntime.DecisionAllowSession {
+		t.Fatalf("expected runtime resolve decision allow_session, got %+v", runtime.lastResolved)
+	}
+}
+
+func TestRuntimePermissionRequestHandlerAutoApprovesWhenFullAccessEnabled(t *testing.T) {
+	runtime := &permissionTestRuntime{}
+	app := newPermissionTestApp(runtime)
+	app.fullAccessModeEnabled = true
+
+	event := agentruntime.RuntimeEvent{
+		Type: agentruntime.EventPermissionRequested,
+		Payload: agentruntime.PermissionRequestPayload{
+			RequestID: "perm-auto",
+			ToolName:  "bash",
+			Target:    "git status",
+		},
+	}
+	if dirty := runtimeEventPermissionRequestHandler(app, event); dirty {
+		t.Fatalf("permission request should not mark transcript dirty")
+	}
+	if app.pendingPermission != nil {
+		t.Fatalf("expected no pending permission prompt in full access mode")
+	}
+	if app.deferredEventCmd == nil {
+		t.Fatalf("expected full access mode to schedule auto-approval command")
+	}
+
+	msg := app.deferredEventCmd()
+	done, ok := msg.(permissionResolutionFinishedMsg)
+	if !ok {
+		t.Fatalf("expected permissionResolutionFinishedMsg, got %T", msg)
+	}
+	if done.RequestID != "perm-auto" || done.Decision != string(agentruntime.DecisionAllowSession) {
+		t.Fatalf("unexpected auto-approval payload: %+v", done)
+	}
+	if runtime.lastResolved.RequestID != "perm-auto" || runtime.lastResolved.Decision != agentruntime.DecisionAllowSession {
+		t.Fatalf("unexpected runtime resolve input: %+v", runtime.lastResolved)
+	}
+}

--- a/internal/tui/core/app/view.go
+++ b/internal/tui/core/app/view.go
@@ -527,6 +527,10 @@ func maskedSecret(value string) string {
 }
 
 func (a App) renderPrompt(width int) string {
+	if a.pendingFullAccessPrompt != nil {
+		box := a.styles.inputBoxFocused
+		return box.Width(width).Margin(1, 0, 0, 0).Render(a.renderFullAccessPrompt())
+	}
 	if a.pendingPermission != nil {
 		box := a.styles.inputBoxFocused
 		return box.Width(width).Margin(1, 0, 0, 0).Render(a.renderPermissionPrompt())


### PR DESCRIPTION
## 背景
希望增加一个“完全访问模式（Full Access）”：
- 开启后自动审批所有工具请求，避免运行中反复弹权限框。
- 启用时必须先弹风险确认（Y/N）。
- 提供快捷键快速开关（采用非冲突键 `Ctrl+F`）。

## 变更
- 同步上游：当前分支已先 fast-forward 到 `upstream/main`。
- 新增 Full Access 风险确认弹窗：
  - `internal/tui/core/app/full_access_prompt.go`
  - 支持 `y/n` 快捷确认，或 `Up/Down + Enter`。
- 新增 Full Access 模式状态：
  - `appRuntimeState` 增加 `fullAccessModeEnabled` 与 `pendingFullAccessPrompt`。
- 新增快捷键：
  - `Ctrl+F` 切换 Full Access（首次启用前弹风险确认）。
  - 更新 keymap 与 startup quick actions 展示。
- 自动审批逻辑：
  - 在 `runtimeEventPermissionRequestHandler` 中，当 Full Access 已开启时，自动提交 `allow_session`，不再展示权限审批弹窗。
- UI 渲染：
  - `renderPrompt` 支持显示 Full Access 风险确认弹窗。
  - startup screen 在 Full Access 风险弹窗期间隐藏。

## 测试
已新增/更新测试：
- `full_access_prompt_test.go`
- `update_full_access_test.go`
- `keymap_test.go`

已执行：
- `go test ./internal/tui/core/app -run "TestNormalizeFullAccessPromptSelectionWrap|TestParseFullAccessPromptShortcut|TestFormatFullAccessPromptLines|TestRenderFullAccessPrompt|TestRenderPromptWithPendingFullAccessPrompt|TestToggleFullAccessModeOpensPromptAndDisables|TestUpdatePendingFullAccessPromptInputEnableAutoApprovesPendingPermission|TestRuntimePermissionRequestHandlerAutoApprovesWhenFullAccessEnabled"`
- `go test ./internal/tui/core/app -run "TestApplyComponentLayoutKeepsTranscriptHeightInSyncWithWaterfall|TestRenderHelpShowsCtrlLAndError|TestToggleFullAccessModeOpensPromptAndDisables|TestRuntimePermissionRequestHandlerAutoApprovesWhenFullAccessEnabled"`
- `go test ./internal/tui/core/app -run "TestViewStartupScreenRendersStartupSections|TestRenderWaterfallShowsStartupScreenForEmptyDraft|TestStartupQuickActionKeyWidthBranches"`

说明：`go test ./internal/tui/core/app` 全量在当前环境仍有既有的 Windows TempDir 清理类偶发失败（与本改动无直接关系）。
