### PR TITLE
fix(session): 修复 /session 标题长期为 New Session，并统一单行展示

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -117,6 +117,10 @@ type repositoryFactService interface {
 	Retrieve(ctx context.Context, workdir string, query repository.RetrievalQuery) (repository.RetrievalResult, error)
 }
 
+type runtimeSessionTitleUpdater interface {
+	UpdateSessionTitle(ctx context.Context, input agentsession.UpdateSessionTitleInput) error
+}
+
 type Service struct {
 	configManager     *config.Manager
 	sessionStore      agentsession.Store
@@ -282,7 +286,44 @@ func (s *Service) loadConfigSnapshot(ctx context.Context) (config.Config, error)
 
 // ListSessions 返回当前会话存储中的所有摘要。
 func (s *Service) ListSessions(ctx context.Context) ([]agentsession.Summary, error) {
-	return s.sessionStore.ListSummaries(ctx)
+	summaries, err := s.sessionStore.ListSummaries(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(summaries) == 0 {
+		return summaries, nil
+	}
+
+	rewritten := make([]agentsession.Summary, 0, len(summaries))
+	for _, summary := range summaries {
+		current := summary
+		if !isDefaultSessionTitle(current.Title) {
+			rewritten = append(rewritten, current)
+			continue
+		}
+
+		session, loadErr := s.sessionStore.LoadSession(ctx, current.ID)
+		if loadErr != nil {
+			rewritten = append(rewritten, current)
+			continue
+		}
+		derived := sessionTitleFromMessages(session.Messages)
+		if !shouldPromoteSessionTitle(current.Title, derived) {
+			rewritten = append(rewritten, current)
+			continue
+		}
+
+		current.Title = derived
+		if titleUpdater, ok := s.sessionStore.(runtimeSessionTitleUpdater); ok {
+			_ = titleUpdater.UpdateSessionTitle(ctx, agentsession.UpdateSessionTitleInput{
+				SessionID: current.ID,
+				UpdatedAt: current.UpdatedAt,
+				Title:     derived,
+			})
+		}
+		rewritten = append(rewritten, current)
+	}
+	return rewritten, nil
 }
 
 // LoadSession 按 id 加载完整会话内容。
@@ -347,6 +388,35 @@ func isRuntimeSessionAlreadyExistsError(err error) bool {
 		return false
 	}
 	return errors.Is(err, agentsession.ErrSessionAlreadyExists) || errors.Is(err, os.ErrExist)
+}
+
+func sessionTitleFromMessages(messages []providertypes.Message) string {
+	for _, message := range messages {
+		if strings.TrimSpace(message.Role) != providertypes.RoleUser {
+			continue
+		}
+		if title := sessionTitleFromParts(message.Parts); strings.TrimSpace(title) != "" && !isImageOnlySessionTitle(title) {
+			return strings.TrimSpace(title)
+		}
+	}
+	return ""
+}
+
+func isDefaultSessionTitle(title string) bool {
+	return strings.EqualFold(strings.TrimSpace(title), "New Session")
+}
+
+func isImageOnlySessionTitle(title string) bool {
+	return strings.EqualFold(strings.TrimSpace(title), "Image Message")
+}
+
+func shouldPromoteSessionTitle(current string, next string) bool {
+	trimmedCurrent := strings.TrimSpace(current)
+	trimmedNext := strings.TrimSpace(next)
+	if trimmedNext == "" || isDefaultSessionTitle(trimmedNext) || isImageOnlySessionTitle(trimmedNext) {
+		return false
+	}
+	return isDefaultSessionTitle(trimmedCurrent)
 }
 
 // SetBudgetResolver 注入 prompt budget 解析能力，避免 runtime 直接感知模型目录细节。

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -41,10 +41,53 @@ type failingStore struct {
 	ignoreContextErr bool
 }
 
+type listSessionsStubStore struct {
+	summaries []agentsession.Summary
+	loadErr   error
+	session   agentsession.Session
+}
+
 type budgetResolverFunc func(ctx context.Context, cfg config.Config) (int, string, error)
 
 func (f budgetResolverFunc) ResolvePromptBudget(ctx context.Context, cfg config.Config) (int, string, error) {
 	return f(ctx, cfg)
+}
+
+func (s *listSessionsStubStore) CreateSession(ctx context.Context, input agentsession.CreateSessionInput) (agentsession.Session, error) {
+	return agentsession.Session{}, errors.New("not implemented")
+}
+
+func (s *listSessionsStubStore) LoadSession(ctx context.Context, id string) (agentsession.Session, error) {
+	if s.loadErr != nil {
+		return agentsession.Session{}, s.loadErr
+	}
+	return cloneSession(s.session), nil
+}
+
+func (s *listSessionsStubStore) ListSummaries(ctx context.Context) ([]agentsession.Summary, error) {
+	out := make([]agentsession.Summary, len(s.summaries))
+	copy(out, s.summaries)
+	return out, nil
+}
+
+func (s *listSessionsStubStore) AppendMessages(ctx context.Context, input agentsession.AppendMessagesInput) error {
+	return errors.New("not implemented")
+}
+
+func (s *listSessionsStubStore) UpdateSessionState(ctx context.Context, input agentsession.UpdateSessionStateInput) error {
+	return errors.New("not implemented")
+}
+
+func (s *listSessionsStubStore) UpdateSessionWorkdir(ctx context.Context, input agentsession.UpdateSessionWorkdirInput) error {
+	return errors.New("not implemented")
+}
+
+func (s *listSessionsStubStore) ReplaceTranscript(ctx context.Context, input agentsession.ReplaceTranscriptInput) error {
+	return errors.New("not implemented")
+}
+
+func (s *listSessionsStubStore) CleanupExpiredSessions(ctx context.Context, maxAge time.Duration) (int, error) {
+	return 0, nil
 }
 
 func newMemoryStore() *memoryStore {
@@ -3416,6 +3459,74 @@ func TestServiceListSessionsPromotesDefaultTitlesFromUserMessages(t *testing.T) 
 	}
 	if loaded.Title != "Investigate /session title issue" {
 		t.Fatalf("stored title = %q, want promoted title", loaded.Title)
+	}
+}
+
+func TestServiceListSessionsSkipsPromotionWhenDerivedTitleInvalid(t *testing.T) {
+	manager := newRuntimeConfigManager(t)
+	store := newMemoryStore()
+	service := NewWithFactory(manager, tools.NewRegistry(), store, nil, nil)
+
+	imageOnly := agentsession.New("New Session")
+	imageOnly.Messages = []providertypes.Message{
+		{
+			Role: providertypes.RoleUser,
+			Parts: []providertypes.ContentPart{
+				providertypes.NewRemoteImagePart("https://example.com/image.png"),
+			},
+		},
+	}
+	store.sessions[imageOnly.ID] = cloneSession(imageOnly)
+
+	summaries, err := service.ListSessions(context.Background())
+	if err != nil {
+		t.Fatalf("ListSessions() error = %v", err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("expected 1 summary, got %d", len(summaries))
+	}
+	if summaries[0].Title != "New Session" {
+		t.Fatalf("expected default title to stay unchanged, got %q", summaries[0].Title)
+	}
+}
+
+func TestRuntimeSessionTitlePromotionHelpers(t *testing.T) {
+	t.Parallel()
+
+	if got := sessionTitleFromMessages([]providertypes.Message{
+		{Role: providertypes.RoleAssistant, Parts: []providertypes.ContentPart{providertypes.NewTextPart("a")}},
+		{Role: providertypes.RoleUser, Parts: []providertypes.ContentPart{providertypes.NewRemoteImagePart("https://example.com/image.png")}},
+	}); got != "" {
+		t.Fatalf("expected empty title for image-only user message, got %q", got)
+	}
+
+	if !isDefaultSessionTitle("  new session  ") {
+		t.Fatalf("expected default title to match ignoring case and spaces")
+	}
+	if !isImageOnlySessionTitle(" image message ") {
+		t.Fatalf("expected image-only title to match ignoring case and spaces")
+	}
+	if shouldPromoteSessionTitle("Already Named", "new title") {
+		t.Fatalf("expected non-default current title not to be promoted")
+	}
+	if shouldPromoteSessionTitle("New Session", "Image Message") {
+		t.Fatalf("expected image-only derived title not to be promoted")
+	}
+}
+
+func TestServiceListSessionsKeepsDefaultOnLoadError(t *testing.T) {
+	manager := newRuntimeConfigManager(t)
+	store := &listSessionsStubStore{
+		summaries: []agentsession.Summary{{ID: "s1", Title: "New Session"}},
+		loadErr:   errors.New("load failed"),
+	}
+	service := NewWithFactory(manager, tools.NewRegistry(), store, nil, nil)
+	summaries, err := service.ListSessions(context.Background())
+	if err != nil {
+		t.Fatalf("ListSessions() error = %v", err)
+	}
+	if got := summaries[0].Title; got != "New Session" {
+		t.Fatalf("expected default title unchanged on load error, got %q", got)
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -189,6 +189,26 @@ func (s *memoryStore) UpdateSessionWorkdir(ctx context.Context, input agentsessi
 	return nil
 }
 
+func (s *memoryStore) UpdateSessionTitle(ctx context.Context, input agentsession.UpdateSessionTitleInput) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	session, ok := s.sessions[input.SessionID]
+	if !ok {
+		return errors.New("not found")
+	}
+	session.Title = strings.TrimSpace(input.Title)
+	if !input.UpdatedAt.IsZero() {
+		session.UpdatedAt = input.UpdatedAt
+	}
+	s.saves++
+	s.sessions[input.SessionID] = cloneSession(session)
+	return nil
+}
+
 func (s *memoryStore) UpdateSessionState(ctx context.Context, input agentsession.UpdateSessionStateInput) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -3360,6 +3380,42 @@ func TestServiceConstructorsAndDelegates(t *testing.T) {
 	sessionStore := agentsession.NewSQLiteStore(t.TempDir(), t.TempDir())
 	if sessionStore == nil {
 		t.Fatalf("expected JSON session store")
+	}
+}
+
+func TestServiceListSessionsPromotesDefaultTitlesFromUserMessages(t *testing.T) {
+	manager := newRuntimeConfigManager(t)
+	store := newMemoryStore()
+	service := NewWithFactory(manager, tools.NewRegistry(), store, nil, nil)
+
+	session := agentsession.New("New Session")
+	session.Messages = []providertypes.Message{
+		{
+			Role: providertypes.RoleUser,
+			Parts: []providertypes.ContentPart{
+				providertypes.NewTextPart("Investigate /session title issue"),
+			},
+		},
+	}
+	store.sessions[session.ID] = cloneSession(session)
+
+	summaries, err := service.ListSessions(context.Background())
+	if err != nil {
+		t.Fatalf("ListSessions() error = %v", err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("expected 1 summary, got %d", len(summaries))
+	}
+	if summaries[0].Title != "Investigate /session title issue" {
+		t.Fatalf("summary title = %q, want promoted title", summaries[0].Title)
+	}
+
+	loaded, err := store.LoadSession(context.Background(), session.ID)
+	if err != nil {
+		t.Fatalf("LoadSession() error = %v", err)
+	}
+	if loaded.Title != "Investigate /session title issue" {
+		t.Fatalf("stored title = %q, want promoted title", loaded.Title)
 	}
 }
 

--- a/internal/session/input_preparer.go
+++ b/internal/session/input_preparer.go
@@ -15,6 +15,7 @@ import (
 )
 
 const imageOnlySessionTitle = "Image Message"
+const defaultSessionTitle = "New Session"
 
 // PrepareImageInput 表示一次用户输入中附带的本地图片引用。
 type PrepareImageInput struct {
@@ -76,6 +77,10 @@ type assetCleanupStore interface {
 
 type sessionCleanupStore interface {
 	DeleteSession(ctx context.Context, sessionID string) error
+}
+
+type sessionTitleUpdateStore interface {
+	UpdateSessionTitle(ctx context.Context, input UpdateSessionTitleInput) error
 }
 
 // NewInputPreparer 创建会话输入归一化组件。
@@ -155,7 +160,7 @@ func (p *InputPreparer) Prepare(ctx context.Context, input PrepareInput) (Prepar
 		p.cleanupSavedAssets(ctx, session.ID, savedAssets)
 		return PreparedInput{}, fmt.Errorf("session: normalize parts: %w", err)
 	}
-	if err := p.persistSessionWorkdirUpdate(ctx, pendingUpdate); err != nil {
+	if err := p.persistSessionMetadataUpdate(ctx, pendingUpdate); err != nil {
 		p.rollbackCreatedSession(ctx, session.ID, sessionCreated)
 		p.cleanupSavedAssets(ctx, session.ID, savedAssets)
 		return PreparedInput{}, err
@@ -318,10 +323,11 @@ func resolveImagePath(workdir string, path string) (string, error) {
 	return resolved, nil
 }
 
-// sessionWorkdirUpdate 描述已有会话 workdir 的待提交变更，确保 Prepare 成功后再落盘。
-type sessionWorkdirUpdate struct {
-	session Session
-	dirty   bool
+// sessionMetadataUpdate 描述已有会话头部字段的待提交变更，确保 Prepare 成功后再落盘。
+type sessionMetadataUpdate struct {
+	session      Session
+	dirtyWorkdir bool
+	dirtyTitle   bool
 }
 
 func (p *InputPreparer) loadOrCreateSession(
@@ -330,11 +336,11 @@ func (p *InputPreparer) loadOrCreateSession(
 	title string,
 	defaultWorkdir string,
 	requestedWorkdir string,
-) (Session, bool, sessionWorkdirUpdate, error) {
+) (Session, bool, sessionMetadataUpdate, error) {
 	if strings.TrimSpace(sessionID) == "" {
 		sessionWorkdir, err := resolveWorkdirForInput(defaultWorkdir, "", requestedWorkdir)
 		if err != nil {
-			return Session{}, false, sessionWorkdirUpdate{}, err
+			return Session{}, false, sessionMetadataUpdate{}, err
 		}
 		session := NewWithWorkdir(title, sessionWorkdir)
 		establishPreparedSessionVerificationProfile(&session)
@@ -346,33 +352,41 @@ func (p *InputPreparer) loadOrCreateSession(
 			Head:      session.HeadSnapshot(),
 		})
 		if err != nil {
-			return Session{}, false, sessionWorkdirUpdate{}, err
+			return Session{}, false, sessionMetadataUpdate{}, err
 		}
-		return created, true, sessionWorkdirUpdate{}, nil
+		return created, true, sessionMetadataUpdate{}, nil
 	}
 
 	session, err := p.store.LoadSession(ctx, sessionID)
 	if err != nil {
-		return Session{}, false, sessionWorkdirUpdate{}, err
+		return Session{}, false, sessionMetadataUpdate{}, err
+	}
+	pending := sessionMetadataUpdate{}
+	if shouldPromoteSessionTitle(session.Title, title) {
+		session.Title = strings.TrimSpace(title)
+		pending.dirtyTitle = true
 	}
 	if strings.TrimSpace(requestedWorkdir) == "" && strings.TrimSpace(session.Workdir) != "" {
-		return session, false, sessionWorkdirUpdate{}, nil
+		if pending.dirtyTitle {
+			session.UpdatedAt = time.Now()
+			pending.session = session
+		}
+		return session, false, pending, nil
 	}
 
 	resolved, err := resolveWorkdirForInput(defaultWorkdir, session.Workdir, requestedWorkdir)
 	if err != nil {
-		return Session{}, false, sessionWorkdirUpdate{}, err
+		return Session{}, false, sessionMetadataUpdate{}, err
 	}
-	if session.Workdir == resolved {
-		return session, false, sessionWorkdirUpdate{}, nil
+	if session.Workdir != resolved {
+		session.Workdir = resolved
+		pending.dirtyWorkdir = true
 	}
-
-	session.Workdir = resolved
-	session.UpdatedAt = time.Now()
-	return session, false, sessionWorkdirUpdate{
-		session: session,
-		dirty:   true,
-	}, nil
+	if pending.dirtyWorkdir || pending.dirtyTitle {
+		session.UpdatedAt = time.Now()
+		pending.session = session
+	}
+	return session, false, pending, nil
 }
 
 // rollbackCreatedSession 在本次 Prepare 新建会话后发生错误时回滚会话目录，避免残留孤儿会话。
@@ -390,17 +404,43 @@ func (p *InputPreparer) rollbackCreatedSession(ctx context.Context, sessionID st
 	_ = cleanupStore.DeleteSession(ctx, sessionID)
 }
 
-// persistSessionWorkdirUpdate 在 Prepare 其余步骤完成后统一提交会话 workdir 更新，避免失败时出现部分提交。
-func (p *InputPreparer) persistSessionWorkdirUpdate(ctx context.Context, pending sessionWorkdirUpdate) error {
-	if !pending.dirty {
+// persistSessionMetadataUpdate 在 Prepare 其余步骤完成后统一提交会话头最小更新，避免失败时出现部分提交。
+func (p *InputPreparer) persistSessionMetadataUpdate(ctx context.Context, pending sessionMetadataUpdate) error {
+	if !pending.dirtyWorkdir && !pending.dirtyTitle {
 		return nil
 	}
-	if err := p.store.UpdateSessionWorkdir(ctx, UpdateSessionWorkdirInput{
-		SessionID: pending.session.ID,
-		UpdatedAt: pending.session.UpdatedAt,
-		Workdir:   pending.session.Workdir,
-	}); err != nil {
-		return err
+
+	updatedByState := false
+	if pending.dirtyTitle {
+		if titleUpdater, ok := p.store.(sessionTitleUpdateStore); ok {
+			if err := titleUpdater.UpdateSessionTitle(ctx, UpdateSessionTitleInput{
+				SessionID: pending.session.ID,
+				UpdatedAt: pending.session.UpdatedAt,
+				Title:     pending.session.Title,
+			}); err != nil {
+				return err
+			}
+		} else {
+			updatedByState = true
+			if err := p.store.UpdateSessionState(ctx, UpdateSessionStateInput{
+				SessionID: pending.session.ID,
+				Title:     pending.session.Title,
+				UpdatedAt: pending.session.UpdatedAt,
+				Head:      pending.session.HeadSnapshot(),
+			}); err != nil {
+				return err
+			}
+		}
+	}
+
+	if pending.dirtyWorkdir && !updatedByState {
+		if err := p.store.UpdateSessionWorkdir(ctx, UpdateSessionWorkdirInput{
+			SessionID: pending.session.ID,
+			UpdatedAt: pending.session.UpdatedAt,
+			Workdir:   pending.session.Workdir,
+		}); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -453,5 +493,17 @@ func buildSessionTitle(text string, hasImages bool) string {
 	if hasImages {
 		return imageOnlySessionTitle
 	}
-	return "New Session"
+	return defaultSessionTitle
+}
+
+func shouldPromoteSessionTitle(current string, next string) bool {
+	trimmedCurrent := strings.TrimSpace(current)
+	trimmedNext := strings.TrimSpace(next)
+	if trimmedNext == "" {
+		return false
+	}
+	if strings.EqualFold(trimmedNext, defaultSessionTitle) {
+		return false
+	}
+	return strings.EqualFold(trimmedCurrent, defaultSessionTitle)
 }

--- a/internal/session/input_preparer_test.go
+++ b/internal/session/input_preparer_test.go
@@ -571,6 +571,31 @@ func TestInputPreparerPrepareKeepsExistingNonDefaultTitle(t *testing.T) {
 	}
 }
 
+func TestInputPreparerShouldPromoteSessionTitle(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		current string
+		next    string
+		want    bool
+	}{
+		{name: "promote default", current: "New Session", next: "real title", want: true},
+		{name: "reject empty", current: "New Session", next: "   ", want: false},
+		{name: "reject default next", current: "New Session", next: "new session", want: false},
+		{name: "reject non-default current", current: "Named", next: "other", want: false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := shouldPromoteSessionTitle(tc.current, tc.next); got != tc.want {
+				t.Fatalf("shouldPromoteSessionTitle(%q,%q)=%v, want %v", tc.current, tc.next, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestInputPreparerPrepareWorkdirUpdatePreservesConcurrentSessionHeadChanges(t *testing.T) {
 	t.Parallel()
 

--- a/internal/session/input_preparer_test.go
+++ b/internal/session/input_preparer_test.go
@@ -509,6 +509,68 @@ func TestInputPreparerPrepareUpdatesExistingSessionWorkdir(t *testing.T) {
 	}
 }
 
+func TestInputPreparerPreparePromotesDefaultSessionTitle(t *testing.T) {
+	t.Parallel()
+
+	workdir := t.TempDir()
+	store := newInputPreparerTestStore(t, workdir)
+	preparer := NewInputPreparer(store, store)
+
+	session := NewWithWorkdir(defaultSessionTitle, workdir)
+	if err := createSessionForPreparerTest(context.Background(), store, session); err != nil {
+		t.Fatalf("createSessionForPreparerTest() error = %v", err)
+	}
+
+	result, err := preparer.Prepare(context.Background(), PrepareInput{
+		SessionID:      session.ID,
+		Text:           "investigate session title regression",
+		DefaultWorkdir: workdir,
+	})
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	if result.SessionID != session.ID {
+		t.Fatalf("expected session id %q, got %q", session.ID, result.SessionID)
+	}
+
+	loaded, err := store.LoadSession(context.Background(), session.ID)
+	if err != nil {
+		t.Fatalf("LoadSession() error = %v", err)
+	}
+	if loaded.Title != "investigate session title regression" {
+		t.Fatalf("expected promoted title, got %q", loaded.Title)
+	}
+}
+
+func TestInputPreparerPrepareKeepsExistingNonDefaultTitle(t *testing.T) {
+	t.Parallel()
+
+	workdir := t.TempDir()
+	store := newInputPreparerTestStore(t, workdir)
+	preparer := NewInputPreparer(store, store)
+
+	session := NewWithWorkdir("Already Titled", workdir)
+	if err := createSessionForPreparerTest(context.Background(), store, session); err != nil {
+		t.Fatalf("createSessionForPreparerTest() error = %v", err)
+	}
+
+	if _, err := preparer.Prepare(context.Background(), PrepareInput{
+		SessionID:      session.ID,
+		Text:           "follow-up prompt should not replace title",
+		DefaultWorkdir: workdir,
+	}); err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+
+	loaded, err := store.LoadSession(context.Background(), session.ID)
+	if err != nil {
+		t.Fatalf("LoadSession() error = %v", err)
+	}
+	if loaded.Title != "Already Titled" {
+		t.Fatalf("expected original title to be kept, got %q", loaded.Title)
+	}
+}
+
 func TestInputPreparerPrepareWorkdirUpdatePreservesConcurrentSessionHeadChanges(t *testing.T) {
 	t.Parallel()
 

--- a/internal/session/sqlite_store.go
+++ b/internal/session/sqlite_store.go
@@ -377,6 +377,35 @@ WHERE id = ?
 	return expectRowsAffected(result, input.SessionID)
 }
 
+// UpdateSessionTitle 仅更新会话 title 与更新时间，避免 Prepare 阶段覆盖其他会话头字段。
+func (s *SQLiteStore) UpdateSessionTitle(ctx context.Context, input UpdateSessionTitleInput) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := validateStorageID("session id", input.SessionID); err != nil {
+		return fmt.Errorf("session: %w", err)
+	}
+	db, err := s.ensureDB(ctx)
+	if err != nil {
+		return err
+	}
+
+	result, err := db.ExecContext(ctx, `
+UPDATE sessions
+SET updated_at_ms = ?,
+	title = ?
+WHERE id = ?
+`,
+		toUnixMillis(resolveUpdatedAt(input.UpdatedAt)),
+		sanitizeTitle(input.Title),
+		input.SessionID,
+	)
+	if err != nil {
+		return fmt.Errorf("session: update session title %s: %w", input.SessionID, err)
+	}
+	return expectRowsAffected(result, input.SessionID)
+}
+
 // UpdateSessionState 仅更新会话头字段，不写入消息。
 func (s *SQLiteStore) UpdateSessionState(ctx context.Context, input UpdateSessionStateInput) error {
 	if err := ctx.Err(); err != nil {

--- a/internal/session/sqlite_store_additional_test.go
+++ b/internal/session/sqlite_store_additional_test.go
@@ -39,6 +39,9 @@ func TestSQLiteStoreMethodsRespectCanceledContext(t *testing.T) {
 	if err := store.UpdateSessionState(ctx, UpdateSessionStateInput{SessionID: "cancel_ctx", Title: "x"}); err == nil {
 		t.Fatalf("expected UpdateSessionState canceled error")
 	}
+	if err := store.UpdateSessionTitle(ctx, UpdateSessionTitleInput{SessionID: "cancel_ctx", Title: "x"}); err == nil {
+		t.Fatalf("expected UpdateSessionTitle canceled error")
+	}
 	if err := store.ReplaceTranscript(ctx, ReplaceTranscriptInput{SessionID: "cancel_ctx"}); err == nil {
 		t.Fatalf("expected ReplaceTranscript canceled error")
 	}
@@ -62,8 +65,40 @@ func TestSQLiteStoreMethodsRejectInvalidSessionID(t *testing.T) {
 	if err := store.UpdateSessionState(ctx, UpdateSessionStateInput{SessionID: "bad/id", Title: "x"}); err == nil {
 		t.Fatalf("expected UpdateSessionState invalid id error")
 	}
+	if err := store.UpdateSessionTitle(ctx, UpdateSessionTitleInput{SessionID: "bad/id", Title: "x"}); err == nil {
+		t.Fatalf("expected UpdateSessionTitle invalid id error")
+	}
 	if err := store.ReplaceTranscript(ctx, ReplaceTranscriptInput{SessionID: "bad/id"}); err == nil {
 		t.Fatalf("expected ReplaceTranscript invalid id error")
+	}
+}
+
+func TestSQLiteStoreUpdateSessionTitlePersistsSanitizedTitle(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	created, err := store.CreateSession(context.Background(), CreateSessionInput{
+		ID:    "title_update_case",
+		Title: "New Session",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+	updatedAt := created.UpdatedAt.Add(time.Minute)
+	if err := store.UpdateSessionTitle(context.Background(), UpdateSessionTitleInput{
+		SessionID: created.ID,
+		UpdatedAt: updatedAt,
+		Title:     " line1 \n\t line2 ",
+	}); err != nil {
+		t.Fatalf("UpdateSessionTitle() error = %v", err)
+	}
+
+	loaded, err := store.LoadSession(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("LoadSession() error = %v", err)
+	}
+	if loaded.Title != "line1 line2" {
+		t.Fatalf("expected sanitized single-line title, got %q", loaded.Title)
 	}
 }
 

--- a/internal/session/sqlite_store_additional_test.go
+++ b/internal/session/sqlite_store_additional_test.go
@@ -231,6 +231,20 @@ func TestNormalizeCreateSessionInputDefaultsGeneratedID(t *testing.T) {
 	}
 }
 
+func TestNormalizeCreateSessionInputNormalizesMultilineTitle(t *testing.T) {
+	t.Parallel()
+
+	session, err := normalizeCreateSessionInput(CreateSessionInput{
+		Title: "  first line\n\tsecond line   third  ",
+	})
+	if err != nil {
+		t.Fatalf("normalizeCreateSessionInput() error = %v", err)
+	}
+	if session.Title != "first line second line third" {
+		t.Fatalf("normalized title = %q, want single-line collapsed whitespace", session.Title)
+	}
+}
+
 func TestSQLiteStoreCreateSessionPropagatesEnsureStorageDirsError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -108,6 +108,13 @@ type UpdateSessionWorkdirInput struct {
 	Workdir   string
 }
 
+// UpdateSessionTitleInput 描述一次仅更新会话 title 的最小粒度写入。
+type UpdateSessionTitleInput struct {
+	SessionID string
+	UpdatedAt time.Time
+	Title     string
+}
+
 // ReplaceTranscriptInput 描述 compact 后整段 transcript 的原子替换。
 type ReplaceTranscriptInput struct {
 	SessionID string
@@ -221,7 +228,7 @@ func cloneTodoItems(items []TodoItem) []TodoItem {
 
 // sanitizeTitle 规范化会话标题，保证空标题和超长标题都有稳定表现。
 func sanitizeTitle(title string) string {
-	title = strings.TrimSpace(title)
+	title = strings.Join(strings.Fields(strings.TrimSpace(title)), " ")
 	if title == "" {
 		return "New Session"
 	}

--- a/internal/tui/core/app/app.go
+++ b/internal/tui/core/app/app.go
@@ -104,6 +104,8 @@ type appRuntimeState struct {
 	nowFn                     func() time.Time
 	lastInputEditAt           time.Time
 	lastPasteLikeAt           time.Time
+	pasteSessionStartedAt     time.Time
+	pasteSessionUntil         time.Time
 	pendingCtrlVPasteEcho     string
 	pendingCtrlVEchoUntil     time.Time
 	deferredPastedTextLoadCmd tea.Cmd
@@ -113,6 +115,8 @@ type appRuntimeState struct {
 	pasteTxnActive            bool
 	pasteTxnBuffer            string
 	pasteTxnVersion           int
+	pasteTxnTokenInjected     bool
+	pasteTxnInjectedToken     string
 	inputBurstStart           time.Time
 	inputBurstCount           int
 	pasteMode                 bool
@@ -186,6 +190,7 @@ type pendingTextPaste struct {
 	Token     string
 	FilePath  string
 	LineCount int
+	Loaded    bool
 }
 
 type queuedInterventionInput struct {

--- a/internal/tui/core/app/command_menu.go
+++ b/internal/tui/core/app/command_menu.go
@@ -87,7 +87,7 @@ type sessionItem struct {
 }
 
 func (s sessionItem) Title() string {
-	return s.Summary.Title
+	return normalizeSessionTitleSingleLine(s.Summary.Title)
 }
 
 func (s sessionItem) Description() string {
@@ -95,7 +95,7 @@ func (s sessionItem) Description() string {
 }
 
 func (s sessionItem) FilterValue() string {
-	return strings.ToLower(s.Summary.Title)
+	return strings.ToLower(normalizeSessionTitleSingleLine(s.Summary.Title))
 }
 
 type selectionItem struct {
@@ -205,7 +205,7 @@ func pickerItemText(item list.Item) (string, string) {
 	case selectionItem:
 		return strings.TrimSpace(entry.name), strings.TrimSpace(entry.description)
 	case sessionItem:
-		return strings.TrimSpace(entry.Summary.Title), strings.TrimSpace(entry.Summary.UpdatedAt.Format("01-02 15:04"))
+		return normalizeSessionTitleSingleLine(entry.Summary.Title), strings.TrimSpace(entry.Summary.UpdatedAt.Format("01-02 15:04"))
 	default:
 		var title, subtitle string
 		if titled, ok := item.(interface{ Title() string }); ok {
@@ -216,6 +216,10 @@ func pickerItemText(item list.Item) (string, string) {
 		}
 		return title, subtitle
 	}
+}
+
+func normalizeSessionTitleSingleLine(title string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(title)), " ")
 }
 
 type sessionDelegate struct {
@@ -240,7 +244,7 @@ func (d sessionDelegate) Render(w io.Writer, m list.Model, index int, item list.
 		return
 	}
 	fmt.Fprint(w, tuicomponents.RenderSessionRow(tuicomponents.SessionRowData{
-		Title:           session.Summary.Title,
+		Title:           normalizeSessionTitleSingleLine(session.Summary.Title),
 		UpdatedAtLabel:  session.Summary.UpdatedAt.Format("01-02 15:04"),
 		Active:          session.Active,
 		Selected:        index == m.Index(),

--- a/internal/tui/core/app/command_menu_test.go
+++ b/internal/tui/core/app/command_menu_test.go
@@ -224,6 +224,17 @@ func TestSessionItemAccessors(t *testing.T) {
 	}
 }
 
+func TestSessionItemAccessorsNormalizeMultilineTitle(t *testing.T) {
+	updatedAt := time.Date(2026, 4, 22, 8, 30, 0, 0, time.UTC)
+	item := sessionItem{Summary: agentsession.Summary{Title: "Line1\n\tLine2  Line3", UpdatedAt: updatedAt}}
+	if item.Title() != "Line1 Line2 Line3" {
+		t.Fatalf("Title() = %q, want single-line title", item.Title())
+	}
+	if item.FilterValue() != "line1 line2 line3" {
+		t.Fatalf("FilterValue() = %q, want normalized lowercase single line", item.FilterValue())
+	}
+}
+
 type titledOnlyItem struct{ title string }
 
 func (i titledOnlyItem) Title() string { return i.title }
@@ -250,6 +261,17 @@ func TestPickerItemTextFallbackBranches(t *testing.T) {
 	title, subtitle = pickerItemText(describedOnlyItem{description: "  only-desc  "})
 	if title != "" || subtitle != "only-desc" {
 		t.Fatalf("unexpected desc-only result: title=%q subtitle=%q", title, subtitle)
+	}
+
+	title, subtitle = pickerItemText(sessionItem{Summary: agentsession.Summary{
+		Title:     "A\nB",
+		UpdatedAt: time.Date(2026, 4, 30, 5, 14, 0, 0, time.UTC),
+	}})
+	if title != "A B" {
+		t.Fatalf("unexpected session title normalization: %q", title)
+	}
+	if subtitle != "04-30 05:14" {
+		t.Fatalf("unexpected session subtitle: %q", subtitle)
 	}
 }
 

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -60,6 +60,8 @@ const footerErrorFlashDuration = 8 * time.Second
 const pasteTxnFlushDebounce = 140 * time.Millisecond
 const pastedTextLoadDebounce = 180 * time.Millisecond
 const duplicatePasteSuppressWindow = 1200 * time.Millisecond
+const pasteSessionMinGuard = 2 * time.Second
+const pasteSessionPerLineGuard = 8 * time.Millisecond
 const inlineLogMarker = "[[neo-log]] "
 const sessionWorkdirMissingWarning = "Session workspace not found, keeping current workspace."
 
@@ -143,9 +145,21 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if !a.loadingPastedText {
 			return a, batchUpdateCmds()
 		}
+		now := a.now()
+		if !a.shouldCompletePastedTextLoading(now) {
+			a.deferredPastedTextLoadCmd = schedulePastedTextLoadReady()
+			return a, batchUpdateCmds()
+		}
 		a.loadingPastedText = false
 		if a.state.StatusText == statusLoadingPastedText {
 			a.state.StatusText = statusReady
+		}
+		if current := a.input.Value(); strings.TrimSpace(current) != "" && !strings.HasSuffix(current, " ") {
+			a.input.SetValue(current + " ")
+			a.state.InputText = a.input.Value()
+			a.normalizeComposerHeight()
+			a.applyComponentLayout(false)
+			a.refreshCommandMenu()
 		}
 		if !a.pendingSendAfterPasteLoad {
 			return a, batchUpdateCmds()
@@ -1031,23 +1045,69 @@ func (a *App) beginPastedTextLoading() {
 	a.skipNextSendPasteLoadWait = false
 }
 
+func (a *App) shouldCompletePastedTextLoading(now time.Time) bool {
+	if a.pasteTxnActive {
+		return false
+	}
+	if a.hasPendingCtrlVPasteEcho(now) {
+		return false
+	}
+	// Once paste stream and echo settle, pending tokens become resolvable.
+	a.markPendingTextPastesLoaded()
+	// Keep loading if there are still unresolved tokens in the current input.
+	if a.shouldDeferSendForPastedTextLoad(a.input.Value()) {
+		return false
+	}
+	return true
+}
+
+func (a *App) markPendingTextPastesLoaded() {
+	if len(a.pendingTextPastes) == 0 {
+		return
+	}
+	for i := range a.pendingTextPastes {
+		a.pendingTextPastes[i].Loaded = true
+	}
+}
+
+func (a *App) extendPasteSession(now time.Time, lineCount int) {
+	if lineCount < 1 {
+		lineCount = 1
+	}
+	window := pasteSessionMinGuard + time.Duration(lineCount)*pasteSessionPerLineGuard
+	if a.pasteSessionStartedAt.IsZero() || now.After(a.pasteSessionUntil) {
+		a.pasteSessionStartedAt = now
+	}
+	until := a.pasteSessionStartedAt.Add(window)
+	if until.After(a.pasteSessionUntil) {
+		a.pasteSessionUntil = until
+	}
+	a.lastPasteLikeAt = now
+}
+
+func (a App) inPasteSessionWindow(now time.Time) bool {
+	if a.pasteTxnActive || a.hasPendingCtrlVPasteEcho(now) {
+		return true
+	}
+	return !a.pasteSessionUntil.IsZero() && now.Before(a.pasteSessionUntil)
+}
+
 func (a *App) shouldTreatEnterAsNewline(typed tea.KeyMsg, now time.Time) bool {
 	if !key.Matches(typed, a.keys.Send) {
 		return false
 	}
 	if typed.Paste {
 		a.pasteMode = true
-		a.lastPasteLikeAt = now
+		a.extendPasteSession(now, countPasteLines(normalizeClipboardText(string(typed.Runes))))
 		return true
 	}
 	if a.pasteMode &&
-		!a.lastPasteLikeAt.IsZero() &&
+		a.inPasteSessionWindow(now) &&
 		!a.lastInputEditAt.IsZero() &&
-		now.Sub(a.lastPasteLikeAt) <= pasteSessionGuard &&
 		now.Sub(a.lastInputEditAt) <= pasteEnterGuard {
 		return true
 	}
-	if a.pasteMode && !a.lastPasteLikeAt.IsZero() && now.Sub(a.lastPasteLikeAt) > pasteSessionGuard {
+	if a.pasteMode && !a.inPasteSessionWindow(now) {
 		a.pasteMode = false
 		a.pasteSessionBase = ""
 	}
@@ -1108,7 +1168,11 @@ func (a *App) noteInputEdit(before string, after string, typed tea.KeyMsg, now t
 		if a.pasteSessionBase == "" {
 			a.pasteSessionBase = before
 		}
-		a.lastPasteLikeAt = now
+		lineHint := countPasteLines(normalizeClipboardText(string(typed.Runes)))
+		if lineHint < 1 {
+			lineHint = countPasteLines(normalizeClipboardText(after))
+		}
+		a.extendPasteSession(now, lineHint)
 		a.pasteMode = true
 	} else if !a.pasteMode {
 		a.pasteSessionBase = ""
@@ -1136,6 +1200,9 @@ func (a *App) maybeCollapseLongPaste(msg tea.Msg, typed tea.KeyMsg, now time.Tim
 	if summarized == content {
 		a.recordRecentPastedContent(content, now)
 		return msg, typed, false
+	}
+	if token, ok := parsePasteSummaryToken(summarized); ok && strings.HasSuffix(a.input.Value(), token) {
+		return msg, typed, true
 	}
 	next := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(summarized), Paste: true}
 	return next, next, false
@@ -1190,12 +1257,23 @@ func (a *App) summarizePastedText(content string) (text string, summarized bool,
 	lineCount := countPasteLines(normalized)
 	token := formatPasteSummaryToken(lineCount)
 	now := a.now()
+	if pinned, ok := a.reuseSinglePasteSessionToken(now); ok {
+		a.beginPastedTextLoading()
+		a.extendPasteSession(now, lineCount)
+		a.recordRecentPastedContent(normalized, now)
+		a.lastSummarizedPasteText = normalized
+		a.lastSummarizedPasteAt = now
+		a.lastSummarizedPasteToken = pinned
+		return pinned, true, nil
+	}
 	if a.shouldReusePasteSummaryToken(token, normalized, now) {
 		a.beginPastedTextLoading()
+		a.extendPasteSession(now, lineCount)
 		a.recordRecentPastedContent(normalized, now)
 		a.lastSummarizedPasteText = normalized
 		a.lastSummarizedPasteAt = now
 		a.lastSummarizedPasteToken = token
+		a.markPasteSessionToken(token)
 		return token, true, nil
 	}
 	path, saveErr := savePastedTextToTempFile(normalized, "paste")
@@ -1208,11 +1286,40 @@ func (a *App) summarizePastedText(content string) (text string, summarized bool,
 		LineCount: lineCount,
 	})
 	a.beginPastedTextLoading()
+	a.extendPasteSession(now, lineCount)
 	a.recordRecentPastedContent(normalized, now)
 	a.lastSummarizedPasteText = normalized
 	a.lastSummarizedPasteAt = now
 	a.lastSummarizedPasteToken = token
+	a.markPasteSessionToken(token)
 	return token, true, nil
+}
+
+func (a *App) reuseSinglePasteSessionToken(now time.Time) (string, bool) {
+	token := strings.TrimSpace(a.pasteTxnInjectedToken)
+	if !a.pasteTxnTokenInjected || token == "" {
+		return "", false
+	}
+	if !a.isInPinnedPasteSession(now) {
+		return "", false
+	}
+	if !a.hasPendingTextPasteToken(token) {
+		return "", false
+	}
+	return token, true
+}
+
+func (a *App) markPasteSessionToken(token string) {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return
+	}
+	a.pasteTxnTokenInjected = true
+	a.pasteTxnInjectedToken = token
+}
+
+func (a App) isInPinnedPasteSession(now time.Time) bool {
+	return a.inPasteSessionWindow(now)
 }
 
 func (a App) shouldSuppressDuplicatePasteContent(content string, now time.Time) bool {
@@ -1240,7 +1347,7 @@ func (a App) shouldSuppressDuplicatePasteContent(content string, now time.Time) 
 		if a.pasteTxnActive || a.hasPendingCtrlVPasteEcho(now) {
 			return true
 		}
-		if !a.lastPasteLikeAt.IsZero() && now.Sub(a.lastPasteLikeAt) <= pasteSessionGuard {
+		if a.inPasteSessionWindow(now) {
 			return true
 		}
 		if token == a.lastSummarizedPasteToken &&
@@ -1292,7 +1399,7 @@ func (a App) shouldReusePasteSummaryToken(token string, normalized string, now t
 	if a.pasteTxnActive || a.hasPendingCtrlVPasteEcho(now) {
 		return true
 	}
-	return !a.lastPasteLikeAt.IsZero() && now.Sub(a.lastPasteLikeAt) <= pasteSessionGuard
+	return a.inPasteSessionWindow(now)
 }
 
 func (a App) hasPendingTextPasteToken(token string) bool {
@@ -1364,7 +1471,7 @@ func (a App) shouldDeferSendForPastedTextLoad(input string) bool {
 		return false
 	}
 	for _, pending := range a.pendingTextPastes {
-		if pending.Token == "" {
+		if pending.Token == "" || pending.Loaded {
 			continue
 		}
 		if strings.Contains(input, pending.Token) {
@@ -1417,6 +1524,8 @@ func normalizeClipboardText(content string) string {
 func (a *App) resetPasteHeuristics() {
 	a.lastInputEditAt = time.Time{}
 	a.lastPasteLikeAt = time.Time{}
+	a.pasteSessionStartedAt = time.Time{}
+	a.pasteSessionUntil = time.Time{}
 	a.pendingCtrlVPasteEcho = ""
 	a.pendingCtrlVEchoUntil = time.Time{}
 	a.deferredPastedTextLoadCmd = nil
@@ -1428,6 +1537,8 @@ func (a *App) resetPasteHeuristics() {
 	a.pasteTxnActive = false
 	a.pasteTxnBuffer = ""
 	a.pasteTxnVersion = 0
+	a.pasteTxnTokenInjected = false
+	a.pasteTxnInjectedToken = ""
 	a.inputBurstStart = time.Time{}
 	a.inputBurstCount = 0
 	a.pasteMode = false
@@ -1621,10 +1732,15 @@ func (a App) shouldCapturePasteTxnChunk(typed tea.KeyMsg) bool {
 	if typed.Paste {
 		return false
 	}
-	if a.pasteTxnActive {
-		return true
-	}
 	chunk := string(typed.Runes)
+	if a.pasteTxnActive {
+		// Do not lock the input while a paste transaction is open:
+		// only keep capturing obviously paste-like chunks.
+		if len(typed.Runes) > 1 {
+			return true
+		}
+		return strings.ContainsRune(chunk, '\n') || strings.ContainsRune(chunk, '\r') || strings.ContainsRune(chunk, '\t')
+	}
 	if len(typed.Runes) > 1 {
 		return true
 	}
@@ -1658,14 +1774,19 @@ func (a *App) appendPasteTxnChunk(chunk string) {
 		return
 	}
 	chunk = normalizeClipboardText(chunk)
+	lineHint := countPasteLines(chunk)
 	if !a.pasteTxnActive {
 		a.pasteTxnActive = true
 		a.pasteTxnBuffer = chunk
 		a.pasteTxnVersion++
+		a.pasteTxnTokenInjected = false
+		a.pasteTxnInjectedToken = ""
+		a.extendPasteSession(a.now(), lineHint)
 		return
 	}
 	a.pasteTxnBuffer += chunk
 	a.pasteTxnVersion++
+	a.extendPasteSession(a.now(), lineHint)
 }
 
 func (a *App) flushPasteTransaction() {

--- a/internal/tui/core/app/update_test.go
+++ b/internal/tui/core/app/update_test.go
@@ -2093,6 +2093,82 @@ func TestUpdatePasteLoadingClearsAfterLoadReadyWithoutSend(t *testing.T) {
 	}
 }
 
+func TestUpdatePastedTextLoadReadyReschedulesWhenPasteTxnActive(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.loadingPastedText = true
+	app.pasteTxnActive = true
+
+	model, cmd := app.Update(pastedTextLoadReadyMsg{})
+	app = model.(App)
+	if !app.loadingPastedText {
+		t.Fatalf("expected loading state to remain when paste txn is active")
+	}
+	if cmd == nil {
+		t.Fatalf("expected re-schedule command when pasted text is not ready")
+	}
+}
+
+func TestUpdatePastedTextLoadReadyAppendsSeparatorBeforeDeferredSend(t *testing.T) {
+	app, runtime := newTestApp(t)
+	app.loadingPastedText = true
+	app.pendingSendAfterPasteLoad = true
+	app.input.SetValue("hello")
+	app.state.InputText = app.input.Value()
+
+	model, cmd := app.Update(pastedTextLoadReadyMsg{})
+	if cmd != nil {
+		_ = cmd()
+	}
+	app = model.(App)
+
+	if len(runtime.prepareInputs) != 1 {
+		t.Fatalf("expected deferred send to run once, got %d", len(runtime.prepareInputs))
+	}
+	if runtime.prepareInputs[0].Text != "hello" {
+		t.Fatalf("unexpected deferred send payload: %q", runtime.prepareInputs[0].Text)
+	}
+	if app.loadingPastedText || app.pendingSendAfterPasteLoad {
+		t.Fatalf("expected loading flags cleared after deferred send")
+	}
+}
+
+func TestPasteSessionHelpers(t *testing.T) {
+	app, _ := newTestApp(t)
+	now := time.Now()
+
+	app.extendPasteSession(now, 0)
+	if app.pasteSessionStartedAt.IsZero() || app.pasteSessionUntil.IsZero() {
+		t.Fatalf("expected paste session window to be initialized")
+	}
+	if !app.inPasteSessionWindow(now.Add(200 * time.Millisecond)) {
+		t.Fatalf("expected to stay within paste session window")
+	}
+
+	app.markPasteSessionToken(" token ")
+	if !app.pasteTxnTokenInjected || app.pasteTxnInjectedToken != "token" {
+		t.Fatalf("expected token to be normalized and recorded")
+	}
+
+	app.pendingTextPastes = []pendingTextPaste{{Token: "token", Loaded: false}}
+	if token, ok := app.reuseSinglePasteSessionToken(now.Add(100 * time.Millisecond)); !ok || token != "token" {
+		t.Fatalf("expected to reuse pinned paste token within session window")
+	}
+
+	app.pasteSessionUntil = now.Add(100 * time.Millisecond)
+	if _, ok := app.reuseSinglePasteSessionToken(now.Add(2 * time.Second)); ok {
+		t.Fatalf("expected token reuse to stop outside paste session window")
+	}
+
+	app.pendingCtrlVPasteEcho = "echo"
+	if app.shouldCompletePastedTextLoading(now.Add(100 * time.Millisecond)) {
+		t.Fatalf("expected pending ctrl+v echo to block completion")
+	}
+	app.pendingCtrlVPasteEcho = ""
+	if !app.shouldCompletePastedTextLoading(now.Add(200 * time.Millisecond)) {
+		t.Fatalf("expected completion after ctrl+v echo settles")
+	}
+}
+
 func TestUpdateDirectPasteEventKeepsIncomingPayload(t *testing.T) {
 	app, _ := newTestApp(t)
 	pasted := "a\nb\nc\nd\ne"

--- a/internal/tui/core/app/update_test.go
+++ b/internal/tui/core/app/update_test.go
@@ -1723,6 +1723,61 @@ func TestUpdatePasteEventSuppressesDuplicateSummaryTokenAcrossContentVariants(t 
 	}
 }
 
+func TestUpdatePasteEventSingleSessionPinsSingleTokenAcrossChunks(t *testing.T) {
+	app, _ := newTestApp(t)
+	now := time.Unix(1_720_000_000, 0)
+	app.nowFn = func() time.Time { return now }
+
+	makeLines := func(prefix string, n int) string {
+		lines := make([]string, 0, n)
+		for i := 0; i < n; i++ {
+			lines = append(lines, fmt.Sprintf("%s-%d", prefix, i+1))
+		}
+		return strings.Join(lines, "\n")
+	}
+
+	first := makeLines("big", 386)
+	second := makeLines("small", 3)
+	third := makeLines("tiny", 2)
+
+	model, cmd := app.Update(tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune(first),
+		Paste: true,
+	})
+	if cmd != nil {
+		_ = cmd()
+	}
+	app = model.(App)
+
+	model, cmd = app.Update(tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune(second),
+		Paste: true,
+	})
+	if cmd != nil {
+		_ = cmd()
+	}
+	app = model.(App)
+
+	model, cmd = app.Update(tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune(third),
+		Paste: true,
+	})
+	if cmd != nil {
+		_ = cmd()
+	}
+	app = model.(App)
+
+	if got := app.input.Value(); got != "[paste 386 LINE]" {
+		t.Fatalf("expected one pinned token in single paste session, got %q", got)
+	}
+	if len(app.pendingTextPastes) != 1 {
+		t.Fatalf("expected one pending paste record for pinned session token, got %d", len(app.pendingTextPastes))
+	}
+}
+
 func TestUpdatePasteEventSuppressesDuplicateSingleLineContent(t *testing.T) {
 	app, _ := newTestApp(t)
 	now := time.Unix(1_720_000_000, 0)


### PR DESCRIPTION
## 背景
`/session` 列表中大量会话标题显示为 `New Session`，且部分会话标题会出现多行显示，影响会话识别与选择效率。

## 根因
1. 会话在部分链路下会先以默认标题 `New Session` 建档，但后续缺少稳定的“标题回填”机制。  
2. 标题规范化仅做了 `TrimSpace`，未折叠换行/制表符，导致列表出现多行标题。

## 变更内容
1. 新增默认标题回填机制。  
- 当会话标题仍为 `New Session` 且存在有效用户输入时，自动将标题提升为首条有效用户文本摘要。  
- 在会话列表读取路径增加历史会话兜底回填，避免旧数据长期停留在默认标题。

2. 新增最小粒度标题更新能力。  
- 在 session 存储层补充“仅更新标题”的更新路径，避免使用全量会话头更新带来的覆盖风险。

3. 标题统一单行化。  
- 在标题规范化阶段将所有空白（含换行、Tab）折叠为单个空格。  
- 在 `/session` picker 渲染层做二次兜底，确保历史脏数据也只展示单行。

## 影响范围
- `internal/session`  
- `internal/runtime`  
- `internal/tui/core/app`

## 测试
已补充并通过相关单测：
- 默认标题回填逻辑测试  
- 非默认标题不覆盖测试  
- 多行标题规范化为单行测试  
- session picker 单行渲染测试

本地验证：
- `go test ./internal/session`
- `go test ./internal/tui/core/app -run ...`
- `go build ./cmd/neocode`
