### PR TITLE
refactor(provider): 将重试逻辑内聚到 provider 层并延长请求时间

### DIFF
--- a/docs/runtime-provider-event-flow.md
+++ b/docs/runtime-provider-event-flow.md
@@ -14,7 +14,6 @@
 - `phase_changed`
 - `progress_evaluated`
 - `stop_reason_decided`
-- `provider_retry`
 - `permission_requested`
 - `permission_resolved`
 - `budget_checked`

--- a/internal/provider/anthropic/driver.go
+++ b/internal/provider/anthropic/driver.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 	anthroption "github.com/anthropics/anthropic-sdk-go/option"
@@ -66,7 +65,7 @@ func newSDKClient(cfg provider.RuntimeConfig) (anthropic.Client, error) {
 	}
 
 	httpClient := &http.Client{
-		Timeout: 90 * time.Second,
+		Timeout: provider.DefaultSDKRequestTimeout,
 	}
 	options := []anthroption.RequestOption{
 		anthroption.WithHTTPClient(httpClient),

--- a/internal/provider/constants.go
+++ b/internal/provider/constants.go
@@ -1,5 +1,7 @@
 package provider
 
+import "time"
+
 // Driver 与 OpenAI-compatible 协议常量用于在 config/provider 间共享稳定枚举值，避免字面量漂移。
 const (
 	DriverOpenAICompat = "openaicompat"
@@ -8,3 +10,6 @@ const (
 
 	DiscoveryEndpointPathModels = "/models"
 )
+
+// DefaultSDKRequestTimeout 定义 provider 层对外部模型 SDK 请求的统一超时，避免流式请求无限悬挂。
+const DefaultSDKRequestTimeout = 10 * time.Minute

--- a/internal/provider/gemini/driver.go
+++ b/internal/provider/gemini/driver.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"google.golang.org/genai"
 
@@ -71,7 +70,7 @@ func newSDKClient(ctx context.Context, cfg provider.RuntimeConfig) (*genai.Clien
 		return nil, err
 	}
 	httpClient := &http.Client{
-		Timeout: 90 * time.Second,
+		Timeout: provider.DefaultSDKRequestTimeout,
 	}
 	clientConfig := &genai.ClientConfig{
 		APIKey:     apiKey,

--- a/internal/provider/gemini/provider.go
+++ b/internal/provider/gemini/provider.go
@@ -5,9 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand/v2"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"google.golang.org/genai"
 
@@ -17,12 +20,21 @@ import (
 
 const errorPrefix = "gemini provider: "
 
+const (
+	defaultGenerateRetryMax = 2
+	generateRetryBaseWait   = 1 * time.Second
+	generateRetryMaxWait    = 5 * time.Second
+)
+
 // Provider 封装 Gemini native 协议的请求发送与流式响应解析。
 type Provider struct {
 	cfg provider.RuntimeConfig
 
 	mu       sync.Mutex
 	prepared *preparedRequest
+
+	retryBackoff func(attempt int) time.Duration
+	retryWait    func(ctx context.Context, wait time.Duration) error
 }
 
 type preparedRequest struct {
@@ -67,7 +79,11 @@ func New(cfg provider.RuntimeConfig) (*Provider, error) {
 	if strings.TrimSpace(cfg.APIKeyEnv) == "" {
 		return nil, errors.New(errorPrefix + "api_key_env is empty")
 	}
-	return &Provider{cfg: cfg}, nil
+	return &Provider{
+		cfg:          cfg,
+		retryBackoff: generateRetryBackoff,
+		retryWait:    waitForRetry,
+	}, nil
 }
 
 // Generate 发起 Gemini 流式请求，并将 SDK chunk 转为统一流式事件。
@@ -84,9 +100,46 @@ func (p *Provider) Generate(ctx context.Context, req providertypes.GenerateReque
 	if normalizedModel == "" {
 		return errors.New(errorPrefix + "model is empty")
 	}
+	var lastErr error
+	for attempt := 0; attempt <= defaultGenerateRetryMax; attempt++ {
+		if attempt > 0 {
+			wait := generateRetryBaseWait
+			if p.retryBackoff != nil {
+				wait = p.retryBackoff(attempt)
+			}
+			if p.retryWait != nil {
+				if err := p.retryWait(ctx, wait); err != nil {
+					return err
+				}
+			}
+		}
+
+		started, err := p.generateOnce(ctx, normalizedModel, contents, config, events)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if started || !isRetryableGenerateError(err) {
+			return err
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+	}
+	return lastErr
+}
+
+// generateOnce 执行一次 Gemini 流式请求，并在未收到任何输出时返回可重试错误。
+func (p *Provider) generateOnce(
+	ctx context.Context,
+	model string,
+	contents []*genai.Content,
+	config *genai.GenerateContentConfig,
+	events chan<- providertypes.StreamEvent,
+) (bool, error) {
 	client, err := newSDKClient(ctx, p.cfg)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	var (
@@ -95,15 +148,12 @@ func (p *Provider) Generate(ctx context.Context, req providertypes.GenerateReque
 		hasPayload   bool
 		callSeq      int
 	)
-	for chunk, streamErr := range client.Models.GenerateContentStream(ctx, normalizedModel, contents, config) {
+	for chunk, streamErr := range client.Models.GenerateContentStream(ctx, model, contents, config) {
 		if streamErr != nil {
 			if ctxErr := ctx.Err(); ctxErr != nil {
-				return ctxErr
+				return hasPayload, ctxErr
 			}
-			if mappedErr := mapGeminiSDKError(streamErr); mappedErr != nil {
-				return mappedErr
-			}
-			return fmt.Errorf("%sstream generate: %w", errorPrefix, streamErr)
+			return hasPayload, normalizeGenerateError(streamErr)
 		}
 
 		if chunk == nil {
@@ -125,7 +175,7 @@ func (p *Provider) Generate(ctx context.Context, req providertypes.GenerateReque
 				}
 				if strings.TrimSpace(part.Text) != "" {
 					if err := provider.EmitTextDelta(ctx, events, part.Text); err != nil {
-						return err
+						return hasPayload, err
 					}
 				}
 				if part.FunctionCall == nil {
@@ -142,25 +192,25 @@ func (p *Provider) Generate(ctx context.Context, req providertypes.GenerateReque
 					continue
 				}
 				if err := provider.EmitToolCallStart(ctx, events, callSeq-1, callID, name); err != nil {
-					return err
+					return hasPayload, err
 				}
 				argsJSON, err := encodeArguments(part.FunctionCall.Args)
 				if err != nil {
-					return err
+					return hasPayload, err
 				}
 				if err := provider.EmitToolCallDelta(ctx, events, callSeq-1, callID, argsJSON); err != nil {
-					return err
+					return hasPayload, err
 				}
 			}
 		}
 	}
 	if !hasPayload {
-		return fmt.Errorf("%w: empty gemini stream payload", provider.ErrStreamInterrupted)
+		return false, fmt.Errorf("%w: empty gemini stream payload", provider.ErrStreamInterrupted)
 	}
 	if !usage.InputObserved && !usage.OutputObserved {
-		return provider.EmitMessageDone(ctx, events, finishReason, nil)
+		return true, provider.EmitMessageDone(ctx, events, finishReason, nil)
 	}
-	return provider.EmitMessageDone(ctx, events, finishReason, &usage)
+	return true, provider.EmitMessageDone(ctx, events, finishReason, &usage)
 }
 
 // storePreparedRequest 缓存估算阶段的 Gemini 构建结果，供同轮发送直接复用。
@@ -231,6 +281,77 @@ func encodeArguments(args map[string]any) (string, error) {
 // normalizeFinishReason 规范化 Gemini finish reason，便于上层统一处理。
 func normalizeFinishReason(raw string) string {
 	return strings.ToLower(strings.TrimSpace(raw))
+}
+
+// normalizeGenerateError 统一归类 Gemini 流式生成错误，避免把网络异常直接泄漏到 runtime。
+func normalizeGenerateError(err error) error {
+	if mappedErr := mapGeminiSDKError(err); mappedErr != nil {
+		return mappedErr
+	}
+
+	message := strings.TrimSpace(err.Error())
+	if message == "" {
+		message = "unknown stream error"
+	}
+	if isTimeoutGenerateError(err) {
+		return provider.NewTimeoutProviderError("gemini generate timeout: " + message)
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return provider.NewNetworkProviderError("gemini generate network error: " + message)
+	}
+	return fmt.Errorf("%sstream generate: %w", errorPrefix, err)
+}
+
+// isRetryableGenerateError 判断 Gemini provider 是否应在请求级重试当前错误。
+func isRetryableGenerateError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var providerErr *provider.ProviderError
+	return errors.As(err, &providerErr) && providerErr.Retryable
+}
+
+// isTimeoutGenerateError 判断 Gemini 流式生成错误是否由超时触发。
+func isTimeoutGenerateError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+// generateRetryBackoff 计算 Gemini provider 请求级重试的指数退避时长。
+func generateRetryBackoff(attempt int) time.Duration {
+	if attempt <= 0 {
+		return 0
+	}
+	wait := generateRetryBaseWait << (attempt - 1)
+	jitter := float64(wait) * (0.5 + rand.Float64())
+	wait = time.Duration(jitter)
+	if wait > generateRetryMaxWait {
+		wait = generateRetryMaxWait
+	}
+	return wait
+}
+
+// waitForRetry 在重试窗口内等待，同时尊重上层上下文取消。
+func waitForRetry(ctx context.Context, wait time.Duration) error {
+	if wait <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // mapGeminiSDKError 将 Gemini SDK 错误映射为 provider 领域错误，仅保留状态码级别兜底。

--- a/internal/provider/gemini/provider_test.go
+++ b/internal/provider/gemini/provider_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/genai"
+
 	"neo-code/internal/provider"
 	providertypes "neo-code/internal/provider/types"
 )
@@ -493,6 +495,222 @@ func TestNormalizeGenerateErrorMapsNetworkTimeouts(t *testing.T) {
 	err = normalizeGenerateError(net.UnknownNetworkError("dns failure"))
 	if !errors.As(err, &providerErr) || providerErr.Code != provider.ErrorCodeNetwork {
 		t.Fatalf("expected network provider error, got %v", err)
+	}
+}
+
+func TestProviderGenerateReturnsRetryWaitError(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		http.Error(w, "temporary", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	p, err := New(provider.RuntimeConfig{
+		Driver:         provider.DriverGemini,
+		BaseURL:        server.URL,
+		DefaultModel:   "gemini-2.5-flash",
+		APIKeyEnv:      "GEMINI_TEST_KEY",
+		APIKeyResolver: provider.StaticAPIKeyResolver("test-key"),
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	sentinel := errors.New("retry wait failed")
+	p.retryBackoff = func(attempt int) time.Duration {
+		_ = attempt
+		return 0
+	}
+	p.retryWait = func(ctx context.Context, wait time.Duration) error {
+		_ = ctx
+		_ = wait
+		return sentinel
+	}
+
+	events := make(chan providertypes.StreamEvent, 8)
+	err = p.Generate(context.Background(), providertypes.GenerateRequest{
+		Messages: []providertypes.Message{{
+			Role:  providertypes.RoleUser,
+			Parts: []providertypes.ContentPart{providertypes.NewTextPart("hi")},
+		}},
+	}, events)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected retry wait error, got %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("expected one request before retry wait failure, got %d", requests)
+	}
+}
+
+func TestProviderGenerateReturnsEmptyModelForPreparedRequest(t *testing.T) {
+	t.Parallel()
+
+	p, err := New(provider.RuntimeConfig{
+		Driver:         provider.DriverGemini,
+		BaseURL:        "https://generativelanguage.googleapis.com/v1beta",
+		DefaultModel:   "gemini-2.5-flash",
+		APIKeyEnv:      "GEMINI_TEST_KEY",
+		APIKeyResolver: provider.StaticAPIKeyResolver("test-key"),
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	req := providertypes.GenerateRequest{
+		Messages: []providertypes.Message{{
+			Role:  providertypes.RoleUser,
+			Parts: []providertypes.ContentPart{providertypes.NewTextPart("hi")},
+		}},
+	}
+	signature := provider.BuildGenerateRequestSignature(req)
+	p.storePreparedRequest(signature, "   ", nil, nil)
+
+	events := make(chan providertypes.StreamEvent, 4)
+	err = p.Generate(context.Background(), req, events)
+	if err == nil || !strings.Contains(err.Error(), "model is empty") {
+		t.Fatalf("expected model empty error, got %v", err)
+	}
+}
+
+func TestGenerateHelpers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("normalize_model", func(t *testing.T) {
+		t.Parallel()
+		if got := normalizeGeminiModelName(" models/gemini-2.5-pro "); got != "gemini-2.5-pro" {
+			t.Fatalf("normalizeGeminiModelName() = %q", got)
+		}
+		if got := normalizeGeminiModelName("  "); got != "" {
+			t.Fatalf("normalizeGeminiModelName() = %q, want empty", got)
+		}
+	})
+
+	t.Run("encode_arguments", func(t *testing.T) {
+		t.Parallel()
+		encoded, err := encodeArguments(nil)
+		if err != nil || encoded != "{}" {
+			t.Fatalf("encodeArguments(nil) = %q, %v", encoded, err)
+		}
+		_, err = encodeArguments(map[string]any{"bad": make(chan int)})
+		if err == nil || !strings.Contains(err.Error(), "encode function args") {
+			t.Fatalf("expected encode error, got %v", err)
+		}
+	})
+
+	t.Run("retryable_error", func(t *testing.T) {
+		t.Parallel()
+		if isRetryableGenerateError(nil) {
+			t.Fatal("nil should not be retryable")
+		}
+		if isRetryableGenerateError(errors.New("plain")) {
+			t.Fatal("plain error should not be retryable")
+		}
+		if !isRetryableGenerateError(provider.NewNetworkProviderError("temporary")) {
+			t.Fatal("network provider error should be retryable")
+		}
+	})
+
+	t.Run("timeout_error", func(t *testing.T) {
+		t.Parallel()
+		if !isTimeoutGenerateError(context.DeadlineExceeded) {
+			t.Fatal("context deadline should be timeout")
+		}
+		if isTimeoutGenerateError(errors.New("plain")) {
+			t.Fatal("plain error should not be timeout")
+		}
+	})
+}
+
+func TestRetryBackoffAndWait(t *testing.T) {
+	t.Parallel()
+
+	if wait := generateRetryBackoff(0); wait != 0 {
+		t.Fatalf("attempt 0 backoff = %v, want 0", wait)
+	}
+
+	for attempt := 1; attempt <= 6; attempt++ {
+		wait := generateRetryBackoff(attempt)
+		if wait < 0 {
+			t.Fatalf("attempt %d backoff should be non-negative, got %v", attempt, wait)
+		}
+		if wait > generateRetryMaxWait {
+			t.Fatalf("attempt %d backoff should be <= %v, got %v", attempt, generateRetryMaxWait, wait)
+		}
+	}
+
+	if err := waitForRetry(context.Background(), 0); err != nil {
+		t.Fatalf("waitForRetry(0) error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := waitForRetry(ctx, time.Millisecond); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if err := waitForRetry(context.Background(), time.Millisecond); err != nil {
+		t.Fatalf("waitForRetry(timeout) error = %v", err)
+	}
+}
+
+func TestMapGeminiSDKError(t *testing.T) {
+	t.Parallel()
+
+	if err := mapGeminiSDKError(errors.New("plain")); err != nil {
+		t.Fatalf("plain error should not map, got %v", err)
+	}
+
+	cases := []struct {
+		name       string
+		err        error
+		wantCode   provider.ProviderErrorCode
+		wantSubstr string
+	}{
+		{
+			name:       "status from name unauthenticated",
+			err:        genai.APIError{Status: "UNAUTHENTICATED", Message: "bad token"},
+			wantCode:   provider.ErrorCodeAuthFailed,
+			wantSubstr: "bad token",
+		},
+		{
+			name:       "bad request api key heuristic",
+			err:        genai.APIError{Code: http.StatusBadRequest, Message: "x-goog-api-key invalid"},
+			wantCode:   provider.ErrorCodeAuthFailed,
+			wantSubstr: "x-goog-api-key invalid",
+		},
+		{
+			name:       "bad request quota heuristic",
+			err:        &genai.APIError{Code: http.StatusBadRequest, Message: "RESOURCE_EXHAUSTED quota"},
+			wantCode:   provider.ErrorCodeRateLimit,
+			wantSubstr: "RESOURCE_EXHAUSTED quota",
+		},
+		{
+			name:       "permission denied",
+			err:        genai.APIError{Status: "PERMISSION_DENIED", Message: "forbidden"},
+			wantCode:   provider.ErrorCodeForbidden,
+			wantSubstr: "forbidden",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := mapGeminiSDKError(tc.err)
+			if err == nil {
+				t.Fatal("expected mapped error")
+			}
+			var providerErr *provider.ProviderError
+			if !errors.As(err, &providerErr) {
+				t.Fatalf("expected provider error, got %T %v", err, err)
+			}
+			if providerErr.Code != tc.wantCode {
+				t.Fatalf("provider code = %q, want %q", providerErr.Code, tc.wantCode)
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Fatalf("mapped error %q does not contain %q", err.Error(), tc.wantSubstr)
+			}
+		})
 	}
 }
 

--- a/internal/provider/gemini/provider_test.go
+++ b/internal/provider/gemini/provider_test.go
@@ -3,12 +3,15 @@ package gemini
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"neo-code/internal/provider"
 	providertypes "neo-code/internal/provider/types"
@@ -322,6 +325,177 @@ func TestEstimateThenGenerateReusesPreparedRequest(t *testing.T) {
 	}
 }
 
+func TestProviderGenerateRetriesRetryableErrorBeforeStreamStarts(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			http.Error(w, "temporary", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: {\"candidates\":[{\"index\":0,\"content\":{\"parts\":[{\"text\":\"retry ok\"}]}}],\"usageMetadata\":{\"promptTokenCount\":2,\"candidatesTokenCount\":1,\"totalTokenCount\":3}}\n\n")
+		_, _ = fmt.Fprint(w, "data: {\"candidates\":[{\"index\":0,\"finishReason\":\"STOP\",\"content\":{\"parts\":[]}}]}\n\n")
+	}))
+	defer server.Close()
+
+	p, err := New(provider.RuntimeConfig{
+		Driver:         provider.DriverGemini,
+		BaseURL:        server.URL,
+		DefaultModel:   "gemini-2.5-flash",
+		APIKeyEnv:      "GEMINI_TEST_KEY",
+		APIKeyResolver: provider.StaticAPIKeyResolver("test-key"),
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	p.retryBackoff = func(attempt int) time.Duration {
+		_ = attempt
+		return 0
+	}
+	p.retryWait = func(ctx context.Context, wait time.Duration) error {
+		_ = ctx
+		_ = wait
+		return nil
+	}
+
+	events := make(chan providertypes.StreamEvent, 8)
+	if err := p.Generate(context.Background(), providertypes.GenerateRequest{
+		Messages: []providertypes.Message{{
+			Role:  providertypes.RoleUser,
+			Parts: []providertypes.ContentPart{providertypes.NewTextPart("hi")},
+		}},
+	}, events); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("expected 2 requests after retry, got %d", requests)
+	}
+	if len(drainEvents(events)) == 0 {
+		t.Fatal("expected stream events after retry recovery")
+	}
+}
+
+func TestProviderGenerateReturnsRetryableErrorAfterRetryExhausted(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		http.Error(w, "temporary", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	p, err := New(provider.RuntimeConfig{
+		Driver:         provider.DriverGemini,
+		BaseURL:        server.URL,
+		DefaultModel:   "gemini-2.5-flash",
+		APIKeyEnv:      "GEMINI_TEST_KEY",
+		APIKeyResolver: provider.StaticAPIKeyResolver("test-key"),
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	p.retryBackoff = func(attempt int) time.Duration {
+		_ = attempt
+		return 0
+	}
+	p.retryWait = func(ctx context.Context, wait time.Duration) error {
+		_ = ctx
+		_ = wait
+		return nil
+	}
+
+	events := make(chan providertypes.StreamEvent, 8)
+	err = p.Generate(context.Background(), providertypes.GenerateRequest{
+		Messages: []providertypes.Message{{
+			Role:  providertypes.RoleUser,
+			Parts: []providertypes.ContentPart{providertypes.NewTextPart("hi")},
+		}},
+	}, events)
+	if err == nil {
+		t.Fatal("expected retryable error after exhausting retries")
+	}
+	if requests != defaultGenerateRetryMax+1 {
+		t.Fatalf("expected %d requests, got %d", defaultGenerateRetryMax+1, requests)
+	}
+
+	var providerErr *provider.ProviderError
+	if !errors.As(err, &providerErr) || !providerErr.Retryable {
+		t.Fatalf("expected retryable provider error, got %v", err)
+	}
+}
+
+func TestProviderGenerateRetryStateResetsAfterSuccess(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			http.Error(w, "temporary", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: {\"candidates\":[{\"index\":0,\"content\":{\"parts\":[{\"text\":\"ok\"}]}}],\"usageMetadata\":{\"promptTokenCount\":2,\"candidatesTokenCount\":1,\"totalTokenCount\":3}}\n\n")
+		_, _ = fmt.Fprint(w, "data: {\"candidates\":[{\"index\":0,\"finishReason\":\"STOP\",\"content\":{\"parts\":[]}}]}\n\n")
+	}))
+	defer server.Close()
+
+	p, err := New(provider.RuntimeConfig{
+		Driver:         provider.DriverGemini,
+		BaseURL:        server.URL,
+		DefaultModel:   "gemini-2.5-flash",
+		APIKeyEnv:      "GEMINI_TEST_KEY",
+		APIKeyResolver: provider.StaticAPIKeyResolver("test-key"),
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	p.retryBackoff = func(attempt int) time.Duration {
+		_ = attempt
+		return 0
+	}
+	p.retryWait = func(ctx context.Context, wait time.Duration) error {
+		_ = ctx
+		_ = wait
+		return nil
+	}
+
+	for i := 0; i < 2; i++ {
+		events := make(chan providertypes.StreamEvent, 8)
+		if err := p.Generate(context.Background(), providertypes.GenerateRequest{
+			Messages: []providertypes.Message{{
+				Role:  providertypes.RoleUser,
+				Parts: []providertypes.ContentPart{providertypes.NewTextPart("hi")},
+			}},
+		}, events); err != nil {
+			t.Fatalf("Generate() call %d error = %v", i+1, err)
+		}
+	}
+	if requests != 3 {
+		t.Fatalf("expected second request to start from a fresh retry window, got %d total requests", requests)
+	}
+}
+
+func TestNormalizeGenerateErrorMapsNetworkTimeouts(t *testing.T) {
+	t.Parallel()
+
+	timeoutErr := timeoutNetError{message: "i/o timeout"}
+	err := normalizeGenerateError(timeoutErr)
+	var providerErr *provider.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Code != provider.ErrorCodeTimeout {
+		t.Fatalf("expected timeout provider error, got %v", err)
+	}
+
+	err = normalizeGenerateError(net.UnknownNetworkError("dns failure"))
+	if !errors.As(err, &providerErr) || providerErr.Code != provider.ErrorCodeNetwork {
+		t.Fatalf("expected network provider error, got %v", err)
+	}
+}
+
 func drainEvents(events <-chan providertypes.StreamEvent) []providertypes.StreamEvent {
 	var drained []providertypes.StreamEvent
 	for {
@@ -338,6 +512,22 @@ type stubSessionAsset struct {
 	data []byte
 	mime string
 	err  error
+}
+
+type timeoutNetError struct {
+	message string
+}
+
+func (e timeoutNetError) Error() string {
+	return e.message
+}
+
+func (e timeoutNetError) Timeout() bool {
+	return true
+}
+
+func (e timeoutNetError) Temporary() bool {
+	return true
 }
 
 type stubSessionAssetReader struct {

--- a/internal/provider/openaicompat/provider.go
+++ b/internal/provider/openaicompat/provider.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"time"
 
 	"neo-code/internal/provider"
 	"neo-code/internal/provider/openaicompat/chatcompletions"
@@ -131,7 +130,7 @@ func New(cfg provider.RuntimeConfig, opts ...buildOption) (*Provider, error) {
 	return &Provider{
 		cfg: cfg,
 		client: &http.Client{
-			Timeout:   90 * time.Second,
+			Timeout:   provider.DefaultSDKRequestTimeout,
 			Transport: o.transport,
 		},
 	}, nil

--- a/internal/runtime/events.go
+++ b/internal/runtime/events.go
@@ -246,7 +246,6 @@ const (
 	EventError EventType = "error"
 	// EventToolCallThinking 表示模型发起工具调用思考阶段。
 	EventToolCallThinking EventType = "tool_call_thinking"
-	// EventProviderRetry 表示 provider 调用重试。
 	// EventPermissionRequested 表示发起权限请求。
 	EventPermissionRequested EventType = "permission_requested"
 	// EventPermissionResolved 表示权限请求已决议。

--- a/internal/runtime/events.go
+++ b/internal/runtime/events.go
@@ -247,7 +247,6 @@ const (
 	// EventToolCallThinking 表示模型发起工具调用思考阶段。
 	EventToolCallThinking EventType = "tool_call_thinking"
 	// EventProviderRetry 表示 provider 调用重试。
-	EventProviderRetry EventType = "provider_retry"
 	// EventPermissionRequested 表示发起权限请求。
 	EventPermissionRequested EventType = "permission_requested"
 	// EventPermissionResolved 表示权限请求已决议。

--- a/internal/runtime/run.go
+++ b/internal/runtime/run.go
@@ -183,7 +183,7 @@ func (s *Service) Run(ctx context.Context, input UserInput) (err error) {
 				return nil
 			}
 
-			turnOutput, err := s.callProviderWithRetry(ctx, &state, snapshot, modelProvider)
+			turnOutput, err := s.callProvider(ctx, &state, snapshot, modelProvider)
 			if err != nil {
 				if provider.IsContextTooLong(err) &&
 					state.reactiveCompactAttempts < snapshot.Config.Context.Budget.MaxReactiveCompacts {
@@ -479,73 +479,35 @@ func resolveRuntimeMaxTurns(rc config.RuntimeConfig) int {
 	return rc.MaxTurns
 }
 
-// callProviderWithRetry 使用冻结后的 TurnBudgetSnapshot 执行 provider 调用与必要重试。
-func (s *Service) callProviderWithRetry(
+// callProvider 使用冻结后的 TurnBudgetSnapshot 执行单次 provider 调用。
+func (s *Service) callProvider(
 	ctx context.Context,
 	state *runState,
 	snapshot TurnBudgetSnapshot,
-	initialProvider provider.Provider,
+	modelProvider provider.Provider,
 ) (turnProviderOutput, error) {
-	var lastErr error
-
-	for retryAttempt := 0; retryAttempt <= defaultProviderRetryMax; retryAttempt++ {
-		if retryAttempt > 0 {
-			wait := providerRetryBackoff(retryAttempt)
-			s.emitRunScoped(ctx, EventProviderRetry, state,
-				fmt.Sprintf("retrying provider call (attempt %d/%d, wait=%.1fs)...",
-					retryAttempt, defaultProviderRetryMax, wait.Seconds()))
-
-			select {
-			case <-ctx.Done():
-				return turnProviderOutput{}, ctx.Err()
-			case <-time.After(wait):
-			}
-		}
-
-		modelProvider := initialProvider
-		if retryAttempt > 0 {
-			var err error
-			modelProvider, err = s.providerFactory.Build(ctx, snapshot.ProviderConfig)
-			if err != nil {
-				return turnProviderOutput{}, err
-			}
-		}
-
-		streamOutcome := generateStreamingMessage(ctx, modelProvider, snapshot.Request, streaming.Hooks{
-			OnTextDelta: func(text string) {
-				s.emitRunScoped(ctx, EventAgentChunk, state, text)
-			},
-			OnToolCallStart: func(payload providertypes.ToolCallStartPayload) {
-				s.emitRunScoped(ctx, EventToolCallThinking, state, payload.Name)
-			},
-		})
-		if streamOutcome.err != nil {
-			lastErr = streamOutcome.err
-			if !isRetryableProviderError(lastErr) {
-				return turnProviderOutput{}, lastErr
-			}
-			if ctx.Err() != nil {
-				return turnProviderOutput{}, ctx.Err()
-			}
-			continue
-		}
-
-		return turnProviderOutput{
-			assistant: streamOutcome.message,
-			usageObservation: newTurnBudgetUsageObservation(
-				snapshot.ID,
-				streamOutcome.inputTokens,
-				streamOutcome.outputTokens,
-				streamOutcome.inputObserved,
-				streamOutcome.outputObserved,
-			),
-		}, nil
+	streamOutcome := generateStreamingMessage(ctx, modelProvider, snapshot.Request, streaming.Hooks{
+		OnTextDelta: func(text string) {
+			s.emitRunScoped(ctx, EventAgentChunk, state, text)
+		},
+		OnToolCallStart: func(payload providertypes.ToolCallStartPayload) {
+			s.emitRunScoped(ctx, EventToolCallThinking, state, payload.Name)
+		},
+	})
+	if streamOutcome.err != nil {
+		return turnProviderOutput{}, streamOutcome.err
 	}
 
-	if lastErr == nil {
-		lastErr = errors.New("max retries exceeded")
-	}
-	return turnProviderOutput{}, fmt.Errorf("runtime: max retries exhausted, last error: %w", lastErr)
+	return turnProviderOutput{
+		assistant: streamOutcome.message,
+		usageObservation: newTurnBudgetUsageObservation(
+			snapshot.ID,
+			streamOutcome.inputTokens,
+			streamOutcome.outputTokens,
+			streamOutcome.inputObserved,
+			streamOutcome.outputObserved,
+		),
+	}, nil
 }
 
 // emitTokenUsage 在单轮 provider 调用成功后发出 token_usage 事件。

--- a/internal/runtime/runtime_remaining_branches_test.go
+++ b/internal/runtime/runtime_remaining_branches_test.go
@@ -619,24 +619,16 @@ func TestRunAndProviderRetryRemainingBranches(t *testing.T) {
 		}
 	})
 
-	t.Run("callProviderWithRetry exits on context done during backoff wait", func(t *testing.T) {
+	t.Run("callProvider returns context error from provider", func(t *testing.T) {
 		t.Parallel()
 		ctx, cancel := context.WithCancel(context.Background())
-		firstCallDone := make(chan struct{}, 1)
 		providerRetry := &scriptedProvider{chatFn: func(ctx context.Context, req providertypes.GenerateRequest, events chan<- providertypes.StreamEvent) error {
-			select {
-			case firstCallDone <- struct{}{}:
-			default:
-			}
-			return &provider.ProviderError{StatusCode: 500, Code: provider.ErrorCodeServer, Message: "retry", Retryable: true}
-		}}
-		go func() {
-			<-firstCallDone
 			cancel()
-		}()
+			return ctx.Err()
+		}}
 		service := &Service{providerFactory: &scriptedProviderFactory{provider: providerRetry}, events: make(chan RuntimeEvent, 8)}
 		state := newRunState("run-retry-backoff", newRuntimeSession("session-retry-backoff"))
-		_, err := service.callProviderWithRetry(
+		_, err := service.callProvider(
 			ctx,
 			&state,
 			TurnBudgetSnapshot{ProviderConfig: provider.RuntimeConfig{Name: "x"}},
@@ -647,23 +639,24 @@ func TestRunAndProviderRetryRemainingBranches(t *testing.T) {
 		}
 	})
 
-	t.Run("callProviderWithRetry checks ctx after retryable stream error", func(t *testing.T) {
+	t.Run("callProvider returns retryable provider error without retry", func(t *testing.T) {
 		t.Parallel()
-		ctx, cancel := context.WithCancel(context.Background())
 		providerRetry := &scriptedProvider{chatFn: func(ctx context.Context, req providertypes.GenerateRequest, events chan<- providertypes.StreamEvent) error {
-			cancel()
 			return &provider.ProviderError{StatusCode: 500, Code: provider.ErrorCodeServer, Message: "retry", Retryable: true}
 		}}
 		service := &Service{providerFactory: &scriptedProviderFactory{provider: providerRetry}, events: make(chan RuntimeEvent, 8)}
 		state := newRunState("run-retry-ctx-check", newRuntimeSession("session-retry-ctx-check"))
-		_, err := service.callProviderWithRetry(
-			ctx,
+		_, err := service.callProvider(
+			context.Background(),
 			&state,
 			TurnBudgetSnapshot{ProviderConfig: provider.RuntimeConfig{Name: "x"}},
 			providerRetry,
 		)
-		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("expected context.Canceled, got %v", err)
+		if err == nil || !containsError(err, "retry") {
+			t.Fatalf("expected retryable provider error, got %v", err)
+		}
+		if providerRetry.callCount != 1 {
+			t.Fatalf("expected provider to be called once, got %d", providerRetry.callCount)
 		}
 	})
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2350,18 +2350,12 @@ func TestServiceRunErrorPaths(t *testing.T) {
 					},
 				}
 			}(),
-			expectEvents: []EventType{EventUserMessage, EventProviderRetry, EventAgentDone},
+			expectErr:    "internal server error",
+			expectEvents: []EventType{EventUserMessage, EventStopReasonDecided},
 			assert: func(t *testing.T, store *memoryStore, scripted *scriptedProvider, tool *stubTool) {
 				t.Helper()
-				if scripted.callCount < 2 {
-					t.Fatalf("expected at least 2 provider calls (initial + retry), got %d", scripted.callCount)
-				}
-				session := onlySession(t, store)
-				if len(session.Messages) != 2 {
-					t.Fatalf("expected user + assistant messages, got %d", len(session.Messages))
-				}
-				if renderPartsForTest(session.Messages[1].Parts) != "recovered" {
-					t.Fatalf("expected assistant content %q, got %q", "recovered", renderPartsForTest(session.Messages[1].Parts))
+				if scripted.callCount != 1 {
+					t.Fatalf("expected runtime to call provider once, got %d", scripted.callCount)
 				}
 			},
 		},
@@ -2389,7 +2383,7 @@ func TestServiceRunErrorPaths(t *testing.T) {
 			},
 		},
 		{
-			name:  "runtime retry exhausted emits error",
+			name:  "retryable provider error does not trigger runtime retry",
 			input: UserInput{RunID: "run-retry-exhausted", Parts: []providertypes.ContentPart{providertypes.NewTextPart("hello")}},
 			provider: &scriptedProvider{
 				name: "always-500",
@@ -2403,13 +2397,11 @@ func TestServiceRunErrorPaths(t *testing.T) {
 				},
 			},
 			expectErr:    "internal server error",
-			expectEvents: []EventType{EventUserMessage, EventProviderRetry, EventStopReasonDecided},
+			expectEvents: []EventType{EventUserMessage, EventStopReasonDecided},
 			assert: func(t *testing.T, store *memoryStore, scripted *scriptedProvider, tool *stubTool) {
 				t.Helper()
-				// 1 initial + 2 retries = 3 calls
-				if scripted.callCount != defaultProviderRetryMax+1 {
-					t.Fatalf("expected %d provider calls (1 initial + %d retries), got %d",
-						defaultProviderRetryMax+1, defaultProviderRetryMax, scripted.callCount)
+				if scripted.callCount != 1 {
+					t.Fatalf("expected runtime not to retry provider calls, got %d", scripted.callCount)
 				}
 			},
 		},
@@ -3785,75 +3777,6 @@ func TestWorkdirHelperFunctions(t *testing.T) {
 	})
 }
 
-func TestIsRetryableProviderError(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{"nil error", nil, false},
-		{"retryable provider error", &provider.ProviderError{Retryable: true}, true},
-		{"non-retryable provider error", &provider.ProviderError{Retryable: false}, false},
-		{"plain error", errors.New("something failed"), false},
-		{"wrapped retryable", fmt.Errorf("wrapped: %w", &provider.ProviderError{Retryable: true}), true},
-		{"stream interrupted sentinel", provider.ErrStreamInterrupted, false},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			if got := isRetryableProviderError(tt.err); got != tt.want {
-				t.Fatalf("isRetryableProviderError() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestProviderRetryBackoff(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name    string
-		attempt int
-		min     time.Duration
-		max     time.Duration
-	}{
-		{
-			name:    "first retry stays within jittered base window",
-			attempt: 1,
-			min:     500 * time.Millisecond,
-			max:     1500 * time.Millisecond,
-		},
-		{
-			name:    "second retry stays within jittered doubled window",
-			attempt: 2,
-			min:     1 * time.Second,
-			max:     3 * time.Second,
-		},
-		{
-			name:    "large retry is capped at max wait",
-			attempt: 20,
-			min:     providerRetryMaxWait,
-			max:     providerRetryMaxWait,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := providerRetryBackoff(tt.attempt)
-			if got < tt.min || got > tt.max {
-				t.Fatalf("providerRetryBackoff(%d) = %v, want within [%v, %v]", tt.attempt, got, tt.min, tt.max)
-			}
-		})
-	}
-}
-
 func TestStreamAccumulatorBuildMessageRejectsMissingToolName(t *testing.T) {
 	t.Parallel()
 
@@ -4014,7 +3937,7 @@ func TestCallProviderWithRetryReturnsCombinedForwardError(t *testing.T) {
 		},
 	}
 
-	_, err := service.callProviderWithRetry(
+	_, err := service.callProvider(
 		context.Background(),
 		&state,
 		snapshot,

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -1597,7 +1597,6 @@ var runtimeEventHandlerRegistry = map[tuiservices.EventType]func(*App, tuiservic
 	tuiservices.EventAgentChunk:                               runtimeEventAgentChunkHandler,
 	tuiservices.EventToolChunk:                                runtimeEventToolChunkHandler,
 	tuiservices.EventAgentDone:                                runtimeEventAgentDoneHandler,
-	tuiservices.EventProviderRetry:                            runtimeEventProviderRetryHandler,
 	tuiservices.EventPermissionRequested:                      runtimeEventPermissionRequestHandler,
 	tuiservices.EventPermissionResolved:                       runtimeEventPermissionResolvedHandler,
 	tuiservices.EventCompactApplied:                           runtimeEventCompactDoneHandler,
@@ -2264,15 +2263,6 @@ func runtimeEventErrorHandler(a *App, event tuiservices.RuntimeEvent) bool {
 		a.state.ExecutionError = payload
 		a.state.StatusText = payload
 		a.appendActivity("run", "Runtime error", payload, true)
-	}
-	return false
-}
-
-func runtimeEventProviderRetryHandler(a *App, event tuiservices.RuntimeEvent) bool {
-	if payload, ok := event.Payload.(string); ok && strings.TrimSpace(payload) != "" {
-		a.state.StatusText = statusThinking
-		a.runProgressKnown = false
-		a.appendActivity("provider", "Retrying provider call", payload, false)
 	}
 	return false
 }

--- a/internal/tui/core/app/update_test.go
+++ b/internal/tui/core/app/update_test.go
@@ -1839,14 +1839,6 @@ func TestRuntimeEventErrorHandler(t *testing.T) {
 	}
 }
 
-func TestRuntimeEventProviderRetryHandler(t *testing.T) {
-	app, _ := newTestApp(t)
-	runtimeEventProviderRetryHandler(&app, agentruntime.RuntimeEvent{Payload: "retry"})
-	if app.state.StatusText != statusThinking {
-		t.Fatalf("expected thinking status")
-	}
-}
-
 func TestRuntimeEventCompactDoneHandler(t *testing.T) {
 	app, _ := newTestApp(t)
 	payload := agentruntime.CompactResult{TriggerMode: "auto", SavedRatio: 0.5, BeforeChars: 10, AfterChars: 5, TranscriptPath: "path"}

--- a/internal/tui/services/gateway_stream_client.go
+++ b/internal/tui/services/gateway_stream_client.go
@@ -241,7 +241,7 @@ func restoreRuntimePayload(eventType EventType, payload any) (any, error) {
 		return decodeRuntimePayload[RuntimeToolStatusPayload](payload)
 	case EventType(RuntimeEventUsage):
 		return decodeRuntimePayload[RuntimeUsagePayload](payload)
-	case EventAgentChunk, EventToolChunk, EventError, EventProviderRetry, EventToolCallThinking:
+	case EventAgentChunk, EventToolChunk, EventError, EventToolCallThinking:
 		return decodeStringPayload(payload), nil
 	default:
 		return payload, nil

--- a/internal/tui/services/runtime_contract.go
+++ b/internal/tui/services/runtime_contract.go
@@ -321,7 +321,6 @@ const (
 	EventRunCanceled               EventType = "run_canceled"
 	EventError                     EventType = "error"
 	EventToolCallThinking          EventType = "tool_call_thinking"
-	EventProviderRetry             EventType = "provider_retry"
 	EventPermissionRequested       EventType = "permission_requested"
 	EventPermissionResolved        EventType = "permission_resolved"
 	EventCompactStart              EventType = "compact_start"


### PR DESCRIPTION
## 摘要

本次改动将 provider 的重试责任从 runtime 下沉回 provider 层，移除了 runtime 级 `provider_retry` 事件

同时，为 Gemini 增加了请求级最小重试能力，统一了 provider 层 SDK 请求超时默认值，并调整了 TUI / runtime 的事件与测试，使其与新的重试模型保持一致。

## 主要改动

### Provider 层

- 在 `internal/provider/constants.go` 中新增统一的 `DefaultSDKRequestTimeout`
- Anthropic、Gemini、OpenAI-compatible provider 统一使用该 SDK 请求超时
- 将 Gemini 的重试逻辑收敛到 `internal/provider/gemini/provider.go`
- Gemini 仅在**流式输出尚未开始前**，对可重试的网络错误 / 超时错误执行请求级重试
- 将 Gemini 的超时 / 网络错误统一归类为 provider 层 typed error
- 为 Gemini 补充以下测试覆盖：
  - 瞬时失败后的重试恢复
  - 连续可重试错误达到上限后的失败返回
  - 一次成功后，下一次请求不会继承上一次的失败次数

### Runtime / TUI

- 将 runtime 的 provider 执行收敛为单次调用
- 删除 runtime 外层的 provider 重试循环及相关重试状态处理
- 删除 runtime 级 `provider_retry` 事件，并同步清理以下位置：
  - runtime 事件定义
  - TUI runtime contract
  - gateway stream payload 恢复逻辑
  - TUI 事件处理与对应测试
- 更新 runtime 测试，验证 retryable provider error 不再由 runtime 二次重试

## 测试情况

### 已通过

- `go test ./internal/provider/...`
- `go test ./internal/runtime`
- `go test ./internal/tui/...`


## 说明

- Gemini 的重试仅覆盖“尚未产生流式输出”的失败场景，避免重复发出部分流式内容。
- 依赖 SDK 的 provider 继续使用各自 SDK 的重试能力，不再叠加 runtime 重试。