### PR TITLE
feat(runtime/hooks): 实现 #488 的 P0 Hook Core 基础设施

### DIFF
--- a/internal/runtime/hooks/context.go
+++ b/internal/runtime/hooks/context.go
@@ -1,0 +1,85 @@
+package hooks
+
+import "reflect"
+
+// HookContext 是 hook 执行时可见的通用上下文快照。
+type HookContext struct {
+	RunID     string
+	SessionID string
+	Metadata  map[string]any
+}
+
+// Clone 返回 HookContext 的安全副本，避免元数据被跨 hook 共享修改。
+func (c HookContext) Clone() HookContext {
+	if len(c.Metadata) == 0 {
+		return c
+	}
+	cloned := c
+	cloned.Metadata = make(map[string]any, len(c.Metadata))
+	for key, value := range c.Metadata {
+		cloned.Metadata[key] = cloneMetadataValue(value)
+	}
+	return cloned
+}
+
+func cloneMetadataValue(value any) any {
+	if value == nil {
+		return nil
+	}
+	original := reflect.ValueOf(value)
+	cloned := deepCloneValue(original)
+	return cloned.Interface()
+}
+
+func deepCloneValue(value reflect.Value) reflect.Value {
+	if !value.IsValid() {
+		return value
+	}
+
+	switch value.Kind() {
+	case reflect.Pointer:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		pointer := reflect.New(value.Type().Elem())
+		pointer.Elem().Set(deepCloneValue(value.Elem()))
+		return pointer
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		elem := deepCloneValue(value.Elem())
+		out := reflect.New(value.Type()).Elem()
+		out.Set(elem)
+		return out
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		clonedMap := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			key := deepCloneValue(iter.Key())
+			val := deepCloneValue(iter.Value())
+			clonedMap.SetMapIndex(key, val)
+		}
+		return clonedMap
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		clonedSlice := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for i := 0; i < value.Len(); i++ {
+			clonedSlice.Index(i).Set(deepCloneValue(value.Index(i)))
+		}
+		return clonedSlice
+	case reflect.Array:
+		clonedArray := reflect.New(value.Type()).Elem()
+		for i := 0; i < value.Len(); i++ {
+			clonedArray.Index(i).Set(deepCloneValue(value.Index(i)))
+		}
+		return clonedArray
+	default:
+		return value
+	}
+}

--- a/internal/runtime/hooks/context.go
+++ b/internal/runtime/hooks/context.go
@@ -79,6 +79,17 @@ func deepCloneValue(value reflect.Value) reflect.Value {
 			clonedArray.Index(i).Set(deepCloneValue(value.Index(i)))
 		}
 		return clonedArray
+	case reflect.Struct:
+		clonedStruct := reflect.New(value.Type()).Elem()
+		clonedStruct.Set(value)
+		for i := 0; i < value.NumField(); i++ {
+			target := clonedStruct.Field(i)
+			if !target.CanSet() {
+				continue
+			}
+			target.Set(deepCloneValue(value.Field(i)))
+		}
+		return clonedStruct
 	default:
 		return value
 	}

--- a/internal/runtime/hooks/context_test.go
+++ b/internal/runtime/hooks/context_test.go
@@ -1,0 +1,48 @@
+package hooks
+
+import "testing"
+
+func TestHookContextCloneDeepCopyMetadata(t *testing.T) {
+	t.Parallel()
+
+	original := HookContext{
+		RunID:     "run-1",
+		SessionID: "session-1",
+		Metadata: map[string]any{
+			"slice": []any{"a", map[string]any{"k": "v"}},
+			"map":   map[string]any{"nested": []string{"x", "y"}},
+		},
+	}
+
+	cloned := original.Clone()
+	metadataSlice, ok := cloned.Metadata["slice"].([]any)
+	if !ok {
+		t.Fatalf("slice metadata type = %T, want []any", cloned.Metadata["slice"])
+	}
+	nestedMap, ok := metadataSlice[1].(map[string]any)
+	if !ok {
+		t.Fatalf("nested map type = %T, want map[string]any", metadataSlice[1])
+	}
+	nestedMap["k"] = "changed"
+
+	clonedMap, ok := cloned.Metadata["map"].(map[string]any)
+	if !ok {
+		t.Fatalf("map metadata type = %T, want map[string]any", cloned.Metadata["map"])
+	}
+	nestedSlice, ok := clonedMap["nested"].([]string)
+	if !ok {
+		t.Fatalf("nested slice type = %T, want []string", clonedMap["nested"])
+	}
+	nestedSlice[0] = "changed"
+
+	originalSlice := original.Metadata["slice"].([]any)
+	originalNestedMap := originalSlice[1].(map[string]any)
+	if got := originalNestedMap["k"]; got != "v" {
+		t.Fatalf("original nested map value = %v, want v", got)
+	}
+	originalMap := original.Metadata["map"].(map[string]any)
+	originalNestedSlice := originalMap["nested"].([]string)
+	if got := originalNestedSlice[0]; got != "x" {
+		t.Fatalf("original nested slice value = %q, want x", got)
+	}
+}

--- a/internal/runtime/hooks/context_test.go
+++ b/internal/runtime/hooks/context_test.go
@@ -46,3 +46,48 @@ func TestHookContextCloneDeepCopyMetadata(t *testing.T) {
 		t.Fatalf("original nested slice value = %q, want x", got)
 	}
 }
+
+func TestHookContextCloneDeepCopyStructFields(t *testing.T) {
+	t.Parallel()
+
+	type nested struct {
+		Flag bool
+	}
+	type metaPayload struct {
+		Attrs map[string]string
+		Items []int
+		Ref   *nested
+	}
+
+	original := HookContext{
+		Metadata: map[string]any{
+			"struct": metaPayload{
+				Attrs: map[string]string{"k": "v"},
+				Items: []int{1, 2, 3},
+				Ref:   &nested{Flag: true},
+			},
+		},
+	}
+
+	cloned := original.Clone()
+	payload, ok := cloned.Metadata["struct"].(metaPayload)
+	if !ok {
+		t.Fatalf("struct metadata type = %T, want metaPayload", cloned.Metadata["struct"])
+	}
+
+	payload.Attrs["k"] = "changed"
+	payload.Items[0] = 99
+	payload.Ref.Flag = false
+	cloned.Metadata["struct"] = payload
+
+	originPayload := original.Metadata["struct"].(metaPayload)
+	if got := originPayload.Attrs["k"]; got != "v" {
+		t.Fatalf("original Attrs[k] = %q, want v", got)
+	}
+	if got := originPayload.Items[0]; got != 1 {
+		t.Fatalf("original Items[0] = %d, want 1", got)
+	}
+	if got := originPayload.Ref.Flag; got != true {
+		t.Fatalf("original Ref.Flag = %v, want true", got)
+	}
+}

--- a/internal/runtime/hooks/context_test.go
+++ b/internal/runtime/hooks/context_test.go
@@ -1,6 +1,10 @@
 package hooks
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+	"time"
+)
 
 func TestHookContextCloneDeepCopyMetadata(t *testing.T) {
 	t.Parallel()
@@ -89,5 +93,83 @@ func TestHookContextCloneDeepCopyStructFields(t *testing.T) {
 	}
 	if got := originPayload.Ref.Flag; got != true {
 		t.Fatalf("original Ref.Flag = %v, want true", got)
+	}
+}
+
+func TestHookContextCloneNoMetadata(t *testing.T) {
+	t.Parallel()
+
+	original := HookContext{RunID: "run-1", SessionID: "session-1"}
+	cloned := original.Clone()
+	if cloned.RunID != original.RunID || cloned.SessionID != original.SessionID {
+		t.Fatalf("Clone() basic fields mismatch: got %+v, want %+v", cloned, original)
+	}
+	if cloned.Metadata != nil {
+		t.Fatalf("Clone().Metadata = %#v, want nil", cloned.Metadata)
+	}
+}
+
+func TestCloneMetadataValueNil(t *testing.T) {
+	t.Parallel()
+
+	if got := cloneMetadataValue(nil); got != nil {
+		t.Fatalf("cloneMetadataValue(nil) = %#v, want nil", got)
+	}
+}
+
+func TestDeepCloneValueEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	invalid := deepCloneValue(reflect.Value{})
+	if invalid.IsValid() {
+		t.Fatalf("deepCloneValue(invalid).IsValid() = true, want false")
+	}
+
+	var nilPtr *int
+	clonedNilPtr := deepCloneValue(reflect.ValueOf(nilPtr))
+	if !clonedNilPtr.IsNil() {
+		t.Fatalf("cloned nil pointer should be nil")
+	}
+
+	var nilMap map[string]int
+	clonedNilMap := deepCloneValue(reflect.ValueOf(nilMap))
+	if !clonedNilMap.IsNil() {
+		t.Fatalf("cloned nil map should be nil")
+	}
+
+	var nilSlice []int
+	clonedNilSlice := deepCloneValue(reflect.ValueOf(nilSlice))
+	if !clonedNilSlice.IsNil() {
+		t.Fatalf("cloned nil slice should be nil")
+	}
+
+	// 走到 interface nil 分支。
+	nilIfaceValue := reflect.New(reflect.TypeOf((*any)(nil)).Elem()).Elem()
+	clonedNilIface := deepCloneValue(nilIfaceValue)
+	if !clonedNilIface.IsNil() {
+		t.Fatalf("cloned nil interface should be nil")
+	}
+
+	arr := [2]map[string]int{
+		{"a": 1},
+		{"b": 2},
+	}
+	clonedArr := deepCloneValue(reflect.ValueOf(arr)).Interface().([2]map[string]int)
+	clonedArr[0]["a"] = 99
+	if arr[0]["a"] != 1 {
+		t.Fatalf("array nested map shared, got %d, want 1", arr[0]["a"])
+	}
+
+	// time.Time 的内部字段不可 set，可覆盖 struct 分支中的 CanSet=false 路径。
+	valueWithTime := struct {
+		When time.Time
+	}{
+		When: time.Now(),
+	}
+	clonedWithTime := deepCloneValue(reflect.ValueOf(valueWithTime)).Interface().(struct {
+		When time.Time
+	})
+	if !clonedWithTime.When.Equal(valueWithTime.When) {
+		t.Fatalf("cloned struct with time mismatch")
 	}
 }

--- a/internal/runtime/hooks/errors.go
+++ b/internal/runtime/hooks/errors.go
@@ -1,0 +1,20 @@
+package hooks
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrHookAlreadyExists 表示注册了重复 hook ID。
+	ErrHookAlreadyExists = errors.New("hook already exists")
+	// ErrHookNotFound 表示待删除 hook 不存在。
+	ErrHookNotFound = errors.New("hook not found")
+	// ErrInvalidHookSpec 表示 HookSpec 未通过校验。
+	ErrInvalidHookSpec = errors.New("invalid hook spec")
+)
+
+// wrapInvalidSpec 将参数化错误统一包装为 ErrInvalidHookSpec。
+func wrapInvalidSpec(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", ErrInvalidHookSpec, fmt.Sprintf(format, args...))
+}

--- a/internal/runtime/hooks/events.go
+++ b/internal/runtime/hooks/events.go
@@ -1,0 +1,37 @@
+package hooks
+
+import (
+	"context"
+	"time"
+)
+
+// HookEventType 标识 hook 事件类型。
+type HookEventType string
+
+const (
+	// HookEventStarted 表示 hook 执行开始事件。
+	HookEventStarted HookEventType = "hook_started"
+	// HookEventFinished 表示 hook 执行结束事件（pass/block）。
+	HookEventFinished HookEventType = "hook_finished"
+	// HookEventFailed 表示 hook 执行失败事件。
+	HookEventFailed HookEventType = "hook_failed"
+)
+
+// HookEvent 描述 hook 执行过程中的结构化事件。
+type HookEvent struct {
+	Type       HookEventType
+	HookID     string
+	Point      HookPoint
+	Scope      HookScope
+	Kind       HookKind
+	Mode       HookMode
+	Status     HookResultStatus
+	StartedAt  time.Time
+	DurationMS int64
+	Error      string
+}
+
+// EventEmitter 抽象 hook 事件发射器，避免依赖 runtime.Service。
+type EventEmitter interface {
+	EmitHookEvent(ctx context.Context, event HookEvent) error
+}

--- a/internal/runtime/hooks/executor.go
+++ b/internal/runtime/hooks/executor.go
@@ -1,0 +1,294 @@
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// DefaultHookTimeout 是未显式配置 timeout 时的默认执行超时。
+	DefaultHookTimeout = 2 * time.Second
+	// DefaultMaxInFlightHooks 是默认同时在执行中的 hook 上限，用于防止超时后执行堆积。
+	DefaultMaxInFlightHooks = int32(128)
+)
+
+// Executor 负责按点位同步执行 hook 快照。
+type Executor struct {
+	registry       *Registry
+	emitter        EventEmitter
+	defaultTimeout time.Duration
+	maxInFlight    int32
+	inFlight       atomic.Int32
+	now            func() time.Time
+}
+
+// NewExecutor 创建一个同步 hook 执行器。
+func NewExecutor(registry *Registry, emitter EventEmitter, defaultTimeout time.Duration) *Executor {
+	if registry == nil {
+		registry = NewRegistry()
+	}
+	if defaultTimeout <= 0 {
+		defaultTimeout = DefaultHookTimeout
+	}
+	return &Executor{
+		registry:       registry,
+		emitter:        emitter,
+		defaultTimeout: defaultTimeout,
+		maxInFlight:    DefaultMaxInFlightHooks,
+		now:            time.Now,
+	}
+}
+
+// Run 在指定挂载点执行 hook 快照并返回聚合结果。
+func (e *Executor) Run(ctx context.Context, point HookPoint, input HookContext) RunOutput {
+	if e == nil || e.registry == nil {
+		return RunOutput{}
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	specs := e.registry.Resolve(point)
+	if len(specs) == 0 {
+		return RunOutput{}
+	}
+
+	output := RunOutput{
+		Results: make([]HookResult, 0, len(specs)),
+	}
+	for _, spec := range specs {
+		result := e.runOne(ctx, spec, input.Clone())
+		output.Results = append(output.Results, result)
+
+		if result.Status == HookResultBlock {
+			output.Blocked = true
+			output.BlockedBy = spec.ID
+			break
+		}
+		if result.Status == HookResultFailed && spec.FailurePolicy == FailurePolicyFailClosed {
+			output.Blocked = true
+			output.BlockedBy = spec.ID
+			break
+		}
+	}
+	return output
+}
+
+func (e *Executor) runOne(ctx context.Context, spec HookSpec, input HookContext) HookResult {
+	startedAt := e.now()
+	e.emitBestEffort(ctx, HookEvent{
+		Type:      HookEventStarted,
+		HookID:    spec.ID,
+		Point:     spec.Point,
+		Scope:     spec.Scope,
+		Kind:      spec.Kind,
+		Mode:      spec.Mode,
+		StartedAt: startedAt,
+	})
+
+	hookCtx, cancel := e.withHookTimeout(ctx, spec.Timeout)
+	defer cancel()
+
+	result := e.callHandler(hookCtx, spec, input, startedAt)
+	durationMS := e.now().Sub(startedAt).Milliseconds()
+	if durationMS < 0 {
+		durationMS = 0
+	}
+	if result.StartedAt.IsZero() {
+		result.StartedAt = startedAt
+	}
+	if result.DurationMS <= 0 {
+		result.DurationMS = durationMS
+	}
+	if result.HookID == "" {
+		result.HookID = spec.ID
+	}
+	if result.Point == "" {
+		result.Point = spec.Point
+	}
+
+	switch result.Status {
+	case HookResultPass, HookResultBlock:
+		e.emitBestEffort(ctx, HookEvent{
+			Type:       HookEventFinished,
+			HookID:     spec.ID,
+			Point:      spec.Point,
+			Scope:      spec.Scope,
+			Kind:       spec.Kind,
+			Mode:       spec.Mode,
+			Status:     result.Status,
+			StartedAt:  result.StartedAt,
+			DurationMS: result.DurationMS,
+		})
+	case HookResultFailed:
+		e.emitBestEffort(ctx, HookEvent{
+			Type:       HookEventFailed,
+			HookID:     spec.ID,
+			Point:      spec.Point,
+			Scope:      spec.Scope,
+			Kind:       spec.Kind,
+			Mode:       spec.Mode,
+			Status:     result.Status,
+			StartedAt:  result.StartedAt,
+			DurationMS: result.DurationMS,
+			Error:      result.Error,
+		})
+	default:
+		invalidStatus := result.Status
+		result.Status = HookResultFailed
+		if result.Error == "" {
+			result.Error = fmt.Sprintf("hook returned invalid status %q", invalidStatus)
+		}
+		if result.Message == "" {
+			result.Message = result.Error
+		}
+		e.emitBestEffort(ctx, HookEvent{
+			Type:       HookEventFailed,
+			HookID:     spec.ID,
+			Point:      spec.Point,
+			Scope:      spec.Scope,
+			Kind:       spec.Kind,
+			Mode:       spec.Mode,
+			Status:     result.Status,
+			StartedAt:  result.StartedAt,
+			DurationMS: result.DurationMS,
+			Error:      result.Error,
+		})
+	}
+	return result
+}
+
+func (e *Executor) withHookTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	effective := timeout
+	if effective <= 0 {
+		effective = e.defaultTimeout
+	}
+	if effective <= 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, effective)
+}
+
+func (e *Executor) callHandler(
+	ctx context.Context,
+	spec HookSpec,
+	input HookContext,
+	startedAt time.Time,
+) HookResult {
+	if !e.tryAcquireSlot() {
+		err := "hook executor is saturated by in-flight handlers"
+		return HookResult{
+			HookID:    spec.ID,
+			Point:     spec.Point,
+			Status:    HookResultFailed,
+			Message:   err,
+			Error:     err,
+			StartedAt: startedAt,
+		}
+	}
+
+	type invokeResult struct {
+		result HookResult
+		panicV any
+	}
+	resultCh := make(chan invokeResult, 1)
+
+	go func() {
+		defer e.releaseSlot()
+		out := invokeResult{}
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				out.panicV = recovered
+			}
+			resultCh <- out
+		}()
+		out.result = spec.Handler(ctx, input)
+	}()
+
+	select {
+	case <-ctx.Done():
+		err := "hook execution canceled"
+		if ctx.Err() == context.DeadlineExceeded {
+			err = "hook execution timed out"
+		}
+		return HookResult{
+			HookID:    spec.ID,
+			Point:     spec.Point,
+			Status:    HookResultFailed,
+			Message:   err,
+			Error:     err,
+			StartedAt: startedAt,
+		}
+	case outcome := <-resultCh:
+		if outcome.panicV != nil {
+			err := fmt.Sprintf("hook panicked: %v", outcome.panicV)
+			return HookResult{
+				HookID:    spec.ID,
+				Point:     spec.Point,
+				Status:    HookResultFailed,
+				Message:   err,
+				Error:     err,
+				StartedAt: startedAt,
+			}
+		}
+		outcome.result.HookID = spec.ID
+		outcome.result.Point = spec.Point
+		if outcome.result.Status == "" {
+			outcome.result.Status = HookResultPass
+		}
+		if outcome.result.Status != HookResultPass &&
+			outcome.result.Status != HookResultBlock &&
+			outcome.result.Status != HookResultFailed {
+			err := fmt.Sprintf("hook returned invalid status %q", outcome.result.Status)
+			return HookResult{
+				HookID:    spec.ID,
+				Point:     spec.Point,
+				Status:    HookResultFailed,
+				Message:   err,
+				Error:     err,
+				StartedAt: startedAt,
+			}
+		}
+		if outcome.result.Status == HookResultFailed && outcome.result.Error == "" {
+			if outcome.result.Message != "" {
+				outcome.result.Error = outcome.result.Message
+			} else {
+				outcome.result.Error = "hook returned failed status"
+				outcome.result.Message = "hook returned failed status"
+			}
+		}
+		return outcome.result
+	}
+}
+
+func (e *Executor) tryAcquireSlot() bool {
+	limit := e.maxInFlight
+	if limit <= 0 {
+		return true
+	}
+	for {
+		current := e.inFlight.Load()
+		if current >= limit {
+			return false
+		}
+		if e.inFlight.CompareAndSwap(current, current+1) {
+			return true
+		}
+	}
+}
+
+func (e *Executor) releaseSlot() {
+	if e == nil || e.maxInFlight <= 0 {
+		return
+	}
+	e.inFlight.Add(-1)
+}
+
+func (e *Executor) emitBestEffort(ctx context.Context, event HookEvent) {
+	if e == nil || e.emitter == nil {
+		return
+	}
+	_ = e.emitter.EmitHookEvent(ctx, event)
+}

--- a/internal/runtime/hooks/executor.go
+++ b/internal/runtime/hooks/executor.go
@@ -102,12 +102,6 @@ func (e *Executor) runOne(ctx context.Context, spec HookSpec, input HookContext)
 	if result.DurationMS <= 0 {
 		result.DurationMS = durationMS
 	}
-	if result.HookID == "" {
-		result.HookID = spec.ID
-	}
-	if result.Point == "" {
-		result.Point = spec.Point
-	}
 
 	switch result.Status {
 	case HookResultPass, HookResultBlock:
@@ -123,27 +117,6 @@ func (e *Executor) runOne(ctx context.Context, spec HookSpec, input HookContext)
 			DurationMS: result.DurationMS,
 		})
 	case HookResultFailed:
-		e.emitBestEffort(ctx, HookEvent{
-			Type:       HookEventFailed,
-			HookID:     spec.ID,
-			Point:      spec.Point,
-			Scope:      spec.Scope,
-			Kind:       spec.Kind,
-			Mode:       spec.Mode,
-			Status:     result.Status,
-			StartedAt:  result.StartedAt,
-			DurationMS: result.DurationMS,
-			Error:      result.Error,
-		})
-	default:
-		invalidStatus := result.Status
-		result.Status = HookResultFailed
-		if result.Error == "" {
-			result.Error = fmt.Sprintf("hook returned invalid status %q", invalidStatus)
-		}
-		if result.Message == "" {
-			result.Message = result.Error
-		}
 		e.emitBestEffort(ctx, HookEvent{
 			Type:       HookEventFailed,
 			HookID:     spec.ID,

--- a/internal/runtime/hooks/executor_test.go
+++ b/internal/runtime/hooks/executor_test.go
@@ -1,0 +1,386 @@
+package hooks
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type recordingEmitter struct {
+	mu     sync.Mutex
+	events []HookEvent
+	err    error
+}
+
+func (r *recordingEmitter) EmitHookEvent(ctx context.Context, event HookEvent) error {
+	_ = ctx
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, event)
+	return r.err
+}
+
+func (r *recordingEmitter) snapshot() []HookEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]HookEvent, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+func TestExecutorRunPass(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	emitter := &recordingEmitter{}
+	executor := NewExecutor(registry, emitter, 200*time.Millisecond)
+	if err := registry.Register(HookSpec{
+		ID:      "hook-pass",
+		Point:   HookPointBeforeToolCall,
+		Handler: func(context.Context, HookContext) HookResult { return HookResult{Status: HookResultPass} },
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	output := executor.Run(context.Background(), HookPointBeforeToolCall, HookContext{
+		RunID:     "run-1",
+		SessionID: "session-1",
+	})
+	if output.Blocked {
+		t.Fatalf("Blocked = true, want false")
+	}
+	if got := len(output.Results); got != 1 {
+		t.Fatalf("len(Results) = %d, want 1", got)
+	}
+	if output.Results[0].Status != HookResultPass {
+		t.Fatalf("Results[0].Status = %q, want pass", output.Results[0].Status)
+	}
+
+	events := emitter.snapshot()
+	if got := len(events); got != 2 {
+		t.Fatalf("len(events) = %d, want 2", got)
+	}
+	if events[0].Type != HookEventStarted || events[1].Type != HookEventFinished {
+		t.Fatalf("event types = [%s, %s], want [hook_started, hook_finished]", events[0].Type, events[1].Type)
+	}
+}
+
+func TestExecutorRunBlockShortCircuit(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	emitter := &recordingEmitter{}
+	executor := NewExecutor(registry, emitter, 200*time.Millisecond)
+	var calledSecond atomic.Int32
+
+	if err := registry.Register(HookSpec{
+		ID:       "hook-block",
+		Point:    HookPointBeforeToolCall,
+		Priority: 10,
+		Handler: func(context.Context, HookContext) HookResult {
+			return HookResult{Status: HookResultBlock, Message: "blocked"}
+		},
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	if err := registry.Register(HookSpec{
+		ID:       "hook-second",
+		Point:    HookPointBeforeToolCall,
+		Priority: 1,
+		Handler: func(context.Context, HookContext) HookResult {
+			calledSecond.Add(1)
+			return HookResult{Status: HookResultPass}
+		},
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	output := executor.Run(context.Background(), HookPointBeforeToolCall, HookContext{})
+	if !output.Blocked {
+		t.Fatalf("Blocked = false, want true")
+	}
+	if output.BlockedBy != "hook-block" {
+		t.Fatalf("BlockedBy = %q, want hook-block", output.BlockedBy)
+	}
+	if calledSecond.Load() != 0 {
+		t.Fatalf("second hook called = %d, want 0", calledSecond.Load())
+	}
+}
+
+func TestExecutorRunTimeout(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	emitter := &recordingEmitter{}
+	executor := NewExecutor(registry, emitter, 10*time.Millisecond)
+	if err := registry.Register(HookSpec{
+		ID:      "hook-timeout",
+		Point:   HookPointBeforeToolCall,
+		Timeout: 10 * time.Millisecond,
+		Handler: func(context.Context, HookContext) HookResult {
+			time.Sleep(50 * time.Millisecond)
+			return HookResult{Status: HookResultPass}
+		},
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	output := executor.Run(context.Background(), HookPointBeforeToolCall, HookContext{})
+	if got := len(output.Results); got != 1 {
+		t.Fatalf("len(Results) = %d, want 1", got)
+	}
+	if output.Results[0].Status != HookResultFailed {
+		t.Fatalf("status = %q, want failed", output.Results[0].Status)
+	}
+	if !strings.Contains(output.Results[0].Error, "timed out") {
+		t.Fatalf("error = %q, want timeout message", output.Results[0].Error)
+	}
+
+	events := emitter.snapshot()
+	if got := len(events); got != 2 {
+		t.Fatalf("len(events) = %d, want 2", got)
+	}
+	if events[1].Type != HookEventFailed {
+		t.Fatalf("events[1].Type = %q, want hook_failed", events[1].Type)
+	}
+}
+
+func TestExecutorRunPanicRecover(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	emitter := &recordingEmitter{}
+	executor := NewExecutor(registry, emitter, 200*time.Millisecond)
+	if err := registry.Register(HookSpec{
+		ID:    "hook-panic",
+		Point: HookPointBeforeToolCall,
+		Handler: func(context.Context, HookContext) HookResult {
+			panic("boom")
+		},
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	output := executor.Run(context.Background(), HookPointBeforeToolCall, HookContext{})
+	if got := len(output.Results); got != 1 {
+		t.Fatalf("len(Results) = %d, want 1", got)
+	}
+	if output.Results[0].Status != HookResultFailed {
+		t.Fatalf("status = %q, want failed", output.Results[0].Status)
+	}
+	if !strings.Contains(output.Results[0].Error, "panicked") {
+		t.Fatalf("error = %q, want panic message", output.Results[0].Error)
+	}
+}
+
+func TestExecutorRunFailOpenContinues(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	emitter := &recordingEmitter{}
+	executor := NewExecutor(registry, emitter, 200*time.Millisecond)
+
+	if err := registry.Register(HookSpec{
+		ID:            "hook-fail-open",
+		Point:         HookPointBeforeToolCall,
+		Priority:      10,
+		FailurePolicy: FailurePolicyFailOpen,
+		Handler: func(context.Context, HookContext) HookResult {
+			return HookResult{Status: HookResultFailed, Error: "failed-by-design"}
+		},
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	if err := registry.Register(HookSpec{
+		ID:       "hook-pass",
+		Point:    HookPointBeforeToolCall,
+		Priority: 1,
+		Handler:  func(context.Context, HookContext) HookResult { return HookResult{Status: HookResultPass} },
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	output := executor.Run(context.Background(), HookPointBeforeToolCall, HookContext{})
+	if output.Blocked {
+		t.Fatalf("Blocked = true, want false")
+	}
+	if got := len(output.Results); got != 2 {
+		t.Fatalf("len(Results) = %d, want 2", got)
+	}
+	if output.Results[0].Status != HookResultFailed || output.Results[1].Status != HookResultPass {
+		t.Fatalf("statuses = [%q, %q], want [failed, pass]", output.Results[0].Status, output.Results[1].Status)
+	}
+}
+
+func TestExecutorRunFailClosedBlocks(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	emitter := &recordingEmitter{}
+	executor := NewExecutor(registry, emitter, 200*time.Millisecond)
+	var calledSecond atomic.Int32
+
+	if err := registry.Register(HookSpec{
+		ID:            "hook-fail-closed",
+		Point:         HookPointBeforeToolCall,
+		Priority:      10,
+		FailurePolicy: FailurePolicyFailClosed,
+		Handler: func(context.Context, HookContext) HookResult {
+			return HookResult{Status: HookResultFailed, Error: "hard-stop"}
+		},
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	if err := registry.Register(HookSpec{
+		ID:       "hook-second",
+		Point:    HookPointBeforeToolCall,
+		Priority: 1,
+		Handler: func(context.Context, HookContext) HookResult {
+			calledSecond.Add(1)
+			return HookResult{Status: HookResultPass}
+		},
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	output := executor.Run(context.Background(), HookPointBeforeToolCall, HookContext{})
+	if !output.Blocked {
+		t.Fatalf("Blocked = false, want true")
+	}
+	if output.BlockedBy != "hook-fail-closed" {
+		t.Fatalf("BlockedBy = %q, want hook-fail-closed", output.BlockedBy)
+	}
+	if calledSecond.Load() != 0 {
+		t.Fatalf("second hook called = %d, want 0", calledSecond.Load())
+	}
+	if got := len(output.Results); got != 1 {
+		t.Fatalf("len(Results) = %d, want 1", got)
+	}
+}
+
+func TestExecutorRunNoHooks(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	emitter := &recordingEmitter{}
+	executor := NewExecutor(registry, emitter, 200*time.Millisecond)
+
+	output := executor.Run(context.Background(), HookPointBeforeToolCall, HookContext{})
+	if output.Blocked {
+		t.Fatalf("Blocked = true, want false")
+	}
+	if len(output.Results) != 0 {
+		t.Fatalf("len(Results) = %d, want 0", len(output.Results))
+	}
+	if len(emitter.snapshot()) != 0 {
+		t.Fatalf("len(events) = %d, want 0", len(emitter.snapshot()))
+	}
+}
+
+func TestExecutorEventPayloadCompleteness(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	emitter := &recordingEmitter{}
+	executor := NewExecutor(registry, emitter, 200*time.Millisecond)
+
+	if err := registry.Register(HookSpec{
+		ID:      "hook-pass",
+		Point:   HookPointBeforeToolCall,
+		Handler: func(context.Context, HookContext) HookResult { return HookResult{Status: HookResultPass} },
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	_ = executor.Run(context.Background(), HookPointBeforeToolCall, HookContext{})
+	events := emitter.snapshot()
+	if got := len(events); got != 2 {
+		t.Fatalf("len(events) = %d, want 2", got)
+	}
+	finished := events[1]
+	if finished.HookID == "" {
+		t.Fatalf("HookID is empty")
+	}
+	if finished.Point == "" {
+		t.Fatalf("Point is empty")
+	}
+	if finished.Status != HookResultPass {
+		t.Fatalf("Status = %q, want pass", finished.Status)
+	}
+	if finished.StartedAt.IsZero() {
+		t.Fatalf("StartedAt is zero")
+	}
+	if finished.DurationMS < 0 {
+		t.Fatalf("DurationMS = %d, want >= 0", finished.DurationMS)
+	}
+}
+
+func TestExecutorEventEmitterFailureIgnored(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	emitter := &recordingEmitter{err: context.DeadlineExceeded}
+	executor := NewExecutor(registry, emitter, 200*time.Millisecond)
+	if err := registry.Register(HookSpec{
+		ID:      "hook-pass",
+		Point:   HookPointBeforeToolCall,
+		Handler: func(context.Context, HookContext) HookResult { return HookResult{Status: HookResultPass} },
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	output := executor.Run(context.Background(), HookPointBeforeToolCall, HookContext{})
+	if got := len(output.Results); got != 1 {
+		t.Fatalf("len(Results) = %d, want 1", got)
+	}
+	if output.Results[0].Status != HookResultPass {
+		t.Fatalf("status = %q, want pass", output.Results[0].Status)
+	}
+}
+
+func TestExecutorRunSaturationProtection(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	emitter := &recordingEmitter{}
+	executor := NewExecutor(registry, emitter, 10*time.Millisecond)
+	executor.maxInFlight = 1
+
+	releaseCh := make(chan struct{})
+	if err := registry.Register(HookSpec{
+		ID:      "hook-blocking",
+		Point:   HookPointBeforeToolCall,
+		Timeout: 10 * time.Millisecond,
+		Handler: func(context.Context, HookContext) HookResult {
+			<-releaseCh
+			return HookResult{Status: HookResultPass}
+		},
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	first := executor.Run(context.Background(), HookPointBeforeToolCall, HookContext{})
+	if len(first.Results) != 1 || first.Results[0].Status != HookResultFailed {
+		t.Fatalf("first run result = %+v, want single failed result", first.Results)
+	}
+
+	second := executor.Run(context.Background(), HookPointBeforeToolCall, HookContext{})
+	if len(second.Results) != 1 {
+		t.Fatalf("second len(Results) = %d, want 1", len(second.Results))
+	}
+	if second.Results[0].Status != HookResultFailed {
+		t.Fatalf("second status = %q, want failed", second.Results[0].Status)
+	}
+	if !strings.Contains(second.Results[0].Error, "saturated") {
+		t.Fatalf("second error = %q, want saturation message", second.Results[0].Error)
+	}
+
+	close(releaseCh)
+	time.Sleep(20 * time.Millisecond)
+	if got := executor.inFlight.Load(); got != 0 {
+		t.Fatalf("inFlight = %d, want 0 after release", got)
+	}
+}

--- a/internal/runtime/hooks/executor_test.go
+++ b/internal/runtime/hooks/executor_test.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -382,5 +383,281 @@ func TestExecutorRunSaturationProtection(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 	if got := executor.inFlight.Load(); got != 0 {
 		t.Fatalf("inFlight = %d, want 0 after release", got)
+	}
+}
+
+func TestNewExecutorDefaults(t *testing.T) {
+	t.Parallel()
+
+	executor := NewExecutor(nil, nil, 0)
+	if executor == nil {
+		t.Fatalf("NewExecutor() = nil, want non-nil")
+	}
+	if executor.registry == nil {
+		t.Fatalf("registry = nil, want auto-created registry")
+	}
+	if executor.defaultTimeout != DefaultHookTimeout {
+		t.Fatalf("defaultTimeout = %v, want %v", executor.defaultTimeout, DefaultHookTimeout)
+	}
+	if executor.maxInFlight != DefaultMaxInFlightHooks {
+		t.Fatalf("maxInFlight = %d, want %d", executor.maxInFlight, DefaultMaxInFlightHooks)
+	}
+}
+
+func TestExecutorRunNilReceiverOrRegistry(t *testing.T) {
+	t.Parallel()
+
+	var nilExecutor *Executor
+	if out := nilExecutor.Run(nil, HookPointBeforeToolCall, HookContext{}); len(out.Results) != 0 || out.Blocked {
+		t.Fatalf("nil executor Run() = %+v, want zero output", out)
+	}
+
+	executor := &Executor{}
+	if out := executor.Run(nil, HookPointBeforeToolCall, HookContext{}); len(out.Results) != 0 || out.Blocked {
+		t.Fatalf("nil registry Run() = %+v, want zero output", out)
+	}
+}
+
+func TestExecutorRunWithNilContextAndEmitter(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	executor := NewExecutor(registry, nil, 100*time.Millisecond)
+	if err := registry.Register(HookSpec{
+		ID:    "hook-pass",
+		Point: HookPointBeforeToolCall,
+		Handler: func(ctx context.Context, input HookContext) HookResult {
+			if ctx == nil {
+				t.Fatalf("handler ctx is nil")
+			}
+			_ = input
+			return HookResult{Status: HookResultPass}
+		},
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	out := executor.Run(nil, HookPointBeforeToolCall, HookContext{})
+	if len(out.Results) != 1 {
+		t.Fatalf("len(out.Results) = %d, want 1", len(out.Results))
+	}
+	if out.Results[0].Status != HookResultPass {
+		t.Fatalf("status = %q, want pass", out.Results[0].Status)
+	}
+}
+
+func TestExecutorRunInvalidStatus(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	executor := NewExecutor(registry, nil, 100*time.Millisecond)
+	if err := registry.Register(HookSpec{
+		ID:    "hook-invalid-status",
+		Point: HookPointBeforeToolCall,
+		Handler: func(context.Context, HookContext) HookResult {
+			return HookResult{Status: HookResultStatus("unknown")}
+		},
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	out := executor.Run(context.Background(), HookPointBeforeToolCall, HookContext{})
+	if len(out.Results) != 1 {
+		t.Fatalf("len(out.Results) = %d, want 1", len(out.Results))
+	}
+	if out.Results[0].Status != HookResultFailed {
+		t.Fatalf("status = %q, want failed", out.Results[0].Status)
+	}
+	if !strings.Contains(out.Results[0].Error, "invalid status") {
+		t.Fatalf("error = %q, want invalid status", out.Results[0].Error)
+	}
+}
+
+func TestExecutorRunFailedResultBackfill(t *testing.T) {
+	t.Parallel()
+
+	t.Run("failed with message only", func(t *testing.T) {
+		t.Parallel()
+		registry := NewRegistry()
+		executor := NewExecutor(registry, nil, 100*time.Millisecond)
+		if err := registry.Register(HookSpec{
+			ID:    "hook-message-only",
+			Point: HookPointBeforeToolCall,
+			Handler: func(context.Context, HookContext) HookResult {
+				return HookResult{Status: HookResultFailed, Message: "failed-message-only"}
+			},
+		}); err != nil {
+			t.Fatalf("Register() error = %v", err)
+		}
+		out := executor.Run(context.Background(), HookPointBeforeToolCall, HookContext{})
+		got := out.Results[0]
+		if got.Error != "failed-message-only" {
+			t.Fatalf("Error = %q, want failed-message-only", got.Error)
+		}
+	})
+
+	t.Run("failed with empty message and error", func(t *testing.T) {
+		t.Parallel()
+		registry := NewRegistry()
+		executor := NewExecutor(registry, nil, 100*time.Millisecond)
+		if err := registry.Register(HookSpec{
+			ID:    "hook-empty-failed",
+			Point: HookPointBeforeToolCall,
+			Handler: func(context.Context, HookContext) HookResult {
+				return HookResult{Status: HookResultFailed}
+			},
+		}); err != nil {
+			t.Fatalf("Register() error = %v", err)
+		}
+		out := executor.Run(context.Background(), HookPointBeforeToolCall, HookContext{})
+		got := out.Results[0]
+		if got.Error != "hook returned failed status" {
+			t.Fatalf("Error = %q, want hook returned failed status", got.Error)
+		}
+		if got.Message != "hook returned failed status" {
+			t.Fatalf("Message = %q, want hook returned failed status", got.Message)
+		}
+	})
+}
+
+func TestExecutorRunDefaultStatusAndTimingFallback(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	executor := NewExecutor(registry, nil, 100*time.Millisecond)
+	first := time.Unix(100, 0)
+	second := first.Add(-10 * time.Millisecond)
+	var nowCalls atomic.Int32
+	executor.now = func() time.Time {
+		if nowCalls.Add(1) == 1 {
+			return first
+		}
+		return second
+	}
+
+	if err := registry.Register(HookSpec{
+		ID:    "hook-empty-result",
+		Point: HookPointBeforeToolCall,
+		Handler: func(context.Context, HookContext) HookResult {
+			return HookResult{}
+		},
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	out := executor.Run(context.Background(), HookPointBeforeToolCall, HookContext{})
+	if len(out.Results) != 1 {
+		t.Fatalf("len(out.Results) = %d, want 1", len(out.Results))
+	}
+	got := out.Results[0]
+	if got.Status != HookResultPass {
+		t.Fatalf("Status = %q, want pass", got.Status)
+	}
+	if got.StartedAt != first {
+		t.Fatalf("StartedAt = %v, want %v", got.StartedAt, first)
+	}
+	if got.DurationMS != 0 {
+		t.Fatalf("DurationMS = %d, want 0", got.DurationMS)
+	}
+	if got.HookID != "hook-empty-result" {
+		t.Fatalf("HookID = %q, want hook-empty-result", got.HookID)
+	}
+	if got.Point != HookPointBeforeToolCall {
+		t.Fatalf("Point = %q, want %q", got.Point, HookPointBeforeToolCall)
+	}
+}
+
+func TestExecutorRunCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	executor := NewExecutor(registry, nil, 100*time.Millisecond)
+	if err := registry.Register(HookSpec{
+		ID:    "hook-canceled",
+		Point: HookPointBeforeToolCall,
+		Handler: func(ctx context.Context, input HookContext) HookResult {
+			<-ctx.Done()
+			_ = input
+			return HookResult{Status: HookResultPass}
+		},
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	out := executor.Run(ctx, HookPointBeforeToolCall, HookContext{})
+	if len(out.Results) != 1 {
+		t.Fatalf("len(out.Results) = %d, want 1", len(out.Results))
+	}
+	if out.Results[0].Status != HookResultFailed {
+		t.Fatalf("Status = %q, want failed", out.Results[0].Status)
+	}
+	if !strings.Contains(out.Results[0].Error, "canceled") {
+		t.Fatalf("Error = %q, want canceled", out.Results[0].Error)
+	}
+}
+
+func TestExecutorWithHookTimeoutNoTimeoutPath(t *testing.T) {
+	t.Parallel()
+
+	executor := NewExecutor(NewRegistry(), nil, 100*time.Millisecond)
+	executor.defaultTimeout = 0
+
+	ctx, cancel := executor.withHookTimeout(context.Background(), 0)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		t.Fatalf("context done unexpectedly: %v", ctx.Err())
+	default:
+	}
+}
+
+func TestExecutorSlotAndEmitterHelpers(t *testing.T) {
+	t.Parallel()
+
+	executor := NewExecutor(NewRegistry(), nil, 100*time.Millisecond)
+	executor.maxInFlight = 0
+	if !executor.tryAcquireSlot() {
+		t.Fatalf("tryAcquireSlot() = false, want true when limit <= 0")
+	}
+
+	executor.maxInFlight = -1
+	executor.releaseSlot()
+
+	executor.emitBestEffort(context.Background(), HookEvent{})
+
+	var nilExecutor *Executor
+	nilExecutor.releaseSlot()
+	nilExecutor.emitBestEffort(context.Background(), HookEvent{})
+}
+
+func TestExecutorRunSetsFailedEventErrorOnInvalidStatus(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	emitter := &recordingEmitter{err: errors.New("emit failed")}
+	executor := NewExecutor(registry, emitter, 100*time.Millisecond)
+	if err := registry.Register(HookSpec{
+		ID:    "hook-invalid",
+		Point: HookPointBeforeToolCall,
+		Handler: func(context.Context, HookContext) HookResult {
+			return HookResult{Status: HookResultStatus("bad")}
+		},
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	_ = executor.Run(context.Background(), HookPointBeforeToolCall, HookContext{})
+	events := emitter.snapshot()
+	if len(events) != 2 {
+		t.Fatalf("len(events) = %d, want 2", len(events))
+	}
+	if events[1].Type != HookEventFailed {
+		t.Fatalf("events[1].Type = %q, want hook_failed", events[1].Type)
+	}
+	if events[1].Error == "" {
+		t.Fatalf("events[1].Error is empty")
 	}
 }

--- a/internal/runtime/hooks/registry.go
+++ b/internal/runtime/hooks/registry.go
@@ -1,0 +1,112 @@
+package hooks
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+type registryEntry struct {
+	spec HookSpec
+	seq  int64
+}
+
+type resolvedEntry struct {
+	spec HookSpec
+	seq  int64
+}
+
+// Registry 管理 hook 的注册、移除与按点位解析。
+type Registry struct {
+	mu    sync.RWMutex
+	hooks map[string]registryEntry
+	seq   int64
+}
+
+// NewRegistry 创建一个空的 hook 注册表。
+func NewRegistry() *Registry {
+	return &Registry{
+		hooks: make(map[string]registryEntry),
+	}
+}
+
+// Register 注册一个 hook；若 ID 重复则返回 ErrHookAlreadyExists。
+func (r *Registry) Register(spec HookSpec) error {
+	if r == nil {
+		return wrapInvalidSpec("registry is nil")
+	}
+	normalized, err := spec.normalizeAndValidate()
+	if err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.hooks[normalized.ID]; exists {
+		return fmt.Errorf("%w: %s", ErrHookAlreadyExists, normalized.ID)
+	}
+
+	r.seq++
+	r.hooks[normalized.ID] = registryEntry{
+		spec: normalized,
+		seq:  r.seq,
+	}
+	return nil
+}
+
+// Remove 按 ID 删除 hook；若不存在则返回 ErrHookNotFound。
+func (r *Registry) Remove(id string) error {
+	if r == nil {
+		return fmt.Errorf("%w: registry is nil", ErrHookNotFound)
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return fmt.Errorf("%w: id is required", ErrHookNotFound)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.hooks[id]; !exists {
+		return fmt.Errorf("%w: %s", ErrHookNotFound, id)
+	}
+	delete(r.hooks, id)
+	return nil
+}
+
+// Resolve 返回指定点位的 hook 快照，并按优先级稳定排序。
+func (r *Registry) Resolve(point HookPoint) []HookSpec {
+	if r == nil {
+		return nil
+	}
+	point = HookPoint(strings.TrimSpace(string(point)))
+	if point == "" {
+		return nil
+	}
+
+	r.mu.RLock()
+	entries := make([]resolvedEntry, 0, len(r.hooks))
+	for _, entry := range r.hooks {
+		if entry.spec.Point != point {
+			continue
+		}
+		entries = append(entries, resolvedEntry{
+			spec: entry.spec,
+			seq:  entry.seq,
+		})
+	}
+	r.mu.RUnlock()
+
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].spec.Priority != entries[j].spec.Priority {
+			return entries[i].spec.Priority > entries[j].spec.Priority
+		}
+		return entries[i].seq < entries[j].seq
+	})
+
+	out := make([]HookSpec, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, entry.spec)
+	}
+	return out
+}

--- a/internal/runtime/hooks/registry_test.go
+++ b/internal/runtime/hooks/registry_test.go
@@ -1,0 +1,190 @@
+package hooks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestRegistryRegisterAndResolve(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	handler := func(ctx context.Context, input HookContext) HookResult {
+		_ = ctx
+		_ = input
+		return HookResult{Status: HookResultPass}
+	}
+
+	if err := registry.Register(HookSpec{
+		ID:       "hook-a",
+		Point:    HookPointBeforeToolCall,
+		Priority: 10,
+		Handler:  handler,
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	if err := registry.Register(HookSpec{
+		ID:       "hook-b",
+		Point:    HookPointBeforeToolCall,
+		Priority: 20,
+		Handler:  handler,
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	if err := registry.Register(HookSpec{
+		ID:       "hook-c",
+		Point:    HookPointBeforeToolCall,
+		Priority: 10,
+		Handler:  handler,
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	resolved := registry.Resolve(HookPointBeforeToolCall)
+	if len(resolved) != 3 {
+		t.Fatalf("Resolve() len = %d, want 3", len(resolved))
+	}
+
+	gotOrder := []string{resolved[0].ID, resolved[1].ID, resolved[2].ID}
+	wantOrder := []string{"hook-b", "hook-a", "hook-c"}
+	for i := range wantOrder {
+		if gotOrder[i] != wantOrder[i] {
+			t.Fatalf("Resolve() order[%d] = %q, want %q", i, gotOrder[i], wantOrder[i])
+		}
+	}
+}
+
+func TestRegistryRegisterDuplicateID(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	spec := HookSpec{
+		ID:      "hook-a",
+		Point:   HookPointBeforeToolCall,
+		Handler: func(context.Context, HookContext) HookResult { return HookResult{Status: HookResultPass} },
+	}
+	if err := registry.Register(spec); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	err := registry.Register(spec)
+	if !errors.Is(err, ErrHookAlreadyExists) {
+		t.Fatalf("Register() error = %v, want ErrHookAlreadyExists", err)
+	}
+}
+
+func TestRegistryRegisterRejectsUnsupportedPoint(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	err := registry.Register(HookSpec{
+		ID:      "hook-a",
+		Point:   HookPoint("unknown_point"),
+		Handler: func(context.Context, HookContext) HookResult { return HookResult{Status: HookResultPass} },
+	})
+	if !errors.Is(err, ErrInvalidHookSpec) {
+		t.Fatalf("Register() error = %v, want ErrInvalidHookSpec", err)
+	}
+}
+
+func TestRegistryRemove(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	if err := registry.Register(HookSpec{
+		ID:      "hook-a",
+		Point:   HookPointBeforeToolCall,
+		Handler: func(context.Context, HookContext) HookResult { return HookResult{Status: HookResultPass} },
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	if err := registry.Remove("hook-a"); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	if got := len(registry.Resolve(HookPointBeforeToolCall)); got != 0 {
+		t.Fatalf("Resolve() len = %d, want 0", got)
+	}
+
+	err := registry.Remove("hook-a")
+	if !errors.Is(err, ErrHookNotFound) {
+		t.Fatalf("Remove() error = %v, want ErrHookNotFound", err)
+	}
+}
+
+func TestRegistryResolveByPoint(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	if err := registry.Register(HookSpec{
+		ID:      "hook-a",
+		Point:   HookPointBeforeToolCall,
+		Handler: func(context.Context, HookContext) HookResult { return HookResult{Status: HookResultPass} },
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	if err := registry.Register(HookSpec{
+		ID:      "hook-b",
+		Point:   HookPointAfterToolResult,
+		Handler: func(context.Context, HookContext) HookResult { return HookResult{Status: HookResultPass} },
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	if got := len(registry.Resolve(HookPointBeforeToolCall)); got != 1 {
+		t.Fatalf("Resolve(before_tool_call) len = %d, want 1", got)
+	}
+	if got := len(registry.Resolve(HookPointAfterToolResult)); got != 1 {
+		t.Fatalf("Resolve(after_tool_result) len = %d, want 1", got)
+	}
+}
+
+func TestRegistryConcurrentRegisterAndResolve(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	const workers = 32
+	const total = 64
+
+	var registerWG sync.WaitGroup
+	registerWG.Add(total)
+	errCh := make(chan error, total)
+	for i := range total {
+		go func(i int) {
+			defer registerWG.Done()
+			err := registry.Register(HookSpec{
+				ID:      fmt.Sprintf("hook-%d", i),
+				Point:   HookPointBeforeToolCall,
+				Handler: func(context.Context, HookContext) HookResult { return HookResult{Status: HookResultPass} },
+			})
+			if err != nil {
+				errCh <- err
+			}
+		}(i)
+	}
+
+	var resolveWG sync.WaitGroup
+	resolveWG.Add(workers)
+	for range workers {
+		go func() {
+			defer resolveWG.Done()
+			for range 20 {
+				_ = registry.Resolve(HookPointBeforeToolCall)
+			}
+		}()
+	}
+
+	registerWG.Wait()
+	resolveWG.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Fatalf("Register() concurrent error = %v", err)
+	}
+	if got := len(registry.Resolve(HookPointBeforeToolCall)); got != total {
+		t.Fatalf("Resolve() len = %d, want %d", got, total)
+	}
+}

--- a/internal/runtime/hooks/registry_test.go
+++ b/internal/runtime/hooks/registry_test.go
@@ -188,3 +188,33 @@ func TestRegistryConcurrentRegisterAndResolve(t *testing.T) {
 		t.Fatalf("Resolve() len = %d, want %d", got, total)
 	}
 }
+
+func TestRegistryNilAndEmptyInputs(t *testing.T) {
+	t.Parallel()
+
+	var nilRegistry *Registry
+
+	if err := nilRegistry.Register(HookSpec{
+		ID:      "hook-a",
+		Point:   HookPointBeforeToolCall,
+		Handler: func(context.Context, HookContext) HookResult { return HookResult{Status: HookResultPass} },
+	}); !errors.Is(err, ErrInvalidHookSpec) {
+		t.Fatalf("nil Register() error = %v, want ErrInvalidHookSpec", err)
+	}
+
+	if err := nilRegistry.Remove("hook-a"); !errors.Is(err, ErrHookNotFound) {
+		t.Fatalf("nil Remove() error = %v, want ErrHookNotFound", err)
+	}
+
+	if got := nilRegistry.Resolve(HookPointBeforeToolCall); got != nil {
+		t.Fatalf("nil Resolve() = %#v, want nil", got)
+	}
+
+	registry := NewRegistry()
+	if err := registry.Remove(" \n\t "); !errors.Is(err, ErrHookNotFound) {
+		t.Fatalf("Remove(blank) error = %v, want ErrHookNotFound", err)
+	}
+	if got := registry.Resolve(HookPoint(" \t ")); got != nil {
+		t.Fatalf("Resolve(blank point) = %#v, want nil", got)
+	}
+}

--- a/internal/runtime/hooks/result.go
+++ b/internal/runtime/hooks/result.go
@@ -1,0 +1,33 @@
+package hooks
+
+import "time"
+
+// HookResultStatus 表示单个 hook 的执行结果状态。
+type HookResultStatus string
+
+const (
+	// HookResultPass 表示 hook 执行通过。
+	HookResultPass HookResultStatus = "pass"
+	// HookResultBlock 表示 hook 主动阻断后续流程。
+	HookResultBlock HookResultStatus = "block"
+	// HookResultFailed 表示 hook 执行失败（如 panic/timeout/错误）。
+	HookResultFailed HookResultStatus = "failed"
+)
+
+// HookResult 描述单个 hook 的结构化执行结果。
+type HookResult struct {
+	HookID     string
+	Point      HookPoint
+	Status     HookResultStatus
+	Message    string
+	Error      string
+	StartedAt  time.Time
+	DurationMS int64
+}
+
+// RunOutput 是一次点位执行的聚合结果。
+type RunOutput struct {
+	Results   []HookResult
+	Blocked   bool
+	BlockedBy string
+}

--- a/internal/runtime/hooks/types.go
+++ b/internal/runtime/hooks/types.go
@@ -1,0 +1,139 @@
+package hooks
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+// HookPoint 表示 hook 的挂载点标识。
+type HookPoint string
+
+const (
+	// HookPointBeforeToolCall 表示工具调用前挂点。
+	HookPointBeforeToolCall HookPoint = "before_tool_call"
+	// HookPointAfterToolResult 表示工具结果返回后挂点。
+	HookPointAfterToolResult HookPoint = "after_tool_result"
+	// HookPointBeforeCompletionDecision 表示完成决策前挂点。
+	HookPointBeforeCompletionDecision HookPoint = "before_completion_decision"
+)
+
+// HookScope 描述 hook 的来源作用域。
+type HookScope string
+
+const (
+	// HookScopeInternal 表示 runtime 内部 hook。
+	HookScopeInternal HookScope = "internal"
+	// HookScopeUser 表示用户配置 hook（P2 预留）。
+	HookScopeUser HookScope = "user"
+	// HookScopeRepo 表示仓库配置 hook（P3 预留）。
+	HookScopeRepo HookScope = "repo"
+)
+
+// HookKind 描述 hook 处理器类型。
+type HookKind string
+
+const (
+	// HookKindFunction 表示函数型 hook。
+	HookKindFunction HookKind = "function"
+	// HookKindCommand 表示命令型 hook（P6 预留）。
+	HookKindCommand HookKind = "command"
+	// HookKindHTTP 表示 HTTP 型 hook（P6 预留）。
+	HookKindHTTP HookKind = "http"
+	// HookKindPrompt 表示 prompt 型 hook（P6 预留）。
+	HookKindPrompt HookKind = "prompt"
+	// HookKindAgent 表示 agent 型 hook（P6 预留）。
+	HookKindAgent HookKind = "agent"
+)
+
+// HookMode 描述 hook 的执行模式。
+type HookMode string
+
+const (
+	// HookModeSync 表示同步执行。
+	HookModeSync HookMode = "sync"
+	// HookModeAsync 表示异步执行（P5 预留）。
+	HookModeAsync HookMode = "async"
+	// HookModeAsyncRewake 表示异步回灌执行（P5 预留）。
+	HookModeAsyncRewake HookMode = "async_rewake"
+)
+
+// FailurePolicy 描述 hook 失败时的处理策略。
+type FailurePolicy string
+
+const (
+	// FailurePolicyFailOpen 表示失败放行并继续后续 hook。
+	FailurePolicyFailOpen FailurePolicy = "fail_open"
+	// FailurePolicyFailClosed 表示失败即阻断执行。
+	FailurePolicyFailClosed FailurePolicy = "fail_closed"
+)
+
+// HookHandler 定义 hook 的函数处理签名。
+type HookHandler func(ctx context.Context, input HookContext) HookResult
+
+// HookSpec 描述一个可注册的 hook 定义。
+type HookSpec struct {
+	ID            string
+	Point         HookPoint
+	Scope         HookScope
+	Kind          HookKind
+	Mode          HookMode
+	Priority      int
+	Timeout       time.Duration
+	FailurePolicy FailurePolicy
+	Handler       HookHandler
+}
+
+// normalizeAndValidate 将 HookSpec 归一化并校验当前阶段可用字段。
+func (s HookSpec) normalizeAndValidate() (HookSpec, error) {
+	s.ID = strings.TrimSpace(s.ID)
+	s.Point = HookPoint(strings.TrimSpace(string(s.Point)))
+	if s.ID == "" {
+		return HookSpec{}, wrapInvalidSpec("id is required")
+	}
+	if s.Point == "" {
+		return HookSpec{}, wrapInvalidSpec("point is required")
+	}
+	if !isSupportedHookPoint(s.Point) {
+		return HookSpec{}, wrapInvalidSpec("point %q is not supported in P0", s.Point)
+	}
+	if s.Handler == nil {
+		return HookSpec{}, wrapInvalidSpec("handler is required")
+	}
+	if s.Scope == "" {
+		s.Scope = HookScopeInternal
+	}
+	if s.Scope != HookScopeInternal {
+		return HookSpec{}, wrapInvalidSpec("scope %q is not supported in P0", s.Scope)
+	}
+	if s.Kind == "" {
+		s.Kind = HookKindFunction
+	}
+	if s.Kind != HookKindFunction {
+		return HookSpec{}, wrapInvalidSpec("kind %q is not supported in P0", s.Kind)
+	}
+	if s.Mode == "" {
+		s.Mode = HookModeSync
+	}
+	if s.Mode != HookModeSync {
+		return HookSpec{}, wrapInvalidSpec("mode %q is not supported in P0", s.Mode)
+	}
+	if s.FailurePolicy == "" {
+		s.FailurePolicy = FailurePolicyFailOpen
+	}
+	switch s.FailurePolicy {
+	case FailurePolicyFailOpen, FailurePolicyFailClosed:
+	default:
+		return HookSpec{}, wrapInvalidSpec("failure_policy %q is invalid", s.FailurePolicy)
+	}
+	return s, nil
+}
+
+func isSupportedHookPoint(point HookPoint) bool {
+	switch point {
+	case HookPointBeforeToolCall, HookPointAfterToolResult, HookPointBeforeCompletionDecision:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/runtime/hooks/types_test.go
+++ b/internal/runtime/hooks/types_test.go
@@ -1,0 +1,125 @@
+package hooks
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestHookSpecNormalizeAndValidateDefaults(t *testing.T) {
+	t.Parallel()
+
+	spec, err := (HookSpec{
+		ID:      "  hook-1  ",
+		Point:   HookPoint(" before_tool_call "),
+		Handler: func(context.Context, HookContext) HookResult { return HookResult{} },
+	}).normalizeAndValidate()
+	if err != nil {
+		t.Fatalf("normalizeAndValidate() error = %v", err)
+	}
+	if spec.ID != "hook-1" {
+		t.Fatalf("ID = %q, want hook-1", spec.ID)
+	}
+	if spec.Point != HookPointBeforeToolCall {
+		t.Fatalf("Point = %q, want %q", spec.Point, HookPointBeforeToolCall)
+	}
+	if spec.Scope != HookScopeInternal {
+		t.Fatalf("Scope = %q, want %q", spec.Scope, HookScopeInternal)
+	}
+	if spec.Kind != HookKindFunction {
+		t.Fatalf("Kind = %q, want %q", spec.Kind, HookKindFunction)
+	}
+	if spec.Mode != HookModeSync {
+		t.Fatalf("Mode = %q, want %q", spec.Mode, HookModeSync)
+	}
+	if spec.FailurePolicy != FailurePolicyFailOpen {
+		t.Fatalf("FailurePolicy = %q, want %q", spec.FailurePolicy, FailurePolicyFailOpen)
+	}
+}
+
+func TestHookSpecNormalizeAndValidateErrors(t *testing.T) {
+	t.Parallel()
+
+	handler := func(context.Context, HookContext) HookResult { return HookResult{} }
+	cases := []struct {
+		name string
+		spec HookSpec
+	}{
+		{
+			name: "missing id",
+			spec: HookSpec{
+				Point:   HookPointBeforeToolCall,
+				Handler: handler,
+			},
+		},
+		{
+			name: "missing point",
+			spec: HookSpec{
+				ID:      "hook-1",
+				Handler: handler,
+			},
+		},
+		{
+			name: "unsupported point",
+			spec: HookSpec{
+				ID:      "hook-1",
+				Point:   HookPoint("unsupported"),
+				Handler: handler,
+			},
+		},
+		{
+			name: "missing handler",
+			spec: HookSpec{
+				ID:    "hook-1",
+				Point: HookPointBeforeToolCall,
+			},
+		},
+		{
+			name: "unsupported scope",
+			spec: HookSpec{
+				ID:      "hook-1",
+				Point:   HookPointBeforeToolCall,
+				Scope:   HookScopeUser,
+				Handler: handler,
+			},
+		},
+		{
+			name: "unsupported kind",
+			spec: HookSpec{
+				ID:      "hook-1",
+				Point:   HookPointBeforeToolCall,
+				Kind:    HookKindHTTP,
+				Handler: handler,
+			},
+		},
+		{
+			name: "unsupported mode",
+			spec: HookSpec{
+				ID:      "hook-1",
+				Point:   HookPointBeforeToolCall,
+				Mode:    HookModeAsync,
+				Handler: handler,
+			},
+		},
+		{
+			name: "invalid failure policy",
+			spec: HookSpec{
+				ID:            "hook-1",
+				Point:         HookPointBeforeToolCall,
+				FailurePolicy: FailurePolicy("ignore"),
+				Handler:       handler,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := tc.spec.normalizeAndValidate()
+			if !errors.Is(err, ErrInvalidHookSpec) {
+				t.Fatalf("normalizeAndValidate() error = %v, want ErrInvalidHookSpec", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 摘要

实现 #488 的 P0 Runtime Hooks Core（`internal/runtime/hooks`），仅包含 **internal + function + sync** 能力，不接入 runtime 主循环。

## 主要改动

- 新增 Hook 核心类型与严格 P0 校验：
  - `HookSpec`、`HookPoint`、`HookScope`、`HookKind`、`HookMode`、`FailurePolicy`
  - 仅允许 P0 支持值（`internal/function/sync`）与支持的 hook point
- 新增线程安全 `Registry`：
  - `Register` / `Remove` / `Resolve`
  - 稳定排序规则：`priority` 降序 + 注册序号升序
- 新增同步 `Executor`：
  - `Run(ctx, point, input)` 返回 `RunOutput{Results, Blocked, BlockedBy}`
  - 支持 timeout、panic recover、结构化失败结果
  - 支持 `fail_open` / `fail_closed`
  - 支持 `block` 短路
- 新增事件模型与注入式发射接口（不依赖 `runtime.Service`）：
  - `hook_started`、`hook_finished`、`hook_failed`
  - `EventEmitter` best-effort 发射策略
- 新增 `HookContext` 深拷贝，避免 Metadata 嵌套对象跨 hook 共享修改
- 新增在途执行上限保护，降低 timed-out handler 忽略取消时的堆积风险

## 测试覆盖

新增/补齐测试包括：

- Registry：
  - 注册成功 / 重复 ID
  - 删除成功 / 不存在
  - 按 point 解析
  - 稳定排序
  - 并发 register+resolve
  - 不支持 point 校验
- Executor：
  - pass 正常路径
  - block 短路
  - timeout -> failed
  - panic recover -> failed
  - fail_open 继续执行
  - fail_closed 阻断
  - 无 hook 场景
  - 事件字段完整性
  - emitter 失败不影响主流程
  - saturation 保护分支
- Context：
  - Metadata 深拷贝行为

## 验证

- `go test ./internal/runtime/hooks/...`
- `go test -race ./internal/runtime/hooks/...`
- `go test ./internal/runtime/... -run ^$`

## 范围说明

- 本 PR 不接入 runtime 主循环（放到 P1）
- 本 PR 不包含 user/repo/async/external hooks

Closes #488