### PR TITLE
pref(provider):修正 Provider 生成重试默认语义并放宽退避上限

### DIFF
--- a/docs/guides/adding-providers.md
+++ b/docs/guides/adding-providers.md
@@ -108,7 +108,7 @@ generate_idle_timeout_sec: 300
 - `chat_endpoint_path` 为 `/` 表示直连 `base_url`；为空时会按 `chat_api_mode` 自动回填默认子路径（`/chat/completions` 或 `/responses`）。
 - 当 `chat_api_mode` 已显式指定时，`chat_endpoint_path` 可使用任意以 `/` 开头的相对路径；未显式指定时，仅支持标准端点推断（`/chat/completions`、`/responses`、`/`）。
 - `model_source: manual` 时必须提供 `models`，且会忽略 `discovery_endpoint_path`。
-- `generate_max_retries` / `generate_idle_timeout_sec` 用于控制 provider 级生成重试和流空闲超时；未填写或 `<= 0` 时会分别回退到 `5 / 300`。其中 `generate_max_retries` 必须 `<= 20`。
+- `generate_max_retries` / `generate_idle_timeout_sec` 用于控制 provider 级生成重试和流空闲超时；`generate_max_retries` 未填写时默认使用 `5`，显式填写 `0` 表示关闭生成重试，`generate_idle_timeout_sec` 未填写或 `<= 0` 时回退到 `300`。其中 `generate_max_retries` 必须 `<= 20`。
 - `generate_start_timeout_sec` 已改为根 `config.yaml` 顶层字段，不再允许写入 `provider.yaml`；启动时缺失会自动补写默认值 `90`。
 
 ## 测试要求

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -179,7 +179,7 @@ generate_idle_timeout_sec: 300
 
 新增的生成链路控制字段含义如下：
 
-- `generate_max_retries`：额外重试次数，不含首次尝试；`<= 0` 时回退默认值 `5`，且必须 `<= 20`。
+- `generate_max_retries`：额外重试次数，不含首次尝试；未填写时默认使用 `5`，显式填写 `0` 表示关闭生成重试，且必须 `<= 20`。
 - `generate_start_timeout_sec`：写在 `config.yaml` 顶层，从发请求到收到首个有效流 payload 的最长等待窗口；`<= 0` 时回退默认值 `90`。
 - `generate_idle_timeout_sec`：首包后连续没有任何新 payload 的最长空闲窗口；`<= 0` 时回退默认值 `300`。
 

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -1393,6 +1393,55 @@ func TestSaveAndLoadCustomProviderPersistsGenerateControls(t *testing.T) {
 	}
 }
 
+func TestSaveAndLoadCustomProviderPreservesExplicitZeroGenerateRetries(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	const providerName = "zero-retry-provider"
+	err := SaveCustomProviderWithModels(baseDir, SaveCustomProviderInput{
+		Name:                   providerName,
+		Driver:                 provider.DriverOpenAICompat,
+		BaseURL:                "https://llm.example.com/v1",
+		APIKeyEnv:              "ZERO_RETRY_PROVIDER_API_KEY",
+		ModelSource:            ModelSourceDiscover,
+		DiscoveryEndpointPath:  provider.DiscoveryEndpointPathModels,
+		GenerateMaxRetries:     0,
+		GenerateMaxRetriesSet:  true,
+		GenerateIdleTimeoutSec: 420,
+	})
+	if err != nil {
+		t.Fatalf("SaveCustomProviderWithModels() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(baseDir, providersDirName, providerName, customProviderConfigName))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "generate_max_retries: 0") {
+		t.Fatalf("expected generate_max_retries: 0 to be persisted, got %q", content)
+	}
+
+	cfg, err := loadCustomProvider(filepath.Join(baseDir, providersDirName, providerName))
+	if err != nil {
+		t.Fatalf("loadCustomProvider() error = %v", err)
+	}
+	if !cfg.GenerateMaxRetriesSet {
+		t.Fatal("expected explicit zero retry setting to remain marked as configured")
+	}
+	runtimeCfg, err := cfg.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	providerRuntimeCfg, err := runtimeCfg.ToRuntimeConfig()
+	if err != nil {
+		t.Fatalf("ToRuntimeConfig() error = %v", err)
+	}
+	if providerRuntimeCfg.GenerateMaxRetries != 0 {
+		t.Fatalf("expected explicit zero retry setting to disable retries, got %d", providerRuntimeCfg.GenerateMaxRetries)
+	}
+}
+
 func TestSaveCustomProviderOmitsDefaultGenerateControlsWhenUnset(t *testing.T) {
 	t.Parallel()
 
@@ -1420,6 +1469,43 @@ func TestSaveCustomProviderOmitsDefaultGenerateControlsWhenUnset(t *testing.T) {
 	}
 	if strings.Contains(content, "generate_idle_timeout_sec") {
 		t.Fatalf("expected generate_idle_timeout_sec to be omitted, got %q", content)
+	}
+}
+
+func TestLoadCustomProviderUsesDefaultGenerateRetriesWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	const providerName = "default-retry-provider"
+	err := SaveCustomProviderWithModels(baseDir, SaveCustomProviderInput{
+		Name:                  providerName,
+		Driver:                provider.DriverOpenAICompat,
+		BaseURL:               "https://llm.example.com/v1",
+		APIKeyEnv:             "DEFAULT_RETRY_PROVIDER_API_KEY",
+		ModelSource:           ModelSourceDiscover,
+		DiscoveryEndpointPath: provider.DiscoveryEndpointPathModels,
+	})
+	if err != nil {
+		t.Fatalf("SaveCustomProviderWithModels() error = %v", err)
+	}
+
+	cfg, err := loadCustomProvider(filepath.Join(baseDir, providersDirName, providerName))
+	if err != nil {
+		t.Fatalf("loadCustomProvider() error = %v", err)
+	}
+	if cfg.GenerateMaxRetriesSet {
+		t.Fatal("expected omitted generate_max_retries to remain unset")
+	}
+	resolved, err := cfg.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	runtimeCfg, err := resolved.ToRuntimeConfig()
+	if err != nil {
+		t.Fatalf("ToRuntimeConfig() error = %v", err)
+	}
+	if runtimeCfg.GenerateMaxRetries != provider.DefaultGenerateMaxRetries {
+		t.Fatalf("expected omitted generate_max_retries to use default %d, got %d", provider.DefaultGenerateMaxRetries, runtimeCfg.GenerateMaxRetries)
 	}
 }
 

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -28,6 +28,7 @@ type ProviderConfig struct {
 	Model                  string                          `yaml:"model"`
 	APIKeyEnv              string                          `yaml:"api_key_env"`
 	GenerateMaxRetries     int                             `yaml:"generate_max_retries,omitempty"`
+	GenerateMaxRetriesSet  bool                            `yaml:"-"`
 	GenerateIdleTimeoutSec int                             `yaml:"generate_idle_timeout_sec,omitempty"`
 	ModelSource            string                          `yaml:"-"`
 	ChatAPIMode            string                          `yaml:"-"`
@@ -169,6 +170,14 @@ func (p ProviderConfig) Resolve() (ResolvedProviderConfig, error) {
 	}, nil
 }
 
+// resolveGenerateMaxRetries 统一解析 provider 级生成重试次数，兼容“未配置使用默认值”和“显式 0 关闭重试”两种语义。
+func (p ProviderConfig) resolveGenerateMaxRetries() int {
+	if p.GenerateMaxRetriesSet || p.GenerateMaxRetries > 0 {
+		return provider.NormalizeGenerateMaxRetries(p.GenerateMaxRetries)
+	}
+	return provider.DefaultGenerateMaxRetries
+}
+
 func cloneProviders(providers []ProviderConfig) []ProviderConfig {
 	if len(providers) == 0 {
 		return nil
@@ -283,7 +292,7 @@ func (p ResolvedProviderConfig) ToRuntimeConfig() (provider.RuntimeConfig, error
 		ChatAPIMode:           chatAPIMode,
 		ChatEndpointPath:      chatEndpointPath,
 		DiscoveryEndpointPath: discoveryEndpointPath,
-		GenerateMaxRetries:    provider.NormalizeGenerateMaxRetries(p.GenerateMaxRetries),
+		GenerateMaxRetries:    p.resolveGenerateMaxRetries(),
 		GenerateStartTimeout:  provider.NormalizeGenerateStartTimeout(time.Duration(p.GenerateStartTimeoutSec) * time.Second),
 		GenerateIdleTimeout:   provider.NormalizeGenerateIdleTimeout(time.Duration(p.GenerateIdleTimeoutSec) * time.Second),
 	}, nil

--- a/internal/config/provider_custom_normalize.go
+++ b/internal/config/provider_custom_normalize.go
@@ -21,6 +21,7 @@ func NormalizeCustomProviderInput(input SaveCustomProviderInput) (SaveCustomProv
 		ChatEndpointPath:       strings.TrimSpace(input.ChatEndpointPath),
 		APIKeyEnv:              strings.TrimSpace(input.APIKeyEnv),
 		GenerateMaxRetries:     normalizeOptionalGenerateInt(input.GenerateMaxRetries),
+		GenerateMaxRetriesSet:  input.GenerateMaxRetriesSet || input.GenerateMaxRetries > 0,
 		GenerateIdleTimeoutSec: normalizeOptionalGenerateInt(input.GenerateIdleTimeoutSec),
 		DiscoveryEndpointPath:  strings.TrimSpace(input.DiscoveryEndpointPath),
 	}
@@ -118,6 +119,7 @@ func validateNormalizedCustomProviderInput(input SaveCustomProviderInput) error 
 		BaseURL:                input.BaseURL,
 		APIKeyEnv:              input.APIKeyEnv,
 		GenerateMaxRetries:     input.GenerateMaxRetries,
+		GenerateMaxRetriesSet:  input.GenerateMaxRetriesSet,
 		GenerateIdleTimeoutSec: input.GenerateIdleTimeoutSec,
 		ModelSource:            input.ModelSource,
 		ChatAPIMode:            input.ChatAPIMode,

--- a/internal/config/provider_loader.go
+++ b/internal/config/provider_loader.go
@@ -24,7 +24,7 @@ type customProviderFile struct {
 	Name                   string                    `yaml:"name"`
 	Driver                 string                    `yaml:"driver"`
 	APIKeyEnv              string                    `yaml:"api_key_env"`
-	GenerateMaxRetries     int                       `yaml:"generate_max_retries,omitempty"`
+	GenerateMaxRetries     *int                      `yaml:"generate_max_retries,omitempty"`
 	GenerateIdleTimeoutSec int                       `yaml:"generate_idle_timeout_sec,omitempty"`
 	ModelSource            string                    `yaml:"model_source,omitempty"`
 	ChatAPIMode            string                    `yaml:"chat_api_mode,omitempty"`
@@ -115,7 +115,8 @@ func loadCustomProvider(providerDir string) (ProviderConfig, error) {
 		Driver:                 strings.TrimSpace(file.Driver),
 		BaseURL:                strings.TrimSpace(file.BaseURL),
 		APIKeyEnv:              strings.TrimSpace(file.APIKeyEnv),
-		GenerateMaxRetries:     file.GenerateMaxRetries,
+		GenerateMaxRetries:     optionalIntValue(file.GenerateMaxRetries),
+		GenerateMaxRetriesSet:  file.GenerateMaxRetries != nil,
 		GenerateIdleTimeoutSec: file.GenerateIdleTimeoutSec,
 		ModelSource:            strings.TrimSpace(file.ModelSource),
 		ChatAPIMode:            strings.TrimSpace(file.ChatAPIMode),
@@ -133,6 +134,7 @@ func loadCustomProvider(providerDir string) (ProviderConfig, error) {
 		BaseURL:                normalizedInput.BaseURL,
 		APIKeyEnv:              normalizedInput.APIKeyEnv,
 		GenerateMaxRetries:     normalizedInput.GenerateMaxRetries,
+		GenerateMaxRetriesSet:  normalizedInput.GenerateMaxRetriesSet,
 		GenerateIdleTimeoutSec: normalizedInput.GenerateIdleTimeoutSec,
 		ModelSource:            normalizedInput.ModelSource,
 		ChatAPIMode:            normalizedInput.ChatAPIMode,
@@ -204,6 +206,7 @@ type SaveCustomProviderInput struct {
 	ChatEndpointPath       string
 	APIKeyEnv              string
 	GenerateMaxRetries     int
+	GenerateMaxRetriesSet  bool
 	GenerateIdleTimeoutSec int
 	DiscoveryEndpointPath  string
 	ModelSource            string
@@ -226,7 +229,7 @@ func SaveCustomProviderWithModels(baseDir string, input SaveCustomProviderInput)
 		Name:                   normalizedInput.Name,
 		Driver:                 normalizedInput.Driver,
 		APIKeyEnv:              normalizedInput.APIKeyEnv,
-		GenerateMaxRetries:     normalizedInput.GenerateMaxRetries,
+		GenerateMaxRetries:     optionalIntPointer(normalizedInput.GenerateMaxRetries, normalizedInput.GenerateMaxRetriesSet || normalizedInput.GenerateMaxRetries > 0),
 		GenerateIdleTimeoutSec: normalizedInput.GenerateIdleTimeoutSec,
 		ModelSource:            normalizedInput.ModelSource,
 		ChatAPIMode:            normalizedInput.ChatAPIMode,
@@ -312,4 +315,21 @@ func validateCustomProviderName(name string) error {
 		return fmt.Errorf("config: provider name %q contains unsupported character %q", name, string(r))
 	}
 	return nil
+}
+
+// optionalIntValue 统一读取可选整数字段，避免缺省值和显式零值在解析阶段丢失原始语义。
+func optionalIntValue(value *int) int {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+
+// optionalIntPointer 根据是否显式配置决定是否输出 YAML 字段，保留“未配置”和“显式 0”两种语义差异。
+func optionalIntPointer(value int, configured bool) *int {
+	if !configured {
+		return nil
+	}
+	out := value
+	return &out
 }

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -776,7 +776,7 @@ func TestResolvedProviderConfigToRuntimeConfig(t *testing.T) {
 		ChatAPIMode:           "",
 		ChatEndpointPath:      "",
 		DiscoveryEndpointPath: providerpkg.DiscoveryEndpointPathModels,
-		GenerateMaxRetries:    0,
+		GenerateMaxRetries:    providerpkg.DefaultGenerateMaxRetries,
 		GenerateStartTimeout:  providerpkg.DefaultGenerateStartTimeout,
 		GenerateIdleTimeout:   providerpkg.DefaultGenerateIdleTimeout,
 	}
@@ -799,6 +799,30 @@ func TestResolvedProviderConfigToRuntimeConfig(t *testing.T) {
 		got.GenerateStartTimeout != want.GenerateStartTimeout ||
 		got.GenerateIdleTimeout != want.GenerateIdleTimeout {
 		t.Fatalf("ToRuntimeConfig() = %+v, want %+v", got, want)
+	}
+}
+
+func TestResolvedProviderConfigToRuntimeConfigPreservesExplicitZeroGenerateRetries(t *testing.T) {
+	t.Parallel()
+
+	resolved := ResolvedProviderConfig{
+		ProviderConfig: ProviderConfig{
+			Name:                  "company-gateway",
+			Driver:                "openaicompat",
+			BaseURL:               "https://llm.example.com/v1",
+			Model:                 "server-default",
+			APIKeyEnv:             "COMPANY_GATEWAY_KEY",
+			GenerateMaxRetries:    0,
+			GenerateMaxRetriesSet: true,
+		},
+	}
+
+	got, err := resolved.ToRuntimeConfig()
+	if err != nil {
+		t.Fatalf("ToRuntimeConfig() error = %v", err)
+	}
+	if got.GenerateMaxRetries != 0 {
+		t.Fatalf("expected explicit GenerateMaxRetries=0 to disable retries, got %d", got.GenerateMaxRetries)
 	}
 }
 

--- a/internal/provider/constants.go
+++ b/internal/provider/constants.go
@@ -23,7 +23,7 @@ const (
 	// DefaultGenerateRetryBaseWait 定义生成链路重试退避的基础等待时长。
 	DefaultGenerateRetryBaseWait = 1 * time.Second
 	// DefaultGenerateRetryMaxWait 定义生成链路重试退避的最大等待时长。
-	DefaultGenerateRetryMaxWait = 5 * time.Second
+	DefaultGenerateRetryMaxWait = 7 * time.Second
 	// DefaultSDKRequestTimeout 定义非生成链路访问外部模型 SDK 的统一保底超时。
 	DefaultSDKRequestTimeout = 10 * time.Minute
 )

--- a/internal/provider/constants_test.go
+++ b/internal/provider/constants_test.go
@@ -59,3 +59,11 @@ func TestNormalizeGenerateIdleTimeout(t *testing.T) {
 		t.Fatalf("NormalizeGenerateIdleTimeout(4s) = %s, want %s", got, want)
 	}
 }
+
+func TestDefaultGenerateRetryMaxWait(t *testing.T) {
+	t.Parallel()
+
+	if DefaultGenerateRetryMaxWait != 7*time.Second {
+		t.Fatalf("DefaultGenerateRetryMaxWait = %s, want 7s", DefaultGenerateRetryMaxWait)
+	}
+}


### PR DESCRIPTION
## 之前存在的问题

### 1. `generate_max_retries` 无法区分“未配置”和“显式关闭”

原实现里 `GenerateMaxRetries` 是普通 `int`：

- `provider.yaml` 未填写 `generate_max_retries`
- `provider.yaml` 显式写入 `generate_max_retries: 0`

这两种情况在解码后都会变成 `0`。  
结果是配置层丢失了“字段是否被显式设置”的信息。

直接后果：

- 无法同时满足“未填写时使用默认值 5”和“显式 0 关闭重试”这两种语义
- 实际行为更接近“0 就是不重试”，和文档承诺不一致

### 2. 文档语义与代码实际行为不一致

原文档将 `generate_max_retries` 描述为：

- 未填写或 `<= 0` 时回退默认值 `5`

但生产代码中：

- 配置校验不允许负数
- `0` 会原样进入运行时配置

这意味着正常配置路径几乎不可能触发“负数回退默认值”的语义，文档与实现存在偏差。

### 3. 生成重试退避上限偏紧

原退避窗口是：

- 基线 `1s`
- 上限 `5s`

对短时 429 / 5xx 抖动场景而言，这个上限偏保守。在重试次数有限的情况下，稍微放宽上限可以提升恢复概率，同时不会引入不可控的长时间阻塞。

## 采取的方案

### 方案一：为 `generate_max_retries` 增加“三态语义”

- `GenerateMaxRetries`：继续承载数值
- `GenerateMaxRetriesSet`：记录字段是否被显式配置

运行时语义调整为：

- 未填写：使用默认值 `5`
- 显式 `0`：关闭生成重试
- 显式正数：按配置值生效

这样可以在不大面积改动调用方的前提下，把“默认值”和“显式关闭”重新区分开。

### 方案二：在 `provider.yaml` 读写链路中保留显式零值

为了避免 YAML 层再次吞掉语义，本次对持久化链路做了收口：

- 读取时用可选字段识别 `generate_max_retries` 是否真的出现
- 写入时只有在“显式配置”时才落盘该字段
- 显式写 `0` 时会保留 `generate_max_retries: 0`
- 未配置时继续省略字段，避免污染配置

### 方案三：放宽统一退避上限

保留现有指数退避 + 抖动策略，只把最大等待时间从 `5s` 提升到 `7s`：

- 不改变重试触发时机
- 不改变首包后不重试的边界
- 只提升极端情况下的最大等待窗口

## 改动情况

### 配置与运行时语义修正

涉及文件：

- `internal/config/provider.go`
- `internal/config/provider_loader.go`
- `internal/config/provider_custom_normalize.go`

核心改动：

- 在 `ProviderConfig` 中引入 `GenerateMaxRetriesSet`
- 新增 `resolveGenerateMaxRetries()`，集中解析默认值 / 显式关闭 / 显式数值三种语义
- 让 `provider.yaml` 的 `generate_max_retries` 走“可选字段”解析
- 保存自定义 provider 时保留显式 `0`，未配置时继续省略

### 测试补强

涉及文件：

- `internal/config/provider_test.go`
- `internal/config/loader_test.go`
- `internal/provider/constants_test.go`

新增覆盖点：

- 未配置 `generate_max_retries` 时，运行时默认使用 `5`
- 显式 `generate_max_retries: 0` 时，运行时保持禁用重试
- `provider.yaml` 持久化时，显式 `0` 不会被丢失
- 退避上限常量更新为 `7s`

### 文档对齐

涉及文件：

- `docs/guides/configuration.md`
- `docs/guides/adding-providers.md`

修正内容：

- 明确“未填写默认 5”
- 明确“显式 0 表示关闭重试”
- 保持 `generate_idle_timeout_sec` 的原有默认语义说明不变

