### PR TITLE
refactor(gateway): 传输层抽象与分层 ActionRegistry（Step 1）

### DIFF
--- a/internal/cli/gateway_commands.go
+++ b/internal/cli/gateway_commands.go
@@ -85,18 +85,6 @@ type urlDispatchErrorOutput struct {
 	Message string `json:"message"`
 }
 
-type gatewayServer interface {
-	ListenAddress() string
-	Serve(ctx context.Context, runtimePort gateway.RuntimePort) error
-	Close(ctx context.Context) error
-}
-
-type gatewayNetworkServer interface {
-	ListenAddress() string
-	Serve(ctx context.Context, runtimePort gateway.RuntimePort) error
-	Close(ctx context.Context) error
-}
-
 // defaultNewAuthManager 创建默认网关认证器，并把具体持久化实现收敛在 CLI 装配层内部。
 func defaultNewAuthManager(path string) (gateway.TokenAuthenticator, error) {
 	return gatewayauth.NewManager(path)
@@ -308,28 +296,37 @@ func defaultGatewayCommandRunner(ctx context.Context, options gatewayCommandOpti
 		_ = ipcServer.Close(context.Background())
 		return err
 	}
+	transportAdapters := []gateway.TransportAdapter{ipcServer, networkServer}
+	transportNames := []string{"ipc", "network"}
 	defer func() {
 		relay.Stop()
-		_ = networkServer.Close(context.Background())
-		_ = ipcServer.Close(context.Background())
-	}()
-
-	logger.Printf("gateway ipc listen address: %s", ipcServer.ListenAddress())
-	logger.Printf("gateway network listen address: %s", networkServer.ListenAddress())
-	idleCloser.observe(0)
-
-	go func() {
-		serveErr := networkServer.Serve(runtimeContext, runtimePort)
-		if serveErr != nil && runtimeContext.Err() == nil {
-			logger.Printf(
-				"warning: HTTP server failed to start on %s (port in use?), but IPC server is still running: %v",
-				networkServer.ListenAddress(),
-				serveErr,
-			)
+		for index := len(transportAdapters) - 1; index >= 0; index-- {
+			_ = transportAdapters[index].Close(context.Background())
 		}
 	}()
 
-	return ipcServer.Serve(runtimeContext, runtimePort)
+	for index, adapter := range transportAdapters {
+		logger.Printf("gateway %s listen address: %s", transportNames[index], adapter.ListenAddress())
+	}
+	idleCloser.observe(0)
+
+	for index, adapter := range transportAdapters {
+		if index == 0 {
+			continue
+		}
+		go func(networkAdapter gateway.TransportAdapter) {
+			serveErr := networkAdapter.Serve(runtimeContext, runtimePort)
+			if serveErr != nil && runtimeContext.Err() == nil {
+				logger.Printf(
+					"warning: HTTP server failed to start on %s (port in use?), but IPC server is still running: %v",
+					networkAdapter.ListenAddress(),
+					serveErr,
+				)
+			}
+		}(adapter)
+	}
+
+	return transportAdapters[0].Serve(runtimeContext, runtimePort)
 }
 
 type gatewayIdleShutdownController struct {
@@ -460,12 +457,12 @@ func applyGatewayFlagOverrides(gatewayConfig *config.GatewayConfig, options gate
 }
 
 // defaultNewGatewayServer 创建默认网关服务实例，供命令层启动流程调用。
-func defaultNewGatewayServer(options gateway.ServerOptions) (gatewayServer, error) {
+func defaultNewGatewayServer(options gateway.ServerOptions) (gateway.TransportAdapter, error) {
 	return gateway.NewServer(options)
 }
 
 // defaultNewGatewayNetworkServer 创建默认网关网络访问服务实例，供命令层启动流程调用。
-func defaultNewGatewayNetworkServer(options gateway.NetworkServerOptions) (gatewayNetworkServer, error) {
+func defaultNewGatewayNetworkServer(options gateway.NetworkServerOptions) (gateway.TransportAdapter, error) {
 	return gateway.NewNetworkServer(options)
 }
 

--- a/internal/cli/gateway_commands.go
+++ b/internal/cli/gateway_commands.go
@@ -296,21 +296,27 @@ func defaultGatewayCommandRunner(ctx context.Context, options gatewayCommandOpti
 		_ = ipcServer.Close(context.Background())
 		return err
 	}
-	transportAdapters := []gateway.TransportAdapter{ipcServer, networkServer}
-	transportNames := []string{"ipc", "network"}
+	type transportAdapterEntry struct {
+		name    string
+		adapter gateway.TransportAdapter
+	}
+	transportAdapters := []transportAdapterEntry{
+		{name: "ipc", adapter: ipcServer},
+		{name: "network", adapter: networkServer},
+	}
 	defer func() {
 		relay.Stop()
 		for index := len(transportAdapters) - 1; index >= 0; index-- {
-			_ = transportAdapters[index].Close(context.Background())
+			_ = transportAdapters[index].adapter.Close(context.Background())
 		}
 	}()
 
-	for index, adapter := range transportAdapters {
-		logger.Printf("gateway %s listen address: %s", transportNames[index], adapter.ListenAddress())
+	for _, entry := range transportAdapters {
+		logger.Printf("gateway %s listen address: %s", entry.name, entry.adapter.ListenAddress())
 	}
 	idleCloser.observe(0)
 
-	for index, adapter := range transportAdapters {
+	for index, entry := range transportAdapters {
 		if index == 0 {
 			continue
 		}
@@ -323,10 +329,10 @@ func defaultGatewayCommandRunner(ctx context.Context, options gatewayCommandOpti
 					serveErr,
 				)
 			}
-		}(adapter)
+		}(entry.adapter)
 	}
 
-	return transportAdapters[0].Serve(runtimeContext, runtimePort)
+	return transportAdapters[0].adapter.Serve(runtimeContext, runtimePort)
 }
 
 type gatewayIdleShutdownController struct {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -306,11 +306,11 @@ func TestDefaultGatewayCommandRunnerSuccess(t *testing.T) {
 	newAuthManager = stubGatewayAuthManagerBuilder()
 
 	server := &stubGatewayServer{listenAddress: "stub://gateway"}
-	newGatewayServer = func(options gateway.ServerOptions) (gatewayServer, error) {
+	newGatewayServer = func(options gateway.ServerOptions) (gateway.TransportAdapter, error) {
 		return server, nil
 	}
 	networkServer := &stubGatewayServer{listenAddress: "127.0.0.1:8080"}
-	newGatewayNetwork = func(options gateway.NetworkServerOptions) (gatewayNetworkServer, error) {
+	newGatewayNetwork = func(options gateway.NetworkServerOptions) (gateway.TransportAdapter, error) {
 		return networkServer, nil
 	}
 
@@ -372,10 +372,10 @@ func TestDefaultGatewayCommandRunnerReturnsConstructorError(t *testing.T) {
 	newAuthManager = stubGatewayAuthManagerBuilder()
 
 	expected := errors.New("new gateway server failed")
-	newGatewayServer = func(options gateway.ServerOptions) (gatewayServer, error) {
+	newGatewayServer = func(options gateway.ServerOptions) (gateway.TransportAdapter, error) {
 		return nil, expected
 	}
-	newGatewayNetwork = func(options gateway.NetworkServerOptions) (gatewayNetworkServer, error) {
+	newGatewayNetwork = func(options gateway.NetworkServerOptions) (gateway.TransportAdapter, error) {
 		return &stubGatewayServer{listenAddress: "127.0.0.1:8080"}, nil
 	}
 
@@ -418,10 +418,10 @@ func TestDefaultGatewayCommandRunnerReturnsAuthManagerError(t *testing.T) {
 	newAuthManager = func(string) (gateway.TokenAuthenticator, error) {
 		return nil, errors.New("auth manager failed")
 	}
-	newGatewayServer = func(options gateway.ServerOptions) (gatewayServer, error) {
+	newGatewayServer = func(options gateway.ServerOptions) (gateway.TransportAdapter, error) {
 		return &stubGatewayServer{listenAddress: "stub://gateway"}, nil
 	}
-	newGatewayNetwork = func(options gateway.NetworkServerOptions) (gatewayNetworkServer, error) {
+	newGatewayNetwork = func(options gateway.NetworkServerOptions) (gateway.TransportAdapter, error) {
 		return &stubGatewayServer{listenAddress: "127.0.0.1:8080"}, nil
 	}
 
@@ -453,11 +453,11 @@ func TestDefaultGatewayCommandRunnerReturnsServeError(t *testing.T) {
 		listenAddress: "stub://gateway",
 		serveErr:      expected,
 	}
-	newGatewayServer = func(options gateway.ServerOptions) (gatewayServer, error) {
+	newGatewayServer = func(options gateway.ServerOptions) (gateway.TransportAdapter, error) {
 		return server, nil
 	}
 	networkServer := &stubGatewayServer{listenAddress: "127.0.0.1:8080"}
-	newGatewayNetwork = func(options gateway.NetworkServerOptions) (gatewayNetworkServer, error) {
+	newGatewayNetwork = func(options gateway.NetworkServerOptions) (gateway.TransportAdapter, error) {
 		return networkServer, nil
 	}
 
@@ -491,14 +491,14 @@ func TestDefaultGatewayCommandRunnerDegradesWhenNetworkServeFails(t *testing.T) 
 	newAuthManager = stubGatewayAuthManagerBuilder()
 
 	ipcServer := &stubGatewayServer{listenAddress: "stub://gateway"}
-	newGatewayServer = func(options gateway.ServerOptions) (gatewayServer, error) {
+	newGatewayServer = func(options gateway.ServerOptions) (gateway.TransportAdapter, error) {
 		return ipcServer, nil
 	}
 	networkServer := &stubGatewayServer{
 		listenAddress: "127.0.0.1:8080",
 		serveErr:      errors.New("bind: address already in use"),
 	}
-	newGatewayNetwork = func(options gateway.NetworkServerOptions) (gatewayNetworkServer, error) {
+	newGatewayNetwork = func(options gateway.NetworkServerOptions) (gateway.TransportAdapter, error) {
 		return networkServer, nil
 	}
 
@@ -536,10 +536,10 @@ func TestDefaultGatewayCommandRunnerReturnsNetworkConstructorError(t *testing.T)
 
 	networkErr := errors.New("new network server failed")
 	ipcServer := &stubGatewayServer{listenAddress: "stub://gateway"}
-	newGatewayServer = func(options gateway.ServerOptions) (gatewayServer, error) {
+	newGatewayServer = func(options gateway.ServerOptions) (gateway.TransportAdapter, error) {
 		return ipcServer, nil
 	}
-	newGatewayNetwork = func(options gateway.NetworkServerOptions) (gatewayNetworkServer, error) {
+	newGatewayNetwork = func(options gateway.NetworkServerOptions) (gateway.TransportAdapter, error) {
 		return nil, networkErr
 	}
 

--- a/internal/gateway/bootstrap.go
+++ b/internal/gateway/bootstrap.go
@@ -31,35 +31,9 @@ var allowedSystemToolNames = map[string]struct{}{
 	toolkits.ToolNameMemoRemove:   {},
 }
 
-var requestFrameHandlers = map[FrameAction]requestFrameHandler{
-	FrameActionAuthenticate: func(ctx context.Context, frame MessageFrame, _ RuntimePort) MessageFrame {
-		return handleAuthenticateFrame(ctx, frame)
-	},
-	FrameActionPing: func(ctx context.Context, frame MessageFrame, _ RuntimePort) MessageFrame {
-		return handlePingFrame(ctx, frame)
-	},
-	FrameActionBindStream: func(ctx context.Context, frame MessageFrame, _ RuntimePort) MessageFrame {
-		return handleBindStreamFrame(ctx, frame)
-	},
-	FrameActionWakeOpenURL: func(ctx context.Context, frame MessageFrame, _ RuntimePort) MessageFrame {
-		return handleWakeOpenURLFrame(ctx, frame)
-	},
-	FrameActionRun:                    handleRunFrame,
-	FrameActionCompact:                handleCompactFrame,
-	FrameActionExecuteSystemTool:      handleExecuteSystemToolFrame,
-	FrameActionActivateSessionSkill:   handleActivateSessionSkillFrame,
-	FrameActionDeactivateSessionSkill: handleDeactivateSessionSkillFrame,
-	FrameActionListSessionSkills:      handleListSessionSkillsFrame,
-	FrameActionListAvailableSkills:    handleListAvailableSkillsFrame,
-	FrameActionCancel:                 handleCancelFrame,
-	FrameActionListSessions:           handleListSessionsFrame,
-	FrameActionLoadSession:            handleLoadSessionFrame,
-	FrameActionResolvePermission:      handleResolvePermissionFrame,
-}
-
 // dispatchRequestFrame 统一分发 request 帧到对应处理器。
 func dispatchRequestFrame(ctx context.Context, frame MessageFrame, runtimePort RuntimePort) MessageFrame {
-	handler, ok := requestFrameHandlers[frame.Action]
+	handler, ok := defaultRegistry.Lookup(frame.Action)
 	if !ok {
 		return errorFrame(frame, NewFrameError(ErrorCodeUnsupportedAction, "action is not implemented in gateway step 2"))
 	}

--- a/internal/gateway/contracts.go
+++ b/internal/gateway/contracts.go
@@ -304,3 +304,13 @@ type Gateway interface {
 	// Close 优雅关闭网关服务。
 	Close(ctx context.Context) error
 }
+
+// TransportAdapter defines the shared lifecycle contract for gateway transports.
+type TransportAdapter interface {
+	// ListenAddress returns the listening address for this transport.
+	ListenAddress() string
+	// Serve starts the transport and binds it to the runtime port.
+	Serve(ctx context.Context, runtimePort RuntimePort) error
+	// Close gracefully shuts down the transport.
+	Close(ctx context.Context) error
+}

--- a/internal/gateway/contracts_test.go
+++ b/internal/gateway/contracts_test.go
@@ -67,3 +67,5 @@ func (s *runtimePortCompileStub) LoadSession(_ context.Context, _ LoadSessionInp
 }
 
 var _ RuntimePort = (*runtimePortCompileStub)(nil)
+var _ TransportAdapter = (*Server)(nil)
+var _ TransportAdapter = (*NetworkServer)(nil)

--- a/internal/gateway/registry.go
+++ b/internal/gateway/registry.go
@@ -1,0 +1,115 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// ActionRegistry stores core and extension request handlers.
+type ActionRegistry struct {
+	mu sync.RWMutex
+
+	core     map[FrameAction]requestFrameHandler
+	extended map[FrameAction]requestFrameHandler
+}
+
+var defaultRegistry = NewActionRegistry()
+
+// NewActionRegistry creates a registry with all core handlers preloaded.
+func NewActionRegistry() *ActionRegistry {
+	registry := &ActionRegistry{
+		core:     make(map[FrameAction]requestFrameHandler),
+		extended: make(map[FrameAction]requestFrameHandler),
+	}
+	registry.initCore()
+	return registry
+}
+
+// initCore registers built-in handlers that cannot be overridden.
+func (r *ActionRegistry) initCore() {
+	if r == nil {
+		return
+	}
+	r.core[FrameActionAuthenticate] = func(ctx context.Context, frame MessageFrame, _ RuntimePort) MessageFrame {
+		return handleAuthenticateFrame(ctx, frame)
+	}
+	r.core[FrameActionPing] = func(ctx context.Context, frame MessageFrame, _ RuntimePort) MessageFrame {
+		return handlePingFrame(ctx, frame)
+	}
+	r.core[FrameActionBindStream] = func(ctx context.Context, frame MessageFrame, _ RuntimePort) MessageFrame {
+		return handleBindStreamFrame(ctx, frame)
+	}
+	r.core[FrameActionWakeOpenURL] = func(ctx context.Context, frame MessageFrame, _ RuntimePort) MessageFrame {
+		return handleWakeOpenURLFrame(ctx, frame)
+	}
+	r.core[FrameActionRun] = handleRunFrame
+	r.core[FrameActionCompact] = handleCompactFrame
+	r.core[FrameActionExecuteSystemTool] = handleExecuteSystemToolFrame
+	r.core[FrameActionActivateSessionSkill] = handleActivateSessionSkillFrame
+	r.core[FrameActionDeactivateSessionSkill] = handleDeactivateSessionSkillFrame
+	r.core[FrameActionListSessionSkills] = handleListSessionSkillsFrame
+	r.core[FrameActionListAvailableSkills] = handleListAvailableSkillsFrame
+	r.core[FrameActionCancel] = handleCancelFrame
+	r.core[FrameActionListSessions] = handleListSessionsFrame
+	r.core[FrameActionLoadSession] = handleLoadSessionFrame
+	r.core[FrameActionResolvePermission] = handleResolvePermissionFrame
+}
+
+// Lookup returns the handler for an action.
+func (r *ActionRegistry) Lookup(action FrameAction) (requestFrameHandler, bool) {
+	if r == nil {
+		return nil, false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if handler, ok := r.core[action]; ok {
+		return handler, true
+	}
+	handler, ok := r.extended[action]
+	return handler, ok
+}
+
+// Register adds an extension handler and protects core handlers from override.
+func (r *ActionRegistry) Register(action FrameAction, handler requestFrameHandler) error {
+	if r == nil {
+		return fmt.Errorf("action registry is nil")
+	}
+	if strings.TrimSpace(string(action)) == "" {
+		return fmt.Errorf("action is empty")
+	}
+	if handler == nil {
+		return fmt.Errorf("handler is nil")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.core[action]; exists {
+		return fmt.Errorf("cannot override core handler: %s", action)
+	}
+	if _, exists := r.extended[action]; exists {
+		return fmt.Errorf("action already registered: %s", action)
+	}
+	r.extended[action] = handler
+	return nil
+}
+
+// MustRegister adds an extension handler and panics on registration failure.
+func (r *ActionRegistry) MustRegister(action FrameAction, handler requestFrameHandler) {
+	if err := r.Register(action, handler); err != nil {
+		panic(err)
+	}
+}
+
+// RegisterAction registers an extension handler on the global default registry.
+func RegisterAction(action FrameAction, handler requestFrameHandler) error {
+	return defaultRegistry.Register(action, handler)
+}
+
+// MustRegisterAction registers an extension handler and panics on failure.
+func MustRegisterAction(action FrameAction, handler requestFrameHandler) {
+	defaultRegistry.MustRegister(action, handler)
+}

--- a/internal/gateway/registry_test.go
+++ b/internal/gateway/registry_test.go
@@ -1,0 +1,107 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewActionRegistryHasCoreHandlers(t *testing.T) {
+	registry := NewActionRegistry()
+
+	coreActions := []FrameAction{
+		FrameActionAuthenticate,
+		FrameActionPing,
+		FrameActionBindStream,
+		FrameActionWakeOpenURL,
+		FrameActionRun,
+		FrameActionCompact,
+		FrameActionExecuteSystemTool,
+		FrameActionActivateSessionSkill,
+		FrameActionDeactivateSessionSkill,
+		FrameActionListSessionSkills,
+		FrameActionListAvailableSkills,
+		FrameActionCancel,
+		FrameActionListSessions,
+		FrameActionLoadSession,
+		FrameActionResolvePermission,
+	}
+
+	for _, action := range coreActions {
+		if _, ok := registry.Lookup(action); !ok {
+			t.Fatalf("expected core action %q to be registered", action)
+		}
+	}
+}
+
+func TestActionRegistryRegisterRejectsCoreOverride(t *testing.T) {
+	registry := NewActionRegistry()
+	err := registry.Register(FrameActionPing, func(context.Context, MessageFrame, RuntimePort) MessageFrame {
+		return MessageFrame{Type: FrameTypeAck}
+	})
+	if err == nil {
+		t.Fatal("expected override of core handler to fail")
+	}
+}
+
+func TestActionRegistryRegisterAndLookupExtension(t *testing.T) {
+	registry := NewActionRegistry()
+	handler := func(_ context.Context, frame MessageFrame, _ RuntimePort) MessageFrame {
+		return MessageFrame{
+			Type:      FrameTypeAck,
+			Action:    frame.Action,
+			RequestID: frame.RequestID,
+		}
+	}
+
+	if err := registry.Register(FrameAction("test.extension"), handler); err != nil {
+		t.Fatalf("register extension handler: %v", err)
+	}
+
+	loaded, ok := registry.Lookup(FrameAction("test.extension"))
+	if !ok {
+		t.Fatal("expected extension handler to be discoverable")
+	}
+	if loaded == nil {
+		t.Fatal("expected extension handler to be non-nil")
+	}
+}
+
+func TestActionRegistryRegisterRejectsDuplicateExtension(t *testing.T) {
+	registry := NewActionRegistry()
+	handler := func(context.Context, MessageFrame, RuntimePort) MessageFrame {
+		return MessageFrame{Type: FrameTypeAck}
+	}
+
+	if err := registry.Register(FrameAction("test.duplicate"), handler); err != nil {
+		t.Fatalf("first register should succeed: %v", err)
+	}
+	if err := registry.Register(FrameAction("test.duplicate"), handler); err == nil {
+		t.Fatal("expected duplicate extension registration to fail")
+	}
+}
+
+func TestActionRegistryRegisterRejectsInvalidInputs(t *testing.T) {
+	registry := NewActionRegistry()
+
+	if err := registry.Register("", func(context.Context, MessageFrame, RuntimePort) MessageFrame {
+		return MessageFrame{Type: FrameTypeAck}
+	}); err == nil {
+		t.Fatal("expected empty action to fail")
+	}
+	if err := registry.Register(FrameAction("test.nil"), nil); err == nil {
+		t.Fatal("expected nil handler to fail")
+	}
+}
+
+func TestActionRegistryMustRegisterPanics(t *testing.T) {
+	registry := NewActionRegistry()
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic when must register fails")
+		}
+	}()
+	registry.MustRegister(FrameActionPing, func(context.Context, MessageFrame, RuntimePort) MessageFrame {
+		return MessageFrame{Type: FrameTypeAck}
+	})
+}

--- a/internal/gateway/registry_test_helper_test.go
+++ b/internal/gateway/registry_test_helper_test.go
@@ -1,0 +1,21 @@
+package gateway
+
+import "testing"
+
+func installHandlerRegistryForTest(t *testing.T, handlers map[FrameAction]requestFrameHandler) {
+	t.Helper()
+
+	originalRegistry := defaultRegistry
+	replacement := &ActionRegistry{
+		core:     make(map[FrameAction]requestFrameHandler, len(handlers)),
+		extended: make(map[FrameAction]requestFrameHandler),
+	}
+	for action, handler := range handlers {
+		replacement.core[action] = handler
+	}
+	defaultRegistry = replacement
+
+	t.Cleanup(func() {
+		defaultRegistry = originalRegistry
+	})
+}

--- a/internal/gateway/rpc_dispatch_test.go
+++ b/internal/gateway/rpc_dispatch_test.go
@@ -104,8 +104,7 @@ func (s *rpcRunCaptureRuntimeStub) LoadSession(ctx context.Context, input LoadSe
 }
 
 func TestDispatchRPCRequestResultEncodeError(t *testing.T) {
-	originalHandlers := requestFrameHandlers
-	requestFrameHandlers = map[FrameAction]requestFrameHandler{
+	installHandlerRegistryForTest(t, map[FrameAction]requestFrameHandler{
 		FrameActionPing: func(_ context.Context, frame MessageFrame, _ RuntimePort) MessageFrame {
 			return MessageFrame{
 				Type:      FrameTypeAck,
@@ -116,9 +115,6 @@ func TestDispatchRPCRequestResultEncodeError(t *testing.T) {
 				},
 			}
 		},
-	}
-	t.Cleanup(func() {
-		requestFrameHandlers = originalHandlers
 	})
 
 	response := dispatchRPCRequest(context.Background(), protocol.JSONRPCRequest{
@@ -892,8 +888,7 @@ func TestDispatchRPCRequestMetricsACLDeniedAndFrameErrorLabels(t *testing.T) {
 		t.Fatal("expected acl denied response")
 	}
 
-	originalHandlers := requestFrameHandlers
-	requestFrameHandlers = map[FrameAction]requestFrameHandler{
+	installHandlerRegistryForTest(t, map[FrameAction]requestFrameHandler{
 		FrameActionPing: func(_ context.Context, frame MessageFrame, _ RuntimePort) MessageFrame {
 			return MessageFrame{
 				Type:      FrameTypeError,
@@ -902,8 +897,7 @@ func TestDispatchRPCRequestMetricsACLDeniedAndFrameErrorLabels(t *testing.T) {
 				Error:     NewFrameError(ErrorCodeAccessDenied, "denied by handler"),
 			}
 		},
-	}
-	t.Cleanup(func() { requestFrameHandlers = originalHandlers })
+	})
 
 	frameErrCtx := WithRequestSource(context.Background(), RequestSourceHTTP)
 	frameErrCtx = WithGatewayMetrics(frameErrCtx, metrics)

--- a/internal/gateway/server_additional_test.go
+++ b/internal/gateway/server_additional_test.go
@@ -356,8 +356,7 @@ func TestDispatchRPCRequestInvalidIDReturnsNullID(t *testing.T) {
 
 func TestDispatchRPCRequestConvertsFrameErrorWithoutPayload(t *testing.T) {
 	server := &Server{}
-	originalHandlers := requestFrameHandlers
-	requestFrameHandlers = map[FrameAction]requestFrameHandler{
+	installHandlerRegistryForTest(t, map[FrameAction]requestFrameHandler{
 		FrameActionPing: func(_ context.Context, frame MessageFrame, _ RuntimePort) MessageFrame {
 			return MessageFrame{
 				Type:      FrameTypeError,
@@ -366,9 +365,6 @@ func TestDispatchRPCRequestConvertsFrameErrorWithoutPayload(t *testing.T) {
 				Error:     nil,
 			}
 		},
-	}
-	t.Cleanup(func() {
-		requestFrameHandlers = originalHandlers
 	})
 
 	response := server.dispatchRPCRequest(context.Background(), protocol.JSONRPCRequest{


### PR DESCRIPTION
## 背景
NeoCode 网关层当前的 transport 协议（IPC/HTTP）和 action handler 均以硬编码方式耦合在核心文件中。每次新增接入面（gRPC）或新增能力（飞书、CLI 诊断），都需要直接修改 gateway_commands.go 和 bootstrap.go，违背"对扩展开放、对修改封闭"原则。

##做了什么
1. 新增 TransportAdapter 接口——定义 ListenAddress / Serve / Close 三方法契约，Server 和 NetworkServer 零修改满足
2. 新增分层 ActionRegistry——core map 在 initCore() 中固定注册全部 15 个内置 handler（不可覆盖），extended map 供 Register / MustRegister 动态挂载
3. 分发链路切换——dispatchRequestFrame 从 var requestFrameHandlers map 改为 defaultRegistry.Lookup
4. CLI 装配层重构——删除本地 gatewayServer / gatewayNetworkServer 接口，启动改为 []TransportAdapter 遍历，IPC 保持主阻塞、HTTP goroutine 降级语义不变
5. 测试——新增 6 个 registry 单测（core 不可覆盖、扩展注册、重复冲突、非法输入、panic 路径）+ 编译期接口断言
## 验证
- go build ./... 通过
- go test ./... 全部通过
- TUI 端到端对话链路不受影响
## 影响范围
- 零业务语义变更，JSON-RPC 契约无变化
- 核心 handler 均在 initCore() 中保留，安全边界不变
- 新增 RegisterAction / MustRegisterAction 公开 API，供后续扩展包使用

Closes #474 