### PR TITLE
feat(diag): 实现终端诊断系统 Phase 1 (Manual 模式最小闭环)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,17 @@ neocode --workdir /path/to/your/project
 /skill off <id>       停用 skill
 ```
 
-### 5. url scheme使用
+### 5. 终端诊断（Manual）
+
+```bash
+# 进入代理 shell（Phase1 仅支持 Unix）
+neocode shell
+
+# 在代理 shell 内触发诊断（默认读取 NEOCODE_DIAG_SOCKET）
+neocode diag
+```
+
+### 6. url scheme使用
 详细指南链接： [HTTP URL 唤醒使用指南（用户故事版）](https://neocode-docs.pages.dev/guide/http-daemon-wake-user-guide)
 
 ```bash

--- a/docs/gateway-rpc-api.md
+++ b/docs/gateway-rpc-api.md
@@ -265,7 +265,7 @@ type ExecuteSystemToolParams struct {
   - Failure: 标准 `error`（`missing_required_field` / `invalid_action` 等）
 - Runtime Restriction:
   - 网关层对 `tool_name` 实施白名单校验。
-  - 当前仅允许 memo 系统工具：`memo_list`、`memo_remember`、`memo_recall`、`memo_remove`。
+  - 当前允许 `memo_list`、`memo_remember`、`memo_recall`、`memo_remove`、`diagnose`。
 
 ---
 

--- a/docs/reference/gateway-rpc-api.md
+++ b/docs/reference/gateway-rpc-api.md
@@ -474,7 +474,7 @@ type ExecuteSystemToolParams struct {
 Request 约束：
 1. `tool_name` `MUST` 非空。  
 2. 网关层 `MUST` 对 `tool_name` 做白名单校验。  
-3. 当前白名单仅包含 memo 系统工具：`memo_list`、`memo_remember`、`memo_recall`、`memo_remove`。
+3. 当前白名单包含 `memo_list`、`memo_remember`、`memo_recall`、`memo_remove`、`diagnose`。
 
 Response Schema：
 1. Success：返回 `ack`，`payload` 为系统工具执行结果。  
@@ -1233,7 +1233,7 @@ Failure Response：
 
 Notes：
 
-1. `tool_name` 在网关层按白名单校验，当前仅允许 memo 系统工具。
+1. `tool_name` 在网关层按白名单校验，当前允许 `memo_list`、`memo_remember`、`memo_recall`、`memo_remove`、`diagnose`。
 
 ### gateway.activateSessionSkill
 

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/davidmz/go-pageant v1.0.2 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/creativeprojects/go-selfupdate v1.5.2 h1:3KR3JLrq70oplb9yZzbmJ89qRP78D1AN/9u+l3k0LJ4=
 github.com/creativeprojects/go-selfupdate v1.5.2/go.mod h1:BCOuwIl1dRRCmPNRPH0amULeZqayhKyY2mH/h4va7Dk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -25,6 +25,7 @@ import (
 	"neo-code/internal/skills"
 	"neo-code/internal/tools"
 	"neo-code/internal/tools/bash"
+	diagnosetool "neo-code/internal/tools/diagnose"
 	"neo-code/internal/tools/filesystem"
 	"neo-code/internal/tools/mcp"
 	memotool "neo-code/internal/tools/memo"
@@ -411,6 +412,7 @@ func buildToolRegistry(cfg config.Config) (*tools.Registry, func() error, error)
 	toolRegistry.Register(filesystem.NewGlob(cfg.Workdir))
 	toolRegistry.Register(filesystem.NewEdit(cfg.Workdir))
 	toolRegistry.Register(bash.New(cfg.Workdir, cfg.Shell, time.Duration(cfg.ToolTimeoutSec)*time.Second))
+	toolRegistry.Register(diagnosetool.New())
 	toolRegistry.Register(webfetch.New(webfetch.Config{
 		Timeout:               time.Duration(cfg.ToolTimeoutSec) * time.Second,
 		MaxResponseBytes:      cfg.Tools.WebFetch.MaxResponseBytes,

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -334,6 +334,29 @@ func TestBuildToolRegistryRegistersSpawnSubAgent(t *testing.T) {
 	}
 }
 
+func TestBuildToolRegistryRegistersDiagnose(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.StaticDefaults().Clone()
+	cfg.Workdir = t.TempDir()
+
+	registry, cleanup, err := buildToolRegistry(cfg)
+	if err != nil {
+		t.Fatalf("buildToolRegistry() error = %v", err)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	tool, err := registry.Get(tools.ToolNameDiagnose)
+	if err != nil {
+		t.Fatalf("registry.Get(diagnose) error = %v", err)
+	}
+	if tool.Name() != tools.ToolNameDiagnose {
+		t.Fatalf("tool.Name() = %q, want %q", tool.Name(), tools.ToolNameDiagnose)
+	}
+}
+
 func TestBuildMCPRegistryFromConfig(t *testing.T) {
 	stubClient := &stubMCPServerClient{
 		tools: []mcp.ToolDescriptor{

--- a/internal/cli/gateway_runtime_bridge_test.go
+++ b/internal/cli/gateway_runtime_bridge_test.go
@@ -1847,3 +1847,251 @@ func TestModelDisplayName(t *testing.T) {
 		}
 	})
 }
+
+// ---- marshalManualModelsForGateway ----
+
+func TestMarshalManualModelsForGatewayEmptyReturnsEmpty(t *testing.T) {
+	if got := marshalManualModelsForGateway(nil); got != "" {
+		t.Fatalf("expected empty for nil, got %q", got)
+	}
+	if got := marshalManualModelsForGateway([]providertypes.ModelDescriptor{}); got != "" {
+		t.Fatalf("expected empty for empty slice, got %q", got)
+	}
+}
+
+func TestMarshalManualModelsForGatewaySkipsEmptyID(t *testing.T) {
+	got := marshalManualModelsForGateway([]providertypes.ModelDescriptor{
+		{ID: "", Name: "empty ID"},
+		{ID: "valid", Name: "Valid Model"},
+	})
+	if !strings.Contains(got, "valid") {
+		t.Fatalf("result = %q, want contains valid model", got)
+	}
+	if strings.Contains(got, "empty ID") {
+		t.Fatalf("result = %q, should not contain empty ID model", got)
+	}
+}
+
+func TestMarshalManualModelsForGatewayUsesIDAsName(t *testing.T) {
+	got := marshalManualModelsForGateway([]providertypes.ModelDescriptor{
+		{ID: "gpt-4", Name: ""},
+	})
+	if !strings.Contains(got, `"name":"gpt-4"`) {
+		t.Fatalf("result = %q, want name to fall back to id", got)
+	}
+}
+
+func TestMarshalManualModelsForGatewayWithContextAndOutputTokens(t *testing.T) {
+	got := marshalManualModelsForGateway([]providertypes.ModelDescriptor{
+		{ID: "gpt-4", Name: "GPT-4", ContextWindow: 8192, MaxOutputTokens: 4096},
+	})
+	if !strings.Contains(got, `"context_window":8192`) {
+		t.Fatalf("result = %q, want context_window", got)
+	}
+	if !strings.Contains(got, `"max_output_tokens":4096`) {
+		t.Fatalf("result = %q, want max_output_tokens", got)
+	}
+}
+
+func TestMarshalManualModelsForGatewayAllSkippedReturnsEmpty(t *testing.T) {
+	got := marshalManualModelsForGateway([]providertypes.ModelDescriptor{
+		{ID: "", Name: "skip1"},
+		{ID: "  ", Name: "skip2"},
+	})
+	if got != "" {
+		t.Fatalf("expected empty when all models skipped, got %q", got)
+	}
+}
+
+// ---- ListMCPServers ----
+
+func TestGatewayRuntimePortBridgeListMCPServers(t *testing.T) {
+	cfgMgr := &configManagerStub{
+		cfg: config.Config{
+			Tools: config.ToolsConfig{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "srv-1", Enabled: true},
+					},
+				},
+			},
+		},
+	}
+	stub := &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), stub, testSessionStore, cfgMgr, nil)
+	defer bridge.Close()
+
+	entries, err := bridge.ListMCPServers(context.Background(), gateway.ListMCPServersInput{SubjectID: testBridgeSubjectID})
+	if err != nil {
+		t.Fatalf("ListMCPServers() error = %v", err)
+	}
+	if len(entries) != 1 || entries[0].ID != "srv-1" {
+		t.Fatalf("entries = %+v, want [srv-1]", entries)
+	}
+}
+
+// ---- UpsertMCPServer ----
+
+func TestGatewayRuntimePortBridgeUpsertMCPServerReplacesExisting(t *testing.T) {
+	cfgMgr := &configManagerStub{
+		cfg: config.Config{
+			Tools: config.ToolsConfig{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "srv-1", Enabled: false},
+					},
+				},
+			},
+		},
+	}
+	stub := &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), stub, testSessionStore, cfgMgr, nil)
+	defer bridge.Close()
+
+	err := bridge.UpsertMCPServer(context.Background(), gateway.UpsertMCPServerInput{
+		SubjectID: testBridgeSubjectID,
+		Server:    config.MCPServerConfig{ID: "srv-1", Enabled: true},
+	})
+	if err != nil {
+		t.Fatalf("UpsertMCPServer() error = %v", err)
+	}
+	cfg := cfgMgr.cfg
+	if len(cfg.Tools.MCP.Servers) != 1 {
+		t.Fatalf("servers count = %d, want 1", len(cfg.Tools.MCP.Servers))
+	}
+	if !cfg.Tools.MCP.Servers[0].Enabled {
+		t.Fatal("server should be enabled after upsert")
+	}
+}
+
+func TestGatewayRuntimePortBridgeUpsertMCPServerAppendsNew(t *testing.T) {
+	cfgMgr := &configManagerStub{
+		cfg: config.Config{
+			Tools: config.ToolsConfig{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "srv-1", Enabled: true},
+					},
+				},
+			},
+		},
+	}
+	stub := &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), stub, testSessionStore, cfgMgr, nil)
+	defer bridge.Close()
+
+	err := bridge.UpsertMCPServer(context.Background(), gateway.UpsertMCPServerInput{
+		SubjectID: testBridgeSubjectID,
+		Server:    config.MCPServerConfig{ID: "srv-2", Enabled: true},
+	})
+	if err != nil {
+		t.Fatalf("UpsertMCPServer() error = %v", err)
+	}
+	cfg := cfgMgr.cfg
+	if len(cfg.Tools.MCP.Servers) != 2 {
+		t.Fatalf("servers count = %d, want 2", len(cfg.Tools.MCP.Servers))
+	}
+}
+
+// ---- ListProviders (full path) ----
+
+func TestGatewayRuntimePortBridgeListProvidersWithSelection(t *testing.T) {
+	ps := &providerSelectionStub{
+		listOptions: []configstate.ProviderOption{
+			{ID: " openai ", Name: "OpenAI", Models: []providertypes.ModelDescriptor{{ID: "gpt-4"}}},
+		},
+	}
+	cfgMgr := &configManagerStub{
+		cfg: config.Config{
+			SelectedProvider: "openai",
+			Providers: []config.ProviderConfig{
+				{Name: "openai", Driver: "openai", BaseURL: "https://api.openai.com", APIKeyEnv: "OPENAI_API_KEY", Source: config.ProviderSourceBuiltin},
+			},
+		},
+	}
+	stub := &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), stub, testSessionStore, cfgMgr, ps)
+	defer bridge.Close()
+
+	options, err := bridge.ListProviders(context.Background(), gateway.ListProvidersInput{SubjectID: testBridgeSubjectID})
+	if err != nil {
+		t.Fatalf("ListProviders() error = %v", err)
+	}
+	if len(options) != 1 {
+		t.Fatalf("options len = %d, want 1", len(options))
+	}
+	if options[0].ID != "openai" {
+		t.Fatalf("options[0].ID = %q, want openai", options[0].ID)
+	}
+	if options[0].Driver != "openai" {
+		t.Fatalf("options[0].Driver = %q, want openai", options[0].Driver)
+	}
+	if !options[0].Selected {
+		t.Fatal("openai should be selected")
+	}
+	if len(options[0].Models) != 1 || options[0].Models[0].ID != "gpt-4" {
+		t.Fatalf("Models = %+v, want [gpt-4]", options[0].Models)
+	}
+}
+
+// ---- SetMCPServerEnabled (full path) ----
+
+func TestGatewayRuntimePortBridgeSetMCPServerEnabledSuccess(t *testing.T) {
+	cfgMgr := &configManagerStub{
+		cfg: config.Config{
+			Tools: config.ToolsConfig{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "srv-1", Enabled: false},
+					},
+				},
+			},
+		},
+	}
+	stub := &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), stub, testSessionStore, cfgMgr, nil)
+	defer bridge.Close()
+
+	err := bridge.SetMCPServerEnabled(context.Background(), gateway.SetMCPServerEnabledInput{
+		SubjectID: testBridgeSubjectID,
+		ID:        "srv-1",
+		Enabled:   true,
+	})
+	if err != nil {
+		t.Fatalf("SetMCPServerEnabled() error = %v", err)
+	}
+	if !cfgMgr.cfg.Tools.MCP.Servers[0].Enabled {
+		t.Fatal("server should be enabled after SetMCPServerEnabled")
+	}
+}
+
+// ---- DeleteMCPServer (full path) ----
+
+func TestGatewayRuntimePortBridgeDeleteMCPServerSuccess(t *testing.T) {
+	cfgMgr := &configManagerStub{
+		cfg: config.Config{
+			Tools: config.ToolsConfig{
+				MCP: config.MCPConfig{
+					Servers: []config.MCPServerConfig{
+						{ID: "srv-1", Enabled: true},
+						{ID: "srv-2", Enabled: true},
+					},
+				},
+			},
+		},
+	}
+	stub := &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), stub, testSessionStore, cfgMgr, nil)
+	defer bridge.Close()
+
+	err := bridge.DeleteMCPServer(context.Background(), gateway.DeleteMCPServerInput{
+		SubjectID: testBridgeSubjectID,
+		ID:        "srv-1",
+	})
+	if err != nil {
+		t.Fatalf("DeleteMCPServer() error = %v", err)
+	}
+	if len(cfgMgr.cfg.Tools.MCP.Servers) != 1 || cfgMgr.cfg.Tools.MCP.Servers[0].ID != "srv-2" {
+		t.Fatalf("servers = %+v, want [srv-2]", cfgMgr.cfg.Tools.MCP.Servers)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -98,6 +98,8 @@ func NewRootCommand() *cobra.Command {
 	cmd.AddCommand(
 		newGatewayCommand(),
 		newDaemonCommand(),
+		newShellCommand(),
+		newDiagCommand(),
 		newMigrateCommand(),
 		newVersionCommand(),
 		newUpdateCommand(),

--- a/internal/cli/shell_diag_commands.go
+++ b/internal/cli/shell_diag_commands.go
@@ -1,0 +1,138 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"neo-code/internal/ptyproxy"
+)
+
+var (
+	runShellCommand      = defaultShellCommandRunner
+	runDiagCommand       = defaultDiagCommandRunner
+	runManualShellProxy  = ptyproxy.RunManualShell
+	sendDiagnoseSignalFn = ptyproxy.SendDiagnoseSignal
+	readDiagEnvValue     = os.Getenv
+)
+
+type shellCommandOptions struct {
+	Workdir              string
+	Shell                string
+	SocketPath           string
+	GatewayListenAddress string
+	GatewayTokenFile     string
+}
+
+type diagCommandOptions struct {
+	SocketPath string
+}
+
+// newShellCommand 创建手动诊断入口：拉起 PTY 代理 shell 并在后台监听本地诊断信令。
+func newShellCommand() *cobra.Command {
+	options := &shellCommandOptions{}
+	command := &cobra.Command{
+		Use:          "shell",
+		Short:        "Start manual terminal proxy shell for neocode diag",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		Annotations: map[string]string{
+			commandAnnotationSkipGlobalPreload:     "true",
+			commandAnnotationSkipSilentUpdateCheck: "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runShellCommand(
+				cmd.Context(),
+				shellCommandOptions{
+					Workdir:              strings.TrimSpace(mustReadInheritedWorkdir(cmd)),
+					Shell:                strings.TrimSpace(options.Shell),
+					SocketPath:           strings.TrimSpace(options.SocketPath),
+					GatewayListenAddress: strings.TrimSpace(options.GatewayListenAddress),
+					GatewayTokenFile:     strings.TrimSpace(options.GatewayTokenFile),
+				},
+				cmd.InOrStdin(),
+				cmd.OutOrStdout(),
+				cmd.ErrOrStderr(),
+			)
+		},
+	}
+
+	command.Flags().StringVar(&options.Shell, "shell", "", "shell executable path (default $SHELL or /bin/bash)")
+	command.Flags().StringVar(&options.SocketPath, "socket", "", "diagnose unix socket path override")
+	command.Flags().StringVar(&options.GatewayListenAddress, "gateway-listen", "", "gateway listen address override")
+	command.Flags().StringVar(&options.GatewayTokenFile, "gateway-token-file", "", "gateway token file override")
+	return command
+}
+
+// newDiagCommand 创建手动触发入口：向代理 shell 发送一次诊断信号。
+func newDiagCommand() *cobra.Command {
+	options := &diagCommandOptions{}
+	command := &cobra.Command{
+		Use:          "diag",
+		Short:        "Trigger terminal diagnose in current neocode shell",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		Annotations: map[string]string{
+			commandAnnotationSkipGlobalPreload:     "true",
+			commandAnnotationSkipSilentUpdateCheck: "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			socketPath, err := resolveDiagSocketPath(options.SocketPath)
+			if err != nil {
+				return err
+			}
+			return runDiagCommand(cmd.Context(), diagCommandOptions{
+				SocketPath: socketPath,
+			})
+		},
+	}
+
+	command.Flags().StringVar(&options.SocketPath, "socket", "", "diagnose unix socket path override")
+	return command
+}
+
+// defaultShellCommandRunner 组装 PTY 代理参数并启动手动诊断 shell。
+func defaultShellCommandRunner(
+	ctx context.Context,
+	options shellCommandOptions,
+	stdin io.Reader,
+	stdout io.Writer,
+	stderr io.Writer,
+) error {
+	return runManualShellProxy(ctx, ptyproxy.ManualShellOptions{
+		Workdir:              strings.TrimSpace(options.Workdir),
+		Shell:                strings.TrimSpace(options.Shell),
+		SocketPath:           strings.TrimSpace(options.SocketPath),
+		GatewayListenAddress: strings.TrimSpace(options.GatewayListenAddress),
+		GatewayTokenFile:     strings.TrimSpace(options.GatewayTokenFile),
+		Stdin:                stdin,
+		Stdout:               stdout,
+		Stderr:               stderr,
+	})
+}
+
+// defaultDiagCommandRunner 向 shell 代理发送一次诊断触发信令。
+func defaultDiagCommandRunner(ctx context.Context, options diagCommandOptions) error {
+	return sendDiagnoseSignalFn(ctx, strings.TrimSpace(options.SocketPath))
+}
+
+// resolveDiagSocketPath 按“--socket > NEOCODE_DIAG_SOCKET”优先级解析诊断 socket 路径。
+func resolveDiagSocketPath(socketFlag string) (string, error) {
+	if socketPath := strings.TrimSpace(socketFlag); socketPath != "" {
+		return socketPath, nil
+	}
+	if envValue := strings.TrimSpace(readDiagEnvValue(ptyproxy.DiagSocketEnv)); envValue != "" {
+		return envValue, nil
+	}
+	return "", errors.New(
+		fmt.Sprintf(
+			"diagnose socket is empty: use --socket or set %s in your shell environment",
+			ptyproxy.DiagSocketEnv,
+		),
+	)
+}

--- a/internal/cli/shell_diag_commands_test.go
+++ b/internal/cli/shell_diag_commands_test.go
@@ -1,0 +1,234 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"neo-code/internal/ptyproxy"
+)
+
+func TestShellCommandUsesFlags(t *testing.T) {
+	originalRunner := runShellCommand
+	t.Cleanup(func() { runShellCommand = originalRunner })
+
+	var captured shellCommandOptions
+	runShellCommand = func(_ context.Context, options shellCommandOptions, _ io.Reader, _ io.Writer, _ io.Writer) error {
+		captured = options
+		return nil
+	}
+
+	command := NewRootCommand()
+	command.SetArgs([]string{
+		"--workdir", " /repo ",
+		"shell",
+		"--shell", " /bin/zsh ",
+		"--socket", " /tmp/diag.sock ",
+		"--gateway-listen", " /tmp/gateway.sock ",
+		"--gateway-token-file", " /tmp/auth.json ",
+	})
+	if err := command.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
+	}
+
+	if captured.Workdir != "/repo" {
+		t.Fatalf("workdir = %q, want %q", captured.Workdir, "/repo")
+	}
+	if captured.Shell != "/bin/zsh" {
+		t.Fatalf("shell = %q, want %q", captured.Shell, "/bin/zsh")
+	}
+	if captured.SocketPath != "/tmp/diag.sock" {
+		t.Fatalf("socket = %q, want %q", captured.SocketPath, "/tmp/diag.sock")
+	}
+	if captured.GatewayListenAddress != "/tmp/gateway.sock" {
+		t.Fatalf("gateway-listen = %q, want %q", captured.GatewayListenAddress, "/tmp/gateway.sock")
+	}
+	if captured.GatewayTokenFile != "/tmp/auth.json" {
+		t.Fatalf("gateway-token-file = %q, want %q", captured.GatewayTokenFile, "/tmp/auth.json")
+	}
+}
+
+func TestShellCommandSkipsGlobalPreload(t *testing.T) {
+	originalPreload := runGlobalPreload
+	originalRunner := runShellCommand
+	t.Cleanup(func() { runGlobalPreload = originalPreload })
+	t.Cleanup(func() { runShellCommand = originalRunner })
+
+	var preloadCalled bool
+	runGlobalPreload = func(context.Context) error {
+		preloadCalled = true
+		return errors.New("should be skipped")
+	}
+	runShellCommand = func(context.Context, shellCommandOptions, io.Reader, io.Writer, io.Writer) error {
+		return nil
+	}
+
+	command := NewRootCommand()
+	command.SetArgs([]string{"shell"})
+	if err := command.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
+	}
+	if preloadCalled {
+		t.Fatal("expected global preload to be skipped for shell command")
+	}
+}
+
+func TestShellCommandSkipsSilentUpdateCheck(t *testing.T) {
+	originalSilentCheck := runSilentUpdateCheck
+	originalRunner := runShellCommand
+	t.Cleanup(func() { runSilentUpdateCheck = originalSilentCheck })
+	t.Cleanup(func() { runShellCommand = originalRunner })
+
+	var checkCalled bool
+	runSilentUpdateCheck = func(context.Context) {
+		checkCalled = true
+	}
+	runShellCommand = func(context.Context, shellCommandOptions, io.Reader, io.Writer, io.Writer) error {
+		return nil
+	}
+
+	command := NewRootCommand()
+	command.SetArgs([]string{"shell"})
+	if err := command.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
+	}
+	if checkCalled {
+		t.Fatal("expected silent update check to be skipped for shell command")
+	}
+}
+
+func TestDiagCommandSocketPriority(t *testing.T) {
+	originalRunner := runDiagCommand
+	originalReadEnv := readDiagEnvValue
+	t.Cleanup(func() { runDiagCommand = originalRunner })
+	t.Cleanup(func() { readDiagEnvValue = originalReadEnv })
+
+	var captured diagCommandOptions
+	runDiagCommand = func(_ context.Context, options diagCommandOptions) error {
+		captured = options
+		return nil
+	}
+	readDiagEnvValue = func(key string) string {
+		if key == ptyproxy.DiagSocketEnv {
+			return "/tmp/from-env.sock"
+		}
+		return ""
+	}
+
+	command := NewRootCommand()
+	command.SetArgs([]string{"diag", "--socket", " /tmp/from-flag.sock "})
+	if err := command.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
+	}
+	if captured.SocketPath != "/tmp/from-flag.sock" {
+		t.Fatalf("socket = %q, want %q", captured.SocketPath, "/tmp/from-flag.sock")
+	}
+}
+
+func TestDiagCommandUsesEnvFallback(t *testing.T) {
+	originalRunner := runDiagCommand
+	originalReadEnv := readDiagEnvValue
+	t.Cleanup(func() { runDiagCommand = originalRunner })
+	t.Cleanup(func() { readDiagEnvValue = originalReadEnv })
+
+	var captured diagCommandOptions
+	runDiagCommand = func(_ context.Context, options diagCommandOptions) error {
+		captured = options
+		return nil
+	}
+	readDiagEnvValue = func(key string) string {
+		if key == ptyproxy.DiagSocketEnv {
+			return " /tmp/from-env.sock "
+		}
+		return ""
+	}
+
+	command := NewRootCommand()
+	command.SetArgs([]string{"diag"})
+	if err := command.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
+	}
+	if captured.SocketPath != "/tmp/from-env.sock" {
+		t.Fatalf("socket = %q, want %q", captured.SocketPath, "/tmp/from-env.sock")
+	}
+}
+
+func TestDiagCommandSocketMissing(t *testing.T) {
+	originalReadEnv := readDiagEnvValue
+	t.Cleanup(func() { readDiagEnvValue = originalReadEnv })
+	readDiagEnvValue = func(string) string { return "" }
+
+	command := NewRootCommand()
+	command.SetArgs([]string{"diag"})
+	err := command.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("expected missing socket error")
+	}
+	if !strings.Contains(err.Error(), "--socket") {
+		t.Fatalf("error = %v, want contains --socket", err)
+	}
+	if !strings.Contains(err.Error(), ptyproxy.DiagSocketEnv) {
+		t.Fatalf("error = %v, want contains %s", err, ptyproxy.DiagSocketEnv)
+	}
+}
+
+func TestDiagCommandSkipsGlobalPreload(t *testing.T) {
+	originalPreload := runGlobalPreload
+	originalRunner := runDiagCommand
+	originalReadEnv := readDiagEnvValue
+	t.Cleanup(func() { runGlobalPreload = originalPreload })
+	t.Cleanup(func() { runDiagCommand = originalRunner })
+	t.Cleanup(func() { readDiagEnvValue = originalReadEnv })
+
+	var preloadCalled bool
+	runGlobalPreload = func(context.Context) error {
+		preloadCalled = true
+		return errors.New("should be skipped")
+	}
+	runDiagCommand = func(context.Context, diagCommandOptions) error { return nil }
+	readDiagEnvValue = func(string) string { return "/tmp/diag.sock" }
+
+	command := NewRootCommand()
+	command.SetArgs([]string{"diag"})
+	if err := command.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
+	}
+	if preloadCalled {
+		t.Fatal("expected global preload to be skipped for diag command")
+	}
+}
+
+func TestDefaultShellCommandRunnerForwardsUnsupportedError(t *testing.T) {
+	originalManualShell := runManualShellProxy
+	t.Cleanup(func() { runManualShellProxy = originalManualShell })
+	runManualShellProxy = func(context.Context, ptyproxy.ManualShellOptions) error {
+		return errors.New("manual shell mode is only supported on unix-like systems in phase1")
+	}
+
+	err := defaultShellCommandRunner(context.Background(), shellCommandOptions{}, os.Stdin, io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("expected unsupported error")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "only supported on unix-like systems") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestDefaultDiagCommandRunnerForwardsUnsupportedError(t *testing.T) {
+	originalSend := sendDiagnoseSignalFn
+	t.Cleanup(func() { sendDiagnoseSignalFn = originalSend })
+	sendDiagnoseSignalFn = func(context.Context, string) error {
+		return errors.New("manual shell mode is only supported on unix-like systems in phase1")
+	}
+
+	err := defaultDiagCommandRunner(context.Background(), diagCommandOptions{SocketPath: "/tmp/diag.sock"})
+	if err == nil {
+		t.Fatal("expected unsupported error")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "only supported on unix-like systems") {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/internal/context/source_plan_mode_test.go
+++ b/internal/context/source_plan_mode_test.go
@@ -1,0 +1,129 @@
+package context
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	agentsession "neo-code/internal/session"
+)
+
+func TestPlanModeSectionsReturnsNilForEmptyStage(t *testing.T) {
+	t.Parallel()
+
+	source := planModeContextSource{}
+	sections, err := source.Sections(context.Background(), BuildInput{
+		AgentMode: agentsession.AgentModePlan,
+		PlanStage: "",
+	})
+	if err != nil {
+		t.Fatalf("Sections() error = %v", err)
+	}
+	if sections != nil {
+		t.Fatalf("expected nil sections for empty stage, got %v", sections)
+	}
+}
+
+func TestPlanModeSectionsReturnsWithoutPlanWhenNil(t *testing.T) {
+	t.Parallel()
+
+	source := planModeContextSource{}
+	sections, err := source.Sections(context.Background(), BuildInput{
+		AgentMode:   agentsession.AgentModeBuild,
+		PlanStage:   "build",
+		CurrentPlan: nil,
+	})
+	if err != nil {
+		t.Fatalf("Sections() error = %v", err)
+	}
+	if len(sections) == 0 {
+		t.Fatal("expected at least plan mode section")
+	}
+	hasPlanSection := false
+	for _, s := range sections {
+		if s.Title == "Current Plan" {
+			hasPlanSection = true
+		}
+	}
+	if hasPlanSection {
+		t.Fatal("expected no Current Plan section when CurrentPlan is nil")
+	}
+}
+
+func TestPlanModeSectionsContextError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	source := planModeContextSource{}
+	_, err := source.Sections(ctx, BuildInput{
+		PlanStage: "plan",
+	})
+	if err == nil {
+		t.Fatal("expected context error")
+	}
+	if !strings.Contains(err.Error(), "canceled") {
+		t.Fatalf("error = %v, want context canceled", err)
+	}
+}
+
+func TestRenderCurrentPlanSectionNilPlan(t *testing.T) {
+	t.Parallel()
+
+	section := renderCurrentPlanSection(nil, false)
+	if section.Title != "" || section.Content != "" {
+		t.Fatalf("expected empty section for nil plan, got %+v", section)
+	}
+}
+
+func TestRenderPlanModeSectionBuildStage(t *testing.T) {
+	t.Parallel()
+
+	section := renderPlanModeSection(agentsession.AgentModeBuild, "build")
+	if section.Title != "Plan Mode" {
+		t.Fatalf("title = %q, want %q", section.Title, "Plan Mode")
+	}
+	if !strings.Contains(section.Content, `"build"`) {
+		t.Fatalf("content = %q, want contains build mode", section.Content)
+	}
+}
+
+func TestRenderPlanModeSectionUnknownStage(t *testing.T) {
+	t.Parallel()
+
+	section := renderPlanModeSection(agentsession.AgentModePlan, "unknown-stage")
+	if section.Title != "Plan Mode" {
+		t.Fatalf("title = %q, want %q", section.Title, "Plan Mode")
+	}
+	if !strings.Contains(section.Content, `"unknown-stage"`) {
+		t.Fatalf("content = %q, want contains stage", section.Content)
+	}
+}
+
+func TestRenderCurrentPlanSectionInjectsFullPlan(t *testing.T) {
+	t.Parallel()
+
+	plan := &agentsession.PlanArtifact{
+		ID:       "plan-full",
+		Revision: 2,
+		Status:   agentsession.PlanStatusApproved,
+		Spec: agentsession.PlanSpec{
+			Goal:        "完整计划",
+			Steps:       []string{"步骤一"},
+			Verify:      []string{"验证一"},
+			OpenQuestions: []string{"问题一"},
+		},
+		Summary: agentsession.SummaryView{
+			Goal: "完整计划",
+		},
+	}
+
+	section := renderCurrentPlanSection(plan, true)
+	if section.Title != "Current Plan" {
+		t.Fatalf("title = %q, want %q", section.Title, "Current Plan")
+	}
+	if !strings.Contains(section.Content, "full_plan_view:") {
+		t.Fatalf("content should include full_plan_view, got %q", section.Content)
+	}
+}

--- a/internal/gateway/bootstrap.go
+++ b/internal/gateway/bootstrap.go
@@ -31,6 +31,7 @@ var allowedSystemToolNames = map[string]struct{}{
 	toolkits.ToolNameMemoRemember: {},
 	toolkits.ToolNameMemoRecall:   {},
 	toolkits.ToolNameMemoRemove:   {},
+	toolkits.ToolNameDiagnose:     {},
 }
 
 // dispatchRequestFrame 统一分发 request 帧到对应处理器。

--- a/internal/gateway/bootstrap_test.go
+++ b/internal/gateway/bootstrap_test.go
@@ -1217,6 +1217,35 @@ func TestHandleExecuteSystemToolFrameBranches(t *testing.T) {
 		}
 	})
 
+	t.Run("success diagnose", func(t *testing.T) {
+		stub := &bootstrapRuntimeStub{
+			executeSystemToolFn: func(_ context.Context, input ExecuteSystemToolInput) (tools.ToolResult, error) {
+				if input.ToolName != tools.ToolNameDiagnose {
+					t.Fatalf("tool name = %q, want %q", input.ToolName, tools.ToolNameDiagnose)
+				}
+				if string(input.Arguments) != `{"error_log":"fatal","os_env":{"os":"linux"}}` {
+					t.Fatalf("arguments = %s", string(input.Arguments))
+				}
+				return tools.ToolResult{
+					Name:    tools.ToolNameDiagnose,
+					Content: "ok",
+				}, nil
+			},
+		}
+		response := handleExecuteSystemToolFrame(context.Background(), MessageFrame{
+			Type:      FrameTypeRequest,
+			Action:    FrameActionExecuteSystemTool,
+			RequestID: "exec-diagnose-ok-1",
+			Payload: protocol.ExecuteSystemToolParams{
+				ToolName:  tools.ToolNameDiagnose,
+				Arguments: []byte(`{"error_log":"fatal","os_env":{"os":"linux"}}`),
+			},
+		}, stub)
+		if response.Type != FrameTypeAck {
+			t.Fatalf("response type = %q, want %q", response.Type, FrameTypeAck)
+		}
+	})
+
 	t.Run("runtime error", func(t *testing.T) {
 		stub := &bootstrapRuntimeStub{
 			executeSystemToolFn: func(_ context.Context, _ ExecuteSystemToolInput) (tools.ToolResult, error) {

--- a/internal/gateway/client/gateway_rpc_client.go
+++ b/internal/gateway/client/gateway_rpc_client.go
@@ -1,4 +1,4 @@
-package services
+package client
 
 import (
 	"context"
@@ -34,6 +34,9 @@ const (
 	defaultGatewayNotificationQueue          = 256
 	defaultGatewayNotificationEnqueueTimeout = 3 * time.Second
 )
+
+// DefaultGatewayRPCRetryCount 暴露网关 RPC 客户端默认重试次数，供上层适配器复用一致策略。
+const DefaultGatewayRPCRetryCount = defaultGatewayRPCRetryCount
 
 const (
 	gatewayAutoSpawnLogDirPerm  = 0o700
@@ -106,7 +109,7 @@ func (e *gatewayRPCTransportError) Unwrap() error {
 	return e.Err
 }
 
-type gatewayRPCNotification struct {
+type Notification struct {
 	Method string
 	Params json.RawMessage
 }
@@ -145,8 +148,8 @@ type GatewayRPCClient struct {
 	heartbeatCancel context.CancelFunc
 	heartbeatWG     sync.WaitGroup
 
-	notifications              chan gatewayRPCNotification
-	notificationQueue          chan gatewayRPCNotification
+	notifications              chan Notification
+	notificationQueue          chan Notification
 	notificationEnqueueTimeout time.Duration
 	notificationWG             sync.WaitGroup
 	notificationStart          sync.Once
@@ -209,14 +212,14 @@ func NewGatewayRPCClient(options GatewayRPCClientOptions) (*GatewayRPCClient, er
 		dialFn:                     dialFn,
 		closed:                     make(chan struct{}),
 		pending:                    make(map[string]chan gatewayRPCResponse),
-		notifications:              make(chan gatewayRPCNotification, defaultGatewayNotificationBuffer),
-		notificationQueue:          make(chan gatewayRPCNotification, defaultGatewayNotificationQueue),
+		notifications:              make(chan Notification, defaultGatewayNotificationBuffer),
+		notificationQueue:          make(chan Notification, defaultGatewayNotificationQueue),
 		notificationEnqueueTimeout: defaultGatewayNotificationEnqueueTimeout,
 	}, nil
 }
 
 // Notifications 返回网关 JSON-RPC 通知流。
-func (c *GatewayRPCClient) Notifications() <-chan gatewayRPCNotification {
+func (c *GatewayRPCClient) Notifications() <-chan Notification {
 	return c.notifications
 }
 
@@ -514,7 +517,7 @@ func (c *GatewayRPCClient) readLoop(conn net.Conn) {
 			if strings.TrimSpace(method) == "" {
 				continue
 			}
-			notification := gatewayRPCNotification{
+			notification := Notification{
 				Method: method,
 			}
 			if paramsRaw, hasParams := envelope["params"]; hasParams {
@@ -563,7 +566,7 @@ func (c *GatewayRPCClient) startNotificationDispatcher() {
 }
 
 // enqueueNotification 投递通知到内部队列；若背压持续超时则主动断开连接，避免 readLoop 无限阻塞。
-func (c *GatewayRPCClient) enqueueNotification(notification gatewayRPCNotification) bool {
+func (c *GatewayRPCClient) enqueueNotification(notification Notification) bool {
 	enqueueTimeout := c.notificationEnqueueTimeout
 	if enqueueTimeout <= 0 {
 		enqueueTimeout = defaultGatewayNotificationEnqueueTimeout

--- a/internal/gateway/client/gateway_rpc_client_additional_test.go
+++ b/internal/gateway/client/gateway_rpc_client_additional_test.go
@@ -1,4 +1,4 @@
-package services
+package client
 
 import (
 	"bytes"
@@ -160,8 +160,8 @@ func TestGatewayRPCClientPendingAndForceCloseBranches(t *testing.T) {
 	client := &GatewayRPCClient{
 		closed:            make(chan struct{}),
 		pending:           map[string]chan gatewayRPCResponse{},
-		notifications:     make(chan gatewayRPCNotification, 1),
-		notificationQueue: make(chan gatewayRPCNotification, 1),
+		notifications:     make(chan Notification, 1),
+		notificationQueue: make(chan Notification, 1),
 	}
 
 	ch := make(chan gatewayRPCResponse, 1)
@@ -197,7 +197,7 @@ func TestGatewayRPCClientPendingAndForceCloseBranches(t *testing.T) {
 	if ok := client.registerPending("req-3", make(chan gatewayRPCResponse, 1)); ok {
 		t.Fatalf("registerPending should fail after client closed")
 	}
-	client.enqueueNotification(gatewayRPCNotification{Method: protocol.MethodGatewayEvent})
+	client.enqueueNotification(Notification{Method: protocol.MethodGatewayEvent})
 
 	resetConn := &stubConn{}
 	client.conn = resetConn
@@ -306,8 +306,8 @@ func TestGatewayRPCClientCallOnceBranches(t *testing.T) {
 		retryCount:        1,
 		closed:            make(chan struct{}),
 		pending:           make(map[string]chan gatewayRPCResponse),
-		notifications:     make(chan gatewayRPCNotification, 4),
-		notificationQueue: make(chan gatewayRPCNotification, 4),
+		notifications:     make(chan Notification, 4),
+		notificationQueue: make(chan Notification, 4),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -343,8 +343,8 @@ func TestGatewayRPCClientCallOnceResponseBranches(t *testing.T) {
 			retryCount:        1,
 			closed:            make(chan struct{}),
 			pending:           make(map[string]chan gatewayRPCResponse),
-			notifications:     make(chan gatewayRPCNotification, 4),
-			notificationQueue: make(chan gatewayRPCNotification, 4),
+			notifications:     make(chan Notification, 4),
+			notificationQueue: make(chan Notification, 4),
 			conn:              &stubConn{},
 		}
 	}
@@ -416,8 +416,8 @@ func TestGatewayRPCClientReadLoopAdditionalBranches(t *testing.T) {
 	client := &GatewayRPCClient{
 		closed:            make(chan struct{}),
 		pending:           make(map[string]chan gatewayRPCResponse),
-		notifications:     make(chan gatewayRPCNotification, 4),
-		notificationQueue: make(chan gatewayRPCNotification, 4),
+		notifications:     make(chan Notification, 4),
+		notificationQueue: make(chan Notification, 4),
 	}
 	client.startNotificationDispatcher()
 	go client.readLoop(clientConn)
@@ -443,8 +443,8 @@ func TestGatewayRPCClientNotificationDispatcherStopsOnCloseSignal(t *testing.T) 
 	client := &GatewayRPCClient{
 		closed:            make(chan struct{}),
 		pending:           make(map[string]chan gatewayRPCResponse),
-		notifications:     make(chan gatewayRPCNotification, 1),
-		notificationQueue: make(chan gatewayRPCNotification, 1),
+		notifications:     make(chan Notification, 1),
+		notificationQueue: make(chan Notification, 1),
 	}
 	client.startNotificationDispatcher()
 	close(client.closed)
@@ -458,8 +458,8 @@ func TestGatewayRPCClientEnqueueNotificationDoesNotDropUnderQueuePressure(t *tes
 	client := &GatewayRPCClient{
 		closed:            make(chan struct{}),
 		pending:           make(map[string]chan gatewayRPCResponse),
-		notifications:     make(chan gatewayRPCNotification, 1),
-		notificationQueue: make(chan gatewayRPCNotification, 1),
+		notifications:     make(chan Notification, 1),
+		notificationQueue: make(chan Notification, 1),
 	}
 	client.startNotificationDispatcher()
 	t.Cleanup(func() { _ = client.Close() })
@@ -476,7 +476,7 @@ func TestGatewayRPCClientEnqueueNotificationDoesNotDropUnderQueuePressure(t *tes
 		enqueueWG.Add(1)
 		go func(index int) {
 			defer enqueueWG.Done()
-			client.enqueueNotification(gatewayRPCNotification{
+			client.enqueueNotification(Notification{
 				Method: protocol.MethodGatewayEvent,
 				Params: json.RawMessage(`{"index":` + strconv.Itoa(index) + `}`),
 			})
@@ -516,8 +516,8 @@ func TestGatewayRPCClientReadLoopFailsFastOnNotificationBackpressure(t *testing.
 	client := &GatewayRPCClient{
 		closed:                     make(chan struct{}),
 		pending:                    make(map[string]chan gatewayRPCResponse),
-		notifications:              make(chan gatewayRPCNotification),
-		notificationQueue:          make(chan gatewayRPCNotification, 1),
+		notifications:              make(chan Notification),
+		notificationQueue:          make(chan Notification, 1),
 		notificationEnqueueTimeout: 50 * time.Millisecond,
 	}
 	client.startNotificationDispatcher()
@@ -552,19 +552,19 @@ func TestGatewayRPCClientEnqueueNotificationUnblocksOnClose(t *testing.T) {
 	client := &GatewayRPCClient{
 		closed:                     make(chan struct{}),
 		pending:                    make(map[string]chan gatewayRPCResponse),
-		notifications:              make(chan gatewayRPCNotification),
-		notificationQueue:          make(chan gatewayRPCNotification, 1),
+		notifications:              make(chan Notification),
+		notificationQueue:          make(chan Notification, 1),
 		notificationEnqueueTimeout: time.Second,
 	}
 	client.startNotificationDispatcher()
 
 	// 首条通知占满队列，第二条通知会阻塞在 enqueue，关闭客户端后应立即退出。
-	client.notificationQueue <- gatewayRPCNotification{Method: protocol.MethodGatewayEvent}
+	client.notificationQueue <- Notification{Method: protocol.MethodGatewayEvent}
 
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		client.enqueueNotification(gatewayRPCNotification{Method: protocol.MethodGatewayEvent})
+		client.enqueueNotification(Notification{Method: protocol.MethodGatewayEvent})
 	}()
 
 	time.Sleep(20 * time.Millisecond)
@@ -583,8 +583,8 @@ func TestGatewayRPCClientWriteRequestFailure(t *testing.T) {
 	client := &GatewayRPCClient{
 		closed:            make(chan struct{}),
 		pending:           make(map[string]chan gatewayRPCResponse),
-		notifications:     make(chan gatewayRPCNotification, 1),
-		notificationQueue: make(chan gatewayRPCNotification, 1),
+		notifications:     make(chan Notification, 1),
+		notificationQueue: make(chan Notification, 1),
 	}
 	conn := &stubConn{writeErr: errors.New("write failed")}
 	err := client.writeRequest(conn, protocol.JSONRPCRequest{JSONRPC: protocol.JSONRPCVersion, ID: json.RawMessage(`\"id\"`), Method: "m"})
@@ -777,8 +777,8 @@ func TestGatewayRPCClientCloseStopsSpawnedGatewayProcess(t *testing.T) {
 	client := &GatewayRPCClient{
 		closed:            make(chan struct{}),
 		pending:           make(map[string]chan gatewayRPCResponse),
-		notifications:     make(chan gatewayRPCNotification, 1),
-		notificationQueue: make(chan gatewayRPCNotification, 1),
+		notifications:     make(chan Notification, 1),
+		notificationQueue: make(chan Notification, 1),
 		spawnedCmd:        spawnedCmd,
 	}
 
@@ -797,8 +797,8 @@ func TestGatewayRPCClientWatchSpawnedGatewayProcessResetsAutoSpawnAttempt(t *tes
 	client := &GatewayRPCClient{
 		closed:            make(chan struct{}),
 		pending:           make(map[string]chan gatewayRPCResponse),
-		notifications:     make(chan gatewayRPCNotification, 1),
-		notificationQueue: make(chan gatewayRPCNotification, 1),
+		notifications:     make(chan Notification, 1),
+		notificationQueue: make(chan Notification, 1),
 		autoSpawnAttempt:  true,
 		spawnedCmd:        spawnedCmd,
 		spawnedCmdDone:    done,
@@ -832,8 +832,8 @@ func TestGatewayRPCClientResetConnectionClearsAutoSpawnAttempt(t *testing.T) {
 	client := &GatewayRPCClient{
 		closed:            make(chan struct{}),
 		pending:           make(map[string]chan gatewayRPCResponse),
-		notifications:     make(chan gatewayRPCNotification, 1),
-		notificationQueue: make(chan gatewayRPCNotification, 1),
+		notifications:     make(chan Notification, 1),
+		notificationQueue: make(chan Notification, 1),
 		autoSpawnAttempt:  true,
 	}
 

--- a/internal/gateway/client/gateway_rpc_client_hardlink_unix.go
+++ b/internal/gateway/client/gateway_rpc_client_hardlink_unix.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package services
+package client
 
 import (
 	"os"

--- a/internal/gateway/client/gateway_rpc_client_hardlink_windows.go
+++ b/internal/gateway/client/gateway_rpc_client_hardlink_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package services
+package client
 
 import "os"
 

--- a/internal/gateway/client/gateway_rpc_client_test.go
+++ b/internal/gateway/client/gateway_rpc_client_test.go
@@ -1,4 +1,4 @@
-package services
+package client
 
 import (
 	"context"

--- a/internal/ptyproxy/options.go
+++ b/internal/ptyproxy/options.go
@@ -1,0 +1,80 @@
+package ptyproxy
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// DiagSocketEnv 是 shell 子进程内用于定位诊断 socket 的环境变量名。
+	DiagSocketEnv = "NEOCODE_DIAG_SOCKET"
+	// DefaultRingBufferCapacity 定义诊断日志缓存窗口的默认字节上限（64KB）。
+	DefaultRingBufferCapacity = 64 * 1024
+)
+
+// ManualShellOptions 定义 Manual 模式代理 shell 的启动参数。
+type ManualShellOptions struct {
+	Workdir              string
+	Shell                string
+	SocketPath           string
+	GatewayListenAddress string
+	GatewayTokenFile     string
+	Stdin                io.Reader
+	Stdout               io.Writer
+	Stderr               io.Writer
+}
+
+// NormalizeShellOptions 补齐默认 I/O 与工作目录，避免调用方遗漏基础参数。
+func NormalizeShellOptions(options ManualShellOptions) (ManualShellOptions, error) {
+	normalized := options
+	if normalized.Stdin == nil {
+		normalized.Stdin = os.Stdin
+	}
+	if normalized.Stdout == nil {
+		normalized.Stdout = os.Stdout
+	}
+	if normalized.Stderr == nil {
+		normalized.Stderr = os.Stderr
+	}
+
+	workdir := strings.TrimSpace(normalized.Workdir)
+	if workdir == "" {
+		currentDir, err := os.Getwd()
+		if err != nil {
+			return ManualShellOptions{}, fmt.Errorf("ptyproxy: resolve current workdir: %w", err)
+		}
+		workdir = currentDir
+	}
+	absoluteWorkdir, err := filepath.Abs(filepath.Clean(workdir))
+	if err != nil {
+		return ManualShellOptions{}, fmt.Errorf("ptyproxy: resolve workdir: %w", err)
+	}
+	normalized.Workdir = absoluteWorkdir
+	normalized.Shell = strings.TrimSpace(normalized.Shell)
+	normalized.SocketPath = strings.TrimSpace(normalized.SocketPath)
+	normalized.GatewayListenAddress = strings.TrimSpace(normalized.GatewayListenAddress)
+	normalized.GatewayTokenFile = strings.TrimSpace(normalized.GatewayTokenFile)
+	return normalized, nil
+}
+
+// MergeEnvVar 以覆盖方式注入环境变量，确保同名旧值不会污染子进程。
+func MergeEnvVar(environment []string, key string, value string) []string {
+	trimmedKey := strings.TrimSpace(key)
+	if trimmedKey == "" {
+		return append([]string(nil), environment...)
+	}
+	normalizedValue := strings.TrimSpace(value)
+	prefix := strings.ToUpper(trimmedKey) + "="
+	merged := make([]string, 0, len(environment)+1)
+	for _, item := range environment {
+		if strings.HasPrefix(strings.ToUpper(item), prefix) {
+			continue
+		}
+		merged = append(merged, item)
+	}
+	merged = append(merged, trimmedKey+"="+normalizedValue)
+	return merged
+}

--- a/internal/ptyproxy/options_test.go
+++ b/internal/ptyproxy/options_test.go
@@ -92,14 +92,3 @@ func TestNormalizeShellOptionsResolvesEmptyWorkdir(t *testing.T) {
 		t.Fatal("Workdir should not be empty after normalization")
 	}
 }
-
-func TestNormalizeShellOptionsFailsOnBadGetwd(t *testing.T) {
-	// Remove read permission on a parent dir to cause Getwd failure.
-	// We simulate by providing a non-empty but unresolvable path.
-	_, err := NormalizeShellOptions(ManualShellOptions{
-		Workdir: string([]byte{0}),
-	})
-	if err == nil {
-		t.Fatal("expected error for invalid workdir path")
-	}
-}

--- a/internal/ptyproxy/options_test.go
+++ b/internal/ptyproxy/options_test.go
@@ -1,0 +1,27 @@
+package ptyproxy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMergeEnvVarOverridesExistingValue(t *testing.T) {
+	merged := MergeEnvVar([]string{
+		"PATH=/bin",
+		"NEOCODE_DIAG_SOCKET=/tmp/old.sock",
+		"HOME=/home/tester",
+	}, DiagSocketEnv, "/tmp/new.sock")
+
+	var socketEntries []string
+	for _, item := range merged {
+		if strings.HasPrefix(item, DiagSocketEnv+"=") {
+			socketEntries = append(socketEntries, item)
+		}
+	}
+	if len(socketEntries) != 1 {
+		t.Fatalf("socket entries len = %d, want 1", len(socketEntries))
+	}
+	if socketEntries[0] != DiagSocketEnv+"=/tmp/new.sock" {
+		t.Fatalf("socket entry = %q", socketEntries[0])
+	}
+}

--- a/internal/ptyproxy/options_test.go
+++ b/internal/ptyproxy/options_test.go
@@ -25,3 +25,81 @@ func TestMergeEnvVarOverridesExistingValue(t *testing.T) {
 		t.Fatalf("socket entry = %q", socketEntries[0])
 	}
 }
+
+func TestMergeEnvVarEmptyKeyReturnsCopy(t *testing.T) {
+	original := []string{"PATH=/bin", "HOME=/home/tester"}
+	merged := MergeEnvVar(original, "", "/tmp/new.sock")
+	if len(merged) != len(original) {
+		t.Fatalf("merged len = %d, want %d", len(merged), len(original))
+	}
+	for i, item := range original {
+		if merged[i] != item {
+			t.Fatalf("merged[%d] = %q, want %q", i, merged[i], item)
+		}
+	}
+}
+
+func TestNormalizeShellOptionsDefaultsStdio(t *testing.T) {
+	opts, err := NormalizeShellOptions(ManualShellOptions{
+		Workdir: "/tmp",
+		Shell:   "/bin/bash",
+	})
+	if err != nil {
+		t.Fatalf("NormalizeShellOptions() error = %v", err)
+	}
+	if opts.Stdin == nil {
+		t.Fatal("Stdin should not be nil after normalization")
+	}
+	if opts.Stdout == nil {
+		t.Fatal("Stdout should not be nil after normalization")
+	}
+	if opts.Stderr == nil {
+		t.Fatal("Stderr should not be nil after normalization")
+	}
+}
+
+func TestNormalizeShellOptionsTrimsWhitespace(t *testing.T) {
+	opts, err := NormalizeShellOptions(ManualShellOptions{
+		Workdir:              "/tmp",
+		Shell:                "  /bin/zsh  ",
+		SocketPath:           "  /tmp/diag.sock  ",
+		GatewayListenAddress: "  /tmp/gw.sock  ",
+		GatewayTokenFile:     "  /tmp/token  ",
+	})
+	if err != nil {
+		t.Fatalf("NormalizeShellOptions() error = %v", err)
+	}
+	if opts.Shell != "/bin/zsh" {
+		t.Fatalf("Shell = %q, want %q", opts.Shell, "/bin/zsh")
+	}
+	if opts.SocketPath != "/tmp/diag.sock" {
+		t.Fatalf("SocketPath = %q, want %q", opts.SocketPath, "/tmp/diag.sock")
+	}
+	if opts.GatewayListenAddress != "/tmp/gw.sock" {
+		t.Fatalf("GatewayListenAddress = %q, want %q", opts.GatewayListenAddress, "/tmp/gw.sock")
+	}
+	if opts.GatewayTokenFile != "/tmp/token" {
+		t.Fatalf("GatewayTokenFile = %q, want %q", opts.GatewayTokenFile, "/tmp/token")
+	}
+}
+
+func TestNormalizeShellOptionsResolvesEmptyWorkdir(t *testing.T) {
+	opts, err := NormalizeShellOptions(ManualShellOptions{})
+	if err != nil {
+		t.Fatalf("NormalizeShellOptions() error = %v", err)
+	}
+	if opts.Workdir == "" {
+		t.Fatal("Workdir should not be empty after normalization")
+	}
+}
+
+func TestNormalizeShellOptionsFailsOnBadGetwd(t *testing.T) {
+	// Remove read permission on a parent dir to cause Getwd failure.
+	// We simulate by providing a non-empty but unresolvable path.
+	_, err := NormalizeShellOptions(ManualShellOptions{
+		Workdir: string([]byte{0}),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid workdir path")
+	}
+}

--- a/internal/ptyproxy/proxy_unix.go
+++ b/internal/ptyproxy/proxy_unix.go
@@ -1,0 +1,630 @@
+//go:build !windows
+
+package ptyproxy
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/creack/pty"
+	"golang.org/x/term"
+
+	"neo-code/internal/gateway"
+	gatewayclient "neo-code/internal/gateway/client"
+	"neo-code/internal/gateway/protocol"
+	"neo-code/internal/tools"
+)
+
+const (
+	diagSignalPayload      = "diagnose\n"
+	diagSignalAckPayload   = "1"
+	diagnoseCallTimeout    = 10 * time.Second
+	diagSocketReadDeadline = 2 * time.Second
+	proxyInitializedBanner = "[ NeoCode Proxy initialized ]"
+	proxyExitedBanner      = "[ NeoCode Proxy exited ]"
+)
+
+var (
+	hostTerminalInput = os.Stdin
+	isTerminalFD      = term.IsTerminal
+	makeRawTerminal   = term.MakeRaw
+	restoreTerminal   = term.Restore
+
+	proxyOutputLineEndingNormalizer = strings.NewReplacer(
+		"\r\n", "\n",
+		"\r", "\n",
+		"\n", "\r\n",
+	)
+)
+
+type diagnoseToolArgs struct {
+	ErrorLog    string            `json:"error_log"`
+	OSEnv       map[string]string `json:"os_env"`
+	CommandText string            `json:"command_text"`
+	ExitCode    int               `json:"exit_code"`
+}
+
+type diagnoseToolResult struct {
+	Confidence            float64  `json:"confidence"`
+	RootCause             string   `json:"root_cause"`
+	FixCommands           []string `json:"fix_commands"`
+	InvestigationCommands []string `json:"investigation_commands"`
+}
+
+type diagSignalRequest struct {
+	done chan struct{}
+}
+
+// RunManualShell 启动 Manual 模式终端代理，提供 PTY 透明透传与诊断触发能力。
+func RunManualShell(ctx context.Context, options ManualShellOptions) error {
+	normalized, err := NormalizeShellOptions(options)
+	if err != nil {
+		return err
+	}
+
+	shellPath := resolveShellPath(normalized.Shell)
+	if shellPath == "" {
+		return errors.New("ptyproxy: shell executable is empty")
+	}
+
+	listener, socketPath, err := listenDiagSocket(normalized.SocketPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = listener.Close()
+		_ = os.Remove(socketPath)
+	}()
+
+	var outputMu sync.Mutex
+	synchronizedOutput := &serializedWriter{writer: normalized.Stdout, lock: &outputMu}
+	buffer := NewUTF8RingBuffer(DefaultRingBufferCapacity)
+	outputSink := io.MultiWriter(synchronizedOutput, buffer)
+
+	triggerCh := make(chan diagSignalRequest, 1)
+	acceptCtx, cancelAccept := context.WithCancel(context.Background())
+	var acceptWG sync.WaitGroup
+	acceptWG.Add(1)
+	go func() {
+		defer acceptWG.Done()
+		serveDiagSocket(acceptCtx, listener, triggerCh, normalized.Stderr)
+	}()
+
+	diagCtx, cancelDiag := context.WithCancel(context.Background())
+	var diagWG sync.WaitGroup
+	diagWG.Add(1)
+	go func() {
+		defer diagWG.Done()
+		consumeDiagSignals(diagCtx, triggerCh, synchronizedOutput, buffer, normalized, socketPath)
+	}()
+
+	restoreRawTerminal, err := enableHostTerminalRawMode()
+	if err != nil {
+		cancelAccept()
+		cancelDiag()
+		acceptWG.Wait()
+		diagWG.Wait()
+		return err
+	}
+	defer func() {
+		_ = restoreRawTerminal()
+	}()
+
+	command := buildShellCommand(shellPath, normalized, socketPath)
+
+	ptyFile, err := pty.Start(command)
+	if err != nil {
+		cancelAccept()
+		cancelDiag()
+		acceptWG.Wait()
+		diagWG.Wait()
+		return fmt.Errorf("ptyproxy: start pty shell: %w", err)
+	}
+	defer func() {
+		_ = ptyFile.Close()
+	}()
+
+	if err := pty.InheritSize(os.Stdin, ptyFile); err != nil && normalized.Stderr != nil {
+		writeProxyf(normalized.Stderr, "neocode shell: inherit terminal size failed: %v\n", err)
+	}
+	stopResizeWatcher := watchPTYWindowResize(normalized.Stderr, ptyFile)
+	defer stopResizeWatcher()
+
+	printProxyInitializedBanner(synchronizedOutput)
+
+	go func() {
+		_, _ = io.Copy(ptyFile, normalized.Stdin)
+	}()
+	go func() {
+		_, _ = io.Copy(outputSink, ptyFile)
+	}()
+
+	waitDone := make(chan error, 1)
+	go func() {
+		waitDone <- command.Wait()
+	}()
+
+	var waitErr error
+	select {
+	case <-ctx.Done():
+		if command.Process != nil {
+			_ = command.Process.Kill()
+		}
+		waitErr = <-waitDone
+	case waitErr = <-waitDone:
+	}
+
+	printProxyExitedBanner(synchronizedOutput)
+
+	_ = ptyFile.Close()
+	cancelAccept()
+	_ = listener.Close()
+	acceptWG.Wait()
+	cancelDiag()
+	diagWG.Wait()
+
+	if waitErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(waitErr, &exitErr) {
+			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+				return fmt.Errorf("ptyproxy: shell exited with code %d", status.ExitStatus())
+			}
+		}
+		return waitErr
+	}
+	return nil
+}
+
+// printProxyInitializedBanner 在 PTY 会话启动前输出代理已就绪提示。
+func printProxyInitializedBanner(writer io.Writer) {
+	if writer == nil {
+		return
+	}
+	writeProxyLine(writer, proxyInitializedBanner)
+}
+
+// printProxyExitedBanner 在 PTY 会话结束后输出代理退出提示。
+func printProxyExitedBanner(writer io.Writer) {
+	if writer == nil {
+		return
+	}
+	writeProxyText(writer, "\r\n"+proxyExitedBanner+"\r\n")
+}
+
+// enableHostTerminalRawMode 将宿主终端切换到原始模式，并返回可恢复终端状态的函数。
+func enableHostTerminalRawMode() (func() error, error) {
+	if hostTerminalInput == nil {
+		return func() error { return nil }, nil
+	}
+
+	fd := int(hostTerminalInput.Fd())
+	if !isTerminalFD(fd) {
+		return func() error { return nil }, nil
+	}
+
+	originalState, err := makeRawTerminal(fd)
+	if err != nil {
+		return nil, fmt.Errorf("ptyproxy: set host terminal raw mode: %w", err)
+	}
+	return func() error {
+		if restoreErr := restoreTerminal(fd, originalState); restoreErr != nil {
+			return fmt.Errorf("ptyproxy: restore host terminal state: %w", restoreErr)
+		}
+		return nil
+	}, nil
+}
+
+// syncPTYWindowSize 将宿主终端窗口尺寸同步到 PTY，避免默认 80 列导致的提示符错位。
+func syncPTYWindowSize(errWriter io.Writer, ptyFile *os.File) {
+	if ptyFile == nil {
+		return
+	}
+	if err := pty.InheritSize(os.Stdin, ptyFile); err != nil && errWriter != nil {
+		writeProxyf(errWriter, "neocode shell: inherit terminal size failed: %v\n", err)
+	}
+}
+
+// watchPTYWindowResize 监听 SIGWINCH 并持续同步 PTY 尺寸，返回停止监听函数。
+func watchPTYWindowResize(errWriter io.Writer, ptyFile *os.File) func() {
+	if ptyFile == nil {
+		return func() {}
+	}
+
+	winchSignals := make(chan os.Signal, 1)
+	signal.Notify(winchSignals, syscall.SIGWINCH)
+
+	stopCh := make(chan struct{})
+	var stopOnce sync.Once
+	var watcherWG sync.WaitGroup
+	watcherWG.Add(1)
+	go func() {
+		defer watcherWG.Done()
+		for {
+			select {
+			case <-stopCh:
+				return
+			case _, ok := <-winchSignals:
+				if !ok {
+					return
+				}
+				syncPTYWindowSize(errWriter, ptyFile)
+			}
+		}
+	}()
+
+	return func() {
+		stopOnce.Do(func() {
+			signal.Stop(winchSignals)
+			close(stopCh)
+			watcherWG.Wait()
+		})
+	}
+}
+
+// writeProxyText 统一将代理自输出的换行规范化为 CRLF，适配 Raw Mode 下的终端显示。
+func writeProxyText(writer io.Writer, text string) {
+	if writer == nil || text == "" {
+		return
+	}
+	_, _ = io.WriteString(writer, proxyOutputLineEndingNormalizer.Replace(text))
+}
+
+// writeProxyLine 向代理输出写入单行文本，并追加 CRLF 换行。
+func writeProxyLine(writer io.Writer, text string) {
+	writeProxyText(writer, text+"\n")
+}
+
+// writeProxyf 使用格式化字符串输出代理信息，并统一换行为 CRLF。
+func writeProxyf(writer io.Writer, format string, args ...any) {
+	writeProxyText(writer, fmt.Sprintf(format, args...))
+}
+
+// SendDiagnoseSignal 连接 shell 代理暴露的本地 socket，并发送一次诊断触发信令。
+func SendDiagnoseSignal(ctx context.Context, socketPath string) error {
+	normalizedSocket := strings.TrimSpace(socketPath)
+	if normalizedSocket == "" {
+		return errors.New("ptyproxy: diagnose socket path is empty")
+	}
+
+	dialer := net.Dialer{}
+	connection, err := dialer.DialContext(ctx, "unix", normalizedSocket)
+	if err != nil {
+		return fmt.Errorf("ptyproxy: connect diagnose socket: %w", err)
+	}
+	defer connection.Close()
+
+	_ = connection.SetWriteDeadline(time.Now().Add(diagSocketReadDeadline))
+	_, err = connection.Write([]byte(diagSignalPayload))
+	if err != nil {
+		return fmt.Errorf("ptyproxy: send diagnose signal: %w", err)
+	}
+
+	waitDone := make(chan error, 1)
+	go func() {
+		_, readErr := io.ReadAll(connection)
+		waitDone <- readErr
+	}()
+
+	select {
+	case <-ctx.Done():
+		_ = connection.SetReadDeadline(time.Now())
+		<-waitDone
+		return fmt.Errorf("ptyproxy: wait diagnose completion: %w", ctx.Err())
+	case readErr := <-waitDone:
+		if readErr != nil && !isClosedNetworkError(readErr) {
+			return fmt.Errorf("ptyproxy: wait diagnose completion: %w", readErr)
+		}
+	}
+	return nil
+}
+
+// buildShellCommand 构建真实 shell 进程，并在子进程环境中注入诊断 socket 变量。
+func buildShellCommand(shellPath string, options ManualShellOptions, socketPath string) *exec.Cmd {
+	command := exec.Command(shellPath)
+	command.Dir = options.Workdir
+	command.Env = MergeEnvVar(os.Environ(), DiagSocketEnv, socketPath)
+	return command
+}
+
+// resolveShellPath 按“显式参数 -> SHELL 环境变量 -> /bin/bash”顺序选择实际 shell。
+func resolveShellPath(shellOption string) string {
+	if trimmed := strings.TrimSpace(shellOption); trimmed != "" {
+		return trimmed
+	}
+	if envShell := strings.TrimSpace(os.Getenv("SHELL")); envShell != "" {
+		return envShell
+	}
+	return "/bin/bash"
+}
+
+// listenDiagSocket 创建并监听 Unix socket；路径为空时按进程生成默认地址。
+func listenDiagSocket(socketOption string) (net.Listener, string, error) {
+	socketPath := strings.TrimSpace(socketOption)
+	if socketPath == "" {
+		socketPath = filepath.Join(os.TempDir(), fmt.Sprintf("neocode-diag-%d.sock", os.Getpid()))
+	}
+	socketPath = filepath.Clean(socketPath)
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0o700); err != nil {
+		return nil, "", fmt.Errorf("ptyproxy: create socket directory: %w", err)
+	}
+	if err := cleanupStaleSocket(socketPath); err != nil {
+		return nil, "", err
+	}
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("ptyproxy: listen diagnose socket: %w", err)
+	}
+	if chmodErr := os.Chmod(socketPath, 0o600); chmodErr != nil {
+		_ = listener.Close()
+		return nil, "", fmt.Errorf("ptyproxy: set diagnose socket permission: %w", chmodErr)
+	}
+	return listener, socketPath, nil
+}
+
+// cleanupStaleSocket 删除历史遗留 socket，防止异常退出后下次监听失败。
+func cleanupStaleSocket(socketPath string) error {
+	info, err := os.Lstat(socketPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("ptyproxy: stat diagnose socket path: %w", err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("ptyproxy: diagnose socket path exists and is not socket: %s", socketPath)
+	}
+	if err := os.Remove(socketPath); err != nil {
+		return fmt.Errorf("ptyproxy: remove stale diagnose socket: %w", err)
+	}
+	return nil
+}
+
+// serveDiagSocket 接收本地诊断触发连接，并向消费协程投递触发信号。
+func serveDiagSocket(ctx context.Context, listener net.Listener, triggerCh chan<- diagSignalRequest, errWriter io.Writer) {
+	for {
+		connection, err := listener.Accept()
+		if err != nil {
+			if ctx.Err() != nil || isClosedNetworkError(err) {
+				return
+			}
+			if errWriter != nil {
+				writeProxyf(errWriter, "neocode diag: accept signal error: %v\n", err)
+			}
+			continue
+		}
+		handleDiagSocketConnection(ctx, connection, triggerCh)
+	}
+}
+
+// handleDiagSocketConnection 处理单个诊断请求连接，并在对应诊断渲染结束后返回 ACK 后断开连接。
+func handleDiagSocketConnection(ctx context.Context, connection net.Conn, triggerCh chan<- diagSignalRequest) {
+	if connection == nil {
+		return
+	}
+	defer connection.Close()
+
+	_ = connection.SetReadDeadline(time.Now().Add(diagSocketReadDeadline))
+	reader := bufio.NewReader(io.LimitReader(connection, 1024))
+	_, _ = reader.ReadString('\n')
+	_ = connection.SetReadDeadline(time.Time{})
+
+	request := diagSignalRequest{
+		done: make(chan struct{}),
+	}
+	select {
+	case <-ctx.Done():
+		return
+	case triggerCh <- request:
+	}
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-request.done:
+		_, _ = connection.Write([]byte(diagSignalAckPayload))
+	}
+}
+
+// consumeDiagSignals 串行消费触发信号并执行诊断调用，避免并发请求互相覆盖终端输出。
+func consumeDiagSignals(
+	ctx context.Context,
+	triggerCh <-chan diagSignalRequest,
+	output io.Writer,
+	buffer *UTF8RingBuffer,
+	options ManualShellOptions,
+	socketPath string,
+) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case request, ok := <-triggerCh:
+			if !ok {
+				return
+			}
+			runSingleDiagnosis(output, buffer, options, socketPath)
+			if request.done != nil {
+				close(request.done)
+			}
+		}
+	}
+}
+
+// runSingleDiagnosis 读取最近日志并调用 gateway.executeSystemTool(diagnose) 获取诊断结果。
+func runSingleDiagnosis(output io.Writer, buffer *UTF8RingBuffer, options ManualShellOptions, socketPath string) {
+	if output == nil {
+		return
+	}
+
+	logSnapshot := buffer.SnapshotString()
+	requestArgs := diagnoseToolArgs{
+		ErrorLog: logSnapshot,
+		OSEnv: map[string]string{
+			"os":     runtime.GOOS,
+			"shell":  resolveShellPath(options.Shell),
+			"cwd":    options.Workdir,
+			"socket": socketPath,
+		},
+		CommandText: "",
+		ExitCode:    0,
+	}
+
+	requestPayload, err := json.Marshal(requestArgs)
+	if err != nil {
+		writeProxyf(output, "\n\033[31m[NeoCode Diagnosis]\033[0m 请求构建失败: %v\n", err)
+		return
+	}
+
+	rpcClient, err := gatewayclient.NewGatewayRPCClient(gatewayclient.GatewayRPCClientOptions{
+		ListenAddress: options.GatewayListenAddress,
+		TokenFile:     options.GatewayTokenFile,
+	})
+	if err != nil {
+		writeProxyf(output, "\n\033[31m[NeoCode Diagnosis]\033[0m 网关客户端初始化失败: %v\n", err)
+		return
+	}
+	defer rpcClient.Close()
+
+	callContext, cancel := context.WithTimeout(context.Background(), diagnoseCallTimeout)
+	defer cancel()
+
+	if err := rpcClient.Authenticate(callContext); err != nil {
+		writeProxyf(output, "\n\033[31m[NeoCode Diagnosis]\033[0m 网关认证失败: %v\n", err)
+		return
+	}
+
+	var frame gateway.MessageFrame
+	if err := rpcClient.CallWithOptions(
+		callContext,
+		protocol.MethodGatewayExecuteSystemTool,
+		protocol.ExecuteSystemToolParams{
+			Workdir:   options.Workdir,
+			ToolName:  tools.ToolNameDiagnose,
+			Arguments: requestPayload,
+		},
+		&frame,
+		gatewayclient.GatewayRPCCallOptions{
+			Timeout: diagnoseCallTimeout,
+			Retries: 0,
+		},
+	); err != nil {
+		writeProxyf(output, "\n\033[31m[NeoCode Diagnosis]\033[0m 诊断调用失败: %v\n", err)
+		return
+	}
+
+	if frame.Type == gateway.FrameTypeError && frame.Error != nil {
+		writeProxyf(
+			output,
+			"\n\033[31m[NeoCode Diagnosis]\033[0m 网关返回错误 (%s): %s\n",
+			strings.TrimSpace(frame.Error.Code),
+			strings.TrimSpace(frame.Error.Message),
+		)
+		return
+	}
+	if frame.Type != gateway.FrameTypeAck {
+		writeProxyf(output, "\n\033[31m[NeoCode Diagnosis]\033[0m 网关返回未知帧: %s\n", frame.Type)
+		return
+	}
+
+	toolResult, err := decodeToolResult(frame.Payload)
+	if err != nil {
+		writeProxyf(output, "\n\033[31m[NeoCode Diagnosis]\033[0m 诊断结果解析失败: %v\n", err)
+		return
+	}
+	renderDiagnosis(output, toolResult.Content, toolResult.IsError)
+}
+
+// decodeToolResult 将网关 payload 反序列化为统一的 ToolResult 结构。
+func decodeToolResult(payload any) (tools.ToolResult, error) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return tools.ToolResult{}, fmt.Errorf("encode tool payload: %w", err)
+	}
+	var result tools.ToolResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return tools.ToolResult{}, fmt.Errorf("decode tool payload: %w", err)
+	}
+	return result, nil
+}
+
+// renderDiagnosis 将工具返回渲染成终端可读格式，并在失败时降级展示原始文本。
+func renderDiagnosis(output io.Writer, content string, isError bool) {
+	headerColor := "\033[36m"
+	if isError {
+		headerColor = "\033[31m"
+	}
+	writeProxyf(output, "\n%s[NeoCode Diagnosis]\033[0m\n", headerColor)
+
+	trimmedContent := strings.TrimSpace(content)
+	if trimmedContent == "" {
+		writeProxyLine(output, "- 无可用诊断内容")
+		return
+	}
+
+	var parsed diagnoseToolResult
+	if err := json.Unmarshal([]byte(trimmedContent), &parsed); err != nil || strings.TrimSpace(parsed.RootCause) == "" {
+		writeProxyLine(output, trimmedContent)
+		return
+	}
+
+	writeProxyf(output, "置信度: %.2f\n", parsed.Confidence)
+	writeProxyf(output, "根因: %s\n", strings.TrimSpace(parsed.RootCause))
+	if len(parsed.InvestigationCommands) > 0 {
+		writeProxyLine(output, "建议排查命令:")
+		for _, command := range parsed.InvestigationCommands {
+			writeProxyf(output, "- %s\n", strings.TrimSpace(command))
+		}
+	}
+	if len(parsed.FixCommands) > 0 {
+		writeProxyLine(output, "建议修复命令:")
+		for _, command := range parsed.FixCommands {
+			writeProxyf(output, "- %s\n", strings.TrimSpace(command))
+		}
+	}
+}
+
+// isClosedNetworkError 识别网络连接已关闭类错误，避免重复打印无效噪声。
+func isClosedNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	lower := strings.ToLower(strings.TrimSpace(err.Error()))
+	return strings.Contains(lower, "use of closed network connection")
+}
+
+// serializedWriter 在并发写入场景下串行化输出，避免诊断内容与 shell 输出交错。
+type serializedWriter struct {
+	writer io.Writer
+	lock   *sync.Mutex
+}
+
+// Write 实现 io.Writer 并在写入前加锁。
+func (w *serializedWriter) Write(payload []byte) (int, error) {
+	if w == nil || w.writer == nil {
+		return len(payload), nil
+	}
+	if w.lock == nil {
+		return w.writer.Write(payload)
+	}
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	return w.writer.Write(payload)
+}

--- a/internal/ptyproxy/proxy_unix.go
+++ b/internal/ptyproxy/proxy_unix.go
@@ -115,6 +115,7 @@ func RunManualShell(ctx context.Context, options ManualShellOptions) error {
 	restoreRawTerminal, err := enableHostTerminalRawMode()
 	if err != nil {
 		cancelAccept()
+		_ = listener.Close()
 		cancelDiag()
 		acceptWG.Wait()
 		diagWG.Wait()
@@ -129,6 +130,7 @@ func RunManualShell(ctx context.Context, options ManualShellOptions) error {
 	ptyFile, err := pty.Start(command)
 	if err != nil {
 		cancelAccept()
+		_ = listener.Close()
 		cancelDiag()
 		acceptWG.Wait()
 		diagWG.Wait()

--- a/internal/ptyproxy/proxy_unix.go
+++ b/internal/ptyproxy/proxy_unix.go
@@ -45,8 +45,8 @@ var (
 	restoreTerminal   = term.Restore
 
 	proxyOutputLineEndingNormalizer = strings.NewReplacer(
-		"\r\n", "\n",
-		"\r", "\n",
+		"\r\n", "\r\n",
+		"\r", "\r\n",
 		"\n", "\r\n",
 	)
 )

--- a/internal/ptyproxy/proxy_unix.go
+++ b/internal/ptyproxy/proxy_unix.go
@@ -202,7 +202,7 @@ func printProxyExitedBanner(writer io.Writer) {
 	if writer == nil {
 		return
 	}
-	writeProxyText(writer, "\r\n"+proxyExitedBanner+"\r\n")
+	_, _ = fmt.Fprint(writer, "\r\n[ NeoCode Proxy exited ]\r\n")
 }
 
 // enableHostTerminalRawMode 将宿主终端切换到原始模式，并返回可恢复终端状态的函数。

--- a/internal/ptyproxy/proxy_unix_test.go
+++ b/internal/ptyproxy/proxy_unix_test.go
@@ -5,7 +5,10 @@ package ptyproxy
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -13,6 +16,10 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"neo-code/internal/gateway"
+	"neo-code/internal/gateway/protocol"
+	"neo-code/internal/tools"
 
 	"golang.org/x/term"
 )
@@ -24,6 +31,75 @@ func assertNoBareLineFeed(t *testing.T, text string) {
 			t.Fatalf("output contains bare LF at index %d: %q", index, text)
 		}
 	}
+}
+
+func findTestShellPath(t *testing.T) string {
+	t.Helper()
+
+	candidates := []string{
+		"/bin/sh",
+		"/usr/bin/sh",
+		"/bin/bash",
+		"/usr/bin/bash",
+	}
+	for _, candidate := range candidates {
+		info, err := os.Stat(candidate)
+		if err == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+	t.Skip("no usable shell executable found for PTY test")
+	return ""
+}
+
+func writeGatewayRPCResult(responseWriter *json.Encoder, id json.RawMessage, result any) error {
+	response, rpcError := protocol.NewJSONRPCResultResponse(id, result)
+	if rpcError != nil {
+		return fmt.Errorf("build jsonrpc response failed: %s", strings.TrimSpace(rpcError.Message))
+	}
+	if err := responseWriter.Encode(response); err != nil {
+		return fmt.Errorf("encode jsonrpc response failed: %w", err)
+	}
+	return nil
+}
+
+func writeGatewayTokenFile(t *testing.T, tokenPath string, token string) {
+	t.Helper()
+	payload := map[string]any{
+		"version":    1,
+		"token":      token,
+		"created_at": time.Now().UTC(),
+		"updated_at": time.Now().UTC(),
+	}
+	raw, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal token payload error = %v", err)
+	}
+	raw = append(raw, '\n')
+	if err := os.WriteFile(tokenPath, raw, 0o600); err != nil {
+		t.Fatalf("write token file error = %v", err)
+	}
+}
+
+func withRawModeDisabledForTest(t *testing.T) {
+	t.Helper()
+	originalInput := hostTerminalInput
+	originalIsTerminal := isTerminalFD
+	originalMakeRaw := makeRawTerminal
+	originalRestore := restoreTerminal
+	t.Cleanup(func() {
+		hostTerminalInput = originalInput
+		isTerminalFD = originalIsTerminal
+		makeRawTerminal = originalMakeRaw
+		restoreTerminal = originalRestore
+	})
+
+	hostTerminalInput = nil
+	isTerminalFD = func(int) bool { return false }
+	makeRawTerminal = func(int) (*term.State, error) {
+		return nil, errors.New("makeRawTerminal should not be called when hostTerminalInput is nil")
+	}
+	restoreTerminal = func(int, *term.State) error { return nil }
 }
 
 func TestBuildShellCommandInjectsDiagEnv(t *testing.T) {
@@ -50,6 +126,83 @@ func TestBuildShellCommandInjectsDiagEnv(t *testing.T) {
 	}
 	if entries[0] != DiagSocketEnv+"=/tmp/new.sock" {
 		t.Fatalf("diag env entry = %q, want %q", entries[0], DiagSocketEnv+"=/tmp/new.sock")
+	}
+}
+
+func TestRunManualShellSuccess(t *testing.T) {
+	withRawModeDisabledForTest(t)
+
+	stdoutBuffer := &bytes.Buffer{}
+	stderrBuffer := &bytes.Buffer{}
+	workdir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := RunManualShell(ctx, ManualShellOptions{
+		Workdir:              workdir,
+		Shell:                findTestShellPath(t),
+		SocketPath:           filepath.Join(t.TempDir(), "diag.sock"),
+		GatewayListenAddress: filepath.Join(t.TempDir(), "missing-gateway.sock"),
+		GatewayTokenFile:     filepath.Join(t.TempDir(), "missing-auth.json"),
+		Stdin:                strings.NewReader("exit 0\n"),
+		Stdout:               stdoutBuffer,
+		Stderr:               stderrBuffer,
+	})
+	if err != nil {
+		t.Fatalf("RunManualShell() error = %v", err)
+	}
+
+	output := stdoutBuffer.String()
+	if !strings.Contains(output, proxyInitializedBanner) {
+		t.Fatalf("stdout = %q, want contains %q", output, proxyInitializedBanner)
+	}
+	if !strings.Contains(output, proxyExitedBanner) {
+		t.Fatalf("stdout = %q, want contains %q", output, proxyExitedBanner)
+	}
+	assertNoBareLineFeed(t, output)
+}
+
+func TestRunManualShellFailsOnMissingShell(t *testing.T) {
+	withRawModeDisabledForTest(t)
+
+	err := RunManualShell(context.Background(), ManualShellOptions{
+		Workdir:    t.TempDir(),
+		Shell:      filepath.Join(t.TempDir(), "missing-shell"),
+		SocketPath: filepath.Join(t.TempDir(), "diag.sock"),
+		Stdin:      strings.NewReader("exit 0\n"),
+		Stdout:     &bytes.Buffer{},
+		Stderr:     &bytes.Buffer{},
+	})
+	if err == nil {
+		t.Fatal("expected shell start error")
+	}
+	if !strings.Contains(err.Error(), "start pty shell") {
+		t.Fatalf("error = %v, want contains %q", err, "start pty shell")
+	}
+}
+
+func TestRunManualShellFailsOnInvalidSocketPath(t *testing.T) {
+	withRawModeDisabledForTest(t)
+
+	workspace := t.TempDir()
+	blockingFile := filepath.Join(workspace, "blocking-file")
+	if err := os.WriteFile(blockingFile, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write blocking file error = %v", err)
+	}
+
+	err := RunManualShell(context.Background(), ManualShellOptions{
+		Workdir:    workspace,
+		Shell:      findTestShellPath(t),
+		SocketPath: filepath.Join(blockingFile, "diag.sock"),
+		Stdin:      strings.NewReader("exit 0\n"),
+		Stdout:     &bytes.Buffer{},
+		Stderr:     &bytes.Buffer{},
+	})
+	if err == nil {
+		t.Fatal("expected socket path error")
+	}
+	if !strings.Contains(err.Error(), "create socket directory") {
+		t.Fatalf("error = %v, want contains %q", err, "create socket directory")
 	}
 }
 
@@ -199,6 +352,135 @@ func TestRunSingleDiagnosisGatewayUnavailableDoesNotPanic(t *testing.T) {
 		t.Fatalf("output = %q, want contains %q", output.String(), "NeoCode Diagnosis")
 	}
 	assertNoBareLineFeed(t, output.String())
+}
+
+func TestRunSingleDiagnosisGatewayHappyPath(t *testing.T) {
+	tempDir := t.TempDir()
+	gatewaySocketPath := filepath.Join(tempDir, "gateway.sock")
+	listener, err := net.Listen("unix", gatewaySocketPath)
+	if err != nil {
+		t.Fatalf("listen gateway socket error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+		_ = os.Remove(gatewaySocketPath)
+	})
+
+	tokenFile := filepath.Join(tempDir, "auth.json")
+	const expectedToken = "diag-test-token"
+	writeGatewayTokenFile(t, tokenFile, expectedToken)
+
+	serverErrCh := make(chan error, 1)
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			serverErrCh <- fmt.Errorf("accept gateway connection: %w", acceptErr)
+			return
+		}
+		defer connection.Close()
+
+		requestReader := json.NewDecoder(connection)
+		responseWriter := json.NewEncoder(connection)
+
+		var authRequest protocol.JSONRPCRequest
+		if err := requestReader.Decode(&authRequest); err != nil {
+			serverErrCh <- fmt.Errorf("decode auth request: %w", err)
+			return
+		}
+		if authRequest.Method != protocol.MethodGatewayAuthenticate {
+			serverErrCh <- fmt.Errorf("auth method = %q, want %q", authRequest.Method, protocol.MethodGatewayAuthenticate)
+			return
+		}
+
+		var authParams protocol.AuthenticateParams
+		if err := json.Unmarshal(authRequest.Params, &authParams); err != nil {
+			serverErrCh <- fmt.Errorf("decode auth params: %w", err)
+			return
+		}
+		if authParams.Token != expectedToken {
+			serverErrCh <- fmt.Errorf("auth token = %q, want %q", authParams.Token, expectedToken)
+			return
+		}
+		if err := writeGatewayRPCResult(responseWriter, authRequest.ID, gateway.MessageFrame{
+			Type:   gateway.FrameTypeAck,
+			Action: gateway.FrameActionAuthenticate,
+		}); err != nil {
+			serverErrCh <- err
+			return
+		}
+
+		var executeRequest protocol.JSONRPCRequest
+		if err := requestReader.Decode(&executeRequest); err != nil {
+			serverErrCh <- fmt.Errorf("decode execute request: %w", err)
+			return
+		}
+		if executeRequest.Method != protocol.MethodGatewayExecuteSystemTool {
+			serverErrCh <- fmt.Errorf(
+				"execute method = %q, want %q",
+				executeRequest.Method,
+				protocol.MethodGatewayExecuteSystemTool,
+			)
+			return
+		}
+
+		var executeParams protocol.ExecuteSystemToolParams
+		if err := json.Unmarshal(executeRequest.Params, &executeParams); err != nil {
+			serverErrCh <- fmt.Errorf("decode execute params: %w", err)
+			return
+		}
+		if executeParams.ToolName != tools.ToolNameDiagnose {
+			serverErrCh <- fmt.Errorf("tool_name = %q, want %q", executeParams.ToolName, tools.ToolNameDiagnose)
+			return
+		}
+
+		responsePayload := tools.ToolResult{
+			Content: `{"confidence":0.95,"root_cause":"disk full","investigation_commands":["df -h"],"fix_commands":["rm -rf /tmp/*"]}`,
+			IsError: false,
+		}
+		if err := writeGatewayRPCResult(responseWriter, executeRequest.ID, gateway.MessageFrame{
+			Type:    gateway.FrameTypeAck,
+			Action:  gateway.FrameActionExecuteSystemTool,
+			Payload: responsePayload,
+		}); err != nil {
+			serverErrCh <- err
+			return
+		}
+		serverErrCh <- nil
+	}()
+
+	logBuffer := NewUTF8RingBuffer(1024)
+	_, _ = logBuffer.Write([]byte("诊断样本日志"))
+	outputBuffer := &bytes.Buffer{}
+	runSingleDiagnosis(outputBuffer, logBuffer, ManualShellOptions{
+		Workdir:              tempDir,
+		Shell:                findTestShellPath(t),
+		GatewayListenAddress: gatewaySocketPath,
+		GatewayTokenFile:     tokenFile,
+	}, filepath.Join(tempDir, "diag.sock"))
+
+	select {
+	case serverErr := <-serverErrCh:
+		if serverErr != nil {
+			t.Fatalf("gateway mock server error = %v", serverErr)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for gateway mock server")
+	}
+
+	output := outputBuffer.String()
+	if !strings.Contains(output, "NeoCode Diagnosis") {
+		t.Fatalf("output = %q, want contains %q", output, "NeoCode Diagnosis")
+	}
+	if !strings.Contains(output, "根因: disk full") {
+		t.Fatalf("output = %q, want contains %q", output, "根因: disk full")
+	}
+	if !strings.Contains(output, "建议排查命令") {
+		t.Fatalf("output = %q, want contains %q", output, "建议排查命令")
+	}
+	if !strings.Contains(output, "建议修复命令") {
+		t.Fatalf("output = %q, want contains %q", output, "建议修复命令")
+	}
+	assertNoBareLineFeed(t, output)
 }
 
 func TestPrintProxyInitializedBanner(t *testing.T) {
@@ -612,6 +894,119 @@ func TestCleanupStaleSocketNotExist(t *testing.T) {
 
 func TestHandleDiagSocketConnectionNil(t *testing.T) {
 	handleDiagSocketConnection(context.Background(), nil, make(chan diagSignalRequest, 1))
+}
+
+func TestHandleDiagSocketConnectionEmitsTriggerAndAck(t *testing.T) {
+	serverConnection, clientConnection := net.Pipe()
+	defer clientConnection.Close()
+
+	triggerCh := make(chan diagSignalRequest, 1)
+	done := make(chan struct{})
+	go func() {
+		handleDiagSocketConnection(context.Background(), serverConnection, triggerCh)
+		close(done)
+	}()
+
+	if _, err := clientConnection.Write([]byte(diagSignalPayload)); err != nil {
+		t.Fatalf("write payload error = %v", err)
+	}
+
+	var request diagSignalRequest
+	select {
+	case request = <-triggerCh:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for trigger request")
+	}
+	if request.done == nil {
+		t.Fatal("request.done should not be nil")
+	}
+
+	if err := clientConnection.SetReadDeadline(time.Now().Add(120 * time.Millisecond)); err != nil {
+		t.Fatalf("set read deadline error = %v", err)
+	}
+	ackBuffer := make([]byte, len(diagSignalAckPayload))
+	if _, err := io.ReadFull(clientConnection, ackBuffer); err == nil {
+		t.Fatalf("ack should not be readable before diagnosis completion, got %q", string(ackBuffer))
+	}
+	_ = clientConnection.SetReadDeadline(time.Time{})
+
+	close(request.done)
+	if _, err := io.ReadFull(clientConnection, ackBuffer); err != nil {
+		t.Fatalf("read ack error = %v", err)
+	}
+	if string(ackBuffer) != diagSignalAckPayload {
+		t.Fatalf("ack payload = %q, want %q", string(ackBuffer), diagSignalAckPayload)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for handleDiagSocketConnection to return")
+	}
+}
+
+func TestServeDiagSocketHandlesUnexpectedAndNormalPayload(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "serve-diag.sock")
+	listener, resolvedPath, err := listenDiagSocket(socketPath)
+	if err != nil {
+		t.Fatalf("listenDiagSocket() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+		_ = os.Remove(resolvedPath)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	triggerCh := make(chan diagSignalRequest, 2)
+	serveDone := make(chan struct{})
+	go func() {
+		serveDiagSocket(ctx, listener, triggerCh, nil)
+		close(serveDone)
+	}()
+
+	sendAndVerify := func(payload string) {
+		t.Helper()
+		connection, err := net.Dial("unix", resolvedPath)
+		if err != nil {
+			t.Fatalf("dial diag socket error = %v", err)
+		}
+		defer connection.Close()
+
+		if _, err := connection.Write([]byte(payload)); err != nil {
+			t.Fatalf("write payload error = %v", err)
+		}
+
+		var request diagSignalRequest
+		select {
+		case request = <-triggerCh:
+		case <-time.After(time.Second):
+			t.Fatalf("timeout waiting for trigger, payload=%q", payload)
+		}
+		if request.done == nil {
+			t.Fatal("request.done should not be nil")
+		}
+		close(request.done)
+
+		ack := make([]byte, len(diagSignalAckPayload))
+		if _, err := io.ReadFull(connection, ack); err != nil {
+			t.Fatalf("read ack error = %v", err)
+		}
+		if string(ack) != diagSignalAckPayload {
+			t.Fatalf("ack payload = %q, want %q", string(ack), diagSignalAckPayload)
+		}
+	}
+
+	sendAndVerify("unexpected-signal\n")
+	sendAndVerify(diagSignalPayload)
+
+	cancel()
+	_ = listener.Close()
+	select {
+	case <-serveDone:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for serveDiagSocket to stop")
+	}
 }
 
 func TestConsumeDiagSignalsContextCancel(t *testing.T) {

--- a/internal/ptyproxy/proxy_unix_test.go
+++ b/internal/ptyproxy/proxy_unix_test.go
@@ -1,0 +1,372 @@
+//go:build !windows
+
+package ptyproxy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/term"
+)
+
+func assertNoBareLineFeed(t *testing.T, text string) {
+	t.Helper()
+	for index := 0; index < len(text); index++ {
+		if text[index] == '\n' && (index == 0 || text[index-1] != '\r') {
+			t.Fatalf("output contains bare LF at index %d: %q", index, text)
+		}
+	}
+}
+
+func TestBuildShellCommandInjectsDiagEnv(t *testing.T) {
+	t.Setenv(DiagSocketEnv, "/tmp/old.sock")
+	command := buildShellCommand("/bin/bash", ManualShellOptions{
+		Workdir: "/tmp",
+	}, "/tmp/new.sock")
+
+	if command.Path != "/bin/bash" {
+		t.Fatalf("command.Path = %q, want %q", command.Path, "/bin/bash")
+	}
+	if command.Dir != "/tmp" {
+		t.Fatalf("command.Dir = %q, want %q", command.Dir, "/tmp")
+	}
+
+	var entries []string
+	for _, item := range command.Env {
+		if strings.HasPrefix(item, DiagSocketEnv+"=") {
+			entries = append(entries, item)
+		}
+	}
+	if len(entries) != 1 {
+		t.Fatalf("diag env entries len = %d, want 1", len(entries))
+	}
+	if entries[0] != DiagSocketEnv+"=/tmp/new.sock" {
+		t.Fatalf("diag env entry = %q, want %q", entries[0], DiagSocketEnv+"=/tmp/new.sock")
+	}
+}
+
+func TestSendDiagnoseSignal(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "diag.sock")
+	listener, resolvedPath, err := listenDiagSocket(socketPath)
+	if err != nil {
+		t.Fatalf("listenDiagSocket() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+		_ = os.Remove(resolvedPath)
+	})
+
+	payloadCh := make(chan string, 1)
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			payloadCh <- "accept-error:" + acceptErr.Error()
+			return
+		}
+		defer connection.Close()
+		buffer := make([]byte, 128)
+		n, readErr := connection.Read(buffer)
+		if readErr != nil {
+			payloadCh <- "read-error:" + readErr.Error()
+			return
+		}
+		payloadCh <- string(buffer[:n])
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := SendDiagnoseSignal(ctx, resolvedPath); err != nil {
+		t.Fatalf("SendDiagnoseSignal() error = %v", err)
+	}
+
+	select {
+	case payload := <-payloadCh:
+		if payload != diagSignalPayload {
+			t.Fatalf("payload = %q, want %q", payload, diagSignalPayload)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for payload")
+	}
+}
+
+func TestSendDiagnoseSignalWaitsForServerCompletion(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "diag-wait.sock")
+	listener, resolvedPath, err := listenDiagSocket(socketPath)
+	if err != nil {
+		t.Fatalf("listenDiagSocket() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+		_ = os.Remove(resolvedPath)
+	})
+
+	const serverDelay = 120 * time.Millisecond
+	serverErrCh := make(chan error, 1)
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			serverErrCh <- acceptErr
+			return
+		}
+		defer connection.Close()
+		buffer := make([]byte, 128)
+		n, readErr := connection.Read(buffer)
+		if readErr != nil {
+			serverErrCh <- readErr
+			return
+		}
+		if string(buffer[:n]) != diagSignalPayload {
+			serverErrCh <- errors.New("unexpected payload")
+			return
+		}
+		time.Sleep(serverDelay)
+		_, writeErr := connection.Write([]byte(diagSignalAckPayload))
+		serverErrCh <- writeErr
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	start := time.Now()
+	if err := SendDiagnoseSignal(ctx, resolvedPath); err != nil {
+		t.Fatalf("SendDiagnoseSignal() error = %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < serverDelay {
+		t.Fatalf("SendDiagnoseSignal returned too early: elapsed=%s, want >= %s", elapsed, serverDelay)
+	}
+
+	select {
+	case serverErr := <-serverErrCh:
+		if serverErr != nil {
+			t.Fatalf("server error = %v", serverErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for server completion")
+	}
+}
+
+func TestListenDiagSocketRecoversStaleSocket(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "stale.sock")
+	staleListener, resolvedPath, err := listenDiagSocket(socketPath)
+	if err != nil {
+		t.Fatalf("prepare stale listener error = %v", err)
+	}
+	_ = staleListener.Close()
+
+	listener, _, err := listenDiagSocket(resolvedPath)
+	if err != nil {
+		t.Fatalf("listenDiagSocket() with stale socket error = %v", err)
+	}
+	_ = listener.Close()
+	_ = os.Remove(resolvedPath)
+}
+
+func TestCleanupStaleSocketRejectsRegularFile(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "not-socket.sock")
+	if err := os.WriteFile(socketPath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file error = %v", err)
+	}
+	err := cleanupStaleSocket(socketPath)
+	if err == nil {
+		t.Fatal("expected non-socket error")
+	}
+	if !strings.Contains(err.Error(), "not socket") {
+		t.Fatalf("error = %v, want contains %q", err, "not socket")
+	}
+}
+
+func TestRunSingleDiagnosisGatewayUnavailableDoesNotPanic(t *testing.T) {
+	buffer := NewUTF8RingBuffer(1024)
+	_, _ = buffer.Write([]byte("中文日志 + \u001b[31merror\u001b[0m"))
+
+	output := &bytes.Buffer{}
+	runSingleDiagnosis(output, buffer, ManualShellOptions{
+		Workdir:              t.TempDir(),
+		Shell:                "/bin/bash",
+		GatewayListenAddress: filepath.Join(t.TempDir(), "missing-gateway.sock"),
+		GatewayTokenFile:     filepath.Join(t.TempDir(), "missing-auth.json"),
+	}, filepath.Join(t.TempDir(), "diag.sock"))
+
+	if !strings.Contains(output.String(), "NeoCode Diagnosis") {
+		t.Fatalf("output = %q, want contains %q", output.String(), "NeoCode Diagnosis")
+	}
+	assertNoBareLineFeed(t, output.String())
+}
+
+func TestPrintProxyInitializedBanner(t *testing.T) {
+	buffer := &bytes.Buffer{}
+	printProxyInitializedBanner(buffer)
+	if buffer.String() != proxyInitializedBanner+"\r\n" {
+		t.Fatalf("banner output = %q, want %q", buffer.String(), proxyInitializedBanner+"\\r\\n")
+	}
+}
+
+func TestPrintProxyExitedBanner(t *testing.T) {
+	buffer := &bytes.Buffer{}
+	printProxyExitedBanner(buffer)
+	if buffer.String() != "\r\n"+proxyExitedBanner+"\r\n" {
+		t.Fatalf("banner output = %q, want %q", buffer.String(), "\\r\\n"+proxyExitedBanner+"\\r\\n")
+	}
+}
+
+func TestRenderDiagnosisUsesCRLFLineEndings(t *testing.T) {
+	buffer := &bytes.Buffer{}
+	renderDiagnosis(buffer, "", false)
+	output := buffer.String()
+	assertNoBareLineFeed(t, output)
+	if !strings.Contains(output, "\r\n") {
+		t.Fatalf("renderDiagnosis output = %q, want contains CRLF", output)
+	}
+}
+
+func TestEnableHostTerminalRawModeSkipsNonTerminal(t *testing.T) {
+	originalInput := hostTerminalInput
+	originalIsTerminal := isTerminalFD
+	originalMakeRaw := makeRawTerminal
+	originalRestore := restoreTerminal
+	t.Cleanup(func() {
+		hostTerminalInput = originalInput
+		isTerminalFD = originalIsTerminal
+		makeRawTerminal = originalMakeRaw
+		restoreTerminal = originalRestore
+	})
+
+	filePath := filepath.Join(t.TempDir(), "stdin.txt")
+	if err := os.WriteFile(filePath, []byte("stdin"), 0o600); err != nil {
+		t.Fatalf("write stdin file error = %v", err)
+	}
+	inputFile, err := os.Open(filePath)
+	if err != nil {
+		t.Fatalf("open stdin file error = %v", err)
+	}
+	defer inputFile.Close()
+
+	hostTerminalInput = inputFile
+	isTerminalFD = func(int) bool { return false }
+
+	makeRawCalled := false
+	makeRawTerminal = func(int) (*term.State, error) {
+		makeRawCalled = true
+		return &term.State{}, nil
+	}
+	restoreFn, err := enableHostTerminalRawMode()
+	if err != nil {
+		t.Fatalf("enableHostTerminalRawMode() error = %v", err)
+	}
+	if makeRawCalled {
+		t.Fatal("makeRawTerminal should not be called for non-terminal input")
+	}
+	if restoreErr := restoreFn(); restoreErr != nil {
+		t.Fatalf("restoreFn() error = %v", restoreErr)
+	}
+}
+
+func TestEnableHostTerminalRawModeCallsMakeRawAndRestore(t *testing.T) {
+	originalInput := hostTerminalInput
+	originalIsTerminal := isTerminalFD
+	originalMakeRaw := makeRawTerminal
+	originalRestore := restoreTerminal
+	t.Cleanup(func() {
+		hostTerminalInput = originalInput
+		isTerminalFD = originalIsTerminal
+		makeRawTerminal = originalMakeRaw
+		restoreTerminal = originalRestore
+	})
+
+	filePath := filepath.Join(t.TempDir(), "stdin-terminal.txt")
+	if err := os.WriteFile(filePath, []byte("stdin"), 0o600); err != nil {
+		t.Fatalf("write stdin file error = %v", err)
+	}
+	inputFile, err := os.Open(filePath)
+	if err != nil {
+		t.Fatalf("open stdin file error = %v", err)
+	}
+	defer inputFile.Close()
+	hostTerminalInput = inputFile
+
+	expectedFD := int(inputFile.Fd())
+	state := &term.State{}
+	makeRawCalled := false
+	restoreCalled := false
+
+	isTerminalFD = func(fd int) bool {
+		if fd != expectedFD {
+			t.Fatalf("isTerminal fd = %d, want %d", fd, expectedFD)
+		}
+		return true
+	}
+	makeRawTerminal = func(fd int) (*term.State, error) {
+		if fd != expectedFD {
+			t.Fatalf("makeRaw fd = %d, want %d", fd, expectedFD)
+		}
+		makeRawCalled = true
+		return state, nil
+	}
+	restoreTerminal = func(fd int, restored *term.State) error {
+		if fd != expectedFD {
+			t.Fatalf("restore fd = %d, want %d", fd, expectedFD)
+		}
+		if restored != state {
+			t.Fatalf("restore state pointer mismatch")
+		}
+		restoreCalled = true
+		return nil
+	}
+
+	restoreFn, err := enableHostTerminalRawMode()
+	if err != nil {
+		t.Fatalf("enableHostTerminalRawMode() error = %v", err)
+	}
+	if !makeRawCalled {
+		t.Fatal("expected makeRawTerminal to be called")
+	}
+	if restoreErr := restoreFn(); restoreErr != nil {
+		t.Fatalf("restoreFn() error = %v", restoreErr)
+	}
+	if !restoreCalled {
+		t.Fatal("expected restoreTerminal to be called")
+	}
+}
+
+func TestEnableHostTerminalRawModeMakeRawError(t *testing.T) {
+	originalInput := hostTerminalInput
+	originalIsTerminal := isTerminalFD
+	originalMakeRaw := makeRawTerminal
+	originalRestore := restoreTerminal
+	t.Cleanup(func() {
+		hostTerminalInput = originalInput
+		isTerminalFD = originalIsTerminal
+		makeRawTerminal = originalMakeRaw
+		restoreTerminal = originalRestore
+	})
+
+	filePath := filepath.Join(t.TempDir(), "stdin-error.txt")
+	if err := os.WriteFile(filePath, []byte("stdin"), 0o600); err != nil {
+		t.Fatalf("write stdin file error = %v", err)
+	}
+	inputFile, err := os.Open(filePath)
+	if err != nil {
+		t.Fatalf("open stdin file error = %v", err)
+	}
+	defer inputFile.Close()
+	hostTerminalInput = inputFile
+
+	isTerminalFD = func(int) bool { return true }
+	makeRawTerminal = func(int) (*term.State, error) {
+		return nil, errors.New("raw mode failed")
+	}
+
+	_, err = enableHostTerminalRawMode()
+	if err == nil {
+		t.Fatal("expected raw mode error")
+	}
+	if !strings.Contains(err.Error(), "set host terminal raw mode") {
+		t.Fatalf("error = %v, want contains %q", err, "set host terminal raw mode")
+	}
+}

--- a/internal/ptyproxy/proxy_unix_test.go
+++ b/internal/ptyproxy/proxy_unix_test.go
@@ -527,7 +527,10 @@ func TestWatchPTYWindowResizeNilPTY(t *testing.T) {
 }
 
 func TestDecodeToolResult(t *testing.T) {
-	result, err := decodeToolResult([]byte(`{"content":"ok","isError":false}`))
+	result, err := decodeToolResult(map[string]any{
+		"content": "ok",
+		"isError": false,
+	})
 	if err != nil {
 		t.Fatalf("decodeToolResult() error = %v", err)
 	}
@@ -585,7 +588,7 @@ func TestRenderDiagnosisErrorHeader(t *testing.T) {
 
 func TestRenderDiagnosisFullContent(t *testing.T) {
 	var buffer bytes.Buffer
-	renderDiagnosis(&buffer, `{"confidence":0.95,"rootCause":"disk full","investigationCommands":["df -h"],"fixCommands":["rm -rf /tmp/*"]}`, false)
+	renderDiagnosis(&buffer, `{"confidence":0.95,"root_cause":"disk full","investigation_commands":["df -h"],"fix_commands":["rm -rf /tmp/*"]}`, false)
 	output := buffer.String()
 	assertNoBareLineFeed(t, output)
 	if !strings.Contains(output, "置信度: 0.95") {

--- a/internal/ptyproxy/proxy_unix_test.go
+++ b/internal/ptyproxy/proxy_unix_test.go
@@ -6,9 +6,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 

--- a/internal/ptyproxy/proxy_unix_test.go
+++ b/internal/ptyproxy/proxy_unix_test.go
@@ -370,3 +370,262 @@ func TestEnableHostTerminalRawModeMakeRawError(t *testing.T) {
 		t.Fatalf("error = %v, want contains %q", err, "set host terminal raw mode")
 	}
 }
+
+func TestResolveShellPathDefaultsToBinBash(t *testing.T) {
+	t.Setenv("SHELL", "")
+	path := resolveShellPath("")
+	if path != "/bin/bash" {
+		t.Fatalf("resolveShellPath() = %q, want %q", path, "/bin/bash")
+	}
+}
+
+func TestResolveShellPathUsesShellEnv(t *testing.T) {
+	t.Setenv("SHELL", "/bin/zsh")
+	path := resolveShellPath("")
+	if path != "/bin/zsh" {
+		t.Fatalf("resolveShellPath() = %q, want %q", path, "/bin/zsh")
+	}
+}
+
+func TestResolveShellPathPrefersExplicit(t *testing.T) {
+	t.Setenv("SHELL", "/bin/zsh")
+	path := resolveShellPath("/bin/fish")
+	if path != "/bin/fish" {
+		t.Fatalf("resolveShellPath() = %q, want %q", path, "/bin/fish")
+	}
+}
+
+func TestIsClosedNetworkErrorNil(t *testing.T) {
+	if isClosedNetworkError(nil) {
+		t.Fatal("isClosedNetworkError(nil) should be false")
+	}
+}
+
+func TestIsClosedNetworkErrorDetectsNetErrClosed(t *testing.T) {
+	if !isClosedNetworkError(net.ErrClosed) {
+		t.Fatal("isClosedNetworkError(net.ErrClosed) should be true")
+	}
+}
+
+func TestIsClosedNetworkErrorDetectsStringMatch(t *testing.T) {
+	err := errors.New("use of closed network connection")
+	if !isClosedNetworkError(err) {
+		t.Fatal("isClosedNetworkError() should be true for closed connection string")
+	}
+}
+
+func TestIsClosedNetworkErrorNonMatch(t *testing.T) {
+	err := errors.New("some other error")
+	if isClosedNetworkError(err) {
+		t.Fatal("isClosedNetworkError() should be false for unrelated error")
+	}
+}
+
+func TestSerializedWriterNilWriter(t *testing.T) {
+	var w *serializedWriter
+	n, err := w.Write([]byte("hello"))
+	if err != nil {
+		t.Fatalf("Write() on nil receiver error = %v", err)
+	}
+	if n != len("hello") {
+		t.Fatalf("Write() n = %d, want %d", n, len("hello"))
+	}
+}
+
+func TestSerializedWriterNilLock(t *testing.T) {
+	var buffer bytes.Buffer
+	w := &serializedWriter{writer: &buffer, lock: nil}
+	n, err := w.Write([]byte("data"))
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if n != 4 {
+		t.Fatalf("Write() n = %d, want 4", n)
+	}
+	if buffer.String() != "data" {
+		t.Fatalf("buffer = %q, want %q", buffer.String(), "data")
+	}
+}
+
+func TestSerializedWriterWithLock(t *testing.T) {
+	var buffer bytes.Buffer
+	var mu sync.Mutex
+	w := &serializedWriter{writer: &buffer, lock: &mu}
+	n, err := w.Write([]byte("locked-write"))
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if n != len("locked-write") {
+		t.Fatalf("Write() n = %d, want %d", n, len("locked-write"))
+	}
+	if buffer.String() != "locked-write" {
+		t.Fatalf("buffer = %q, want %q", buffer.String(), "locked-write")
+	}
+}
+
+func TestWriteProxyTextNilWriter(t *testing.T) {
+	writeProxyText(nil, "text")
+	writeProxyLine(nil, "text")
+}
+
+func TestWriteProxyTextEmptyText(t *testing.T) {
+	var buffer bytes.Buffer
+	writeProxyText(&buffer, "")
+	if buffer.Len() != 0 {
+		t.Fatalf("expected empty output, got %q", buffer.String())
+	}
+}
+
+func TestWriteProxyTextNormalizesLineEndings(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"hello\nworld", "hello\r\nworld"},
+		{"hello\r\nworld", "hello\r\nworld"},
+		{"hello\rworld", "hello\r\nworld"},
+		{"line1\nline2\nline3", "line1\r\nline2\r\nline3"},
+	}
+	for _, tt := range tests {
+		var buffer bytes.Buffer
+		writeProxyText(&buffer, tt.input)
+		if buffer.String() != tt.expected {
+			t.Fatalf("writeProxyText(%q) = %q, want %q", tt.input, buffer.String(), tt.expected)
+		}
+	}
+}
+
+func TestWriteProxyLine(t *testing.T) {
+	var buffer bytes.Buffer
+	writeProxyLine(&buffer, "header")
+	// writeProxyText with "\n" appended → normalized to "\r\n"
+	if buffer.String() != "header\r\n" {
+		t.Fatalf("writeProxyLine output = %q, want %q", buffer.String(), "header\\r\\n")
+	}
+}
+
+func TestWriteProxyf(t *testing.T) {
+	var buffer bytes.Buffer
+	writeProxyf(&buffer, "count=%d, name=%s", 42, "test")
+	expected := "count=42, name=test"
+	// writeProxyf → writeProxyText which normalizes
+	got := buffer.String()
+	if got != expected {
+		t.Fatalf("writeProxyf output = %q, want %q", got, expected)
+	}
+}
+
+func TestSyncPTYWindowSizeNilPTY(t *testing.T) {
+	syncPTYWindowSize(nil, nil)
+}
+
+func TestWatchPTYWindowResizeNilPTY(t *testing.T) {
+	stop := watchPTYWindowResize(nil, nil)
+	stop()
+}
+
+func TestDecodeToolResult(t *testing.T) {
+	result, err := decodeToolResult([]byte(`{"content":"ok","isError":false}`))
+	if err != nil {
+		t.Fatalf("decodeToolResult() error = %v", err)
+	}
+	if result.Content != "ok" {
+		t.Fatalf("Content = %q, want %q", result.Content, "ok")
+	}
+	if result.IsError {
+		t.Fatal("IsError should be false")
+	}
+}
+
+func TestDecodeToolResultInvalidPayload(t *testing.T) {
+	_, err := decodeToolResult([]byte(`not-json`))
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+}
+
+func TestDecodeToolResultFromStruct(t *testing.T) {
+	result, err := decodeToolResult(map[string]any{"content": "from-map", "isError": true})
+	if err != nil {
+		t.Fatalf("decodeToolResult() error = %v", err)
+	}
+	if result.Content != "from-map" {
+		t.Fatalf("Content = %q, want %q", result.Content, "from-map")
+	}
+	if !result.IsError {
+		t.Fatal("IsError should be true")
+	}
+}
+
+func TestRenderDiagnosisNilOutput(t *testing.T) {
+	renderDiagnosis(nil, "some content", false)
+}
+
+func TestRenderDiagnosisEmptyContent(t *testing.T) {
+	var buffer bytes.Buffer
+	renderDiagnosis(&buffer, "", false)
+	output := buffer.String()
+	if !strings.Contains(output, "无可用诊断内容") {
+		t.Fatalf("output = %q, want contains %q", output, "无可用诊断内容")
+	}
+	assertNoBareLineFeed(t, output)
+}
+
+func TestRenderDiagnosisErrorHeader(t *testing.T) {
+	var buffer bytes.Buffer
+	renderDiagnosis(&buffer, `{"confidence":0.9,"rootCause":"OOM","fixCommands":["free -h"]}`, true)
+	output := buffer.String()
+	assertNoBareLineFeed(t, output)
+	if !strings.Contains(output, "\033[31m") {
+		t.Fatalf("error output should use red color, got %q", output)
+	}
+}
+
+func TestRenderDiagnosisFullContent(t *testing.T) {
+	var buffer bytes.Buffer
+	renderDiagnosis(&buffer, `{"confidence":0.95,"rootCause":"disk full","investigationCommands":["df -h"],"fixCommands":["rm -rf /tmp/*"]}`, false)
+	output := buffer.String()
+	assertNoBareLineFeed(t, output)
+	if !strings.Contains(output, "置信度: 0.95") {
+		t.Fatalf("output = %q, want contains %q", output, "置信度: 0.95")
+	}
+	if !strings.Contains(output, "建议排查命令") {
+		t.Fatalf("output = %q, want contains %q", output, "建议排查命令")
+	}
+	if !strings.Contains(output, "建议修复命令") {
+		t.Fatalf("output = %q, want contains %q", output, "建议修复命令")
+	}
+}
+
+func TestCleanupStaleSocketNotExist(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "nonexistent.sock")
+	err := cleanupStaleSocket(socketPath)
+	if err != nil {
+		t.Fatalf("cleanupStaleSocket() error = %v, want nil", err)
+	}
+}
+
+func TestHandleDiagSocketConnectionNil(t *testing.T) {
+	handleDiagSocketConnection(context.Background(), nil, make(chan diagSignalRequest, 1))
+}
+
+func TestConsumeDiagSignalsContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	consumeDiagSignals(ctx, nil, nil, nil, ManualShellOptions{}, "")
+}
+
+func TestConsumeDiagSignalsChannelClosed(t *testing.T) {
+	ch := make(chan diagSignalRequest)
+	close(ch)
+	consumeDiagSignals(context.Background(), ch, nil, nil, ManualShellOptions{}, "")
+}
+
+func TestPrintProxyFunctionsNilWriter(t *testing.T) {
+	printProxyInitializedBanner(nil)
+	printProxyExitedBanner(nil)
+}
+
+func TestRunSingleDiagnosisNilOutput(t *testing.T) {
+	runSingleDiagnosis(nil, nil, ManualShellOptions{}, "")
+}

--- a/internal/ptyproxy/proxy_windows.go
+++ b/internal/ptyproxy/proxy_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package ptyproxy
+
+import (
+	"context"
+	"errors"
+)
+
+var errUnsupportedPlatform = errors.New("ptyproxy: manual shell mode is only supported on unix-like systems in phase1")
+
+// RunManualShell 在 Windows 平台返回明确不支持错误，避免误判为静默失败。
+func RunManualShell(context.Context, ManualShellOptions) error {
+	return errUnsupportedPlatform
+}
+
+// SendDiagnoseSignal 在 Windows 平台返回明确不支持错误。
+func SendDiagnoseSignal(context.Context, string) error {
+	return errUnsupportedPlatform
+}

--- a/internal/ptyproxy/ring_buffer.go
+++ b/internal/ptyproxy/ring_buffer.go
@@ -1,0 +1,104 @@
+package ptyproxy
+
+import (
+	"strings"
+	"sync"
+	"unicode/utf8"
+)
+
+// UTF8RingBuffer 提供按字节上限滚动缓存，并在截断时保持 UTF-8 边界安全。
+type UTF8RingBuffer struct {
+	capacity int
+
+	mu   sync.Mutex
+	data []byte
+}
+
+// NewUTF8RingBuffer 创建指定容量的 UTF-8 安全 Ring Buffer；非正容量时退化为 1 字节。
+func NewUTF8RingBuffer(capacity int) *UTF8RingBuffer {
+	if capacity <= 0 {
+		capacity = 1
+	}
+	return &UTF8RingBuffer{
+		capacity: capacity,
+		data:     make([]byte, 0, capacity),
+	}
+}
+
+// Write 将新输出追加到缓冲区，并在超限时保留末尾窗口且修正 UTF-8 边界。
+func (b *UTF8RingBuffer) Write(payload []byte) (int, error) {
+	if b == nil {
+		return len(payload), nil
+	}
+	if len(payload) == 0 {
+		return 0, nil
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.data = append(b.data, payload...)
+	if len(b.data) > b.capacity {
+		b.data = b.data[len(b.data)-b.capacity:]
+	}
+	b.data = normalizeUTF8Window(b.data)
+	return len(payload), nil
+}
+
+// SnapshotBytes 返回当前缓冲区的 UTF-8 安全快照副本。
+func (b *UTF8RingBuffer) SnapshotBytes() []byte {
+	if b == nil {
+		return nil
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	safe := normalizeUTF8Window(b.data)
+	cloned := make([]byte, len(safe))
+	copy(cloned, safe)
+	return cloned
+}
+
+// SnapshotString 返回当前缓冲区的 UTF-8 安全文本快照。
+func (b *UTF8RingBuffer) SnapshotString() string {
+	if b == nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b.SnapshotBytes()))
+}
+
+// normalizeUTF8Window 将窗口裁剪为合法 UTF-8 字节序列，避免多字节字符被截断产生乱码。
+func normalizeUTF8Window(raw []byte) []byte {
+	if len(raw) == 0 {
+		return raw
+	}
+
+	trimmed := trimUTF8ContinuationPrefix(raw)
+	if len(trimmed) == 0 {
+		return trimmed
+	}
+	if utf8.Valid(trimmed) {
+		return trimmed
+	}
+
+	// 尾部只可能出现被截断的多字节字符，逐字节回退直到合法为止。
+	for end := len(trimmed); end > 0; end-- {
+		candidate := trimmed[:end]
+		if utf8.Valid(candidate) {
+			return candidate
+		}
+	}
+	return nil
+}
+
+// trimUTF8ContinuationPrefix 去掉开头残留的 continuation byte，避免窗口从字符中间起始。
+func trimUTF8ContinuationPrefix(raw []byte) []byte {
+	start := 0
+	for start < len(raw) && start < utf8.UTFMax-1 {
+		if raw[start]&0xC0 != 0x80 {
+			break
+		}
+		start++
+	}
+	return raw[start:]
+}

--- a/internal/ptyproxy/ring_buffer_test.go
+++ b/internal/ptyproxy/ring_buffer_test.go
@@ -1,0 +1,63 @@
+package ptyproxy
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestUTF8RingBufferSnapshotKeepsUTF8Boundary(t *testing.T) {
+	buffer := NewUTF8RingBuffer(8)
+
+	_, _ = buffer.Write([]byte("abc你"))
+	_, _ = buffer.Write([]byte("好"))
+
+	snapshot := buffer.SnapshotString()
+	if !utf8.ValidString(snapshot) {
+		t.Fatalf("snapshot is not utf8 valid: %q", snapshot)
+	}
+	if strings.ContainsRune(snapshot, '\uFFFD') {
+		t.Fatalf("snapshot contains replacement rune: %q", snapshot)
+	}
+}
+
+func TestUTF8RingBufferConcurrentWriteAndCapacity(t *testing.T) {
+	buffer := NewUTF8RingBuffer(64 * 1024)
+
+	const goroutines = 8
+	const rounds = 500
+
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(goroutines)
+	for index := 0; index < goroutines; index++ {
+		go func() {
+			defer waitGroup.Done()
+			for round := 0; round < rounds; round++ {
+				_, _ = buffer.Write([]byte("日志-中文-ansi-\u001b[31mred\u001b[0m\n"))
+			}
+		}()
+	}
+	waitGroup.Wait()
+
+	snapshot := buffer.SnapshotBytes()
+	if len(snapshot) > 64*1024 {
+		t.Fatalf("snapshot size = %d, want <= %d", len(snapshot), 64*1024)
+	}
+	if !utf8.Valid(snapshot) {
+		t.Fatalf("snapshot bytes are not utf8 valid")
+	}
+	if strings.ContainsRune(string(snapshot), '\uFFFD') {
+		t.Fatalf("snapshot contains replacement rune")
+	}
+}
+
+func TestNormalizeUTF8WindowStripsBrokenPrefixAndSuffix(t *testing.T) {
+	// "你" = e4 bd a0，"好" = e5 a5 bd
+	raw := []byte{0xBD, 0xA0, 0xE5, 0xA5}
+
+	safe := normalizeUTF8Window(raw)
+	if len(safe) != 0 {
+		t.Fatalf("safe len = %d, want 0 for fully broken window", len(safe))
+	}
+}

--- a/internal/ptyproxy/ring_buffer_test.go
+++ b/internal/ptyproxy/ring_buffer_test.go
@@ -61,3 +61,98 @@ func TestNormalizeUTF8WindowStripsBrokenPrefixAndSuffix(t *testing.T) {
 		t.Fatalf("safe len = %d, want 0 for fully broken window", len(safe))
 	}
 }
+
+func TestNormalizeUTF8WindowEmptyInput(t *testing.T) {
+	result := normalizeUTF8Window(nil)
+	if result != nil {
+		t.Fatalf("expected nil for nil input, got %v", result)
+	}
+	result = normalizeUTF8Window([]byte{})
+	if len(result) != 0 {
+		t.Fatalf("expected empty for empty input, got %d bytes", len(result))
+	}
+}
+
+func TestNormalizeUTF8WindowValidInput(t *testing.T) {
+	input := []byte("hello world")
+	result := normalizeUTF8Window(input)
+	if string(result) != "hello world" {
+		t.Fatalf("expected %q, got %q", "hello world", string(result))
+	}
+}
+
+func TestNormalizeUTF8WindowPartialTrimRecoversValid(t *testing.T) {
+	// "你" = E4 BD A0; prepend continuation bytes then append partial sequence
+	raw := []byte{0xBD, 0xA0, 0xE4, 0xBD, 0xA0, 0xE5}
+	safe := normalizeUTF8Window(raw)
+	// After trimming leading continuation bytes: [E4 BD A0 E5]
+	// E5 is start of 3-byte sequence but incomplete → trim to [E4 BD A0] = "你"
+	if string(safe) != "你" {
+		t.Fatalf("expected %q, got %q", "你", string(safe))
+	}
+}
+
+func TestNewUTF8RingBufferNonPositive(t *testing.T) {
+	zero := NewUTF8RingBuffer(0)
+	if zero.capacity != 1 {
+		t.Fatalf("capacity = %d, want 1", zero.capacity)
+	}
+	negative := NewUTF8RingBuffer(-5)
+	if negative.capacity != 1 {
+		t.Fatalf("capacity = %d, want 1", negative.capacity)
+	}
+}
+
+func TestUTF8RingBufferNilWrite(t *testing.T) {
+	var buffer *UTF8RingBuffer
+	n, err := buffer.Write([]byte("hello"))
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if n != len("hello") {
+		t.Fatalf("Write() n = %d, want %d", n, len("hello"))
+	}
+}
+
+func TestUTF8RingBufferNilSnapshotBytes(t *testing.T) {
+	var buffer *UTF8RingBuffer
+	result := buffer.SnapshotBytes()
+	if result != nil {
+		t.Fatalf("expected nil, got %v", result)
+	}
+}
+
+func TestUTF8RingBufferNilSnapshotString(t *testing.T) {
+	var buffer *UTF8RingBuffer
+	result := buffer.SnapshotString()
+	if result != "" {
+		t.Fatalf("expected empty string, got %q", result)
+	}
+}
+
+func TestUTF8RingBufferEmptyWrite(t *testing.T) {
+	buffer := NewUTF8RingBuffer(8)
+	n, err := buffer.Write(nil)
+	if err != nil {
+		t.Fatalf("Write(nil) error = %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("Write(nil) n = %d, want 0", n)
+	}
+	n, err = buffer.Write([]byte{})
+	if err != nil {
+		t.Fatalf("Write(empty) error = %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("Write(empty) n = %d, want 0", n)
+	}
+}
+
+func TestUTF8RingBufferCapacityBoundary(t *testing.T) {
+	buffer := NewUTF8RingBuffer(5)
+	_, _ = buffer.Write([]byte("abcdefgh"))
+	snapshot := buffer.SnapshotString()
+	if len(snapshot) > 5 {
+		t.Fatalf("snapshot length = %d, want <= 5", len(snapshot))
+	}
+}

--- a/internal/session/plan_test.go
+++ b/internal/session/plan_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -186,5 +187,270 @@ func TestRenderPlanContentIncludesAllSections(t *testing.T) {
 	}
 	if strings.Contains(rendered, "todo-2") {
 		t.Fatalf("RenderPlanContent() should skip terminal todos, got %q", rendered)
+	}
+}
+
+func TestRenderPlanContentReturnsEmptyOnEmptyGoal(t *testing.T) {
+	t.Parallel()
+
+	rendered := RenderPlanContent(PlanSpec{
+		Goal:  "",
+		Steps: []string{"步骤一"},
+	})
+	if rendered != "" {
+		t.Fatalf("RenderPlanContent() = %q, want empty", rendered)
+	}
+}
+
+func TestRenderPlanContentOmittedSections(t *testing.T) {
+	t.Parallel()
+
+	rendered := RenderPlanContent(PlanSpec{
+		Goal: "仅目标",
+	})
+	wantSubstrings := []string{"目标", "仅目标"}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("RenderPlanContent() = %q, want substring %q", rendered, want)
+		}
+	}
+	// Should not contain these sections when empty
+	unwanted := []string{"实施步骤", "约束", "验证", "当前待办", "未决问题"}
+	for _, unwantedStr := range unwanted {
+		if strings.Contains(rendered, unwantedStr) {
+			t.Fatalf("RenderPlanContent() = %q, should not contain %q", rendered, unwantedStr)
+		}
+	}
+}
+
+func TestNormalizePlanStatusDefaultsToDraft(t *testing.T) {
+	t.Parallel()
+
+	if got := NormalizePlanStatus(""); got != PlanStatusDraft {
+		t.Fatalf("NormalizePlanStatus('') = %q, want %q", got, PlanStatusDraft)
+	}
+	if got := NormalizePlanStatus("invalid"); got != PlanStatusDraft {
+		t.Fatalf("NormalizePlanStatus('invalid') = %q, want %q", got, PlanStatusDraft)
+	}
+}
+
+func TestNormalizePlanArtifactNilPlan(t *testing.T) {
+	t.Parallel()
+
+	got, err := NormalizePlanArtifact(nil)
+	if err != nil {
+		t.Fatalf("NormalizePlanArtifact(nil) error = %v", err)
+	}
+	if got != nil {
+		t.Fatalf("NormalizePlanArtifact(nil) = %v, want nil", got)
+	}
+}
+
+func TestNormalizePlanArtifactEmptyID(t *testing.T) {
+	t.Parallel()
+
+	_, err := NormalizePlanArtifact(&PlanArtifact{
+		ID:  "",
+		Spec: PlanSpec{
+			Goal:   "测试",
+			Steps:  []string{"步骤一"},
+			Verify: []string{"验证一"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected empty id error")
+	}
+	if !strings.Contains(err.Error(), "plan id is empty") {
+		t.Fatalf("error = %v, want contains %q", err, "plan id is empty")
+	}
+}
+
+func TestNormalizePlanSpecEmptyGoalError(t *testing.T) {
+	t.Parallel()
+
+	_, err := NormalizePlanSpec(PlanSpec{
+		Goal:  "",
+		Steps: []string{"步骤一"},
+	})
+	if err == nil {
+		t.Fatal("expected empty goal error")
+	}
+	if !strings.Contains(err.Error(), "plan goal is empty") {
+		t.Fatalf("error = %v, want contains %q", err, "plan goal is empty")
+	}
+}
+
+func TestNormalizePlanSpecGoalTrimsWhitespace(t *testing.T) {
+	t.Parallel()
+
+	_, err := NormalizePlanSpec(PlanSpec{
+		Goal:  "  ",
+		Steps: []string{"步骤一"},
+	})
+	if err == nil {
+		t.Fatal("expected error for whitespace-only goal")
+	}
+}
+
+func TestBuildSummaryViewErrorReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	summary := BuildSummaryView(PlanSpec{Goal: ""})
+	if summary.Goal != "" {
+		t.Fatalf("Goal = %q, want empty", summary.Goal)
+	}
+}
+
+func TestClampStringListMaxItems(t *testing.T) {
+	t.Parallel()
+
+	items := []string{"a", "b", "c", "d", "e"}
+	got := clampStringList(items, 3)
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	if got[0] != "a" || got[1] != "b" || got[2] != "c" {
+		t.Fatalf("clampStringList = %+v, want [a b c]", got)
+	}
+
+	gotAll := clampStringList(items, 10)
+	if len(gotAll) != 5 {
+		t.Fatalf("len = %d, want 5", len(gotAll))
+	}
+	gotZero := clampStringList(items, 0)
+	if len(gotZero) != 5 {
+		t.Fatalf("len = %d, want 5 when maxItems <= 0", len(gotZero))
+	}
+}
+
+func TestSummaryViewStructurallyValidDetectsInvalid(t *testing.T) {
+	t.Parallel()
+
+	spec := PlanSpec{Goal: "目标", Steps: []string{"步骤一"}, Verify: []string{"验证一"}}
+	// Empty goal
+	if summaryViewStructurallyValid(SummaryView{}, spec) {
+		t.Fatal("expected false for empty summary")
+	}
+	// Missing key steps
+	if summaryViewStructurallyValid(SummaryView{Goal: "目标", Verify: []string{"v"}}, spec) {
+		t.Fatal("expected false for missing key steps")
+	}
+	// Unknown active todo IDs
+	if summaryViewStructurallyValid(SummaryView{
+		Goal:          "目标",
+		KeySteps:      []string{"步骤一"},
+		Verify:        []string{"验证一"},
+		ActiveTodoIDs: []string{"unknown"},
+	}, spec) {
+		t.Fatal("expected false for unknown todo IDs")
+	}
+}
+
+func TestCollectActiveTodoIDsEmptyOrLimit(t *testing.T) {
+	t.Parallel()
+
+	// Empty items
+	if got := collectActiveTodoIDs(nil, 5); got != nil {
+		t.Fatalf("expected nil for empty items, got %v", got)
+	}
+	// Limit <= 0
+	if got := collectActiveTodoIDs([]TodoItem{{ID: "t1", Status: TodoStatusPending}}, 0); got != nil {
+		t.Fatalf("expected nil for zero limit, got %v", got)
+	}
+	// All terminal → empty
+	items := []TodoItem{
+		{ID: "t1", Content: "已完成", Status: TodoStatusCompleted},
+		{ID: "t2", Content: "已失败", Status: TodoStatusFailed},
+	}
+	if got := collectActiveTodoIDs(items, 5); got != nil {
+		t.Fatalf("expected nil when all todos terminal, got %v", got)
+	}
+	// Limits to max
+	manyItems := make([]TodoItem, 10)
+	for i := 0; i < 10; i++ {
+		manyItems[i] = TodoItem{ID: fmt.Sprintf("t-%d", i), Content: "待执行", Status: TodoStatusPending}
+	}
+	got := collectActiveTodoIDs(manyItems, 3)
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+}
+
+func TestCollectActiveTodoLinesEmptyOrTerminal(t *testing.T) {
+	t.Parallel()
+
+	// Empty items
+	if got := collectActiveTodoLines(nil); got != nil {
+		t.Fatalf("expected nil for empty items, got %v", got)
+	}
+	// All terminal
+	items := []TodoItem{
+		{ID: "t1", Content: "已完成", Status: TodoStatusCompleted},
+	}
+	if got := collectActiveTodoLines(items); got != nil {
+		t.Fatalf("expected nil when all terminal, got %v", got)
+	}
+}
+
+func TestNormalizePlanStatusCompleted(t *testing.T) {
+	t.Parallel()
+
+	if got := NormalizePlanStatus(PlanStatusCompleted); got != PlanStatusCompleted {
+		t.Fatalf("NormalizePlanStatus(completed) = %q, want %q", got, PlanStatusCompleted)
+	}
+}
+
+func TestNormalizePlanArtifactSpecErrorPropagated(t *testing.T) {
+	t.Parallel()
+
+	_, err := NormalizePlanArtifact(&PlanArtifact{
+		ID:  "plan-err",
+		Spec: PlanSpec{
+			Goal: "",
+			Todos: []TodoItem{
+				{ID: "t1", Content: "todo", Dependencies: []string{"unknown"}},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected spec validation error")
+	}
+}
+
+func TestNormalizePlanSpecTodoValidationError(t *testing.T) {
+	t.Parallel()
+
+	_, err := NormalizePlanSpec(PlanSpec{
+		Goal: "test",
+		Todos: []TodoItem{
+			{ID: "t1", Content: "todo", Dependencies: []string{"nonexistent"}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown dependency")
+	}
+	if !strings.Contains(err.Error(), "unknown dependency") {
+		t.Fatalf("error = %v, want contains 'unknown dependency'", err)
+	}
+}
+
+func TestRenderBulletListEmptyOrBlank(t *testing.T) {
+	t.Parallel()
+
+	if got := renderBulletList(nil); got != "" {
+		t.Fatalf("expected empty for nil, got %q", got)
+	}
+	if got := renderBulletList([]string{}); got != "" {
+		t.Fatalf("expected empty for empty, got %q", got)
+	}
+	// All blank items
+	if got := renderBulletList([]string{"  ", ""}); got != "" {
+		t.Fatalf("expected empty for blank items, got %q", got)
+	}
+	// Mixed blank and valid
+	got := renderBulletList([]string{"step 1", "", "step 3"})
+	want := "- step 1\n- step 3"
+	if got != want {
+		t.Fatalf("renderBulletList = %q, want %q", got, want)
 	}
 }

--- a/internal/tools/diagnose/tool.go
+++ b/internal/tools/diagnose/tool.go
@@ -1,0 +1,137 @@
+package diagnose
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"neo-code/internal/tools"
+)
+
+const diagnoseToolName = tools.ToolNameDiagnose
+
+type diagnoseInput struct {
+	ErrorLog    string            `json:"error_log"`
+	OSEnv       map[string]string `json:"os_env"`
+	CommandText string            `json:"command_text"`
+	ExitCode    int               `json:"exit_code"`
+}
+
+type diagnoseOutput struct {
+	Confidence            float64  `json:"confidence"`
+	RootCause             string   `json:"root_cause"`
+	FixCommands           []string `json:"fix_commands"`
+	InvestigationCommands []string `json:"investigation_commands"`
+}
+
+// Tool 提供 gateway.executeSystemTool(diagnose) 的最小可用实现。
+type Tool struct{}
+
+// New 创建 diagnose 工具实例。
+func New() *Tool {
+	return &Tool{}
+}
+
+// Name 返回工具唯一名称。
+func (t *Tool) Name() string {
+	return diagnoseToolName
+}
+
+// Description 返回工具描述信息。
+func (t *Tool) Description() string {
+	return "Diagnose terminal failures from recent shell output and environment context."
+}
+
+// Schema 返回 diagnose 参数结构定义。
+func (t *Tool) Schema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"error_log": map[string]any{
+				"type": "string",
+			},
+			"os_env": map[string]any{
+				"type":                 "object",
+				"additionalProperties": map[string]any{"type": "string"},
+			},
+			"command_text": map[string]any{
+				"type": "string",
+			},
+			"exit_code": map[string]any{
+				"type": "integer",
+			},
+		},
+		"required": []string{"error_log", "os_env"},
+	}
+}
+
+// MicroCompactPolicy 保留诊断结果，避免在短期压缩时丢失排障上下文。
+func (t *Tool) MicroCompactPolicy() tools.MicroCompactPolicy {
+	return tools.MicroCompactPolicyPreserveHistory
+}
+
+// Execute 校验输入并返回 Mock 诊断结构，供 Phase1 链路联调。
+func (t *Tool) Execute(ctx context.Context, call tools.ToolCallInput) (tools.ToolResult, error) {
+	if err := ctx.Err(); err != nil {
+		return tools.NewErrorResult(diagnoseToolName, tools.NormalizeErrorReason(diagnoseToolName, err), "", nil), err
+	}
+	input, err := parseDiagnoseInput(call.Arguments)
+	if err != nil {
+		return tools.NewErrorResult(diagnoseToolName, tools.NormalizeErrorReason(diagnoseToolName, err), "", nil), err
+	}
+
+	result := diagnoseOutput{
+		Confidence: 0.62,
+		RootCause:  "mock: diagnose tool wiring is active; please replace with real analyzer in next phase",
+		FixCommands: []string{
+			"neocode diag",
+		},
+		InvestigationCommands: []string{
+			"pwd",
+			"env | grep -E 'NEOCODE_DIAG_SOCKET|SHELL'",
+		},
+	}
+	if strings.TrimSpace(input.CommandText) != "" {
+		result.InvestigationCommands = append(result.InvestigationCommands, strings.TrimSpace(input.CommandText))
+	}
+
+	raw, marshalErr := json.Marshal(result)
+	if marshalErr != nil {
+		wrapped := fmt.Errorf("%s: encode mock result: %w", diagnoseToolName, marshalErr)
+		return tools.NewErrorResult(diagnoseToolName, tools.NormalizeErrorReason(diagnoseToolName, wrapped), "", nil), wrapped
+	}
+
+	return tools.ToolResult{
+		Name:    diagnoseToolName,
+		Content: string(raw),
+		Metadata: map[string]any{
+			"mock":            true,
+			"error_log_bytes": len(input.ErrorLog),
+		},
+	}, nil
+}
+
+// parseDiagnoseInput 解析并校验 diagnose 工具输入参数。
+func parseDiagnoseInput(arguments []byte) (diagnoseInput, error) {
+	trimmed := strings.TrimSpace(string(arguments))
+	if trimmed == "" || strings.EqualFold(trimmed, "null") {
+		return diagnoseInput{}, errors.New("diagnose: error_log is required")
+	}
+
+	var input diagnoseInput
+	if err := json.Unmarshal(arguments, &input); err != nil {
+		return diagnoseInput{}, fmt.Errorf("diagnose: invalid arguments: %w", err)
+	}
+	input.ErrorLog = strings.TrimSpace(input.ErrorLog)
+	input.CommandText = strings.TrimSpace(input.CommandText)
+
+	if input.ErrorLog == "" {
+		return diagnoseInput{}, errors.New("diagnose: error_log is required")
+	}
+	if len(input.OSEnv) == 0 {
+		return diagnoseInput{}, errors.New("diagnose: os_env is required")
+	}
+	return input, nil
+}

--- a/internal/tools/diagnose/tool_test.go
+++ b/internal/tools/diagnose/tool_test.go
@@ -86,6 +86,116 @@ func TestToolExecuteInvalidJSON(t *testing.T) {
 	}
 }
 
+func TestToolExecuteEmptyArguments(t *testing.T) {
+	tool := New()
+	_, err := tool.Execute(context.Background(), tools.ToolCallInput{
+		Arguments: []byte(``),
+	})
+	if err == nil {
+		t.Fatal("expected error for empty arguments")
+	}
+	if !strings.Contains(err.Error(), "error_log is required") {
+		t.Fatalf("error = %v, want contains %q", err, "error_log is required")
+	}
+}
+
+func TestToolExecuteNullArguments(t *testing.T) {
+	tool := New()
+	_, err := tool.Execute(context.Background(), tools.ToolCallInput{
+		Arguments: []byte(`null`),
+	})
+	if err == nil {
+		t.Fatal("expected error for null arguments")
+	}
+	if !strings.Contains(err.Error(), "error_log is required") {
+		t.Fatalf("error = %v, want contains %q", err, "error_log is required")
+	}
+}
+
+func TestToolExecuteMissingOSEnv(t *testing.T) {
+	tool := New()
+	_, err := tool.Execute(context.Background(), tools.ToolCallInput{
+		Arguments: []byte(`{"error_log":"fatal error","os_env":{}}`),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing os_env")
+	}
+	if !strings.Contains(err.Error(), "os_env is required") {
+		t.Fatalf("error = %v, want contains %q", err, "os_env is required")
+	}
+}
+
+func TestToolExecuteWithCommandText(t *testing.T) {
+	tool := New()
+	result, err := tool.Execute(context.Background(), tools.ToolCallInput{
+		Arguments: []byte(`{"error_log":"err","os_env":{"os":"linux"},"command_text":"go test"}`),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("result.IsError = true, want false")
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(result.Content), &decoded); err != nil {
+		t.Fatalf("content should be valid JSON: %v", err)
+	}
+	investigation, ok := decoded["investigation_commands"].([]any)
+	if !ok || len(investigation) == 0 {
+		t.Fatalf("expected non-empty investigation_commands when command_text is set")
+	}
+	// "go test" should be appended to investigation commands
+	found := false
+	for _, cmd := range investigation {
+		if cmd == "go test" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("investigation_commands = %v, should contain 'go test'", investigation)
+	}
+}
+
+func TestToolExecuteContextCancelled(t *testing.T) {
+	tool := New()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result, err := tool.Execute(ctx, tools.ToolCallInput{
+		Arguments: []byte(`{"error_log":"err","os_env":{"os":"linux"}}`),
+	})
+	if err == nil {
+		t.Fatal("expected context error")
+	}
+	if !result.IsError {
+		t.Fatalf("result.IsError = false, want true")
+	}
+}
+
+func TestParseDiagnoseInputEmptyOrNull(t *testing.T) {
+	_, err := parseDiagnoseInput([]byte(``))
+	if err == nil {
+		t.Fatal("expected error for empty input")
+	}
+	_, err = parseDiagnoseInput([]byte(`null`))
+	if err == nil {
+		t.Fatal("expected error for null input")
+	}
+}
+
+func TestParseDiagnoseInputMissingErrorLog(t *testing.T) {
+	_, err := parseDiagnoseInput([]byte(`{"error_log":" ","os_env":{"os":"linux"}}`))
+	if err == nil {
+		t.Fatal("expected error for whitespace error_log")
+	}
+}
+
+func TestParseDiagnoseInputMissingOSEnv(t *testing.T) {
+	_, err := parseDiagnoseInput([]byte(`{"error_log":"fatal error","os_env":{}}`))
+	if err == nil {
+		t.Fatal("expected error for empty os_env")
+	}
+}
+
 func toString(value any) string {
 	text, _ := value.(string)
 	return text

--- a/internal/tools/diagnose/tool_test.go
+++ b/internal/tools/diagnose/tool_test.go
@@ -1,0 +1,92 @@
+package diagnose
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"neo-code/internal/tools"
+)
+
+func TestToolMetadata(t *testing.T) {
+	tool := New()
+	if tool.Name() != tools.ToolNameDiagnose {
+		t.Fatalf("Name() = %q, want %q", tool.Name(), tools.ToolNameDiagnose)
+	}
+	if strings.TrimSpace(tool.Description()) == "" {
+		t.Fatal("Description() should not be empty")
+	}
+	if tool.Schema() == nil {
+		t.Fatal("Schema() should not be nil")
+	}
+	if tool.MicroCompactPolicy() != tools.MicroCompactPolicyPreserveHistory {
+		t.Fatalf("MicroCompactPolicy() = %q, want %q", tool.MicroCompactPolicy(), tools.MicroCompactPolicyPreserveHistory)
+	}
+}
+
+func TestToolExecuteSuccess(t *testing.T) {
+	tool := New()
+	result, err := tool.Execute(context.Background(), tools.ToolCallInput{
+		Arguments: []byte(`{
+			"error_log":"fatal: example",
+			"os_env":{"os":"linux","shell":"/bin/bash"},
+			"command_text":"go test ./...",
+			"exit_code":1
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("result.IsError = true, want false; result = %+v", result)
+	}
+	if result.Name != tools.ToolNameDiagnose {
+		t.Fatalf("result.Name = %q, want %q", result.Name, tools.ToolNameDiagnose)
+	}
+
+	var decoded map[string]any
+	if unmarshalErr := json.Unmarshal([]byte(result.Content), &decoded); unmarshalErr != nil {
+		t.Fatalf("content should be valid JSON, got err = %v", unmarshalErr)
+	}
+	if strings.TrimSpace(toString(decoded["root_cause"])) == "" {
+		t.Fatalf("root_cause should not be empty: %v", decoded)
+	}
+	if mock, _ := result.Metadata["mock"].(bool); !mock {
+		t.Fatalf("metadata.mock = %#v, want true", result.Metadata["mock"])
+	}
+}
+
+func TestToolExecuteValidationError(t *testing.T) {
+	tool := New()
+	_, err := tool.Execute(context.Background(), tools.ToolCallInput{
+		Arguments: []byte(`{"error_log":" ","os_env":{}}`),
+	})
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "error_log is required") {
+		t.Fatalf("error = %v, want contains %q", err, "error_log is required")
+	}
+}
+
+func TestToolExecuteInvalidJSON(t *testing.T) {
+	tool := New()
+	result, err := tool.Execute(context.Background(), tools.ToolCallInput{
+		Arguments: []byte(`{`),
+	})
+	if err == nil {
+		t.Fatal("expected json error, got nil")
+	}
+	if !result.IsError {
+		t.Fatalf("result.IsError = false, want true; result = %+v", result)
+	}
+	if !strings.Contains(err.Error(), "invalid arguments") {
+		t.Fatalf("error = %v, want contains %q", err, "invalid arguments")
+	}
+}
+
+func toString(value any) string {
+	text, _ := value.(string)
+	return text
+}

--- a/internal/tools/manager_test.go
+++ b/internal/tools/manager_test.go
@@ -1731,6 +1731,17 @@ func TestBuildPermissionAction(t *testing.T) {
 			wantTarget:   "todo-1",
 		},
 		{
+			name: "diagnose maps to read action",
+			input: ToolCallInput{
+				Name:      ToolNameDiagnose,
+				Arguments: []byte(`{"error_log":"fatal","os_env":{"os":"linux"}}`),
+			},
+			wantType:     security.ActionTypeRead,
+			wantResource: ToolNameDiagnose,
+			wantOp:       "diagnose",
+			wantTarget:   "diagnose",
+		},
+		{
 			name: "spawn subagent maps to write action",
 			input: ToolCallInput{
 				Name:      ToolNameSpawnSubAgent,

--- a/internal/tools/names.go
+++ b/internal/tools/names.go
@@ -15,4 +15,5 @@ const (
 	ToolNameMemoRecall          = "memo_recall"
 	ToolNameMemoList            = "memo_list"
 	ToolNameMemoRemove          = "memo_remove"
+	ToolNameDiagnose            = "diagnose"
 )

--- a/internal/tools/permission_mapper.go
+++ b/internal/tools/permission_mapper.go
@@ -117,6 +117,11 @@ func buildPermissionAction(input ToolCallInput) (security.Action, error) {
 	case ToolNameMemoRemove:
 		action.Type = security.ActionTypeWrite
 		action.Payload.Operation = "memo_remove"
+	case ToolNameDiagnose:
+		action.Type = security.ActionTypeRead
+		action.Payload.Operation = "diagnose"
+		action.Payload.TargetType = security.TargetTypeCommand
+		action.Payload.Target = "diagnose"
 	default:
 		if strings.HasPrefix(strings.ToLower(toolName), "mcp.") {
 			toolIdentity := normalizeMCPToolIdentity(toolName)

--- a/internal/tui/services/gateway_rpc_client_bridge.go
+++ b/internal/tui/services/gateway_rpc_client_bridge.go
@@ -1,0 +1,25 @@
+package services
+
+import gatewayclient "neo-code/internal/gateway/client"
+
+// GatewayRPCClientOptions 复用 gateway client 包的客户端选项定义。
+type GatewayRPCClientOptions = gatewayclient.GatewayRPCClientOptions
+
+// GatewayRPCCallOptions 复用 gateway client 包的单次调用选项定义。
+type GatewayRPCCallOptions = gatewayclient.GatewayRPCCallOptions
+
+// GatewayRPCError 复用 gateway client 包的结构化 RPC 错误定义。
+type GatewayRPCError = gatewayclient.GatewayRPCError
+
+// GatewayRPCClient 复用 gateway client 包的客户端类型。
+type GatewayRPCClient = gatewayclient.GatewayRPCClient
+
+// gatewayRPCNotification 复用网关通知负载结构，保持 TUI 流处理器签名稳定。
+type gatewayRPCNotification = gatewayclient.Notification
+
+const defaultGatewayRPCRetryCount = gatewayclient.DefaultGatewayRPCRetryCount
+
+// NewGatewayRPCClient 创建并返回网关 RPC 客户端。
+func NewGatewayRPCClient(options GatewayRPCClientOptions) (*GatewayRPCClient, error) {
+	return gatewayclient.NewGatewayRPCClient(options)
+}

--- a/internal/tui/services/remote_runtime_adapter.go
+++ b/internal/tui/services/remote_runtime_adapter.go
@@ -24,7 +24,9 @@ const (
 )
 
 var (
-	newGatewayRPCClientFactory    = NewGatewayRPCClient
+	newGatewayRPCClientFactory = func(options GatewayRPCClientOptions) (remoteGatewayRPCClient, error) {
+		return NewGatewayRPCClient(options)
+	}
 	newGatewayStreamClientFactory = NewGatewayStreamClient
 	// ErrUnsupportedActionInGatewayMode 标记 gateway runtime 当前不支持的本地动作。
 	ErrUnsupportedActionInGatewayMode = errors.New(unsupportedActionInGatewayMode)

--- a/internal/tui/services/remote_runtime_adapter_additional_test.go
+++ b/internal/tui/services/remote_runtime_adapter_additional_test.go
@@ -2,9 +2,7 @@ package services
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"net"
 	"strings"
 	"testing"
 	"time"
@@ -25,36 +23,15 @@ func TestNewRemoteRuntimeAdapterBranches(t *testing.T) {
 		newGatewayStreamClientFactory = originalStreamFactory
 	})
 
-	newGatewayRPCClientFactory = func(options GatewayRPCClientOptions) (*GatewayRPCClient, error) {
+	newGatewayRPCClientFactory = func(options GatewayRPCClientOptions) (remoteGatewayRPCClient, error) {
 		if strings.TrimSpace(options.ListenAddress) == "error" {
 			return nil, errors.New("build rpc failed")
 		}
-		client := &GatewayRPCClient{
-			listenAddress:     options.ListenAddress,
-			token:             "token",
-			requestTimeout:    time.Second,
-			retryCount:        1,
-			closed:            make(chan struct{}),
-			pending:           make(map[string]chan gatewayRPCResponse),
-			notifications:     make(chan gatewayRPCNotification, 4),
-			notificationQueue: make(chan gatewayRPCNotification, 4),
+		client := &stubRemoteRPCClient{
+			notifications: make(chan gatewayRPCNotification, 4),
 		}
-		client.dialFn = func(_ string) (net.Conn, error) {
-			if options.ListenAddress == "dial-failed" {
-				return nil, errors.New("dial failed")
-			}
-			clientConn, serverConn := net.Pipe()
-			go func() {
-				defer serverConn.Close()
-				decoder := json.NewDecoder(serverConn)
-				encoder := json.NewEncoder(serverConn)
-				request := readRPCRequestOrFail(decoder)
-				writeRPCResultOrFail(encoder, request.ID, gateway.MessageFrame{
-					Type:   gateway.FrameTypeAck,
-					Action: gateway.FrameActionAuthenticate,
-				})
-			}()
-			return clientConn, nil
+		if options.ListenAddress == "dial-failed" {
+			client.authErr = errors.New("dial failed")
 		}
 		return client, nil
 	}

--- a/scripts/generate_gateway_rpc_examples/main.go
+++ b/scripts/generate_gateway_rpc_examples/main.go
@@ -566,7 +566,7 @@ func buildMethodExamples() ([]methodExample, error) {
 			Success: executeSystemToolSuccess,
 			Failure: executeSystemToolFailure,
 			Notes: []string{
-				"`tool_name` 在网关层按白名单校验，当前仅允许 memo 系统工具。",
+				"`tool_name` 在网关层按白名单校验，当前允许 memo 系列工具与 diagnose。",
 			},
 		},
 		{


### PR DESCRIPTION
## 🎯 背景与目标
为了打造沉浸式的 NeoCode 终端协作体验，本 PR 落地了 `Terminal Diagnostic System` (终端诊断系统) 的 Phase 1。该阶段重点打通了：**底层 PTY 劫持 -> Ring Buffer 缓存 -> 跨进程 Socket 触发 -> 网关工具链路由 -> 原位结果渲染** 的全链路闭环，为后续真正接入 LLM 根因分析奠定了坚实的基础设施。

## 🚀 核心更新内容

### 1. 架构解耦与重构
- **Client 下沉**：将 `gateway_rpc_client` 从 TUI 展现层彻底抽离并下沉至 `internal/gateway/client`，清理了业务职责，实现各组件间统一且干净的网关调用复用。

### 2. 底层 PTY 代理中枢 (`internal/ptyproxy`)
- **透明透传**：基于 `creack/pty` 实现了对 Bash/Zsh 的子进程拉起与标准流的 `io.Copy` 透明代理。
- **日志缓存**：自研了基于 UTF-8 边界安全的内存 `RingBuffer` (64KB)，防止终端报错日志溢出，并保障日志截取不产生乱码。
- **跨平台防呆**：当前阶段优雅降级非 Unix 系统，Windows 环境下执行命令会温和提示不支持。

### 3. IPC 通信与命令行扩展 (`internal/cli`)
- **新命令**：新增 `neocode shell`（启动主代理与 Unix Socket 监听）与 `neocode diag`（轻量化纯发信令客户端）。
- **隐式路由**：子 Shell 启动时自动注入环境变量 `NEOCODE_DIAG_SOCKET`，实现了父子进程无感知的 IPC 路由互通。

### 4. 系统工具集成 (`internal/tools`)
- **工具白名单**：开发了受保护的内置系统工具 `diagnose`，并在 `names.go` 与 `bootstrap.go` 中完成系统级注册验证。
- **Mock 联调**：当前 Phase 1 返回结构化的 Mock 数据字典（置信度、根因、修复命令），验证端到端链路的可行性。

## 🛠️ 关键体验优化 (UX Improvements)
本 PR 深入处理了多个典型的底层终端痛点，保障商业级手感：
- **无缝拖拽 (SIGWINCH)**：通过 `pty.InheritSize` 与监听 `SIGWINCH` 信号，使得代理能够动态继承宿主终端尺寸，彻底解决了由于尺寸未同步导致的**“长命令输入覆盖重写”** Bug。
- **纯净的 Raw Mode**：严格管理 `term.MakeRaw` 与 `Restore` 状态，消灭了双重回显（结巴）、CPR（光标位置报告）乱码，并优雅吞噬了 `Ctrl+V` 带来的 `^[[200~` 括号粘贴符。
- **同步防干扰排版**：强制规范了 Raw 模式下的 `\r\n` 渲染；并将异步的 `neocode diag` 改造为阻塞等待结果完成，避免原生 Bash Prompt 越界“插队”。
- **平滑登出**：移除了标准输入阻塞（Stdin Deadlock）导致卡死的问题，并在进出 Shell 时增加 `[ NeoCode Proxy initialized/exited ]` 提示。

## 🧪 测试路径
1. **编译构建**：`go build -o neocode ./cmd/neocode`
2. **启动代理壳**：输入 `./neocode shell` 进入接管模式，确认常规操作（如 `ls`）与缩放终端无异常。
3. **制造错误**：执行 `cat /a/non-existent/file`。
4. **发起诊断**：执行 `./neocode diag`。
5. **预期结果**：终端光标处将立刻排版优美地打印出：`[NeoCode Diagnosis]` 相关 Mock 数据及建议指令。输入 `exit` 顺畅退出代理。

## 📋 提交前检查清单 (Checklist)
- [x] 所有新增加的文件与功能符合架构解耦底线规则 (`AGENTS.md`)。
- [x] 工具集与 Gateway 客户端通信无遗漏未加密密钥。
- [x] CLI 帮助文档和使用说明已同步。
- [x] （如有）关键的边界测试与网络中断测试通过。

Closes #524 