### PR TITLE
feat: 终端诊断 Phase 2 + 供应商与模型管理 — PTY 代理架构升级与自动诊断闭环

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,17 +124,80 @@ neocode --workdir /path/to/your/project
 /skill off <id>       停用 skill
 ```
 
-### 5. 终端诊断（Manual）
+### 5. CLI 路由速查
+
+#### Provider 管理
+
+用于新增、查看、删除自定义 provider，变更会落在 `~/.neocode/providers/`。
 
 ```bash
-# 进入代理 shell（Phase1 仅支持 Unix）
-neocode shell
+# 新增自定义 provider（要求先设置好 --api-key-env 指向的环境变量）
+neocode provider add <name> --driver <driver> --url <url> --api-key-env <env> [--discovery-endpoint <path>]
 
-# 在代理 shell 内触发诊断（默认读取 NEOCODE_DIAG_SOCKET）
-neocode diag
+# 示例
+export MOCK_KEY="sk-xxx"
+neocode provider add my-openai --driver openaicompat --url https://api.openai.com/v1 --api-key-env MOCK_KEY --discovery-endpoint /v1/models
+
+# 列出所有 provider
+neocode provider ls
+
+# 删除自定义 provider
+neocode provider rm my-openai
 ```
 
-### 6. url scheme使用
+#### Model 选择
+
+用于查看当前 provider 的模型候选，并切换到指定模型。
+
+```bash
+# 列出当前 provider 可用模型（优先本地快照，必要时触发一次同步发现）
+neocode model ls
+
+# 切换当前模型（会校验模型是否属于当前 provider）
+neocode model set <model-id>
+
+# 示例
+neocode model set gpt-4.1
+```
+
+#### Provider + Model 一步切换
+
+用于切换 provider，并可通过 `--model` 覆盖自动选择的模型。
+
+```bash
+# 仅切换 provider（自动修正到可用模型）
+neocode use <provider>
+
+# 切换 provider 并指定模型（会做模型归属校验）
+neocode use <provider> --model <model-id>
+
+# 示例
+neocode use openai --model gpt-4.1
+```
+
+### 6. Shell 诊断代理
+
+用于进入代理 shell、初始化 shell integration、手动触发诊断和控制自动诊断模式。
+
+```bash
+# 进入代理 shell（当前仅支持 Unix-like）
+neocode shell
+
+# 输出 shell integration 脚本（支持写法：--init <shell>）
+neocode shell --init bash
+neocode shell --init zsh
+
+# 触发一次手动诊断（两种写法等价）
+neocode diag
+neocode diag diagnose
+
+# 自动诊断开关与状态查询
+neocode diag auto on
+neocode diag auto off
+neocode diag auto status
+```
+
+### 7. url scheme使用
 详细指南链接： [HTTP URL 唤醒使用指南（用户故事版）](https://neocode-docs.pages.dev/guide/http-daemon-wake-user-guide)
 
 ```bash

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -15,7 +15,9 @@ type mockSelectionService struct {
 	listModelsSnapshotFn   func(ctx context.Context) ([]providertypes.ModelDescriptor, error)
 	setCurrentModelFn      func(ctx context.Context, modelID string) (configstate.Selection, error)
 	selectProviderFn       func(ctx context.Context, providerName string) (configstate.Selection, error)
+	selectProviderModelFn  func(ctx context.Context, providerName string, modelID string) (configstate.Selection, error)
 	createCustomProviderFn func(ctx context.Context, input configstate.CreateCustomProviderInput) (configstate.Selection, error)
+	removeCustomProviderFn func(ctx context.Context, name string) error
 }
 
 func (m *mockSelectionService) ListModels(ctx context.Context) ([]providertypes.ModelDescriptor, error) {
@@ -46,6 +48,17 @@ func (m *mockSelectionService) SelectProvider(ctx context.Context, providerName 
 	return configstate.Selection{}, nil
 }
 
+func (m *mockSelectionService) SelectProviderWithModel(
+	ctx context.Context,
+	providerName string,
+	modelID string,
+) (configstate.Selection, error) {
+	if m != nil && m.selectProviderModelFn != nil {
+		return m.selectProviderModelFn(ctx, providerName, modelID)
+	}
+	return configstate.Selection{}, nil
+}
+
 func (m *mockSelectionService) CreateCustomProvider(
 	ctx context.Context,
 	input configstate.CreateCustomProviderInput,
@@ -54,6 +67,13 @@ func (m *mockSelectionService) CreateCustomProvider(
 		return m.createCustomProviderFn(ctx, input)
 	}
 	return configstate.Selection{}, nil
+}
+
+func (m *mockSelectionService) RemoveCustomProvider(ctx context.Context, name string) error {
+	if m != nil && m.removeCustomProviderFn != nil {
+		return m.removeCustomProviderFn(ctx, name)
+	}
+	return nil
 }
 
 func staticSelectionResolver(svc SelectionService) selectionServiceResolver {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"context"
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	configstate "neo-code/internal/config/state"
+	providertypes "neo-code/internal/provider/types"
+)
+
+type mockSelectionService struct {
+	listModelsFn           func(ctx context.Context) ([]providertypes.ModelDescriptor, error)
+	listModelsSnapshotFn   func(ctx context.Context) ([]providertypes.ModelDescriptor, error)
+	setCurrentModelFn      func(ctx context.Context, modelID string) (configstate.Selection, error)
+	selectProviderFn       func(ctx context.Context, providerName string) (configstate.Selection, error)
+	createCustomProviderFn func(ctx context.Context, input configstate.CreateCustomProviderInput) (configstate.Selection, error)
+}
+
+func (m *mockSelectionService) ListModels(ctx context.Context) ([]providertypes.ModelDescriptor, error) {
+	if m != nil && m.listModelsFn != nil {
+		return m.listModelsFn(ctx)
+	}
+	return nil, nil
+}
+
+func (m *mockSelectionService) ListModelsSnapshot(ctx context.Context) ([]providertypes.ModelDescriptor, error) {
+	if m != nil && m.listModelsSnapshotFn != nil {
+		return m.listModelsSnapshotFn(ctx)
+	}
+	return nil, nil
+}
+
+func (m *mockSelectionService) SetCurrentModel(ctx context.Context, modelID string) (configstate.Selection, error) {
+	if m != nil && m.setCurrentModelFn != nil {
+		return m.setCurrentModelFn(ctx, modelID)
+	}
+	return configstate.Selection{}, nil
+}
+
+func (m *mockSelectionService) SelectProvider(ctx context.Context, providerName string) (configstate.Selection, error) {
+	if m != nil && m.selectProviderFn != nil {
+		return m.selectProviderFn(ctx, providerName)
+	}
+	return configstate.Selection{}, nil
+}
+
+func (m *mockSelectionService) CreateCustomProvider(
+	ctx context.Context,
+	input configstate.CreateCustomProviderInput,
+) (configstate.Selection, error) {
+	if m != nil && m.createCustomProviderFn != nil {
+		return m.createCustomProviderFn(ctx, input)
+	}
+	return configstate.Selection{}, nil
+}
+
+func staticSelectionResolver(svc SelectionService) selectionServiceResolver {
+	return selectionServiceResolverFunc(func(*cobra.Command) (SelectionService, error) {
+		if svc == nil {
+			return nil, errors.New("selection service unavailable")
+		}
+		return svc, nil
+	})
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -18,6 +18,7 @@ type mockSelectionService struct {
 	selectProviderModelFn  func(ctx context.Context, providerName string, modelID string) (configstate.Selection, error)
 	createCustomProviderFn func(ctx context.Context, input configstate.CreateCustomProviderInput) (configstate.Selection, error)
 	removeCustomProviderFn func(ctx context.Context, name string) error
+	listProviderOptionsFn  func(ctx context.Context) ([]configstate.ProviderOption, error)
 }
 
 func (m *mockSelectionService) ListModels(ctx context.Context) ([]providertypes.ModelDescriptor, error) {
@@ -74,6 +75,13 @@ func (m *mockSelectionService) RemoveCustomProvider(ctx context.Context, name st
 		return m.removeCustomProviderFn(ctx, name)
 	}
 	return nil
+}
+
+func (m *mockSelectionService) ListProviderOptions(ctx context.Context) ([]configstate.ProviderOption, error) {
+	if m != nil && m.listProviderOptionsFn != nil {
+		return m.listProviderOptionsFn(ctx)
+	}
+	return nil, nil
 }
 
 func staticSelectionResolver(svc SelectionService) selectionServiceResolver {

--- a/internal/cli/coverage_gaps_test.go
+++ b/internal/cli/coverage_gaps_test.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"neo-code/internal/config"
+	configstate "neo-code/internal/config/state"
+	providertypes "neo-code/internal/provider/types"
+)
+
+func TestCLICoverageGapBranches(t *testing.T) {
+	t.Run("model ls provider lookup and display name branch", func(t *testing.T) {
+		workdir := prepareModelSelectionConfig(t, "m-1")
+		cmd := &cobra.Command{}
+		cmd.Flags().String("workdir", workdir, "")
+		cmd.SetContext(context.Background())
+		out := &bytes.Buffer{}
+		cmd.SetOut(out)
+
+		svc := &mockSelectionService{
+			listModelsSnapshotFn: func(context.Context) ([]providertypes.ModelDescriptor, error) {
+				return []providertypes.ModelDescriptor{
+					{ID: "m-1", Name: "Model One"},
+				}, nil
+			},
+		}
+		if err := defaultModelLsCommandRunner(cmd, svc); err != nil {
+			t.Fatalf("defaultModelLsCommandRunner() error = %v", err)
+		}
+		if !strings.Contains(out.String(), "Model One") {
+			t.Fatalf("output = %q, want contains model display name", out.String())
+		}
+	})
+
+	t.Run("model ls selected provider missing", func(t *testing.T) {
+		workdir := prepareModelSelectionConfig(t, "m-1")
+		loader := config.NewLoader(workdir, config.StaticDefaults())
+		manager := config.NewManager(loader)
+		if _, err := manager.Load(context.Background()); err != nil {
+			t.Fatalf("manager.Load() error = %v", err)
+		}
+		if err := manager.Update(context.Background(), func(cfg *config.Config) error {
+			cfg.SelectedProvider = ""
+			return nil
+		}); err != nil {
+			t.Fatalf("manager.Update() error = %v", err)
+		}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("workdir", workdir, "")
+		cmd.SetContext(context.Background())
+
+		svc := &mockSelectionService{}
+		err := defaultModelLsCommandRunner(cmd, svc)
+		if err == nil {
+			t.Fatal("expected selected provider missing error")
+		}
+	})
+
+	t.Run("model set returns underlying non-model-not-found error", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		svc := &mockSelectionService{
+			setCurrentModelFn: func(context.Context, string) (configstate.Selection, error) {
+				return configstate.Selection{}, errors.New("set model failed")
+			},
+		}
+		err := defaultModelSetCommandRunner(cmd, svc, "m-1")
+		if err == nil || !strings.Contains(err.Error(), "set model failed") {
+			t.Fatalf("err = %v, want contains set model failed", err)
+		}
+	})
+
+	t.Run("provider ls formatting loop branch", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		out := &bytes.Buffer{}
+		cmd.SetOut(out)
+		svc := &mockSelectionService{
+			listProviderOptionsFn: func(context.Context) ([]configstate.ProviderOption, error) {
+				return []configstate.ProviderOption{
+					{
+						ID:     "p1",
+						Name:   "p1",
+						Driver: "openaicompat",
+						Source: "builtin",
+						Models: []providertypes.ModelDescriptor{{ID: "m1"}, {ID: "m2"}},
+					},
+				}, nil
+			},
+		}
+		if err := defaultProviderLsCommandRunner(cmd, svc); err != nil {
+			t.Fatalf("defaultProviderLsCommandRunner() error = %v", err)
+		}
+		if !strings.Contains(out.String(), "Models: 2") {
+			t.Fatalf("output = %q, want contains model count", out.String())
+		}
+	})
+
+	t.Run("use command whitespace model routes to SelectProvider", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		out := &bytes.Buffer{}
+		cmd.SetOut(out)
+
+		selectProviderCalled := false
+		svc := &mockSelectionService{
+			selectProviderFn: func(_ context.Context, provider string) (configstate.Selection, error) {
+				selectProviderCalled = true
+				return configstate.Selection{ProviderID: provider}, nil
+			},
+			selectProviderModelFn: func(context.Context, string, string) (configstate.Selection, error) {
+				return configstate.Selection{}, errors.New("unexpected SelectProviderWithModel call")
+			},
+		}
+		if err := defaultUseCommandRunner(cmd, svc, "openai", useCommandOptions{Model: "   "}); err != nil {
+			t.Fatalf("defaultUseCommandRunner() error = %v", err)
+		}
+		if !selectProviderCalled {
+			t.Fatal("expected SelectProvider to be called")
+		}
+	})
+
+	t.Run("diag auto command struct literal branch", func(t *testing.T) {
+		originalRunner := runDiagAutoCommand
+		t.Cleanup(func() { runDiagAutoCommand = originalRunner })
+
+		var captured diagAutoCommandOptions
+		runDiagAutoCommand = func(_ context.Context, options diagAutoCommandOptions, _ io.Writer) error {
+			captured = options
+			return nil
+		}
+
+		cmd := newDiagAutoCommand()
+		cmd.SetArgs([]string{"on", "--socket", "/tmp/diag.sock"})
+		if err := cmd.ExecuteContext(context.Background()); err != nil {
+			t.Fatalf("ExecuteContext() error = %v", err)
+		}
+		if captured.SocketPath != "/tmp/diag.sock" || !captured.Enabled {
+			t.Fatalf("captured = %+v, want socket=/tmp/diag.sock enabled=true", captured)
+		}
+	})
+
+	t.Run("diag diagnose command socket flag registration", func(t *testing.T) {
+		cmd := newDiagDiagnoseCommand()
+		flag := cmd.Flags().Lookup("socket")
+		if flag == nil {
+			t.Fatal("expected --socket flag on diagnose subcommand")
+		}
+	})
+
+	t.Run("diag auto runner send error branch", func(t *testing.T) {
+		originalSend := sendAutoModeSignalFn
+		t.Cleanup(func() { sendAutoModeSignalFn = originalSend })
+
+		sendAutoModeSignalFn = func(context.Context, string, bool) error {
+			return errors.New("send auto failed")
+		}
+		err := defaultDiagAutoCommandRunner(context.Background(), diagAutoCommandOptions{
+			SocketPath: "/tmp/diag.sock",
+			Enabled:    true,
+		}, &bytes.Buffer{})
+		if err == nil || !strings.Contains(err.Error(), "send auto failed") {
+			t.Fatalf("err = %v, want contains send auto failed", err)
+		}
+	})
+}

--- a/internal/cli/gateway_standalone_test.go
+++ b/internal/cli/gateway_standalone_test.go
@@ -167,6 +167,8 @@ func TestGatewaySubcommandAndStandaloneCommandPropagateSameRunnerError(t *testin
 	}
 
 	standaloneCommand := NewGatewayStandaloneCommand()
+	// 覆盖率模式下 go test 会注入 -test.* 参数，这里显式清空 argv 避免命令误解析。
+	standaloneCommand.SetArgs([]string{})
 	standaloneErr := standaloneCommand.ExecuteContext(context.Background())
 	if !errors.Is(standaloneErr, expectedErr) {
 		t.Fatalf("standalone command error = %v, want %v", standaloneErr, expectedErr)

--- a/internal/cli/model_commands.go
+++ b/internal/cli/model_commands.go
@@ -1,0 +1,142 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"neo-code/internal/config"
+)
+
+var (
+	runModelLsCommand  = defaultModelLsCommandRunner
+	runModelSetCommand = defaultModelSetCommandRunner
+)
+
+// newModelCommand 创建 model 命令组，管理当前 provider 下的模型选择。
+func newModelCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "model",
+		Short:        "Manage model selection for the current provider",
+		SilenceUsage: true,
+	}
+
+	cmd.AddCommand(
+		newModelLsCommand(),
+		newModelSetCommand(),
+	)
+
+	return cmd
+}
+
+// newModelLsCommand 创建 model ls 子命令，列出当前选中 provider 可用的模型。
+func newModelLsCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "ls",
+		Short: "List available models for the current provider",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runModelLsCommand(cmd)
+		},
+	}
+}
+
+// newModelSetCommand 创建 model set 子命令，切换当前使用的模型。
+func newModelSetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <model-id>",
+		Short: "Switch to a specific model",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runModelSetCommand(cmd, args[0])
+		},
+	}
+}
+
+// defaultModelLsCommandRunner 列出当前选中 provider 的所有可用模型。
+func defaultModelLsCommandRunner(cmd *cobra.Command) error {
+	var workdir string
+	if f := cmd.Flag("workdir"); f != nil {
+		workdir = f.Value.String()
+	}
+	loader := config.NewLoader(workdir, config.StaticDefaults())
+	cfg, err := loader.Load(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	selectedName := strings.TrimSpace(cfg.SelectedProvider)
+	if selectedName == "" {
+		return fmt.Errorf("尚未选择任何供应商，请先运行 neocode use <provider>")
+	}
+
+	providerCfg, err := cfg.ProviderByName(selectedName)
+	if err != nil {
+		return fmt.Errorf("当前选中的供应商 %q 不存在: %w", selectedName, err)
+	}
+
+	currentModel := strings.TrimSpace(cfg.CurrentModel)
+	out := cmd.OutOrStdout()
+
+	fmt.Fprintf(out, "供应商: %s\n", providerCfg.Name)
+	fmt.Fprintf(out, "当前模型: %s\n", displayCurrentModel(currentModel))
+	fmt.Fprintln(out, "可用模型:")
+
+	if len(providerCfg.Models) == 0 {
+		fmt.Fprintln(out, "  (无静态模型列表，该供应商使用动态发现)")
+		return nil
+	}
+
+	for _, model := range providerCfg.Models {
+		marker := "  "
+		if strings.EqualFold(strings.TrimSpace(model.ID), currentModel) {
+			marker = "* "
+		}
+		line := fmt.Sprintf("%s%s", marker, strings.TrimSpace(model.ID))
+		if name := strings.TrimSpace(model.Name); name != "" && name != model.ID {
+			line += fmt.Sprintf(" (%s)", name)
+		}
+		fmt.Fprintln(out, line)
+	}
+
+	return nil
+}
+
+// defaultModelSetCommandRunner 切换当前模型，将 current_model 写入配置。
+func defaultModelSetCommandRunner(cmd *cobra.Command, modelID string) error {
+	var workdir string
+	if f := cmd.Flag("workdir"); f != nil {
+		workdir = f.Value.String()
+	}
+	loader := config.NewLoader(workdir, config.StaticDefaults())
+	manager := config.NewManager(loader)
+
+	if _, err := manager.Load(cmd.Context()); err != nil {
+		return err
+	}
+
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return fmt.Errorf("模型 ID 不能为空")
+	}
+
+	err := manager.Update(cmd.Context(), func(cfg *config.Config) error {
+		cfg.CurrentModel = modelID
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "✅ 已切换模型: %s\n", modelID)
+	return nil
+}
+
+// displayCurrentModel 格式化当前模型名称，未设置时显示占位文案。
+func displayCurrentModel(model string) string {
+	if model == "" {
+		return "(未设置，将自动选择)"
+	}
+	return model
+}

--- a/internal/cli/model_commands.go
+++ b/internal/cli/model_commands.go
@@ -1,12 +1,14 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"neo-code/internal/config"
+	configstate "neo-code/internal/config/state"
 )
 
 var (
@@ -16,6 +18,14 @@ var (
 
 // newModelCommand 创建 model 命令组，管理当前 provider 下的模型选择。
 func newModelCommand() *cobra.Command {
+	return newModelCommandWithResolver(newRuntimeSelectionServiceResolver())
+}
+
+// newModelCommandWithResolver 基于注入的选择服务解析器构建 model 命令组。
+func newModelCommandWithResolver(resolver selectionServiceResolver) *cobra.Command {
+	if resolver == nil {
+		resolver = newRuntimeSelectionServiceResolver()
+	}
 	cmd := &cobra.Command{
 		Use:          "model",
 		Short:        "Manage model selection for the current provider",
@@ -23,8 +33,8 @@ func newModelCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		newModelLsCommand(),
-		newModelSetCommand(),
+		newModelLsCommandWithResolver(resolver),
+		newModelSetCommandWithResolver(resolver),
 	)
 
 	return cmd
@@ -32,30 +42,58 @@ func newModelCommand() *cobra.Command {
 
 // newModelLsCommand 创建 model ls 子命令，列出当前选中 provider 可用的模型。
 func newModelLsCommand() *cobra.Command {
+	return newModelLsCommandWithResolver(newRuntimeSelectionServiceResolver())
+}
+
+// newModelLsCommandWithResolver 创建支持依赖注入的 model ls 子命令。
+func newModelLsCommandWithResolver(resolver selectionServiceResolver) *cobra.Command {
+	if resolver == nil {
+		resolver = newRuntimeSelectionServiceResolver()
+	}
 	return &cobra.Command{
 		Use:   "ls",
 		Short: "List available models for the current provider",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runModelLsCommand(cmd)
+			svc, err := resolver.Resolve(cmd)
+			if err != nil {
+				return err
+			}
+			return runModelLsCommand(cmd, svc)
 		},
 	}
 }
 
 // newModelSetCommand 创建 model set 子命令，切换当前使用的模型。
 func newModelSetCommand() *cobra.Command {
+	return newModelSetCommandWithResolver(newRuntimeSelectionServiceResolver())
+}
+
+// newModelSetCommandWithResolver 创建支持依赖注入的 model set 子命令。
+func newModelSetCommandWithResolver(resolver selectionServiceResolver) *cobra.Command {
+	if resolver == nil {
+		resolver = newRuntimeSelectionServiceResolver()
+	}
 	return &cobra.Command{
 		Use:   "set <model-id>",
 		Short: "Switch to a specific model",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runModelSetCommand(cmd, args[0])
+			svc, err := resolver.Resolve(cmd)
+			if err != nil {
+				return err
+			}
+			return runModelSetCommand(cmd, svc, args[0])
 		},
 	}
 }
 
 // defaultModelLsCommandRunner 列出当前选中 provider 的所有可用模型。
-func defaultModelLsCommandRunner(cmd *cobra.Command) error {
+func defaultModelLsCommandRunner(cmd *cobra.Command, svc SelectionService) error {
+	if svc == nil {
+		return fmt.Errorf("selection service is unavailable")
+	}
+
 	var workdir string
 	if f := cmd.Flag("workdir"); f != nil {
 		workdir = f.Value.String()
@@ -83,18 +121,32 @@ func defaultModelLsCommandRunner(cmd *cobra.Command) error {
 	fmt.Fprintf(out, "当前模型: %s\n", displayCurrentModel(currentModel))
 	fmt.Fprintln(out, "可用模型:")
 
-	if len(providerCfg.Models) == 0 {
-		fmt.Fprintln(out, "  (无静态模型列表，该供应商使用动态发现)")
+	models, err := svc.ListModelsSnapshot(cmd.Context())
+	if err != nil {
+		return err
+	}
+	if len(models) == 0 {
+		models, err = svc.ListModels(cmd.Context())
+		if err != nil {
+			return err
+		}
+	}
+	if len(models) == 0 {
+		fmt.Fprintln(out, "  (无可用模型，该供应商使用动态发现)")
 		return nil
 	}
 
-	for _, model := range providerCfg.Models {
+	for _, model := range models {
+		modelID := strings.TrimSpace(model.ID)
+		if modelID == "" {
+			continue
+		}
 		marker := "  "
-		if strings.EqualFold(strings.TrimSpace(model.ID), currentModel) {
+		if strings.EqualFold(modelID, currentModel) {
 			marker = "* "
 		}
-		line := fmt.Sprintf("%s%s", marker, strings.TrimSpace(model.ID))
-		if name := strings.TrimSpace(model.Name); name != "" && name != model.ID {
+		line := fmt.Sprintf("%s%s", marker, modelID)
+		if name := strings.TrimSpace(model.Name); name != "" && name != modelID {
 			line += fmt.Sprintf(" (%s)", name)
 		}
 		fmt.Fprintln(out, line)
@@ -103,17 +155,10 @@ func defaultModelLsCommandRunner(cmd *cobra.Command) error {
 	return nil
 }
 
-// defaultModelSetCommandRunner 切换当前模型，将 current_model 写入配置。
-func defaultModelSetCommandRunner(cmd *cobra.Command, modelID string) error {
-	var workdir string
-	if f := cmd.Flag("workdir"); f != nil {
-		workdir = f.Value.String()
-	}
-	loader := config.NewLoader(workdir, config.StaticDefaults())
-	manager := config.NewManager(loader)
-
-	if _, err := manager.Load(cmd.Context()); err != nil {
-		return err
+// defaultModelSetCommandRunner 切换当前模型，并通过选择服务完成模型归属校验与持久化。
+func defaultModelSetCommandRunner(cmd *cobra.Command, svc SelectionService, modelID string) error {
+	if svc == nil {
+		return fmt.Errorf("selection service is unavailable")
 	}
 
 	modelID = strings.TrimSpace(modelID)
@@ -121,15 +166,32 @@ func defaultModelSetCommandRunner(cmd *cobra.Command, modelID string) error {
 		return fmt.Errorf("模型 ID 不能为空")
 	}
 
-	err := manager.Update(cmd.Context(), func(cfg *config.Config) error {
-		cfg.CurrentModel = modelID
-		return nil
-	})
+	selection, err := svc.SetCurrentModel(cmd.Context(), modelID)
 	if err != nil {
+		if errors.Is(err, configstate.ErrModelNotFound) {
+			var workdir string
+			if f := cmd.Flag("workdir"); f != nil {
+				workdir = f.Value.String()
+			}
+			loader := config.NewLoader(workdir, config.StaticDefaults())
+			cfg, loadErr := loader.Load(cmd.Context())
+			if loadErr != nil {
+				return fmt.Errorf("provider has no model %q: %w", modelID, err)
+			}
+			providerName := strings.TrimSpace(cfg.SelectedProvider)
+			if providerName == "" {
+				return fmt.Errorf("provider has no model %q: %w", modelID, err)
+			}
+			return fmt.Errorf("provider %q has no model %q: %w", providerName, modelID, err)
+		}
 		return err
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "✅ 已切换模型: %s\n", modelID)
+	activeModel := strings.TrimSpace(selection.ModelID)
+	if activeModel == "" {
+		activeModel = modelID
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "✅ 已切换模型: %s\n", activeModel)
 	return nil
 }
 

--- a/internal/cli/model_commands.go
+++ b/internal/cli/model_commands.go
@@ -121,11 +121,20 @@ func defaultModelLsCommandRunner(cmd *cobra.Command, svc SelectionService) error
 	fmt.Fprintf(out, "当前模型: %s\n", displayCurrentModel(currentModel))
 	fmt.Fprintln(out, "可用模型:")
 
+	snapshotErr := error(nil)
 	models, err := svc.ListModelsSnapshot(cmd.Context())
 	if err != nil {
-		return err
+		snapshotErr = err
+		models = nil
 	}
 	if len(models) == 0 {
+		if snapshotErr != nil {
+			_, _ = fmt.Fprintf(
+				cmd.ErrOrStderr(),
+				"warning: model snapshot unavailable, fallback to live discovery: %v\n",
+				snapshotErr,
+			)
+		}
 		models, err = svc.ListModels(cmd.Context())
 		if err != nil {
 			return err

--- a/internal/cli/model_commands_test.go
+++ b/internal/cli/model_commands_test.go
@@ -1,0 +1,195 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"neo-code/internal/config"
+)
+
+func TestModelCommand(t *testing.T) {
+	cmd := newModelCommand()
+	if cmd.Use != "model" {
+		t.Errorf("expected use 'model', got %s", cmd.Use)
+	}
+}
+
+func TestModelLsCommand(t *testing.T) {
+	cmd := newModelLsCommand()
+	if cmd.Use != "ls" {
+		t.Errorf("expected use 'ls', got %s", cmd.Use)
+	}
+
+	called := false
+	runModelLsCommand = func(c *cobra.Command) error {
+		called = true
+		return errors.New("mock error")
+	}
+	defer func() { runModelLsCommand = defaultModelLsCommandRunner }()
+
+	cmd.SetArgs([]string{})
+	if err := cmd.ExecuteContext(context.Background()); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !called {
+		t.Fatal("runner not called")
+	}
+}
+
+func TestModelSetCommand(t *testing.T) {
+	cmd := newModelSetCommand()
+	if cmd.Use != "set <model-id>" {
+		t.Errorf("expected use 'set <model-id>', got %s", cmd.Use)
+	}
+
+	called := false
+	runModelSetCommand = func(c *cobra.Command, modelID string) error {
+		called = true
+		if modelID != "gpt-5.4" {
+			t.Errorf("expected 'gpt-5.4', got %s", modelID)
+		}
+		return errors.New("mock error")
+	}
+	defer func() { runModelSetCommand = defaultModelSetCommandRunner }()
+
+	cmd.SetArgs([]string{"gpt-5.4"})
+	if err := cmd.ExecuteContext(context.Background()); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !called {
+		t.Fatal("runner not called")
+	}
+}
+
+func TestDefaultModelLsCommandRunner_BuiltinProvider(t *testing.T) {
+	workdir := t.TempDir()
+
+	// 加载默认配置并设置 selected_provider 为 builtin openai
+	loader := config.NewLoader(workdir, config.StaticDefaults())
+	manager := config.NewManager(loader)
+	if _, err := manager.Load(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.Update(context.Background(), func(cfg *config.Config) error {
+		cfg.SelectedProvider = "openai"
+		cfg.CurrentModel = "gpt-5.4"
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("workdir", workdir, "")
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetContext(context.Background())
+
+	err := defaultModelLsCommandRunner(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "openai") {
+		t.Errorf("expected output to contain 'openai', got %s", output)
+	}
+	if !strings.Contains(output, "gpt-5.4") {
+		t.Errorf("expected output to contain 'gpt-5.4', got %s", output)
+	}
+	// 当前模型应有 * 标记
+	if !strings.Contains(output, "* gpt-5.4") {
+		t.Errorf("expected current model to be marked with *, got %s", output)
+	}
+}
+
+func TestDefaultModelLsCommandRunner_NoSelectedProvider(t *testing.T) {
+	workdir := t.TempDir()
+
+	loader := config.NewLoader(workdir, config.StaticDefaults())
+	manager := config.NewManager(loader)
+	if _, err := manager.Load(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// 清空 selected_provider
+	if err := manager.Update(context.Background(), func(cfg *config.Config) error {
+		cfg.SelectedProvider = "openai"
+		cfg.CurrentModel = ""
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// 再次清空，写入一个空值是不行的（会被校验拒绝），所以测试 no-provider 场景用一个不同的方式
+	// 实际上 selected_provider 被校验逻辑要求非空，所以我们测试正常的未设置 current_model 场景
+	cmd := &cobra.Command{}
+	cmd.Flags().String("workdir", workdir, "")
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetContext(context.Background())
+
+	err := defaultModelLsCommandRunner(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "(未设置，将自动选择)") {
+		t.Errorf("expected output to contain auto-select hint, got %s", output)
+	}
+}
+
+func TestDefaultModelSetCommandRunner(t *testing.T) {
+	workdir := t.TempDir()
+
+	// 预创建配置
+	loader := config.NewLoader(workdir, config.StaticDefaults())
+	manager := config.NewManager(loader)
+	if _, err := manager.Load(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.Update(context.Background(), func(cfg *config.Config) error {
+		cfg.SelectedProvider = "openai"
+		cfg.CurrentModel = "gpt-5.4"
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("workdir", workdir, "")
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetContext(context.Background())
+
+	err := defaultModelSetCommandRunner(cmd, "gpt-4o")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 验证 current_model 已更新
+	cfg, err := loader.Load(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.CurrentModel != "gpt-4o" {
+		t.Errorf("expected current model 'gpt-4o', got %s", cfg.CurrentModel)
+	}
+
+	// 空模型 ID 应报错
+	err = defaultModelSetCommandRunner(cmd, "  ")
+	if err == nil {
+		t.Fatal("expected error for empty model ID, got nil")
+	}
+}
+
+func TestDisplayCurrentModel(t *testing.T) {
+	if got := displayCurrentModel(""); !strings.Contains(got, "未设置") {
+		t.Errorf("expected empty model to show hint, got %s", got)
+	}
+	if got := displayCurrentModel("gpt-5.4"); got != "gpt-5.4" {
+		t.Errorf("expected 'gpt-5.4', got %s", got)
+	}
+}

--- a/internal/cli/model_commands_test.go
+++ b/internal/cli/model_commands_test.go
@@ -8,188 +8,281 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
 	"neo-code/internal/config"
+	configstate "neo-code/internal/config/state"
+	providertypes "neo-code/internal/provider/types"
 )
 
 func TestModelCommand(t *testing.T) {
 	cmd := newModelCommand()
 	if cmd.Use != "model" {
-		t.Errorf("expected use 'model', got %s", cmd.Use)
+		t.Fatalf("cmd.Use = %q, want %q", cmd.Use, "model")
 	}
 }
 
 func TestModelLsCommand(t *testing.T) {
-	cmd := newModelLsCommand()
+	svc := &mockSelectionService{}
+	cmd := newModelLsCommandWithResolver(staticSelectionResolver(svc))
 	if cmd.Use != "ls" {
-		t.Errorf("expected use 'ls', got %s", cmd.Use)
+		t.Fatalf("cmd.Use = %q, want %q", cmd.Use, "ls")
 	}
+
+	originalRunner := runModelLsCommand
+	t.Cleanup(func() { runModelLsCommand = originalRunner })
 
 	called := false
-	runModelLsCommand = func(c *cobra.Command) error {
+	runModelLsCommand = func(c *cobra.Command, gotSvc SelectionService) error {
 		called = true
+		if gotSvc != svc {
+			t.Fatalf("injected service mismatch")
+		}
 		return errors.New("mock error")
 	}
-	defer func() { runModelLsCommand = defaultModelLsCommandRunner }()
 
 	cmd.SetArgs([]string{})
-	if err := cmd.ExecuteContext(context.Background()); err == nil {
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if !called {
-		t.Fatal("runner not called")
+		t.Fatal("expected runModelLsCommand called")
 	}
 }
 
 func TestModelSetCommand(t *testing.T) {
-	cmd := newModelSetCommand()
+	svc := &mockSelectionService{}
+	cmd := newModelSetCommandWithResolver(staticSelectionResolver(svc))
 	if cmd.Use != "set <model-id>" {
-		t.Errorf("expected use 'set <model-id>', got %s", cmd.Use)
+		t.Fatalf("cmd.Use = %q, want %q", cmd.Use, "set <model-id>")
 	}
 
+	originalRunner := runModelSetCommand
+	t.Cleanup(func() { runModelSetCommand = originalRunner })
+
 	called := false
-	runModelSetCommand = func(c *cobra.Command, modelID string) error {
+	runModelSetCommand = func(c *cobra.Command, gotSvc SelectionService, modelID string) error {
 		called = true
+		if gotSvc != svc {
+			t.Fatalf("injected service mismatch")
+		}
 		if modelID != "gpt-5.4" {
-			t.Errorf("expected 'gpt-5.4', got %s", modelID)
+			t.Fatalf("modelID = %q, want %q", modelID, "gpt-5.4")
 		}
 		return errors.New("mock error")
 	}
-	defer func() { runModelSetCommand = defaultModelSetCommandRunner }()
 
 	cmd.SetArgs([]string{"gpt-5.4"})
-	if err := cmd.ExecuteContext(context.Background()); err == nil {
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if !called {
-		t.Fatal("runner not called")
+		t.Fatal("expected runModelSetCommand called")
 	}
 }
 
-func TestDefaultModelLsCommandRunner_BuiltinProvider(t *testing.T) {
-	workdir := t.TempDir()
-
-	// 加载默认配置并设置 selected_provider 为 builtin openai
-	loader := config.NewLoader(workdir, config.StaticDefaults())
-	manager := config.NewManager(loader)
-	if _, err := manager.Load(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	if err := manager.Update(context.Background(), func(cfg *config.Config) error {
-		cfg.SelectedProvider = "openai"
-		cfg.CurrentModel = "gpt-5.4"
-		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	cmd := &cobra.Command{}
-	cmd.Flags().String("workdir", workdir, "")
-	out := new(bytes.Buffer)
-	cmd.SetOut(out)
-	cmd.SetContext(context.Background())
-
-	err := defaultModelLsCommandRunner(cmd)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	output := out.String()
-	if !strings.Contains(output, "openai") {
-		t.Errorf("expected output to contain 'openai', got %s", output)
-	}
-	if !strings.Contains(output, "gpt-5.4") {
-		t.Errorf("expected output to contain 'gpt-5.4', got %s", output)
-	}
-	// 当前模型应有 * 标记
-	if !strings.Contains(output, "* gpt-5.4") {
-		t.Errorf("expected current model to be marked with *, got %s", output)
-	}
-}
-
-func TestDefaultModelLsCommandRunner_NoSelectedProvider(t *testing.T) {
-	workdir := t.TempDir()
-
-	loader := config.NewLoader(workdir, config.StaticDefaults())
-	manager := config.NewManager(loader)
-	if _, err := manager.Load(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	// 清空 selected_provider
-	if err := manager.Update(context.Background(), func(cfg *config.Config) error {
-		cfg.SelectedProvider = "openai"
-		cfg.CurrentModel = ""
-		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
-	// 再次清空，写入一个空值是不行的（会被校验拒绝），所以测试 no-provider 场景用一个不同的方式
-	// 实际上 selected_provider 被校验逻辑要求非空，所以我们测试正常的未设置 current_model 场景
-	cmd := &cobra.Command{}
-	cmd.Flags().String("workdir", workdir, "")
-	out := new(bytes.Buffer)
-	cmd.SetOut(out)
-	cmd.SetContext(context.Background())
-
-	err := defaultModelLsCommandRunner(cmd)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestDefaultModelLsCommandRunner(t *testing.T) {
+	tests := []struct {
+		name           string
+		currentModel   string
+		snapshotModels []providertypes.ModelDescriptor
+		snapshotErr    error
+		listModels     []providertypes.ModelDescriptor
+		listErr        error
+		wantOutput     []string
+		wantErr        string
+		wantListCalled bool
+	}{
+		{
+			name:         "snapshot models with current marker",
+			currentModel: "gpt-5.4",
+			snapshotModels: []providertypes.ModelDescriptor{
+				{ID: "gpt-5.4", Name: "GPT-5.4"},
+				{ID: "gpt-4o"},
+			},
+			wantOutput: []string{
+				"供应商: openai",
+				"* gpt-5.4 (GPT-5.4)",
+				"gpt-4o",
+			},
+		},
+		{
+			name:           "fallback to list models when snapshot empty",
+			currentModel:   "gpt-4o",
+			snapshotModels: []providertypes.ModelDescriptor{},
+			listModels: []providertypes.ModelDescriptor{
+				{ID: "gpt-4o", Name: "GPT-4o"},
+			},
+			wantOutput:     []string{"* gpt-4o (GPT-4o)"},
+			wantListCalled: true,
+		},
+		{
+			name:           "both snapshot and list empty",
+			currentModel:   "gpt-4o",
+			snapshotModels: []providertypes.ModelDescriptor{},
+			listModels:     []providertypes.ModelDescriptor{},
+			wantOutput:     []string{"无可用模型，该供应商使用动态发现"},
+			wantListCalled: true,
+		},
+		{
+			name:         "snapshot error",
+			currentModel: "gpt-4o",
+			snapshotErr:  errors.New("snapshot unavailable"),
+			wantErr:      "snapshot unavailable",
+		},
+		{
+			name:           "list error after snapshot miss",
+			currentModel:   "gpt-4o",
+			snapshotModels: []providertypes.ModelDescriptor{},
+			listErr:        errors.New("catalog unavailable"),
+			wantErr:        "catalog unavailable",
+			wantListCalled: true,
+		},
 	}
 
-	output := out.String()
-	if !strings.Contains(output, "(未设置，将自动选择)") {
-		t.Errorf("expected output to contain auto-select hint, got %s", output)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			workdir := prepareModelSelectionConfig(t, tc.currentModel)
+			cmd := &cobra.Command{}
+			cmd.Flags().String("workdir", workdir, "")
+			output := &bytes.Buffer{}
+			cmd.SetOut(output)
+			cmd.SetContext(context.Background())
+
+			listCalled := false
+			svc := &mockSelectionService{
+				listModelsSnapshotFn: func(context.Context) ([]providertypes.ModelDescriptor, error) {
+					return tc.snapshotModels, tc.snapshotErr
+				},
+				listModelsFn: func(context.Context) ([]providertypes.ModelDescriptor, error) {
+					listCalled = true
+					return tc.listModels, tc.listErr
+				},
+			}
+
+			err := defaultModelLsCommandRunner(cmd, svc)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want contains %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("defaultModelLsCommandRunner() error = %v", err)
+			}
+			if listCalled != tc.wantListCalled {
+				t.Fatalf("listCalled = %v, want %v", listCalled, tc.wantListCalled)
+			}
+			for _, fragment := range tc.wantOutput {
+				if !strings.Contains(output.String(), fragment) {
+					t.Fatalf("output = %q, want contains %q", output.String(), fragment)
+				}
+			}
+		})
 	}
 }
 
 func TestDefaultModelSetCommandRunner(t *testing.T) {
-	workdir := t.TempDir()
+	workdir := prepareModelSelectionConfig(t, "gpt-5.4")
 
-	// 预创建配置
-	loader := config.NewLoader(workdir, config.StaticDefaults())
-	manager := config.NewManager(loader)
-	if _, err := manager.Load(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	if err := manager.Update(context.Background(), func(cfg *config.Config) error {
-		cfg.SelectedProvider = "openai"
-		cfg.CurrentModel = "gpt-5.4"
-		return nil
-	}); err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name       string
+		modelID    string
+		service    SelectionService
+		wantErr    string
+		wantOutput string
+	}{
+		{
+			name:    "switch model success",
+			modelID: "gpt-4o",
+			service: &mockSelectionService{
+				setCurrentModelFn: func(_ context.Context, modelID string) (configstate.Selection, error) {
+					return configstate.Selection{ProviderID: "openai", ModelID: modelID}, nil
+				},
+			},
+			wantOutput: "已切换模型: gpt-4o",
+		},
+		{
+			name:    "empty model id",
+			modelID: "  ",
+			service: &mockSelectionService{
+				setCurrentModelFn: func(_ context.Context, modelID string) (configstate.Selection, error) {
+					return configstate.Selection{}, nil
+				},
+			},
+			wantErr: "模型 ID 不能为空",
+		},
+		{
+			name:    "model not found",
+			modelID: "missing",
+			service: &mockSelectionService{
+				setCurrentModelFn: func(_ context.Context, modelID string) (configstate.Selection, error) {
+					return configstate.Selection{}, configstate.ErrModelNotFound
+				},
+			},
+			wantErr: `provider "openai" has no model "missing"`,
+		},
+		{
+			name:    "service error",
+			modelID: "gpt-4o",
+			service: &mockSelectionService{
+				setCurrentModelFn: func(_ context.Context, modelID string) (configstate.Selection, error) {
+					return configstate.Selection{}, errors.New("catalog down")
+				},
+			},
+			wantErr: "catalog down",
+		},
 	}
 
-	cmd := &cobra.Command{}
-	cmd.Flags().String("workdir", workdir, "")
-	out := new(bytes.Buffer)
-	cmd.SetOut(out)
-	cmd.SetContext(context.Background())
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.Flags().String("workdir", workdir, "")
+			output := &bytes.Buffer{}
+			cmd.SetOut(output)
+			cmd.SetContext(context.Background())
 
-	err := defaultModelSetCommandRunner(cmd, "gpt-4o")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	// 验证 current_model 已更新
-	cfg, err := loader.Load(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.CurrentModel != "gpt-4o" {
-		t.Errorf("expected current model 'gpt-4o', got %s", cfg.CurrentModel)
-	}
-
-	// 空模型 ID 应报错
-	err = defaultModelSetCommandRunner(cmd, "  ")
-	if err == nil {
-		t.Fatal("expected error for empty model ID, got nil")
+			err := defaultModelSetCommandRunner(cmd, tc.service, tc.modelID)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want contains %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("defaultModelSetCommandRunner() error = %v", err)
+			}
+			if !strings.Contains(output.String(), tc.wantOutput) {
+				t.Fatalf("output = %q, want contains %q", output.String(), tc.wantOutput)
+			}
+		})
 	}
 }
 
 func TestDisplayCurrentModel(t *testing.T) {
 	if got := displayCurrentModel(""); !strings.Contains(got, "未设置") {
-		t.Errorf("expected empty model to show hint, got %s", got)
+		t.Fatalf("displayCurrentModel(\"\") = %q, want contains 未设置", got)
 	}
 	if got := displayCurrentModel("gpt-5.4"); got != "gpt-5.4" {
-		t.Errorf("expected 'gpt-5.4', got %s", got)
+		t.Fatalf("displayCurrentModel() = %q, want %q", got, "gpt-5.4")
 	}
+}
+
+func prepareModelSelectionConfig(t *testing.T, currentModel string) string {
+	t.Helper()
+	workdir := t.TempDir()
+	loader := config.NewLoader(workdir, config.StaticDefaults())
+	manager := config.NewManager(loader)
+	if _, err := manager.Load(context.Background()); err != nil {
+		t.Fatalf("manager.Load() error = %v", err)
+	}
+	if err := manager.Update(context.Background(), func(cfg *config.Config) error {
+		cfg.SelectedProvider = "openai"
+		cfg.CurrentModel = strings.TrimSpace(currentModel)
+		return nil
+	}); err != nil {
+		t.Fatalf("manager.Update() error = %v", err)
+	}
+	return workdir
 }

--- a/internal/cli/model_commands_test.go
+++ b/internal/cli/model_commands_test.go
@@ -147,6 +147,7 @@ func TestDefaultModelLsCommandRunner(t *testing.T) {
 		listModels     []providertypes.ModelDescriptor
 		listErr        error
 		wantOutput     []string
+		wantErrOutput  []string
 		wantErr        string
 		wantListCalled bool
 	}{
@@ -185,7 +186,12 @@ func TestDefaultModelLsCommandRunner(t *testing.T) {
 			name:         "snapshot error",
 			currentModel: "gpt-4o",
 			snapshotErr:  errors.New("snapshot unavailable"),
-			wantErr:      "snapshot unavailable",
+			listModels: []providertypes.ModelDescriptor{
+				{ID: "gpt-4o", Name: "GPT-4o"},
+			},
+			wantOutput:     []string{"* gpt-4o (GPT-4o)"},
+			wantErrOutput:  []string{"snapshot unavailable", "fallback to live discovery"},
+			wantListCalled: true,
 		},
 		{
 			name:           "list error after snapshot miss",
@@ -203,7 +209,9 @@ func TestDefaultModelLsCommandRunner(t *testing.T) {
 			cmd := &cobra.Command{}
 			cmd.Flags().String("workdir", workdir, "")
 			output := &bytes.Buffer{}
+			errOutput := &bytes.Buffer{}
 			cmd.SetOut(output)
+			cmd.SetErr(errOutput)
 			cmd.SetContext(context.Background())
 
 			listCalled := false
@@ -233,6 +241,11 @@ func TestDefaultModelLsCommandRunner(t *testing.T) {
 			for _, fragment := range tc.wantOutput {
 				if !strings.Contains(output.String(), fragment) {
 					t.Fatalf("output = %q, want contains %q", output.String(), fragment)
+				}
+			}
+			for _, fragment := range tc.wantErrOutput {
+				if !strings.Contains(errOutput.String(), fragment) {
+					t.Fatalf("stderr = %q, want contains %q", errOutput.String(), fragment)
 				}
 			}
 		})

--- a/internal/cli/model_commands_test.go
+++ b/internal/cli/model_commands_test.go
@@ -21,6 +21,26 @@ func TestModelCommand(t *testing.T) {
 	}
 }
 
+func TestModelCommandBuildersUseDefaultResolverWhenNil(t *testing.T) {
+	cmd := newModelCommandWithResolver(nil)
+	if cmd.Use != "model" {
+		t.Fatalf("cmd.Use = %q, want %q", cmd.Use, "model")
+	}
+	if len(cmd.Commands()) != 2 {
+		t.Fatalf("len(model subcommands) = %d, want 2", len(cmd.Commands()))
+	}
+
+	ls := newModelLsCommand()
+	if ls.Use != "ls" {
+		t.Fatalf("ls.Use = %q, want %q", ls.Use, "ls")
+	}
+
+	set := newModelSetCommand()
+	if set.Use != "set <model-id>" {
+		t.Fatalf("set.Use = %q, want %q", set.Use, "set <model-id>")
+	}
+}
+
 func TestModelLsCommand(t *testing.T) {
 	svc := &mockSelectionService{}
 	cmd := newModelLsCommandWithResolver(staticSelectionResolver(svc))
@@ -80,6 +100,42 @@ func TestModelSetCommand(t *testing.T) {
 	if !called {
 		t.Fatal("expected runModelSetCommand called")
 	}
+}
+
+func TestModelCommandResolverFallbackAndResolveError(t *testing.T) {
+	t.Run("fallback to default resolver when nil", func(t *testing.T) {
+		ls := newModelLsCommandWithResolver(nil)
+		if ls.Use != "ls" {
+			t.Fatalf("ls.Use = %q, want ls", ls.Use)
+		}
+
+		set := newModelSetCommandWithResolver(nil)
+		if set.Use != "set <model-id>" {
+			t.Fatalf("set.Use = %q, want set <model-id>", set.Use)
+		}
+	})
+
+	t.Run("ls resolve error", func(t *testing.T) {
+		cmd := newModelLsCommandWithResolver(selectionServiceResolverFunc(func(*cobra.Command) (SelectionService, error) {
+			return nil, errors.New("resolve failed")
+		}))
+		cmd.SetArgs([]string{})
+		err := cmd.ExecuteContext(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "resolve failed") {
+			t.Fatalf("err = %v, want contains resolve failed", err)
+		}
+	})
+
+	t.Run("set resolve error", func(t *testing.T) {
+		cmd := newModelSetCommandWithResolver(selectionServiceResolverFunc(func(*cobra.Command) (SelectionService, error) {
+			return nil, errors.New("resolve failed")
+		}))
+		cmd.SetArgs([]string{"gpt-4o"})
+		err := cmd.ExecuteContext(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "resolve failed") {
+			t.Fatalf("err = %v, want contains resolve failed", err)
+		}
+	})
 }
 
 func TestDefaultModelLsCommandRunner(t *testing.T) {
@@ -267,6 +323,118 @@ func TestDisplayCurrentModel(t *testing.T) {
 	if got := displayCurrentModel("gpt-5.4"); got != "gpt-5.4" {
 		t.Fatalf("displayCurrentModel() = %q, want %q", got, "gpt-5.4")
 	}
+}
+
+func TestModelCommandRunnerErrorBranches(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	if err := defaultModelLsCommandRunner(cmd, nil); err == nil || !strings.Contains(err.Error(), "selection service") {
+		t.Fatalf("defaultModelLsCommandRunner(nil) err = %v", err)
+	}
+	if err := defaultModelSetCommandRunner(cmd, nil, "gpt-4o"); err == nil || !strings.Contains(err.Error(), "selection service") {
+		t.Fatalf("defaultModelSetCommandRunner(nil) err = %v", err)
+	}
+}
+
+func TestDefaultModelLsCommandRunnerSelectionConfigErrors(t *testing.T) {
+	t.Run("no selected provider", func(t *testing.T) {
+		workdir := prepareModelSelectionConfig(t, "gpt-5.4")
+		loader := config.NewLoader(workdir, config.StaticDefaults())
+		manager := config.NewManager(loader)
+		if _, err := manager.Load(context.Background()); err != nil {
+			t.Fatalf("manager.Load() error = %v", err)
+		}
+		if err := manager.Update(context.Background(), func(cfg *config.Config) error {
+			cfg.SelectedProvider = ""
+			cfg.CurrentModel = ""
+			return nil
+		}); err != nil {
+			t.Fatalf("manager.Update() error = %v", err)
+		}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("workdir", workdir, "")
+		cmd.SetContext(context.Background())
+		err := defaultModelLsCommandRunner(cmd, &mockSelectionService{})
+		if err == nil || !strings.Contains(err.Error(), "neocode use") {
+			t.Fatalf("err = %v, want contains neocode use", err)
+		}
+	})
+
+	t.Run("selected provider missing in config", func(t *testing.T) {
+		workdir := prepareModelSelectionConfig(t, "gpt-5.4")
+		loader := config.NewLoader(workdir, config.StaticDefaults())
+		manager := config.NewManager(loader)
+		if _, err := manager.Load(context.Background()); err != nil {
+			t.Fatalf("manager.Load() error = %v", err)
+		}
+		if err := manager.Update(context.Background(), func(cfg *config.Config) error {
+			cfg.SelectedProvider = "missing-provider"
+			return nil
+		}); err != nil {
+			t.Fatalf("manager.Update() error = %v", err)
+		}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("workdir", workdir, "")
+		cmd.SetContext(context.Background())
+		err := defaultModelLsCommandRunner(cmd, &mockSelectionService{})
+		if err == nil || !strings.Contains(err.Error(), "missing-provider") {
+			t.Fatalf("err = %v, want contains missing-provider", err)
+		}
+	})
+}
+
+func TestDefaultModelSetCommandRunnerAdditionalBranches(t *testing.T) {
+	t.Run("model not found and selected provider empty", func(t *testing.T) {
+		workdir := prepareModelSelectionConfig(t, "gpt-5.4")
+		loader := config.NewLoader(workdir, config.StaticDefaults())
+		manager := config.NewManager(loader)
+		if _, err := manager.Load(context.Background()); err != nil {
+			t.Fatalf("manager.Load() error = %v", err)
+		}
+		if err := manager.Update(context.Background(), func(cfg *config.Config) error {
+			cfg.SelectedProvider = ""
+			return nil
+		}); err != nil {
+			t.Fatalf("manager.Update() error = %v", err)
+		}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("workdir", workdir, "")
+		cmd.SetContext(context.Background())
+		svc := &mockSelectionService{
+			setCurrentModelFn: func(context.Context, string) (configstate.Selection, error) {
+				return configstate.Selection{}, configstate.ErrModelNotFound
+			},
+		}
+		err := defaultModelSetCommandRunner(cmd, svc, "missing-model")
+		if err == nil || !strings.Contains(err.Error(), `provider has no model "missing-model"`) {
+			t.Fatalf("err = %v", err)
+		}
+	})
+
+	t.Run("set current model success with empty selection model", func(t *testing.T) {
+		workdir := prepareModelSelectionConfig(t, "gpt-5.4")
+		cmd := &cobra.Command{}
+		cmd.Flags().String("workdir", workdir, "")
+		out := &bytes.Buffer{}
+		cmd.SetOut(out)
+		cmd.SetContext(context.Background())
+
+		svc := &mockSelectionService{
+			setCurrentModelFn: func(_ context.Context, _ string) (configstate.Selection, error) {
+				return configstate.Selection{ProviderID: "openai", ModelID: ""}, nil
+			},
+		}
+		if err := defaultModelSetCommandRunner(cmd, svc, "gpt-4o"); err != nil {
+			t.Fatalf("defaultModelSetCommandRunner() error = %v", err)
+		}
+		if !strings.Contains(out.String(), "gpt-4o") {
+			t.Fatalf("output = %q, want contains gpt-4o", out.String())
+		}
+	})
 }
 
 func prepareModelSelectionConfig(t *testing.T, currentModel string) string {

--- a/internal/cli/provider_commands.go
+++ b/internal/cli/provider_commands.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"neo-code/internal/config"
+)
+
+type providerAddOptions struct {
+	Driver                string
+	URL                   string
+	APIKeyEnv             string
+	DiscoveryEndpointPath string
+}
+
+var (
+	runProviderAddCommand = defaultProviderAddCommandRunner
+	runProviderLsCommand  = defaultProviderLsCommandRunner
+	runProviderRmCommand  = defaultProviderRmCommandRunner
+)
+
+// newProviderCommand 创建 provider 命令组，管理自定义供应商配置。
+func newProviderCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "provider",
+		Short:        "Manage custom providers",
+		SilenceUsage: true,
+	}
+
+	cmd.AddCommand(
+		newProviderAddCommand(),
+		newProviderLsCommand(),
+		newProviderRmCommand(),
+	)
+
+	return cmd
+}
+
+func newProviderAddCommand() *cobra.Command {
+	var opts providerAddOptions
+	cmd := &cobra.Command{
+		Use:   "add <name>",
+		Short: "Add a custom provider",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProviderAddCommand(cmd, args[0], opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Driver, "driver", "", "Provider driver (e.g., openaicompat)")
+	cmd.Flags().StringVar(&opts.URL, "url", "", "Provider API base URL")
+	cmd.Flags().StringVar(&opts.APIKeyEnv, "api-key-env", "", "Environment variable for API key")
+	cmd.Flags().StringVar(&opts.DiscoveryEndpointPath, "discovery-endpoint", "", "Discovery endpoint path (optional)")
+
+	_ = cmd.MarkFlagRequired("driver")
+	_ = cmd.MarkFlagRequired("url")
+	_ = cmd.MarkFlagRequired("api-key-env")
+
+	return cmd
+}
+
+func defaultProviderAddCommandRunner(cmd *cobra.Command, name string, opts providerAddOptions) error {
+	var workdir string
+	if f := cmd.Flag("workdir"); f != nil {
+		workdir = f.Value.String()
+	}
+	loader := config.NewLoader(workdir, config.StaticDefaults())
+	baseDir := loader.BaseDir()
+
+	discoveryPath := opts.DiscoveryEndpointPath
+	if discoveryPath == "" && opts.Driver == "openaicompat" {
+		discoveryPath = "/v1/models"
+	}
+
+	input := config.SaveCustomProviderInput{
+		Name:                  name,
+		Driver:                opts.Driver,
+		BaseURL:               opts.URL,
+		APIKeyEnv:             opts.APIKeyEnv,
+		ModelSource:           "discover",
+		DiscoveryEndpointPath: discoveryPath,
+	}
+
+	if err := config.SaveCustomProviderWithModels(baseDir, input); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "✅ 供应商 %s 添加成功！请记得在终端配置: export %s=\"sk-...\"\n", name, opts.APIKeyEnv)
+	return nil
+}
+
+
+
+func newProviderLsCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "ls",
+		Short: "List all providers",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProviderLsCommand(cmd)
+		},
+	}
+}
+
+func defaultProviderLsCommandRunner(cmd *cobra.Command) error {
+	var workdir string
+	if f := cmd.Flag("workdir"); f != nil {
+		workdir = f.Value.String()
+	}
+	loader := config.NewLoader(workdir, config.StaticDefaults())
+	cfg, err := loader.Load(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	for _, p := range cfg.Providers {
+		fmt.Fprintf(cmd.OutOrStdout(), "- %s (Driver: %s, Source: %s)\n", p.Name, p.Driver, p.Source)
+	}
+	return nil
+}
+
+func newProviderRmCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "rm <name>",
+		Short: "Remove a custom provider",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProviderRmCommand(cmd, args[0])
+		},
+	}
+}
+
+func defaultProviderRmCommandRunner(cmd *cobra.Command, name string) error {
+	var workdir string
+	if f := cmd.Flag("workdir"); f != nil {
+		workdir = f.Value.String()
+	}
+	loader := config.NewLoader(workdir, config.StaticDefaults())
+	baseDir := loader.BaseDir()
+
+	if err := config.DeleteCustomProvider(baseDir, name); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "✅ 供应商 %s 已删除\n", name)
+	return nil
+}

--- a/internal/cli/provider_commands.go
+++ b/internal/cli/provider_commands.go
@@ -2,10 +2,13 @@ package cli
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"neo-code/internal/config"
+	configstate "neo-code/internal/config/state"
 )
 
 type providerAddOptions struct {
@@ -23,6 +26,15 @@ var (
 
 // newProviderCommand 创建 provider 命令组，管理自定义供应商配置。
 func newProviderCommand() *cobra.Command {
+	return newProviderCommandWithResolver(newRuntimeSelectionServiceResolver())
+}
+
+// newProviderCommandWithResolver 基于注入的选择服务解析器构建 provider 命令组。
+func newProviderCommandWithResolver(resolver selectionServiceResolver) *cobra.Command {
+	if resolver == nil {
+		resolver = newRuntimeSelectionServiceResolver()
+	}
+
 	cmd := &cobra.Command{
 		Use:          "provider",
 		Short:        "Manage custom providers",
@@ -30,7 +42,7 @@ func newProviderCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		newProviderAddCommand(),
+		newProviderAddCommandWithResolver(resolver),
 		newProviderLsCommand(),
 		newProviderRmCommand(),
 	)
@@ -38,14 +50,28 @@ func newProviderCommand() *cobra.Command {
 	return cmd
 }
 
+// newProviderAddCommand 创建 provider add 子命令。
 func newProviderAddCommand() *cobra.Command {
+	return newProviderAddCommandWithResolver(newRuntimeSelectionServiceResolver())
+}
+
+// newProviderAddCommandWithResolver 创建支持依赖注入的 provider add 子命令。
+func newProviderAddCommandWithResolver(resolver selectionServiceResolver) *cobra.Command {
+	if resolver == nil {
+		resolver = newRuntimeSelectionServiceResolver()
+	}
+
 	var opts providerAddOptions
 	cmd := &cobra.Command{
 		Use:   "add <name>",
 		Short: "Add a custom provider",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runProviderAddCommand(cmd, args[0], opts)
+			svc, err := resolver.Resolve(cmd)
+			if err != nil {
+				return err
+			}
+			return runProviderAddCommand(cmd, svc, args[0], opts)
 		},
 	}
 
@@ -61,37 +87,59 @@ func newProviderAddCommand() *cobra.Command {
 	return cmd
 }
 
-func defaultProviderAddCommandRunner(cmd *cobra.Command, name string, opts providerAddOptions) error {
-	var workdir string
-	if f := cmd.Flag("workdir"); f != nil {
-		workdir = f.Value.String()
+// defaultProviderAddCommandRunner 通过选择服务创建自定义 provider，确保冲突检测与回滚链路生效。
+func defaultProviderAddCommandRunner(
+	cmd *cobra.Command,
+	svc SelectionService,
+	name string,
+	opts providerAddOptions,
+) error {
+	if svc == nil {
+		return fmt.Errorf("selection service is unavailable")
 	}
-	loader := config.NewLoader(workdir, config.StaticDefaults())
-	baseDir := loader.BaseDir()
 
-	discoveryPath := opts.DiscoveryEndpointPath
-	if discoveryPath == "" && opts.Driver == "openaicompat" {
+	apiKeyEnv := strings.TrimSpace(opts.APIKeyEnv)
+	if apiKeyEnv == "" {
+		return fmt.Errorf("api-key-env 不能为空")
+	}
+	apiKey := strings.TrimSpace(os.Getenv(apiKeyEnv))
+	if apiKey == "" {
+		return fmt.Errorf("请先设置 $%s 环境变量", apiKeyEnv)
+	}
+
+	driver := strings.TrimSpace(opts.Driver)
+	discoveryPath := strings.TrimSpace(opts.DiscoveryEndpointPath)
+	if discoveryPath == "" && strings.EqualFold(driver, "openaicompat") {
 		discoveryPath = "/v1/models"
 	}
 
-	input := config.SaveCustomProviderInput{
-		Name:                  name,
-		Driver:                opts.Driver,
-		BaseURL:               opts.URL,
-		APIKeyEnv:             opts.APIKeyEnv,
-		ModelSource:           "discover",
+	input := configstate.CreateCustomProviderInput{
+		Name:                  strings.TrimSpace(name),
+		Driver:                driver,
+		BaseURL:               strings.TrimSpace(opts.URL),
+		APIKeyEnv:             apiKeyEnv,
+		APIKey:                apiKey,
+		ModelSource:           config.ModelSourceDiscover,
 		DiscoveryEndpointPath: discoveryPath,
 	}
 
-	if err := config.SaveCustomProviderWithModels(baseDir, input); err != nil {
+	selection, err := svc.CreateCustomProvider(cmd.Context(), input)
+	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "✅ 供应商 %s 添加成功！请记得在终端配置: export %s=\"sk-...\"\n", name, opts.APIKeyEnv)
+	providerName := strings.TrimSpace(selection.ProviderID)
+	if providerName == "" {
+		providerName = strings.TrimSpace(name)
+	}
+	modelName := strings.TrimSpace(selection.ModelID)
+	if modelName == "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "✅ 供应商 %s 添加成功\n", providerName)
+		return nil
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "✅ 供应商 %s 添加成功，当前模型: %s\n", providerName, modelName)
 	return nil
 }
-
-
 
 func newProviderLsCommand() *cobra.Command {
 	return &cobra.Command{

--- a/internal/cli/provider_commands.go
+++ b/internal/cli/provider_commands.go
@@ -1,9 +1,12 @@
 package cli
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -18,13 +21,15 @@ type providerAddOptions struct {
 	DiscoveryEndpointPath string
 }
 
+const providerAddSelectionTimeout = 15 * time.Second
+
 var (
 	runProviderAddCommand = defaultProviderAddCommandRunner
 	runProviderLsCommand  = defaultProviderLsCommandRunner
 	runProviderRmCommand  = defaultProviderRmCommandRunner
 )
 
-// newProviderCommand 创建 provider 命令组，管理自定义供应商配置。
+// newProviderCommand 创建 provider 命令组，管理自定义提供商配置。
 func newProviderCommand() *cobra.Command {
 	return newProviderCommandWithResolver(newRuntimeSelectionServiceResolver())
 }
@@ -44,7 +49,7 @@ func newProviderCommandWithResolver(resolver selectionServiceResolver) *cobra.Co
 	cmd.AddCommand(
 		newProviderAddCommandWithResolver(resolver),
 		newProviderLsCommand(),
-		newProviderRmCommand(),
+		newProviderRmCommandWithResolver(resolver),
 	)
 
 	return cmd
@@ -123,8 +128,13 @@ func defaultProviderAddCommandRunner(
 		DiscoveryEndpointPath: discoveryPath,
 	}
 
-	selection, err := svc.CreateCustomProvider(cmd.Context(), input)
+	opCtx, cancel := context.WithTimeout(cmd.Context(), providerAddSelectionTimeout)
+	defer cancel()
+	selection, err := svc.CreateCustomProvider(opCtx, input)
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("provider add 超时（%s），请稍后重试: %w", providerAddSelectionTimeout, err)
+		}
 		return err
 	}
 
@@ -134,10 +144,10 @@ func defaultProviderAddCommandRunner(
 	}
 	modelName := strings.TrimSpace(selection.ModelID)
 	if modelName == "" {
-		fmt.Fprintf(cmd.OutOrStdout(), "✅ 供应商 %s 添加成功\n", providerName)
+		fmt.Fprintf(cmd.OutOrStdout(), "✅ 提供商 %s 添加成功\n", providerName)
 		return nil
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "✅ 供应商 %s 添加成功，当前模型: %s\n", providerName, modelName)
+	fmt.Fprintf(cmd.OutOrStdout(), "✅ 提供商 %s 添加成功，当前模型: %s\n", providerName, modelName)
 	return nil
 }
 
@@ -169,28 +179,35 @@ func defaultProviderLsCommandRunner(cmd *cobra.Command) error {
 }
 
 func newProviderRmCommand() *cobra.Command {
+	return newProviderRmCommandWithResolver(newRuntimeSelectionServiceResolver())
+}
+
+func newProviderRmCommandWithResolver(resolver selectionServiceResolver) *cobra.Command {
+	if resolver == nil {
+		resolver = newRuntimeSelectionServiceResolver()
+	}
 	return &cobra.Command{
 		Use:   "rm <name>",
 		Short: "Remove a custom provider",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runProviderRmCommand(cmd, args[0])
+			svc, err := resolver.Resolve(cmd)
+			if err != nil {
+				return err
+			}
+			return runProviderRmCommand(cmd, svc, args[0])
 		},
 	}
 }
 
-func defaultProviderRmCommandRunner(cmd *cobra.Command, name string) error {
-	var workdir string
-	if f := cmd.Flag("workdir"); f != nil {
-		workdir = f.Value.String()
+func defaultProviderRmCommandRunner(cmd *cobra.Command, svc SelectionService, name string) error {
+	if svc == nil {
+		return fmt.Errorf("selection service is unavailable")
 	}
-	loader := config.NewLoader(workdir, config.StaticDefaults())
-	baseDir := loader.BaseDir()
-
-	if err := config.DeleteCustomProvider(baseDir, name); err != nil {
+	if err := svc.RemoveCustomProvider(cmd.Context(), name); err != nil {
 		return err
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "✅ 供应商 %s 已删除\n", name)
+	fmt.Fprintf(cmd.OutOrStdout(), "✅ 提供商 %s 已删除\n", name)
 	return nil
 }

--- a/internal/cli/provider_commands.go
+++ b/internal/cli/provider_commands.go
@@ -48,7 +48,7 @@ func newProviderCommandWithResolver(resolver selectionServiceResolver) *cobra.Co
 
 	cmd.AddCommand(
 		newProviderAddCommandWithResolver(resolver),
-		newProviderLsCommand(),
+		newProviderLsCommandWithResolver(resolver),
 		newProviderRmCommandWithResolver(resolver),
 	)
 
@@ -152,28 +152,40 @@ func defaultProviderAddCommandRunner(
 }
 
 func newProviderLsCommand() *cobra.Command {
+	return newProviderLsCommandWithResolver(newRuntimeSelectionServiceResolver())
+}
+
+func newProviderLsCommandWithResolver(resolver selectionServiceResolver) *cobra.Command {
+	if resolver == nil {
+		resolver = newRuntimeSelectionServiceResolver()
+	}
 	return &cobra.Command{
 		Use:   "ls",
 		Short: "List all providers",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runProviderLsCommand(cmd)
+			svc, err := resolver.Resolve(cmd)
+			if err != nil {
+				return err
+			}
+			return runProviderLsCommand(cmd, svc)
 		},
 	}
 }
 
-func defaultProviderLsCommandRunner(cmd *cobra.Command) error {
-	var workdir string
-	if f := cmd.Flag("workdir"); f != nil {
-		workdir = f.Value.String()
+func defaultProviderLsCommandRunner(cmd *cobra.Command, svc SelectionService) error {
+	if svc == nil {
+		return fmt.Errorf("selection service is unavailable")
 	}
-	loader := config.NewLoader(workdir, config.StaticDefaults())
-	cfg, err := loader.Load(cmd.Context())
+
+	options, err := svc.ListProviderOptions(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	for _, p := range cfg.Providers {
-		fmt.Fprintf(cmd.OutOrStdout(), "- %s (Driver: %s, Source: %s)\n", p.Name, p.Driver, p.Source)
+	for _, opt := range options {
+		modelCount := len(opt.Models)
+		fmt.Fprintf(cmd.OutOrStdout(), "- %s (Driver: %s, Source: %s, Models: %d)\n",
+			opt.Name, opt.Driver, opt.Source, modelCount)
 	}
 	return nil
 }

--- a/internal/cli/provider_commands_additional_test.go
+++ b/internal/cli/provider_commands_additional_test.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"neo-code/internal/config"
+	configstate "neo-code/internal/config/state"
+	providertypes "neo-code/internal/provider/types"
+)
+
+func TestProviderCommandResolverFallbackAndResolveError(t *testing.T) {
+	t.Run("fallback to default resolver when nil", func(t *testing.T) {
+		add := newProviderAddCommandWithResolver(nil)
+		if add.Use != "add <name>" {
+			t.Fatalf("add.Use = %q, want add <name>", add.Use)
+		}
+		ls := newProviderLsCommandWithResolver(nil)
+		if ls.Use != "ls" {
+			t.Fatalf("ls.Use = %q, want ls", ls.Use)
+		}
+		rm := newProviderRmCommandWithResolver(nil)
+		if rm.Use != "rm <name>" {
+			t.Fatalf("rm.Use = %q, want rm <name>", rm.Use)
+		}
+	})
+
+	resolverErr := selectionServiceResolverFunc(func(*cobra.Command) (SelectionService, error) {
+		return nil, errors.New("resolve failed")
+	})
+
+	t.Run("add resolve error", func(t *testing.T) {
+		cmd := newProviderAddCommandWithResolver(resolverErr)
+		cmd.SetArgs([]string{"custom", "--driver", "openaicompat", "--url", "http://mock", "--api-key-env", "KEY"})
+		err := cmd.ExecuteContext(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "resolve failed") {
+			t.Fatalf("err = %v, want contains resolve failed", err)
+		}
+	})
+
+	t.Run("ls resolve error", func(t *testing.T) {
+		cmd := newProviderLsCommandWithResolver(resolverErr)
+		err := cmd.ExecuteContext(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "resolve failed") {
+			t.Fatalf("err = %v, want contains resolve failed", err)
+		}
+	})
+
+	t.Run("rm resolve error", func(t *testing.T) {
+		cmd := newProviderRmCommandWithResolver(resolverErr)
+		cmd.SetArgs([]string{"custom"})
+		err := cmd.ExecuteContext(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "resolve failed") {
+			t.Fatalf("err = %v, want contains resolve failed", err)
+		}
+	})
+}
+
+func TestDefaultProviderAddCommandRunnerProviderNameFallback(t *testing.T) {
+	t.Setenv("PROVIDER_KEY_FALLBACK", "sk-test")
+	cmd := &cobra.Command{}
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetContext(context.Background())
+
+	svc := &mockSelectionService{
+		createCustomProviderFn: func(ctx context.Context, input configstate.CreateCustomProviderInput) (configstate.Selection, error) {
+			return configstate.Selection{ProviderID: "", ModelID: "m-1"}, nil
+		},
+	}
+	err := defaultProviderAddCommandRunner(cmd, svc, "fallback-provider", providerAddOptions{
+		Driver:    "openaicompat",
+		URL:       "http://mock",
+		APIKeyEnv: "PROVIDER_KEY_FALLBACK",
+	})
+	if err != nil {
+		t.Fatalf("defaultProviderAddCommandRunner() error = %v", err)
+	}
+	if !strings.Contains(out.String(), "fallback-provider") {
+		t.Fatalf("output = %q, want contains fallback provider name", out.String())
+	}
+}
+
+func TestDefaultProviderLsAndRmCommandRunnerAdditionalBranches(t *testing.T) {
+	t.Run("ls multiple providers formatting", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		out := &bytes.Buffer{}
+		cmd.SetOut(out)
+		cmd.SetContext(context.Background())
+
+		svc := &mockSelectionService{
+			listProviderOptionsFn: func(context.Context) ([]configstate.ProviderOption, error) {
+				return []configstate.ProviderOption{
+					{ID: "p1", Name: "p1", Driver: "openaicompat", Source: string(config.ProviderSourceBuiltin), Models: []providertypes.ModelDescriptor{{ID: "m1"}}},
+					{ID: "p2", Name: "p2", Driver: "anthropic", Source: string(config.ProviderSourceCustom), Models: []providertypes.ModelDescriptor{{ID: "m1"}, {ID: "m2"}}},
+				}, nil
+			},
+		}
+
+		if err := defaultProviderLsCommandRunner(cmd, svc); err != nil {
+			t.Fatalf("defaultProviderLsCommandRunner() error = %v", err)
+		}
+		if !strings.Contains(out.String(), "p1") || !strings.Contains(out.String(), "p2") {
+			t.Fatalf("output = %q, want contains p1 and p2", out.String())
+		}
+	})
+
+	t.Run("rm returns service error", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		svc := &mockSelectionService{
+			removeCustomProviderFn: func(context.Context, string) error {
+				return errors.New("remove failed")
+			},
+		}
+		err := defaultProviderRmCommandRunner(cmd, svc, "bad-provider")
+		if err == nil || !strings.Contains(err.Error(), "remove failed") {
+			t.Fatalf("err = %v, want contains remove failed", err)
+		}
+	})
+}

--- a/internal/cli/provider_commands_test.go
+++ b/internal/cli/provider_commands_test.go
@@ -80,7 +80,8 @@ func TestProviderLsCommand(t *testing.T) {
 }
 
 func TestProviderRmCommand(t *testing.T) {
-	cmd := newProviderRmCommand()
+	svc := &mockSelectionService{}
+	cmd := newProviderRmCommandWithResolver(staticSelectionResolver(svc))
 	if cmd.Use != "rm <name>" {
 		t.Fatalf("cmd.Use = %q, want %q", cmd.Use, "rm <name>")
 	}
@@ -89,8 +90,11 @@ func TestProviderRmCommand(t *testing.T) {
 	t.Cleanup(func() { runProviderRmCommand = originalRunner })
 
 	called := false
-	runProviderRmCommand = func(c *cobra.Command, name string) error {
+	runProviderRmCommand = func(c *cobra.Command, gotSvc SelectionService, name string) error {
 		called = true
+		if gotSvc != svc {
+			t.Fatalf("injected service mismatch")
+		}
 		if name != "my-provider" {
 			t.Fatalf("name = %q, want %q", name, "my-provider")
 		}
@@ -143,7 +147,7 @@ func TestDefaultProviderAddCommandRunner(t *testing.T) {
 					return configstate.Selection{ProviderID: input.Name, ModelID: "m-1"}, nil
 				},
 			},
-			wantOutput: "供应商 my-provider 添加成功，当前模型: m-1",
+			wantOutput: "提供商 my-provider 添加成功，当前模型: m-1",
 			assertInput: func(t *testing.T, input configstate.CreateCustomProviderInput) {
 				t.Helper()
 				if input.Driver != "openaicompat" {
@@ -173,6 +177,22 @@ func TestDefaultProviderAddCommandRunner(t *testing.T) {
 				},
 			},
 			wantErr: "conflict",
+		},
+		{
+			name:     "timeout error",
+			envName:  "MOCK_KEY_TIMEOUT",
+			envValue: "sk-test",
+			opts: providerAddOptions{
+				Driver:    "openaicompat",
+				URL:       "http://mock",
+				APIKeyEnv: "MOCK_KEY_TIMEOUT",
+			},
+			service: &mockSelectionService{
+				createCustomProviderFn: func(ctx context.Context, input configstate.CreateCustomProviderInput) (configstate.Selection, error) {
+					return configstate.Selection{}, context.DeadlineExceeded
+				},
+			},
+			wantErr: "provider add 超时",
 		},
 	}
 
@@ -242,15 +262,20 @@ func TestDefaultProviderLsAndRmCommandRunner(t *testing.T) {
 		t.Fatalf("output = %q, want contains my-provider", output.String())
 	}
 
-	if err := defaultProviderRmCommandRunner(cmd, "my-provider"); err != nil {
+	removed := ""
+	svc := &mockSelectionService{
+		removeCustomProviderFn: func(ctx context.Context, name string) error {
+			removed = name
+			return nil
+		},
+	}
+	if err := defaultProviderRmCommandRunner(cmd, svc, "my-provider"); err != nil {
 		t.Fatalf("defaultProviderRmCommandRunner() error = %v", err)
 	}
-
-	output.Reset()
-	if err := defaultProviderLsCommandRunner(cmd); err != nil {
-		t.Fatalf("defaultProviderLsCommandRunner() error = %v", err)
+	if removed != "my-provider" {
+		t.Fatalf("removed = %q, want my-provider", removed)
 	}
-	if strings.Contains(output.String(), "my-provider") {
-		t.Fatalf("output = %q, should not contain my-provider", output.String())
+	if !strings.Contains(output.String(), "提供商 my-provider 已删除") {
+		t.Fatalf("output = %q, want contains remove message", output.String())
 	}
 }

--- a/internal/cli/provider_commands_test.go
+++ b/internal/cli/provider_commands_test.go
@@ -1,0 +1,141 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestProviderCommand(t *testing.T) {
+	cmd := newProviderCommand()
+	if cmd.Use != "provider" {
+		t.Errorf("expected use 'provider', got %s", cmd.Use)
+	}
+}
+
+func TestProviderAddCommand(t *testing.T) {
+	cmd := newProviderAddCommand()
+	if cmd.Use != "add <name>" {
+		t.Errorf("expected use 'add <name>', got %s", cmd.Use)
+	}
+
+	called := false
+	runProviderAddCommand = func(c *cobra.Command, name string, opts providerAddOptions) error {
+		called = true
+		if name != "my-provider" {
+			t.Errorf("expected 'my-provider', got %s", name)
+		}
+		if opts.Driver != "openaicompat" {
+			t.Errorf("expected 'openaicompat', got %s", opts.Driver)
+		}
+		return errors.New("mock error")
+	}
+	defer func() { runProviderAddCommand = defaultProviderAddCommandRunner }()
+
+	cmd.SetArgs([]string{"my-provider", "--driver", "openaicompat", "--url", "http://mock", "--api-key-env", "MOCK_KEY"})
+	if err := cmd.ExecuteContext(context.Background()); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !called {
+		t.Fatal("runner not called")
+	}
+}
+
+func TestProviderLsCommand(t *testing.T) {
+	cmd := newProviderLsCommand()
+	if cmd.Use != "ls" {
+		t.Errorf("expected use 'ls', got %s", cmd.Use)
+	}
+
+	called := false
+	runProviderLsCommand = func(c *cobra.Command) error {
+		called = true
+		return errors.New("mock error")
+	}
+	defer func() { runProviderLsCommand = defaultProviderLsCommandRunner }()
+
+	cmd.SetArgs([]string{})
+	if err := cmd.ExecuteContext(context.Background()); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !called {
+		t.Fatal("runner not called")
+	}
+}
+
+func TestProviderRmCommand(t *testing.T) {
+	cmd := newProviderRmCommand()
+	if cmd.Use != "rm <name>" {
+		t.Errorf("expected use 'rm <name>', got %s", cmd.Use)
+	}
+
+	called := false
+	runProviderRmCommand = func(c *cobra.Command, name string) error {
+		called = true
+		if name != "my-provider" {
+			t.Errorf("expected 'my-provider', got %s", name)
+		}
+		return errors.New("mock error")
+	}
+	defer func() { runProviderRmCommand = defaultProviderRmCommandRunner }()
+
+	cmd.SetArgs([]string{"my-provider"})
+	if err := cmd.ExecuteContext(context.Background()); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !called {
+		t.Fatal("runner not called")
+	}
+}
+
+func TestDefaultProviderRunners(t *testing.T) {
+	workdir := t.TempDir()
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("workdir", workdir, "")
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+
+	// Add
+	opts := providerAddOptions{
+		Driver:                "openaicompat",
+		URL:                   "http://mock",
+		APIKeyEnv:             "MOCK_KEY",
+		DiscoveryEndpointPath: "/v1/models",
+	}
+	err := defaultProviderAddCommandRunner(cmd, "my-provider", opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Ls
+	out.Reset()
+	cmd.SetContext(context.Background())
+	err = defaultProviderLsCommandRunner(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "my-provider") {
+		t.Errorf("expected output to contain 'my-provider', got %s", out.String())
+	}
+
+	// Rm
+	err = defaultProviderRmCommandRunner(cmd, "my-provider")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Ls again
+	out.Reset()
+	err = defaultProviderLsCommandRunner(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(out.String(), "my-provider") {
+		t.Errorf("expected output to not contain 'my-provider', got %s", out.String())
+	}
+}

--- a/internal/cli/provider_commands_test.go
+++ b/internal/cli/provider_commands_test.go
@@ -8,134 +8,249 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"neo-code/internal/config"
+	configstate "neo-code/internal/config/state"
 )
 
 func TestProviderCommand(t *testing.T) {
 	cmd := newProviderCommand()
 	if cmd.Use != "provider" {
-		t.Errorf("expected use 'provider', got %s", cmd.Use)
+		t.Fatalf("cmd.Use = %q, want %q", cmd.Use, "provider")
 	}
 }
 
 func TestProviderAddCommand(t *testing.T) {
-	cmd := newProviderAddCommand()
+	svc := &mockSelectionService{}
+	cmd := newProviderAddCommandWithResolver(staticSelectionResolver(svc))
 	if cmd.Use != "add <name>" {
-		t.Errorf("expected use 'add <name>', got %s", cmd.Use)
+		t.Fatalf("cmd.Use = %q, want %q", cmd.Use, "add <name>")
 	}
 
+	originalRunner := runProviderAddCommand
+	t.Cleanup(func() { runProviderAddCommand = originalRunner })
+
 	called := false
-	runProviderAddCommand = func(c *cobra.Command, name string, opts providerAddOptions) error {
+	runProviderAddCommand = func(c *cobra.Command, gotSvc SelectionService, name string, opts providerAddOptions) error {
 		called = true
+		if gotSvc != svc {
+			t.Fatalf("injected service mismatch")
+		}
 		if name != "my-provider" {
-			t.Errorf("expected 'my-provider', got %s", name)
+			t.Fatalf("name = %q, want %q", name, "my-provider")
 		}
 		if opts.Driver != "openaicompat" {
-			t.Errorf("expected 'openaicompat', got %s", opts.Driver)
+			t.Fatalf("opts.Driver = %q, want %q", opts.Driver, "openaicompat")
 		}
 		return errors.New("mock error")
 	}
-	defer func() { runProviderAddCommand = defaultProviderAddCommandRunner }()
 
 	cmd.SetArgs([]string{"my-provider", "--driver", "openaicompat", "--url", "http://mock", "--api-key-env", "MOCK_KEY"})
-	if err := cmd.ExecuteContext(context.Background()); err == nil {
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if !called {
-		t.Fatal("runner not called")
+		t.Fatal("expected runProviderAddCommand called")
 	}
 }
 
 func TestProviderLsCommand(t *testing.T) {
 	cmd := newProviderLsCommand()
 	if cmd.Use != "ls" {
-		t.Errorf("expected use 'ls', got %s", cmd.Use)
+		t.Fatalf("cmd.Use = %q, want %q", cmd.Use, "ls")
 	}
+
+	originalRunner := runProviderLsCommand
+	t.Cleanup(func() { runProviderLsCommand = originalRunner })
 
 	called := false
 	runProviderLsCommand = func(c *cobra.Command) error {
 		called = true
 		return errors.New("mock error")
 	}
-	defer func() { runProviderLsCommand = defaultProviderLsCommandRunner }()
 
-	cmd.SetArgs([]string{})
-	if err := cmd.ExecuteContext(context.Background()); err == nil {
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if !called {
-		t.Fatal("runner not called")
+		t.Fatal("expected runProviderLsCommand called")
 	}
 }
 
 func TestProviderRmCommand(t *testing.T) {
 	cmd := newProviderRmCommand()
 	if cmd.Use != "rm <name>" {
-		t.Errorf("expected use 'rm <name>', got %s", cmd.Use)
+		t.Fatalf("cmd.Use = %q, want %q", cmd.Use, "rm <name>")
 	}
+
+	originalRunner := runProviderRmCommand
+	t.Cleanup(func() { runProviderRmCommand = originalRunner })
 
 	called := false
 	runProviderRmCommand = func(c *cobra.Command, name string) error {
 		called = true
 		if name != "my-provider" {
-			t.Errorf("expected 'my-provider', got %s", name)
+			t.Fatalf("name = %q, want %q", name, "my-provider")
 		}
 		return errors.New("mock error")
 	}
-	defer func() { runProviderRmCommand = defaultProviderRmCommandRunner }()
 
 	cmd.SetArgs([]string{"my-provider"})
-	if err := cmd.ExecuteContext(context.Background()); err == nil {
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if !called {
-		t.Fatal("runner not called")
+		t.Fatal("expected runProviderRmCommand called")
 	}
 }
 
-func TestDefaultProviderRunners(t *testing.T) {
-	workdir := t.TempDir()
+func TestDefaultProviderAddCommandRunner(t *testing.T) {
+	tests := []struct {
+		name        string
+		envName     string
+		envValue    string
+		opts        providerAddOptions
+		service     SelectionService
+		wantErr     string
+		wantOutput  string
+		assertInput func(t *testing.T, input configstate.CreateCustomProviderInput)
+	}{
+		{
+			name:    "missing api key env value",
+			envName: "MOCK_KEY_EMPTY",
+			opts: providerAddOptions{
+				Driver:    "openaicompat",
+				URL:       "http://mock",
+				APIKeyEnv: "MOCK_KEY_EMPTY",
+			},
+			service: &mockSelectionService{},
+			wantErr: "请先设置 $MOCK_KEY_EMPTY 环境变量",
+		},
+		{
+			name:     "create provider success with default discovery path",
+			envName:  "MOCK_KEY_OK",
+			envValue: "sk-test",
+			opts: providerAddOptions{
+				Driver:    "openaicompat",
+				URL:       "http://mock",
+				APIKeyEnv: "MOCK_KEY_OK",
+			},
+			service: &mockSelectionService{
+				createCustomProviderFn: func(ctx context.Context, input configstate.CreateCustomProviderInput) (configstate.Selection, error) {
+					return configstate.Selection{ProviderID: input.Name, ModelID: "m-1"}, nil
+				},
+			},
+			wantOutput: "供应商 my-provider 添加成功，当前模型: m-1",
+			assertInput: func(t *testing.T, input configstate.CreateCustomProviderInput) {
+				t.Helper()
+				if input.Driver != "openaicompat" {
+					t.Fatalf("input.Driver = %q, want openaicompat", input.Driver)
+				}
+				if input.APIKey != "sk-test" {
+					t.Fatalf("input.APIKey = %q, want sk-test", input.APIKey)
+				}
+				if input.DiscoveryEndpointPath != "/v1/models" {
+					t.Fatalf("input.DiscoveryEndpointPath = %q, want /v1/models", input.DiscoveryEndpointPath)
+				}
+			},
+		},
+		{
+			name:     "service error",
+			envName:  "MOCK_KEY_ERR",
+			envValue: "sk-test",
+			opts: providerAddOptions{
+				Driver:                "openaicompat",
+				URL:                   "http://mock",
+				APIKeyEnv:             "MOCK_KEY_ERR",
+				DiscoveryEndpointPath: "/custom/models",
+			},
+			service: &mockSelectionService{
+				createCustomProviderFn: func(ctx context.Context, input configstate.CreateCustomProviderInput) (configstate.Selection, error) {
+					return configstate.Selection{}, errors.New("conflict")
+				},
+			},
+			wantErr: "conflict",
+		},
+	}
 
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envName != "" {
+				t.Setenv(tc.envName, tc.envValue)
+			}
+			cmd := &cobra.Command{}
+			output := &bytes.Buffer{}
+			cmd.SetOut(output)
+			cmd.SetContext(context.Background())
+
+			var capturedInput configstate.CreateCustomProviderInput
+			svc := tc.service
+			if mocked, ok := svc.(*mockSelectionService); ok && mocked.createCustomProviderFn != nil {
+				originalFn := mocked.createCustomProviderFn
+				mocked.createCustomProviderFn = func(ctx context.Context, input configstate.CreateCustomProviderInput) (configstate.Selection, error) {
+					capturedInput = input
+					return originalFn(ctx, input)
+				}
+			}
+
+			err := defaultProviderAddCommandRunner(cmd, svc, "my-provider", tc.opts)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want contains %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("defaultProviderAddCommandRunner() error = %v", err)
+			}
+			if tc.assertInput != nil {
+				tc.assertInput(t, capturedInput)
+			}
+			if !strings.Contains(output.String(), tc.wantOutput) {
+				t.Fatalf("output = %q, want contains %q", output.String(), tc.wantOutput)
+			}
+		})
+	}
+}
+
+func TestDefaultProviderLsAndRmCommandRunner(t *testing.T) {
+	workdir := t.TempDir()
 	cmd := &cobra.Command{}
 	cmd.Flags().String("workdir", workdir, "")
-	out := new(bytes.Buffer)
-	cmd.SetOut(out)
-
-	// Add
-	opts := providerAddOptions{
-		Driver:                "openaicompat",
-		URL:                   "http://mock",
-		APIKeyEnv:             "MOCK_KEY",
-		DiscoveryEndpointPath: "/v1/models",
-	}
-	err := defaultProviderAddCommandRunner(cmd, "my-provider", opts)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	// Ls
-	out.Reset()
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
 	cmd.SetContext(context.Background())
-	err = defaultProviderLsCommandRunner(cmd)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !strings.Contains(out.String(), "my-provider") {
-		t.Errorf("expected output to contain 'my-provider', got %s", out.String())
+
+	if err := config.SaveCustomProviderWithModels(workdir, config.SaveCustomProviderInput{
+		Name:                  "my-provider",
+		Driver:                "openaicompat",
+		BaseURL:               "http://mock",
+		APIKeyEnv:             "MY_PROVIDER_KEY",
+		ModelSource:           config.ModelSourceDiscover,
+		DiscoveryEndpointPath: "/v1/models",
+	}); err != nil {
+		t.Fatalf("SaveCustomProviderWithModels() error = %v", err)
 	}
 
-	// Rm
-	err = defaultProviderRmCommandRunner(cmd, "my-provider")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err := defaultProviderLsCommandRunner(cmd); err != nil {
+		t.Fatalf("defaultProviderLsCommandRunner() error = %v", err)
+	}
+	if !strings.Contains(output.String(), "my-provider") {
+		t.Fatalf("output = %q, want contains my-provider", output.String())
 	}
 
-	// Ls again
-	out.Reset()
-	err = defaultProviderLsCommandRunner(cmd)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err := defaultProviderRmCommandRunner(cmd, "my-provider"); err != nil {
+		t.Fatalf("defaultProviderRmCommandRunner() error = %v", err)
 	}
-	if strings.Contains(out.String(), "my-provider") {
-		t.Errorf("expected output to not contain 'my-provider', got %s", out.String())
+
+	output.Reset()
+	if err := defaultProviderLsCommandRunner(cmd); err != nil {
+		t.Fatalf("defaultProviderLsCommandRunner() error = %v", err)
+	}
+	if strings.Contains(output.String(), "my-provider") {
+		t.Fatalf("output = %q, should not contain my-provider", output.String())
 	}
 }

--- a/internal/cli/provider_commands_test.go
+++ b/internal/cli/provider_commands_test.go
@@ -20,6 +20,29 @@ func TestProviderCommand(t *testing.T) {
 	}
 }
 
+func TestProviderCommandBuildersUseDefaultResolverWhenNil(t *testing.T) {
+	cmd := newProviderCommandWithResolver(nil)
+	if cmd.Use != "provider" {
+		t.Fatalf("cmd.Use = %q, want %q", cmd.Use, "provider")
+	}
+	if len(cmd.Commands()) != 3 {
+		t.Fatalf("len(provider subcommands) = %d, want 3", len(cmd.Commands()))
+	}
+
+	add := newProviderAddCommand()
+	if add.Use != "add <name>" {
+		t.Fatalf("add.Use = %q, want %q", add.Use, "add <name>")
+	}
+	ls := newProviderLsCommand()
+	if ls.Use != "ls" {
+		t.Fatalf("ls.Use = %q, want %q", ls.Use, "ls")
+	}
+	rm := newProviderRmCommand()
+	if rm.Use != "rm <name>" {
+		t.Fatalf("rm.Use = %q, want %q", rm.Use, "rm <name>")
+	}
+}
+
 func TestProviderAddCommand(t *testing.T) {
 	svc := &mockSelectionService{}
 	cmd := newProviderAddCommandWithResolver(staticSelectionResolver(svc))
@@ -283,5 +306,52 @@ func TestDefaultProviderLsAndRmCommandRunner(t *testing.T) {
 	}
 	if !strings.Contains(output.String(), "提供商 my-provider 已删除") {
 		t.Fatalf("output = %q, want contains remove message", output.String())
+	}
+}
+
+func TestDefaultProviderCommandRunnersErrorBranches(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	if err := defaultProviderAddCommandRunner(cmd, nil, "provider", providerAddOptions{}); err == nil || !strings.Contains(err.Error(), "selection service") {
+		t.Fatalf("defaultProviderAddCommandRunner(nil) err = %v", err)
+	}
+	if err := defaultProviderLsCommandRunner(cmd, nil); err == nil || !strings.Contains(err.Error(), "selection service") {
+		t.Fatalf("defaultProviderLsCommandRunner(nil) err = %v", err)
+	}
+	if err := defaultProviderRmCommandRunner(cmd, nil, "provider"); err == nil || !strings.Contains(err.Error(), "selection service") {
+		t.Fatalf("defaultProviderRmCommandRunner(nil) err = %v", err)
+	}
+
+	t.Setenv("PROVIDER_KEY_FOR_TEST", "sk-test")
+	if err := defaultProviderAddCommandRunner(cmd, &mockSelectionService{}, "provider", providerAddOptions{
+		Driver: "openaicompat", URL: "http://mock", APIKeyEnv: " ",
+	}); err == nil || !strings.Contains(err.Error(), "api-key-env") {
+		t.Fatalf("defaultProviderAddCommandRunner(empty env) err = %v", err)
+	}
+}
+
+func TestDefaultProviderAddCommandRunnerWithoutModelOutput(t *testing.T) {
+	t.Setenv("PROVIDER_KEY_NO_MODEL", "sk-test")
+	cmd := &cobra.Command{}
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetContext(context.Background())
+
+	svc := &mockSelectionService{
+		createCustomProviderFn: func(ctx context.Context, input configstate.CreateCustomProviderInput) (configstate.Selection, error) {
+			return configstate.Selection{ProviderID: "provider-no-model", ModelID: ""}, nil
+		},
+	}
+	err := defaultProviderAddCommandRunner(cmd, svc, "provider-no-model", providerAddOptions{
+		Driver:    "openaicompat",
+		URL:       "http://mock",
+		APIKeyEnv: "PROVIDER_KEY_NO_MODEL",
+	})
+	if err != nil {
+		t.Fatalf("defaultProviderAddCommandRunner() error = %v", err)
+	}
+	if strings.Contains(out.String(), "当前模型") {
+		t.Fatalf("output = %q, should not include model message when model id is empty", out.String())
 	}
 }

--- a/internal/cli/provider_commands_test.go
+++ b/internal/cli/provider_commands_test.go
@@ -56,7 +56,8 @@ func TestProviderAddCommand(t *testing.T) {
 }
 
 func TestProviderLsCommand(t *testing.T) {
-	cmd := newProviderLsCommand()
+	svc := &mockSelectionService{}
+	cmd := newProviderLsCommandWithResolver(staticSelectionResolver(svc))
 	if cmd.Use != "ls" {
 		t.Fatalf("cmd.Use = %q, want %q", cmd.Use, "ls")
 	}
@@ -65,8 +66,11 @@ func TestProviderLsCommand(t *testing.T) {
 	t.Cleanup(func() { runProviderLsCommand = originalRunner })
 
 	called := false
-	runProviderLsCommand = func(c *cobra.Command) error {
+	runProviderLsCommand = func(c *cobra.Command, gotSvc SelectionService) error {
 		called = true
+		if gotSvc != svc {
+			t.Fatalf("injected service mismatch")
+		}
 		return errors.New("mock error")
 	}
 
@@ -244,26 +248,28 @@ func TestDefaultProviderLsAndRmCommandRunner(t *testing.T) {
 	cmd.SetOut(output)
 	cmd.SetContext(context.Background())
 
-	if err := config.SaveCustomProviderWithModels(workdir, config.SaveCustomProviderInput{
-		Name:                  "my-provider",
-		Driver:                "openaicompat",
-		BaseURL:               "http://mock",
-		APIKeyEnv:             "MY_PROVIDER_KEY",
-		ModelSource:           config.ModelSourceDiscover,
-		DiscoveryEndpointPath: "/v1/models",
-	}); err != nil {
-		t.Fatalf("SaveCustomProviderWithModels() error = %v", err)
+	svc := &mockSelectionService{
+		listProviderOptionsFn: func(ctx context.Context) ([]configstate.ProviderOption, error) {
+			return []configstate.ProviderOption{
+				{
+					ID:     "my-provider",
+					Name:   "my-provider",
+					Driver: "openaicompat",
+					Source: string(config.ProviderSourceCustom),
+				},
+			}, nil
+		},
 	}
 
-	if err := defaultProviderLsCommandRunner(cmd); err != nil {
+	if err := defaultProviderLsCommandRunner(cmd, svc); err != nil {
 		t.Fatalf("defaultProviderLsCommandRunner() error = %v", err)
 	}
 	if !strings.Contains(output.String(), "my-provider") {
 		t.Fatalf("output = %q, want contains my-provider", output.String())
 	}
 
-	removed := ""
-	svc := &mockSelectionService{
+	var removed string
+	svc = &mockSelectionService{
 		removeCustomProviderFn: func(ctx context.Context, name string) error {
 			removed = name
 			return nil

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -104,6 +104,7 @@ func NewRootCommand() *cobra.Command {
 		newVersionCommand(),
 		newUpdateCommand(),
 		newProviderCommand(),
+		newModelCommand(),
 		newUseCommand(),
 	)
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -103,6 +103,8 @@ func NewRootCommand() *cobra.Command {
 		newMigrateCommand(),
 		newVersionCommand(),
 		newUpdateCommand(),
+		newProviderCommand(),
+		newUseCommand(),
 	)
 
 	return cmd

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -59,6 +59,7 @@ func Execute(ctx context.Context) error {
 func NewRootCommand() *cobra.Command {
 	settings := viper.New()
 	flags := &GlobalFlags{}
+	selectionResolver := newRuntimeSelectionServiceResolver()
 
 	cmd := &cobra.Command{
 		Use:          "neocode",
@@ -103,9 +104,9 @@ func NewRootCommand() *cobra.Command {
 		newMigrateCommand(),
 		newVersionCommand(),
 		newUpdateCommand(),
-		newProviderCommand(),
-		newModelCommand(),
-		newUseCommand(),
+		newProviderCommandWithResolver(selectionResolver),
+		newModelCommandWithResolver(selectionResolver),
+		newUseCommandWithResolver(selectionResolver),
 	)
 
 	return cmd

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/spf13/cobra"
+
+	"neo-code/internal/app"
+	configstate "neo-code/internal/config/state"
+	providertypes "neo-code/internal/provider/types"
+)
+
+// SelectionService 定义 CLI 选择类命令所需的最小能力集合。
+type SelectionService interface {
+	ListModels(ctx context.Context) ([]providertypes.ModelDescriptor, error)
+	ListModelsSnapshot(ctx context.Context) ([]providertypes.ModelDescriptor, error)
+	SetCurrentModel(ctx context.Context, modelID string) (configstate.Selection, error)
+	SelectProvider(ctx context.Context, providerName string) (configstate.Selection, error)
+	CreateCustomProvider(ctx context.Context, input configstate.CreateCustomProviderInput) (configstate.Selection, error)
+}
+
+// selectionServiceResolver 负责在命令执行时解析并返回可复用的选择服务实例。
+type selectionServiceResolver interface {
+	Resolve(cmd *cobra.Command) (SelectionService, error)
+}
+
+// selectionServiceResolverFunc 允许以函数方式注入选择服务解析逻辑，方便命令层替换与测试。
+type selectionServiceResolverFunc func(cmd *cobra.Command) (SelectionService, error)
+
+// Resolve 调用函数式解析器获取 SelectionService。
+func (f selectionServiceResolverFunc) Resolve(cmd *cobra.Command) (SelectionService, error) {
+	if f == nil {
+		return nil, fmt.Errorf("selection service resolver is nil")
+	}
+	return f(cmd)
+}
+
+// runtimeSelectionServiceResolver 按 workdir 维度缓存状态服务，避免同进程重复装配。
+type runtimeSelectionServiceResolver struct {
+	mu       sync.Mutex
+	services map[string]SelectionService
+}
+
+// newRuntimeSelectionServiceResolver 创建默认 CLI 选择服务解析器。
+func newRuntimeSelectionServiceResolver() selectionServiceResolver {
+	return &runtimeSelectionServiceResolver{
+		services: make(map[string]SelectionService),
+	}
+}
+
+// Resolve 基于命令上下文与 --workdir 装配状态服务，并复用同路径缓存实例。
+func (r *runtimeSelectionServiceResolver) Resolve(cmd *cobra.Command) (SelectionService, error) {
+	if r == nil {
+		return nil, fmt.Errorf("selection service resolver is nil")
+	}
+
+	workdir := strings.TrimSpace(mustReadInheritedWorkdir(cmd))
+	cacheKey := workdir
+
+	r.mu.Lock()
+	if svc, ok := r.services[cacheKey]; ok {
+		r.mu.Unlock()
+		return svc, nil
+	}
+	r.mu.Unlock()
+
+	ctx := context.Background()
+	if cmd != nil && cmd.Context() != nil {
+		ctx = cmd.Context()
+	}
+	shared, _, _, err := app.BuildSharedConfigDeps(ctx, app.BootstrapOptions{Workdir: workdir})
+	if err != nil {
+		return nil, err
+	}
+	if shared.ProviderSelection == nil {
+		return nil, fmt.Errorf("selection service is unavailable")
+	}
+
+	r.mu.Lock()
+	r.services[cacheKey] = shared.ProviderSelection
+	r.mu.Unlock()
+	return shared.ProviderSelection, nil
+}

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -19,7 +19,9 @@ type SelectionService interface {
 	ListModelsSnapshot(ctx context.Context) ([]providertypes.ModelDescriptor, error)
 	SetCurrentModel(ctx context.Context, modelID string) (configstate.Selection, error)
 	SelectProvider(ctx context.Context, providerName string) (configstate.Selection, error)
+	SelectProviderWithModel(ctx context.Context, providerName string, modelID string) (configstate.Selection, error)
 	CreateCustomProvider(ctx context.Context, input configstate.CreateCustomProviderInput) (configstate.Selection, error)
+	RemoveCustomProvider(ctx context.Context, name string) error
 }
 
 // selectionServiceResolver 负责在命令执行时解析并返回可复用的选择服务实例。

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -22,6 +22,7 @@ type SelectionService interface {
 	SelectProviderWithModel(ctx context.Context, providerName string, modelID string) (configstate.Selection, error)
 	CreateCustomProvider(ctx context.Context, input configstate.CreateCustomProviderInput) (configstate.Selection, error)
 	RemoveCustomProvider(ctx context.Context, name string) error
+	ListProviderOptions(ctx context.Context) ([]configstate.ProviderOption, error)
 }
 
 // selectionServiceResolver 负责在命令执行时解析并返回可复用的选择服务实例。

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestSelectionServiceResolverFunc(t *testing.T) {
+	var nilResolver selectionServiceResolverFunc
+	if _, err := nilResolver.Resolve(&cobra.Command{}); err == nil || !strings.Contains(err.Error(), "is nil") {
+		t.Fatalf("Resolve(nil resolver) err = %v, want contains \"is nil\"", err)
+	}
+
+	svc := &mockSelectionService{}
+	resolver := selectionServiceResolverFunc(func(cmd *cobra.Command) (SelectionService, error) {
+		if cmd == nil {
+			t.Fatal("cmd should not be nil")
+		}
+		return svc, nil
+	})
+	got, err := resolver.Resolve(&cobra.Command{})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if got != svc {
+		t.Fatalf("Resolve() service mismatch: got %T", got)
+	}
+}
+
+func TestRuntimeSelectionServiceResolver(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		var resolver *runtimeSelectionServiceResolver
+		if _, err := resolver.Resolve(&cobra.Command{}); err == nil || !strings.Contains(err.Error(), "is nil") {
+			t.Fatalf("Resolve(nil receiver) err = %v, want contains \"is nil\"", err)
+		}
+	})
+
+	t.Run("cache hit", func(t *testing.T) {
+		cached := &mockSelectionService{}
+		resolver := &runtimeSelectionServiceResolver{
+			services: map[string]SelectionService{"": cached},
+		}
+		got, err := resolver.Resolve(nil)
+		if err != nil {
+			t.Fatalf("Resolve(cache hit) error = %v", err)
+		}
+		if got != cached {
+			t.Fatalf("Resolve(cache hit) service mismatch")
+		}
+	})
+
+	t.Run("build and cache by workdir", func(t *testing.T) {
+		home := t.TempDir()
+		workdir := t.TempDir()
+		t.Setenv("HOME", home)
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("workdir", workdir, "")
+		cmd.SetContext(context.Background())
+
+		resolver := newRuntimeSelectionServiceResolver()
+		first, err := resolver.Resolve(cmd)
+		if err != nil {
+			t.Fatalf("Resolve(first) error = %v", err)
+		}
+		if first == nil {
+			t.Fatal("Resolve(first) service is nil")
+		}
+
+		second, err := resolver.Resolve(cmd)
+		if err != nil {
+			t.Fatalf("Resolve(second) error = %v", err)
+		}
+		if second != first {
+			t.Fatal("expected same cached service instance for identical workdir")
+		}
+	})
+}
+
+func TestRuntimeSelectionServiceResolverCachesBuiltService(t *testing.T) {
+	home := t.TempDir()
+	workdir := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("workdir", workdir, "")
+
+	resolver := &runtimeSelectionServiceResolver{services: map[string]SelectionService{}}
+	got, err := resolver.Resolve(cmd)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("Resolve() returned nil service")
+	}
+	cached, ok := resolver.services[workdir]
+	if !ok || cached == nil {
+		t.Fatalf("expected cache entry for workdir %q", workdir)
+	}
+	if cached != got {
+		t.Fatal("expected returned service to be cached instance")
+	}
+}

--- a/internal/cli/shell_diag_commands.go
+++ b/internal/cli/shell_diag_commands.go
@@ -14,16 +14,18 @@ import (
 )
 
 var (
-	runShellCommand       = defaultShellCommandRunner
-	runShellInitCommand   = defaultShellInitCommandRunner
-	runDiagCommand        = defaultDiagCommandRunner
-	runDiagAutoCommand    = defaultDiagAutoCommandRunner
-	runManualShellProxy   = ptyproxy.RunManualShell
-	sendDiagnoseSignalFn  = ptyproxy.SendDiagnoseSignal
-	sendAutoModeSignalFn  = ptyproxy.SendAutoModeSignal
-	buildShellInitScript  = ptyproxy.BuildShellInitScript
-	readDiagEnvValue      = os.Getenv
-	resolveLatestDiagPath = ptyproxy.ResolveLatestRunDiagSocketPath
+	runShellCommand        = defaultShellCommandRunner
+	runShellInitCommand    = defaultShellInitCommandRunner
+	runDiagCommand         = defaultDiagCommandRunner
+	runDiagAutoCommand     = defaultDiagAutoCommandRunner
+	runDiagDiagnoseCommand = defaultDiagCommandRunner
+	runManualShellProxy    = ptyproxy.RunManualShell
+	sendDiagnoseSignalFn   = ptyproxy.SendDiagnoseSignal
+	sendAutoModeSignalFn   = ptyproxy.SendAutoModeSignal
+	queryAutoModeFn        = ptyproxy.QueryAutoMode
+	buildShellInitScript   = ptyproxy.BuildShellInitScript
+	readDiagEnvValue       = os.Getenv
+	resolveLatestDiagPath  = ptyproxy.ResolveLatestRunDiagSocketPath
 )
 
 type shellCommandOptions struct {
@@ -42,6 +44,7 @@ type diagCommandOptions struct {
 type diagAutoCommandOptions struct {
 	SocketPath string
 	Enabled    bool
+	QueryOnly  bool
 }
 
 // newShellCommand 创建终端代理入口：支持启动代理或输出 shell integration 初始化脚本。
@@ -51,15 +54,27 @@ func newShellCommand() *cobra.Command {
 		Use:          "shell",
 		Short:        "Start terminal proxy shell for neocode diagnose",
 		SilenceUsage: true,
-		Args:         cobra.NoArgs,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return nil
+			}
+			if len(args) == 1 && options.Init {
+				return nil
+			}
+			return cobra.NoArgs(cmd, args)
+		},
 		Annotations: map[string]string{
 			commandAnnotationSkipGlobalPreload:     "true",
 			commandAnnotationSkipSilentUpdateCheck: "true",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			shellPath := strings.TrimSpace(options.Shell)
+			if options.Init && shellPath == "" && len(args) == 1 {
+				shellPath = strings.TrimSpace(args[0])
+			}
 			normalized := shellCommandOptions{
 				Workdir:              strings.TrimSpace(mustReadInheritedWorkdir(cmd)),
-				Shell:                strings.TrimSpace(options.Shell),
+				Shell:                shellPath,
 				SocketPath:           strings.TrimSpace(options.SocketPath),
 				GatewayListenAddress: strings.TrimSpace(options.GatewayListenAddress),
 				GatewayTokenFile:     strings.TrimSpace(options.GatewayTokenFile),
@@ -107,7 +122,10 @@ func newDiagCommand() *cobra.Command {
 		},
 	}
 	command.Flags().StringVar(&options.SocketPath, "socket", "", "diagnose unix socket path override")
-	command.AddCommand(newDiagAutoCommand())
+	command.AddCommand(
+		newDiagAutoCommand(),
+		newDiagDiagnoseCommand(),
+	)
 	return command
 }
 
@@ -115,19 +133,22 @@ func newDiagCommand() *cobra.Command {
 func newDiagAutoCommand() *cobra.Command {
 	options := &diagAutoCommandOptions{}
 	command := &cobra.Command{
-		Use:          "auto <on|off>",
+		Use:          "auto <on|off|status>",
 		Short:        "Set auto diagnosis mode in current neocode shell",
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			mode := strings.ToLower(strings.TrimSpace(args[0]))
+			options.QueryOnly = false
 			switch mode {
 			case "on":
 				options.Enabled = true
 			case "off":
 				options.Enabled = false
+			case "status":
+				options.QueryOnly = true
 			default:
-				return fmt.Errorf("unsupported auto mode %q: use on/off", mode)
+				return fmt.Errorf("unsupported auto mode %q: use on/off/status", mode)
 			}
 			socketPath, err := resolveDiagSocketPath(options.SocketPath)
 			if err != nil {
@@ -136,7 +157,28 @@ func newDiagAutoCommand() *cobra.Command {
 			return runDiagAutoCommand(cmd.Context(), diagAutoCommandOptions{
 				SocketPath: socketPath,
 				Enabled:    options.Enabled,
+				QueryOnly:  options.QueryOnly,
 			}, cmd.OutOrStdout())
+		},
+	}
+	command.Flags().StringVar(&options.SocketPath, "socket", "", "diagnose unix socket path override")
+	return command
+}
+
+// newDiagDiagnoseCommand 创建 diagnose 子命令，便于显式表达一次手动诊断请求。
+func newDiagDiagnoseCommand() *cobra.Command {
+	options := &diagCommandOptions{}
+	command := &cobra.Command{
+		Use:          "diagnose",
+		Short:        "Trigger one manual diagnosis in current neocode shell",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			socketPath, err := resolveDiagSocketPath(options.SocketPath)
+			if err != nil {
+				return err
+			}
+			return runDiagDiagnoseCommand(cmd.Context(), diagCommandOptions{SocketPath: socketPath})
 		},
 	}
 	command.Flags().StringVar(&options.SocketPath, "socket", "", "diagnose unix socket path override")
@@ -179,6 +221,21 @@ func defaultDiagCommandRunner(ctx context.Context, options diagCommandOptions) e
 
 // defaultDiagAutoCommandRunner 向 shell 代理发送 auto 模式切换信令。
 func defaultDiagAutoCommandRunner(ctx context.Context, options diagAutoCommandOptions, stdout io.Writer) error {
+	if options.QueryOnly {
+		enabled, err := queryAutoModeFn(ctx, strings.TrimSpace(options.SocketPath))
+		if err != nil {
+			return err
+		}
+		if stdout != nil {
+			if enabled {
+				_, _ = io.WriteString(stdout, "auto mode enabled\n")
+			} else {
+				_, _ = io.WriteString(stdout, "auto mode disabled\n")
+			}
+		}
+		return nil
+	}
+
 	if err := sendAutoModeSignalFn(ctx, strings.TrimSpace(options.SocketPath), options.Enabled); err != nil {
 		return err
 	}

--- a/internal/cli/shell_diag_commands.go
+++ b/internal/cli/shell_diag_commands.go
@@ -14,11 +14,16 @@ import (
 )
 
 var (
-	runShellCommand      = defaultShellCommandRunner
-	runDiagCommand       = defaultDiagCommandRunner
-	runManualShellProxy  = ptyproxy.RunManualShell
-	sendDiagnoseSignalFn = ptyproxy.SendDiagnoseSignal
-	readDiagEnvValue     = os.Getenv
+	runShellCommand       = defaultShellCommandRunner
+	runShellInitCommand   = defaultShellInitCommandRunner
+	runDiagCommand        = defaultDiagCommandRunner
+	runDiagAutoCommand    = defaultDiagAutoCommandRunner
+	runManualShellProxy   = ptyproxy.RunManualShell
+	sendDiagnoseSignalFn  = ptyproxy.SendDiagnoseSignal
+	sendAutoModeSignalFn  = ptyproxy.SendAutoModeSignal
+	buildShellInitScript  = ptyproxy.BuildShellInitScript
+	readDiagEnvValue      = os.Getenv
+	resolveLatestDiagPath = ptyproxy.ResolveLatestRunDiagSocketPath
 )
 
 type shellCommandOptions struct {
@@ -27,18 +32,24 @@ type shellCommandOptions struct {
 	SocketPath           string
 	GatewayListenAddress string
 	GatewayTokenFile     string
+	Init                 bool
 }
 
 type diagCommandOptions struct {
 	SocketPath string
 }
 
-// newShellCommand 创建手动诊断入口：拉起 PTY 代理 shell 并在后台监听本地诊断信令。
+type diagAutoCommandOptions struct {
+	SocketPath string
+	Enabled    bool
+}
+
+// newShellCommand 创建终端代理入口：支持启动代理或输出 shell integration 初始化脚本。
 func newShellCommand() *cobra.Command {
 	options := &shellCommandOptions{}
 	command := &cobra.Command{
 		Use:          "shell",
-		Short:        "Start manual terminal proxy shell for neocode diag",
+		Short:        "Start terminal proxy shell for neocode diagnose",
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
 		Annotations: map[string]string{
@@ -46,15 +57,20 @@ func newShellCommand() *cobra.Command {
 			commandAnnotationSkipSilentUpdateCheck: "true",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			normalized := shellCommandOptions{
+				Workdir:              strings.TrimSpace(mustReadInheritedWorkdir(cmd)),
+				Shell:                strings.TrimSpace(options.Shell),
+				SocketPath:           strings.TrimSpace(options.SocketPath),
+				GatewayListenAddress: strings.TrimSpace(options.GatewayListenAddress),
+				GatewayTokenFile:     strings.TrimSpace(options.GatewayTokenFile),
+				Init:                 options.Init,
+			}
+			if normalized.Init {
+				return runShellInitCommand(cmd.Context(), normalized, cmd.OutOrStdout())
+			}
 			return runShellCommand(
 				cmd.Context(),
-				shellCommandOptions{
-					Workdir:              strings.TrimSpace(mustReadInheritedWorkdir(cmd)),
-					Shell:                strings.TrimSpace(options.Shell),
-					SocketPath:           strings.TrimSpace(options.SocketPath),
-					GatewayListenAddress: strings.TrimSpace(options.GatewayListenAddress),
-					GatewayTokenFile:     strings.TrimSpace(options.GatewayTokenFile),
-				},
+				normalized,
 				cmd.InOrStdin(),
 				cmd.OutOrStdout(),
 				cmd.ErrOrStderr(),
@@ -66,10 +82,11 @@ func newShellCommand() *cobra.Command {
 	command.Flags().StringVar(&options.SocketPath, "socket", "", "diagnose unix socket path override")
 	command.Flags().StringVar(&options.GatewayListenAddress, "gateway-listen", "", "gateway listen address override")
 	command.Flags().StringVar(&options.GatewayTokenFile, "gateway-token-file", "", "gateway token file override")
+	command.Flags().BoolVar(&options.Init, "init", false, "print shell integration script")
 	return command
 }
 
-// newDiagCommand 创建手动触发入口：向代理 shell 发送一次诊断信号。
+// newDiagCommand 创建诊断命令组：默认触发手动诊断，支持 auto on/off 开关控制。
 func newDiagCommand() *cobra.Command {
 	options := &diagCommandOptions{}
 	command := &cobra.Command{
@@ -86,17 +103,47 @@ func newDiagCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runDiagCommand(cmd.Context(), diagCommandOptions{
-				SocketPath: socketPath,
-			})
+			return runDiagCommand(cmd.Context(), diagCommandOptions{SocketPath: socketPath})
 		},
 	}
+	command.Flags().StringVar(&options.SocketPath, "socket", "", "diagnose unix socket path override")
+	command.AddCommand(newDiagAutoCommand())
+	return command
+}
 
+// newDiagAutoCommand 创建 auto on/off 子命令。
+func newDiagAutoCommand() *cobra.Command {
+	options := &diagAutoCommandOptions{}
+	command := &cobra.Command{
+		Use:          "auto <on|off>",
+		Short:        "Set auto diagnosis mode in current neocode shell",
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			mode := strings.ToLower(strings.TrimSpace(args[0]))
+			switch mode {
+			case "on":
+				options.Enabled = true
+			case "off":
+				options.Enabled = false
+			default:
+				return fmt.Errorf("unsupported auto mode %q: use on/off", mode)
+			}
+			socketPath, err := resolveDiagSocketPath(options.SocketPath)
+			if err != nil {
+				return err
+			}
+			return runDiagAutoCommand(cmd.Context(), diagAutoCommandOptions{
+				SocketPath: socketPath,
+				Enabled:    options.Enabled,
+			}, cmd.OutOrStdout())
+		},
+	}
 	command.Flags().StringVar(&options.SocketPath, "socket", "", "diagnose unix socket path override")
 	return command
 }
 
-// defaultShellCommandRunner 组装 PTY 代理参数并启动手动诊断 shell。
+// defaultShellCommandRunner 组装 PTY 代理参数并启动 shell。
 func defaultShellCommandRunner(
 	ctx context.Context,
 	options shellCommandOptions,
@@ -116,18 +163,45 @@ func defaultShellCommandRunner(
 	})
 }
 
-// defaultDiagCommandRunner 向 shell 代理发送一次诊断触发信令。
+// defaultShellInitCommandRunner 输出 shell integration 初始化脚本。
+func defaultShellInitCommandRunner(_ context.Context, options shellCommandOptions, stdout io.Writer) error {
+	if stdout == nil {
+		return nil
+	}
+	_, err := io.WriteString(stdout, buildShellInitScript(strings.TrimSpace(options.Shell))+"\n")
+	return err
+}
+
+// defaultDiagCommandRunner 向 shell 代理发送一次手动诊断信令。
 func defaultDiagCommandRunner(ctx context.Context, options diagCommandOptions) error {
 	return sendDiagnoseSignalFn(ctx, strings.TrimSpace(options.SocketPath))
 }
 
-// resolveDiagSocketPath 按“--socket > NEOCODE_DIAG_SOCKET”优先级解析诊断 socket 路径。
+// defaultDiagAutoCommandRunner 向 shell 代理发送 auto 模式切换信令。
+func defaultDiagAutoCommandRunner(ctx context.Context, options diagAutoCommandOptions, stdout io.Writer) error {
+	if err := sendAutoModeSignalFn(ctx, strings.TrimSpace(options.SocketPath), options.Enabled); err != nil {
+		return err
+	}
+	if stdout != nil {
+		if options.Enabled {
+			_, _ = io.WriteString(stdout, "auto mode enabled\n")
+		} else {
+			_, _ = io.WriteString(stdout, "auto mode disabled\n")
+		}
+	}
+	return nil
+}
+
+// resolveDiagSocketPath 按“--socket > NEOCODE_DIAG_SOCKET > 最新运行目录 socket”解析目标路径。
 func resolveDiagSocketPath(socketFlag string) (string, error) {
 	if socketPath := strings.TrimSpace(socketFlag); socketPath != "" {
 		return socketPath, nil
 	}
 	if envValue := strings.TrimSpace(readDiagEnvValue(ptyproxy.DiagSocketEnv)); envValue != "" {
 		return envValue, nil
+	}
+	if discoveredPath, err := resolveLatestDiagPath(); err == nil && strings.TrimSpace(discoveredPath) != "" {
+		return strings.TrimSpace(discoveredPath), nil
 	}
 	return "", errors.New(
 		fmt.Sprintf(

--- a/internal/cli/shell_diag_commands_test.go
+++ b/internal/cli/shell_diag_commands_test.go
@@ -11,6 +11,26 @@ import (
 	"neo-code/internal/ptyproxy"
 )
 
+func TestShellCommandInitAcceptsPositionalShellArgument(t *testing.T) {
+	originalInitRunner := runShellInitCommand
+	t.Cleanup(func() { runShellInitCommand = originalInitRunner })
+
+	var captured shellCommandOptions
+	runShellInitCommand = func(_ context.Context, options shellCommandOptions, _ io.Writer) error {
+		captured = options
+		return nil
+	}
+
+	command := NewRootCommand()
+	command.SetArgs([]string{"shell", "--init", "/bin/zsh"})
+	if err := command.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
+	}
+	if captured.Shell != "/bin/zsh" {
+		t.Fatalf("shell = %q, want /bin/zsh", captured.Shell)
+	}
+}
+
 func TestShellCommandUsesFlags(t *testing.T) {
 	originalRunner := runShellCommand
 	t.Cleanup(func() { runShellCommand = originalRunner })
@@ -246,6 +266,103 @@ func TestDefaultDiagAutoCommandRunnerPrintsResult(t *testing.T) {
 	}
 }
 
+func TestDefaultRunners(t *testing.T) {
+	t.Run("defaultShellCommandRunner", func(t *testing.T) {
+		originalRun := runManualShellProxy
+		t.Cleanup(func() { runManualShellProxy = originalRun })
+
+		var captured ptyproxy.ManualShellOptions
+		runManualShellProxy = func(_ context.Context, options ptyproxy.ManualShellOptions) error {
+			captured = options
+			return nil
+		}
+
+		stdin := strings.NewReader("input")
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		err := defaultShellCommandRunner(context.Background(), shellCommandOptions{
+			Workdir:              " /repo ",
+			Shell:                " /bin/bash ",
+			SocketPath:           " /tmp/diag.sock ",
+			GatewayListenAddress: " /tmp/gateway.sock ",
+			GatewayTokenFile:     " /tmp/token.json ",
+		}, stdin, stdout, stderr)
+		if err != nil {
+			t.Fatalf("defaultShellCommandRunner() error = %v", err)
+		}
+		if captured.Workdir != "/repo" || captured.Shell != "/bin/bash" {
+			t.Fatalf("captured options = %+v", captured)
+		}
+		if captured.SocketPath != "/tmp/diag.sock" {
+			t.Fatalf("captured.SocketPath = %q, want /tmp/diag.sock", captured.SocketPath)
+		}
+	})
+
+	t.Run("defaultShellInitCommandRunner", func(t *testing.T) {
+		originalScriptBuilder := buildShellInitScript
+		t.Cleanup(func() { buildShellInitScript = originalScriptBuilder })
+		buildShellInitScript = func(shell string) string {
+			if shell != "/bin/bash" {
+				t.Fatalf("shell = %q, want /bin/bash", shell)
+			}
+			return "mock-init-script"
+		}
+
+		if err := defaultShellInitCommandRunner(context.Background(), shellCommandOptions{Shell: "/bin/bash"}, nil); err != nil {
+			t.Fatalf("defaultShellInitCommandRunner(nil stdout) error = %v", err)
+		}
+
+		stdout := &bytes.Buffer{}
+		if err := defaultShellInitCommandRunner(context.Background(), shellCommandOptions{Shell: "/bin/bash"}, stdout); err != nil {
+			t.Fatalf("defaultShellInitCommandRunner() error = %v", err)
+		}
+		if stdout.String() != "mock-init-script\n" {
+			t.Fatalf("stdout = %q, want mock-init-script", stdout.String())
+		}
+	})
+
+	t.Run("defaultDiagCommandRunner", func(t *testing.T) {
+		originalSend := sendDiagnoseSignalFn
+		t.Cleanup(func() { sendDiagnoseSignalFn = originalSend })
+
+		var socket string
+		sendDiagnoseSignalFn = func(_ context.Context, socketPath string) error {
+			socket = socketPath
+			return nil
+		}
+		err := defaultDiagCommandRunner(context.Background(), diagCommandOptions{SocketPath: " /tmp/diag.sock "})
+		if err != nil {
+			t.Fatalf("defaultDiagCommandRunner() error = %v", err)
+		}
+		if socket != "/tmp/diag.sock" {
+			t.Fatalf("socket = %q, want /tmp/diag.sock", socket)
+		}
+	})
+
+	t.Run("defaultDiagAutoCommandRunnerQuery", func(t *testing.T) {
+		originalQuery := queryAutoModeFn
+		t.Cleanup(func() { queryAutoModeFn = originalQuery })
+		queryAutoModeFn = func(_ context.Context, socketPath string) (bool, error) {
+			if socketPath != "/tmp/diag.sock" {
+				t.Fatalf("socketPath = %q", socketPath)
+			}
+			return false, nil
+		}
+
+		stdout := &bytes.Buffer{}
+		err := defaultDiagAutoCommandRunner(context.Background(), diagAutoCommandOptions{
+			SocketPath: "/tmp/diag.sock",
+			QueryOnly:  true,
+		}, stdout)
+		if err != nil {
+			t.Fatalf("defaultDiagAutoCommandRunner(query) error = %v", err)
+		}
+		if !strings.Contains(stdout.String(), "disabled") {
+			t.Fatalf("stdout = %q, want disabled", stdout.String())
+		}
+	})
+}
+
 func TestShellAndDiagCommandsSkipGlobalPreload(t *testing.T) {
 	originalPreload := runGlobalPreload
 	originalShellRunner := runShellCommand
@@ -279,5 +396,161 @@ func TestShellAndDiagCommandsSkipGlobalPreload(t *testing.T) {
 
 	if preloadCalled != 0 {
 		t.Fatalf("expected preload skipped, called %d", preloadCalled)
+	}
+}
+
+func TestDiagSubcommandsAdditionalPaths(t *testing.T) {
+	t.Run("diag diagnose subcommand", func(t *testing.T) {
+		originalRunner := runDiagDiagnoseCommand
+		originalReadEnv := readDiagEnvValue
+		t.Cleanup(func() { runDiagDiagnoseCommand = originalRunner })
+		t.Cleanup(func() { readDiagEnvValue = originalReadEnv })
+
+		readDiagEnvValue = func(string) string { return "/tmp/diag.sock" }
+		called := false
+		runDiagDiagnoseCommand = func(_ context.Context, options diagCommandOptions) error {
+			called = true
+			if options.SocketPath != "/tmp/diag.sock" {
+				t.Fatalf("socket = %q, want /tmp/diag.sock", options.SocketPath)
+			}
+			return nil
+		}
+
+		command := NewRootCommand()
+		command.SetArgs([]string{"diag", "diagnose"})
+		if err := command.ExecuteContext(context.Background()); err != nil {
+			t.Fatalf("ExecuteContext() error = %v", err)
+		}
+		if !called {
+			t.Fatal("expected runDiagDiagnoseCommand called")
+		}
+	})
+
+	t.Run("diag auto status", func(t *testing.T) {
+		originalRunner := runDiagAutoCommand
+		originalReadEnv := readDiagEnvValue
+		t.Cleanup(func() { runDiagAutoCommand = originalRunner })
+		t.Cleanup(func() { readDiagEnvValue = originalReadEnv })
+
+		readDiagEnvValue = func(string) string { return "/tmp/diag.sock" }
+		var captured diagAutoCommandOptions
+		runDiagAutoCommand = func(_ context.Context, options diagAutoCommandOptions, _ io.Writer) error {
+			captured = options
+			return nil
+		}
+
+		command := NewRootCommand()
+		command.SetArgs([]string{"diag", "auto", "status"})
+		if err := command.ExecuteContext(context.Background()); err != nil {
+			t.Fatalf("ExecuteContext() error = %v", err)
+		}
+		if !captured.QueryOnly {
+			t.Fatal("expected QueryOnly=true for status")
+		}
+	})
+
+	t.Run("defaultDiagAutoCommandRunner errors", func(t *testing.T) {
+		originalQuery := queryAutoModeFn
+		originalSend := sendAutoModeSignalFn
+		t.Cleanup(func() { queryAutoModeFn = originalQuery })
+		t.Cleanup(func() { sendAutoModeSignalFn = originalSend })
+
+		queryAutoModeFn = func(context.Context, string) (bool, error) { return false, errors.New("query failed") }
+		if err := defaultDiagAutoCommandRunner(context.Background(), diagAutoCommandOptions{
+			SocketPath: "/tmp/diag.sock",
+			QueryOnly:  true,
+		}, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "query failed") {
+			t.Fatalf("defaultDiagAutoCommandRunner(query error) err = %v", err)
+		}
+
+		sendAutoModeSignalFn = func(context.Context, string, bool) error { return errors.New("send failed") }
+		if err := defaultDiagAutoCommandRunner(context.Background(), diagAutoCommandOptions{
+			SocketPath: "/tmp/diag.sock",
+			Enabled:    false,
+		}, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "send failed") {
+			t.Fatalf("defaultDiagAutoCommandRunner(send error) err = %v", err)
+		}
+	})
+}
+
+func TestShellAndDiagCommandAdditionalBranches(t *testing.T) {
+	t.Run("shell args validation without init", func(t *testing.T) {
+		command := newShellCommand()
+		command.SetArgs([]string{"extra"})
+		err := command.ExecuteContext(context.Background())
+		if err == nil {
+			t.Fatal("expected no-args validation error")
+		}
+	})
+
+	t.Run("diag diagnose with explicit socket flag", func(t *testing.T) {
+		originalRunner := runDiagDiagnoseCommand
+		t.Cleanup(func() { runDiagDiagnoseCommand = originalRunner })
+
+		called := false
+		runDiagDiagnoseCommand = func(_ context.Context, options diagCommandOptions) error {
+			called = true
+			if options.SocketPath != "/tmp/diag-explicit.sock" {
+				t.Fatalf("socket = %q, want /tmp/diag-explicit.sock", options.SocketPath)
+			}
+			return nil
+		}
+
+		command := NewRootCommand()
+		command.SetArgs([]string{"diag", "diagnose", "--socket", "/tmp/diag-explicit.sock"})
+		if err := command.ExecuteContext(context.Background()); err != nil {
+			t.Fatalf("ExecuteContext() error = %v", err)
+		}
+		if !called {
+			t.Fatal("expected runDiagDiagnoseCommand called")
+		}
+	})
+
+	t.Run("resolveDiagSocketPath prefers socket flag", func(t *testing.T) {
+		path, err := resolveDiagSocketPath(" /tmp/from-flag.sock ")
+		if err != nil {
+			t.Fatalf("resolveDiagSocketPath() error = %v", err)
+		}
+		if path != "/tmp/from-flag.sock" {
+			t.Fatalf("path = %q, want /tmp/from-flag.sock", path)
+		}
+	})
+
+	t.Run("defaultDiagAutoCommandRunner disabled output", func(t *testing.T) {
+		originalSend := sendAutoModeSignalFn
+		t.Cleanup(func() { sendAutoModeSignalFn = originalSend })
+		sendAutoModeSignalFn = func(_ context.Context, socketPath string, enabled bool) error {
+			if socketPath != "/tmp/diag.sock" {
+				t.Fatalf("socketPath = %q", socketPath)
+			}
+			if enabled {
+				t.Fatal("expected enabled=false")
+			}
+			return nil
+		}
+
+		stdout := &bytes.Buffer{}
+		err := defaultDiagAutoCommandRunner(context.Background(), diagAutoCommandOptions{
+			SocketPath: "/tmp/diag.sock",
+			Enabled:    false,
+		}, stdout)
+		if err != nil {
+			t.Fatalf("defaultDiagAutoCommandRunner() error = %v", err)
+		}
+		if !strings.Contains(stdout.String(), "disabled") {
+			t.Fatalf("stdout = %q, want disabled", stdout.String())
+		}
+	})
+}
+
+func TestDiagCommandBuildersExposeSocketFlags(t *testing.T) {
+	diag := newDiagDiagnoseCommand()
+	if diag.Flags().Lookup("socket") == nil {
+		t.Fatal("diag diagnose command should expose --socket flag")
+	}
+
+	auto := newDiagAutoCommand()
+	if auto.Flags().Lookup("socket") == nil {
+		t.Fatal("diag auto command should expose --socket flag")
 	}
 }

--- a/internal/cli/shell_diag_commands_test.go
+++ b/internal/cli/shell_diag_commands_test.go
@@ -1,10 +1,10 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
-	"os"
 	"strings"
 	"testing"
 
@@ -51,52 +51,32 @@ func TestShellCommandUsesFlags(t *testing.T) {
 	}
 }
 
-func TestShellCommandSkipsGlobalPreload(t *testing.T) {
-	originalPreload := runGlobalPreload
-	originalRunner := runShellCommand
-	t.Cleanup(func() { runGlobalPreload = originalPreload })
-	t.Cleanup(func() { runShellCommand = originalRunner })
+func TestShellCommandInitPrintsScript(t *testing.T) {
+	originalInitRunner := runShellInitCommand
+	t.Cleanup(func() { runShellInitCommand = originalInitRunner })
 
-	var preloadCalled bool
-	runGlobalPreload = func(context.Context) error {
-		preloadCalled = true
-		return errors.New("should be skipped")
-	}
-	runShellCommand = func(context.Context, shellCommandOptions, io.Reader, io.Writer, io.Writer) error {
+	var called bool
+	runShellInitCommand = func(_ context.Context, options shellCommandOptions, stdout io.Writer) error {
+		called = true
+		if options.Shell != "/bin/bash" {
+			t.Fatalf("shell = %q, want /bin/bash", options.Shell)
+		}
+		_, _ = io.WriteString(stdout, "script-body")
 		return nil
 	}
 
 	command := NewRootCommand()
-	command.SetArgs([]string{"shell"})
+	stdout := &bytes.Buffer{}
+	command.SetOut(stdout)
+	command.SetArgs([]string{"shell", "--init", "--shell", "/bin/bash"})
 	if err := command.ExecuteContext(context.Background()); err != nil {
 		t.Fatalf("ExecuteContext() error = %v", err)
 	}
-	if preloadCalled {
-		t.Fatal("expected global preload to be skipped for shell command")
+	if !called {
+		t.Fatal("expected runShellInitCommand called")
 	}
-}
-
-func TestShellCommandSkipsSilentUpdateCheck(t *testing.T) {
-	originalSilentCheck := runSilentUpdateCheck
-	originalRunner := runShellCommand
-	t.Cleanup(func() { runSilentUpdateCheck = originalSilentCheck })
-	t.Cleanup(func() { runShellCommand = originalRunner })
-
-	var checkCalled bool
-	runSilentUpdateCheck = func(context.Context) {
-		checkCalled = true
-	}
-	runShellCommand = func(context.Context, shellCommandOptions, io.Reader, io.Writer, io.Writer) error {
-		return nil
-	}
-
-	command := NewRootCommand()
-	command.SetArgs([]string{"shell"})
-	if err := command.ExecuteContext(context.Background()); err != nil {
-		t.Fatalf("ExecuteContext() error = %v", err)
-	}
-	if checkCalled {
-		t.Fatal("expected silent update check to be skipped for shell command")
+	if !strings.Contains(stdout.String(), "script-body") {
+		t.Fatalf("stdout = %q, want contains script-body", stdout.String())
 	}
 }
 
@@ -128,22 +108,21 @@ func TestDiagCommandSocketPriority(t *testing.T) {
 	}
 }
 
-func TestDiagCommandUsesEnvFallback(t *testing.T) {
+func TestDiagCommandUsesLatestPathFallback(t *testing.T) {
 	originalRunner := runDiagCommand
 	originalReadEnv := readDiagEnvValue
+	originalLatest := resolveLatestDiagPath
 	t.Cleanup(func() { runDiagCommand = originalRunner })
 	t.Cleanup(func() { readDiagEnvValue = originalReadEnv })
+	t.Cleanup(func() { resolveLatestDiagPath = originalLatest })
+
+	readDiagEnvValue = func(string) string { return "" }
+	resolveLatestDiagPath = func() (string, error) { return "/tmp/discovered.sock", nil }
 
 	var captured diagCommandOptions
 	runDiagCommand = func(_ context.Context, options diagCommandOptions) error {
 		captured = options
 		return nil
-	}
-	readDiagEnvValue = func(key string) string {
-		if key == ptyproxy.DiagSocketEnv {
-			return " /tmp/from-env.sock "
-		}
-		return ""
 	}
 
 	command := NewRootCommand()
@@ -151,15 +130,19 @@ func TestDiagCommandUsesEnvFallback(t *testing.T) {
 	if err := command.ExecuteContext(context.Background()); err != nil {
 		t.Fatalf("ExecuteContext() error = %v", err)
 	}
-	if captured.SocketPath != "/tmp/from-env.sock" {
-		t.Fatalf("socket = %q, want %q", captured.SocketPath, "/tmp/from-env.sock")
+	if captured.SocketPath != "/tmp/discovered.sock" {
+		t.Fatalf("socket = %q, want /tmp/discovered.sock", captured.SocketPath)
 	}
 }
 
 func TestDiagCommandSocketMissing(t *testing.T) {
 	originalReadEnv := readDiagEnvValue
+	originalLatest := resolveLatestDiagPath
 	t.Cleanup(func() { readDiagEnvValue = originalReadEnv })
+	t.Cleanup(func() { resolveLatestDiagPath = originalLatest })
+
 	readDiagEnvValue = func(string) string { return "" }
+	resolveLatestDiagPath = func() (string, error) { return "", errors.New("no socket") }
 
 	command := NewRootCommand()
 	command.SetArgs([]string{"diag"})
@@ -175,60 +158,126 @@ func TestDiagCommandSocketMissing(t *testing.T) {
 	}
 }
 
-func TestDiagCommandSkipsGlobalPreload(t *testing.T) {
-	originalPreload := runGlobalPreload
-	originalRunner := runDiagCommand
+func TestDiagAutoCommandOn(t *testing.T) {
+	originalRunner := runDiagAutoCommand
 	originalReadEnv := readDiagEnvValue
-	t.Cleanup(func() { runGlobalPreload = originalPreload })
-	t.Cleanup(func() { runDiagCommand = originalRunner })
+	t.Cleanup(func() { runDiagAutoCommand = originalRunner })
 	t.Cleanup(func() { readDiagEnvValue = originalReadEnv })
 
-	var preloadCalled bool
+	readDiagEnvValue = func(string) string { return "/tmp/diag.sock" }
+	var captured diagAutoCommandOptions
+	runDiagAutoCommand = func(_ context.Context, options diagAutoCommandOptions, _ io.Writer) error {
+		captured = options
+		return nil
+	}
+
+	command := NewRootCommand()
+	command.SetArgs([]string{"diag", "auto", "on"})
+	if err := command.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
+	}
+	if !captured.Enabled {
+		t.Fatal("expected auto on")
+	}
+	if captured.SocketPath != "/tmp/diag.sock" {
+		t.Fatalf("socket = %q, want /tmp/diag.sock", captured.SocketPath)
+	}
+}
+
+func TestDiagAutoCommandOff(t *testing.T) {
+	originalRunner := runDiagAutoCommand
+	originalReadEnv := readDiagEnvValue
+	t.Cleanup(func() { runDiagAutoCommand = originalRunner })
+	t.Cleanup(func() { readDiagEnvValue = originalReadEnv })
+
+	readDiagEnvValue = func(string) string { return "/tmp/diag.sock" }
+	var captured diagAutoCommandOptions
+	runDiagAutoCommand = func(_ context.Context, options diagAutoCommandOptions, _ io.Writer) error {
+		captured = options
+		return nil
+	}
+
+	command := NewRootCommand()
+	command.SetArgs([]string{"diag", "auto", "off"})
+	if err := command.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
+	}
+	if captured.Enabled {
+		t.Fatal("expected auto off")
+	}
+}
+
+func TestDiagAutoCommandInvalidMode(t *testing.T) {
+	command := NewRootCommand()
+	command.SetArgs([]string{"diag", "auto", "maybe"})
+	err := command.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("expected invalid mode error")
+	}
+	if !strings.Contains(err.Error(), "on/off") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestDefaultDiagAutoCommandRunnerPrintsResult(t *testing.T) {
+	originalSend := sendAutoModeSignalFn
+	t.Cleanup(func() { sendAutoModeSignalFn = originalSend })
+
+	sendAutoModeSignalFn = func(_ context.Context, socketPath string, enabled bool) error {
+		if socketPath != "/tmp/diag.sock" {
+			t.Fatalf("socketPath = %q", socketPath)
+		}
+		if !enabled {
+			t.Fatal("expected enabled=true")
+		}
+		return nil
+	}
+
+	stdout := &bytes.Buffer{}
+	err := defaultDiagAutoCommandRunner(context.Background(), diagAutoCommandOptions{
+		SocketPath: "/tmp/diag.sock",
+		Enabled:    true,
+	}, stdout)
+	if err != nil {
+		t.Fatalf("defaultDiagAutoCommandRunner() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "enabled") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestShellAndDiagCommandsSkipGlobalPreload(t *testing.T) {
+	originalPreload := runGlobalPreload
+	originalShellRunner := runShellCommand
+	originalDiagRunner := runDiagCommand
+	originalReadEnv := readDiagEnvValue
+	t.Cleanup(func() { runGlobalPreload = originalPreload })
+	t.Cleanup(func() { runShellCommand = originalShellRunner })
+	t.Cleanup(func() { runDiagCommand = originalDiagRunner })
+	t.Cleanup(func() { readDiagEnvValue = originalReadEnv })
+
+	preloadCalled := 0
 	runGlobalPreload = func(context.Context) error {
-		preloadCalled = true
+		preloadCalled++
 		return errors.New("should be skipped")
 	}
+	runShellCommand = func(context.Context, shellCommandOptions, io.Reader, io.Writer, io.Writer) error { return nil }
 	runDiagCommand = func(context.Context, diagCommandOptions) error { return nil }
 	readDiagEnvValue = func(string) string { return "/tmp/diag.sock" }
 
 	command := NewRootCommand()
+	command.SetArgs([]string{"shell"})
+	if err := command.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("shell ExecuteContext() error = %v", err)
+	}
+
+	command = NewRootCommand()
 	command.SetArgs([]string{"diag"})
 	if err := command.ExecuteContext(context.Background()); err != nil {
-		t.Fatalf("ExecuteContext() error = %v", err)
-	}
-	if preloadCalled {
-		t.Fatal("expected global preload to be skipped for diag command")
-	}
-}
-
-func TestDefaultShellCommandRunnerForwardsUnsupportedError(t *testing.T) {
-	originalManualShell := runManualShellProxy
-	t.Cleanup(func() { runManualShellProxy = originalManualShell })
-	runManualShellProxy = func(context.Context, ptyproxy.ManualShellOptions) error {
-		return errors.New("manual shell mode is only supported on unix-like systems in phase1")
+		t.Fatalf("diag ExecuteContext() error = %v", err)
 	}
 
-	err := defaultShellCommandRunner(context.Background(), shellCommandOptions{}, os.Stdin, io.Discard, io.Discard)
-	if err == nil {
-		t.Fatal("expected unsupported error")
-	}
-	if !strings.Contains(strings.ToLower(err.Error()), "only supported on unix-like systems") {
-		t.Fatalf("error = %v", err)
-	}
-}
-
-func TestDefaultDiagCommandRunnerForwardsUnsupportedError(t *testing.T) {
-	originalSend := sendDiagnoseSignalFn
-	t.Cleanup(func() { sendDiagnoseSignalFn = originalSend })
-	sendDiagnoseSignalFn = func(context.Context, string) error {
-		return errors.New("manual shell mode is only supported on unix-like systems in phase1")
-	}
-
-	err := defaultDiagCommandRunner(context.Background(), diagCommandOptions{SocketPath: "/tmp/diag.sock"})
-	if err == nil {
-		t.Fatal("expected unsupported error")
-	}
-	if !strings.Contains(strings.ToLower(err.Error()), "only supported on unix-like systems") {
-		t.Fatalf("error = %v", err)
+	if preloadCalled != 0 {
+		t.Fatalf("expected preload skipped, called %d", preloadCalled)
 	}
 }

--- a/internal/cli/use_command.go
+++ b/internal/cli/use_command.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"neo-code/internal/config"
+)
+
+var runUseCommand = defaultUseCommandRunner
+
+// newUseCommand 创建 use 命令，用于全局切换选中的 provider。
+func newUseCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "use <provider>",
+		Short: "Switch to a specific provider",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runUseCommand(cmd, args[0])
+		},
+	}
+}
+
+// defaultUseCommandRunner 执行 provider 切换逻辑。
+func defaultUseCommandRunner(cmd *cobra.Command, name string) error {
+	var workdir string
+	if f := cmd.Flag("workdir"); f != nil {
+		workdir = f.Value.String()
+	}
+	loader := config.NewLoader(workdir, config.StaticDefaults())
+	manager := config.NewManager(loader)
+
+	// 预加载校验配置是否存在
+	if _, err := manager.Load(cmd.Context()); err != nil {
+		return err
+	}
+
+	err := manager.Update(cmd.Context(), func(cfg *config.Config) error {
+		provider, err := cfg.ProviderByName(name)
+		if err != nil {
+			return err
+		}
+		cfg.SelectedProvider = provider.Name
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "✅ 已全局切换到供应商: %s\n", name)
+	return nil
+}

--- a/internal/cli/use_command.go
+++ b/internal/cli/use_command.go
@@ -11,20 +11,27 @@ import (
 
 var runUseCommand = defaultUseCommandRunner
 
-// newUseCommand 创建 use 命令，用于全局切换选中的 provider。
-func newUseCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:   "use <provider>",
-		Short: "Switch to a specific provider",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runUseCommand(cmd, args[0])
-		},
-	}
+type useCommandOptions struct {
+	Model string
 }
 
-// defaultUseCommandRunner 执行 provider 切换逻辑。
-func defaultUseCommandRunner(cmd *cobra.Command, name string) error {
+// newUseCommand 创建 use 命令，用于全局切换选中的 provider，并可选指定模型。
+func newUseCommand() *cobra.Command {
+	var opts useCommandOptions
+	cmd := &cobra.Command{
+		Use:   "use <provider>",
+		Short: "Switch to a specific provider (and optionally a model)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runUseCommand(cmd, args[0], opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.Model, "model", "", "model to select for the provider")
+	return cmd
+}
+
+// defaultUseCommandRunner 执行 provider 切换逻辑，并在指定 --model 时同步设置 current_model。
+func defaultUseCommandRunner(cmd *cobra.Command, name string, opts useCommandOptions) error {
 	var workdir string
 	if f := cmd.Flag("workdir"); f != nil {
 		workdir = f.Value.String()
@@ -37,18 +44,28 @@ func defaultUseCommandRunner(cmd *cobra.Command, name string) error {
 		return err
 	}
 
+	model := strings.TrimSpace(opts.Model)
+
 	err := manager.Update(cmd.Context(), func(cfg *config.Config) error {
 		provider, err := cfg.ProviderByName(name)
 		if err != nil {
 			return err
 		}
 		cfg.SelectedProvider = provider.Name
+		if model != "" {
+			cfg.CurrentModel = model
+		}
 		return nil
 	})
 
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "✅ 已全局切换到供应商: %s\n", name)
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "✅ 已全局切换到供应商: %s\n", name)
+	if model != "" {
+		fmt.Fprintf(out, "✅ 已设置模型: %s\n", model)
+	}
 	return nil
 }

--- a/internal/cli/use_command.go
+++ b/internal/cli/use_command.go
@@ -1,12 +1,13 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
 
-	"neo-code/internal/config"
+	configstate "neo-code/internal/config/state"
 )
 
 var runUseCommand = defaultUseCommandRunner
@@ -17,13 +18,25 @@ type useCommandOptions struct {
 
 // newUseCommand 创建 use 命令，用于全局切换选中的 provider，并可选指定模型。
 func newUseCommand() *cobra.Command {
+	return newUseCommandWithResolver(newRuntimeSelectionServiceResolver())
+}
+
+// newUseCommandWithResolver 创建支持依赖注入的 use 命令。
+func newUseCommandWithResolver(resolver selectionServiceResolver) *cobra.Command {
+	if resolver == nil {
+		resolver = newRuntimeSelectionServiceResolver()
+	}
 	var opts useCommandOptions
 	cmd := &cobra.Command{
 		Use:   "use <provider>",
 		Short: "Switch to a specific provider (and optionally a model)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runUseCommand(cmd, args[0], opts)
+			svc, err := resolver.Resolve(cmd)
+			if err != nil {
+				return err
+			}
+			return runUseCommand(cmd, svc, args[0], opts)
 		},
 	}
 	cmd.Flags().StringVar(&opts.Model, "model", "", "model to select for the provider")
@@ -31,41 +44,42 @@ func newUseCommand() *cobra.Command {
 }
 
 // defaultUseCommandRunner 执行 provider 切换逻辑，并在指定 --model 时同步设置 current_model。
-func defaultUseCommandRunner(cmd *cobra.Command, name string, opts useCommandOptions) error {
-	var workdir string
-	if f := cmd.Flag("workdir"); f != nil {
-		workdir = f.Value.String()
-	}
-	loader := config.NewLoader(workdir, config.StaticDefaults())
-	manager := config.NewManager(loader)
-
-	// 预加载校验配置是否存在
-	if _, err := manager.Load(cmd.Context()); err != nil {
-		return err
+func defaultUseCommandRunner(cmd *cobra.Command, svc SelectionService, name string, opts useCommandOptions) error {
+	if svc == nil {
+		return fmt.Errorf("selection service is unavailable")
 	}
 
+	providerName := strings.TrimSpace(name)
 	model := strings.TrimSpace(opts.Model)
 
-	err := manager.Update(cmd.Context(), func(cfg *config.Config) error {
-		provider, err := cfg.ProviderByName(name)
-		if err != nil {
-			return err
-		}
-		cfg.SelectedProvider = provider.Name
-		if model != "" {
-			cfg.CurrentModel = model
-		}
-		return nil
-	})
-
+	selection, err := svc.SelectProvider(cmd.Context(), providerName)
 	if err != nil {
 		return err
 	}
 
-	out := cmd.OutOrStdout()
-	fmt.Fprintf(out, "✅ 已全局切换到供应商: %s\n", name)
 	if model != "" {
-		fmt.Fprintf(out, "✅ 已设置模型: %s\n", model)
+		selection, err = svc.SetCurrentModel(cmd.Context(), model)
+		if err != nil {
+			if errors.Is(err, configstate.ErrModelNotFound) {
+				return fmt.Errorf("provider %q has no model %q: %w", providerName, model, err)
+			}
+			return err
+		}
+	}
+
+	activeProvider := strings.TrimSpace(selection.ProviderID)
+	if activeProvider == "" {
+		activeProvider = providerName
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "✅ 已全局切换到供应商: %s\n", activeProvider)
+	if model != "" {
+		activeModel := strings.TrimSpace(selection.ModelID)
+		if activeModel == "" {
+			activeModel = model
+		}
+		fmt.Fprintf(out, "✅ 已设置模型: %s\n", activeModel)
 	}
 	return nil
 }

--- a/internal/cli/use_command.go
+++ b/internal/cli/use_command.go
@@ -52,17 +52,21 @@ func defaultUseCommandRunner(cmd *cobra.Command, svc SelectionService, name stri
 	providerName := strings.TrimSpace(name)
 	model := strings.TrimSpace(opts.Model)
 
-	selection, err := svc.SelectProvider(cmd.Context(), providerName)
-	if err != nil {
-		return err
-	}
-
+	var (
+		selection configstate.Selection
+		err       error
+	)
 	if model != "" {
-		selection, err = svc.SetCurrentModel(cmd.Context(), model)
+		selection, err = svc.SelectProviderWithModel(cmd.Context(), providerName, model)
 		if err != nil {
 			if errors.Is(err, configstate.ErrModelNotFound) {
 				return fmt.Errorf("provider %q has no model %q: %w", providerName, model, err)
 			}
+			return err
+		}
+	} else {
+		selection, err = svc.SelectProvider(cmd.Context(), providerName)
+		if err != nil {
 			return err
 		}
 	}

--- a/internal/cli/use_command_test.go
+++ b/internal/cli/use_command_test.go
@@ -49,14 +49,14 @@ func TestUseCommand(t *testing.T) {
 
 func TestDefaultUseCommandRunner(t *testing.T) {
 	tests := []struct {
-		name           string
-		provider       string
-		model          string
-		selectProvider func(context.Context, string) (configstate.Selection, error)
-		setCurrent     func(context.Context, string) (configstate.Selection, error)
-		wantErr        string
-		wantOutput     []string
-		wantSetCalled  bool
+		name                    string
+		provider                string
+		model                   string
+		selectProvider          func(context.Context, string) (configstate.Selection, error)
+		selectProviderWithModel func(context.Context, string, string) (configstate.Selection, error)
+		wantErr                 string
+		wantOutput              []string
+		wantSelectWithModel     bool
 	}{
 		{
 			name:     "switch provider only",
@@ -70,14 +70,11 @@ func TestDefaultUseCommandRunner(t *testing.T) {
 			name:     "switch provider and model",
 			provider: "openai",
 			model:    "gpt-4o",
-			selectProvider: func(_ context.Context, provider string) (configstate.Selection, error) {
-				return configstate.Selection{ProviderID: provider, ModelID: "gpt-5.4"}, nil
+			selectProviderWithModel: func(_ context.Context, provider string, model string) (configstate.Selection, error) {
+				return configstate.Selection{ProviderID: provider, ModelID: model}, nil
 			},
-			setCurrent: func(_ context.Context, model string) (configstate.Selection, error) {
-				return configstate.Selection{ProviderID: "openai", ModelID: model}, nil
-			},
-			wantSetCalled: true,
-			wantOutput:    []string{"已全局切换到供应商: openai", "已设置模型: gpt-4o"},
+			wantSelectWithModel: true,
+			wantOutput:          []string{"已全局切换到供应商: openai", "已设置模型: gpt-4o"},
 		},
 		{
 			name:     "select provider error",
@@ -91,14 +88,11 @@ func TestDefaultUseCommandRunner(t *testing.T) {
 			name:     "model not found",
 			provider: "openai",
 			model:    "missing-model",
-			selectProvider: func(_ context.Context, provider string) (configstate.Selection, error) {
-				return configstate.Selection{ProviderID: provider, ModelID: "gpt-5.4"}, nil
-			},
-			setCurrent: func(_ context.Context, model string) (configstate.Selection, error) {
+			selectProviderWithModel: func(_ context.Context, provider string, model string) (configstate.Selection, error) {
 				return configstate.Selection{}, configstate.ErrModelNotFound
 			},
-			wantSetCalled: true,
-			wantErr:       `provider "openai" has no model "missing-model"`,
+			wantSelectWithModel: true,
+			wantErr:             `provider "openai" has no model "missing-model"`,
 		},
 	}
 
@@ -109,13 +103,13 @@ func TestDefaultUseCommandRunner(t *testing.T) {
 			cmd.SetOut(output)
 			cmd.SetContext(context.Background())
 
-			setCalled := false
+			selectWithModelCalled := false
 			svc := &mockSelectionService{
 				selectProviderFn: tc.selectProvider,
-				setCurrentModelFn: func(ctx context.Context, modelID string) (configstate.Selection, error) {
-					setCalled = true
-					if tc.setCurrent != nil {
-						return tc.setCurrent(ctx, modelID)
+				selectProviderModelFn: func(ctx context.Context, providerName string, modelID string) (configstate.Selection, error) {
+					selectWithModelCalled = true
+					if tc.selectProviderWithModel != nil {
+						return tc.selectProviderWithModel(ctx, providerName, modelID)
 					}
 					return configstate.Selection{}, nil
 				},
@@ -131,8 +125,8 @@ func TestDefaultUseCommandRunner(t *testing.T) {
 			if err != nil {
 				t.Fatalf("defaultUseCommandRunner() error = %v", err)
 			}
-			if setCalled != tc.wantSetCalled {
-				t.Fatalf("setCalled = %v, want %v", setCalled, tc.wantSetCalled)
+			if selectWithModelCalled != tc.wantSelectWithModel {
+				t.Fatalf("selectWithModelCalled = %v, want %v", selectWithModelCalled, tc.wantSelectWithModel)
 			}
 			for _, fragment := range tc.wantOutput {
 				if !strings.Contains(output.String(), fragment) {

--- a/internal/cli/use_command_test.go
+++ b/internal/cli/use_command_test.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"neo-code/internal/config"
+)
+
+func TestUseCommand(t *testing.T) {
+	cmd := newUseCommand()
+	if cmd.Use != "use <provider>" {
+		t.Errorf("expected use 'use <provider>', got %s", cmd.Use)
+	}
+
+	called := false
+	runUseCommand = func(c *cobra.Command, name string, opts useCommandOptions) error {
+		called = true
+		if name != "my-provider" {
+			t.Errorf("expected 'my-provider', got %s", name)
+		}
+		return errors.New("mock error")
+	}
+	defer func() { runUseCommand = defaultUseCommandRunner }()
+
+	cmd.SetArgs([]string{"my-provider"})
+	if err := cmd.ExecuteContext(context.Background()); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !called {
+		t.Fatal("runner not called")
+	}
+}
+
+func TestUseCommandWithModelFlag(t *testing.T) {
+	called := false
+	runUseCommand = func(c *cobra.Command, name string, opts useCommandOptions) error {
+		called = true
+		if name != "my-provider" {
+			t.Errorf("expected 'my-provider', got %s", name)
+		}
+		if opts.Model != "gpt-5.4" {
+			t.Errorf("expected model 'gpt-5.4', got %s", opts.Model)
+		}
+		return nil
+	}
+	defer func() { runUseCommand = defaultUseCommandRunner }()
+
+	cmd := newUseCommand()
+	cmd.SetArgs([]string{"my-provider", "--model", "gpt-5.4"})
+	if err := cmd.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("runner not called")
+	}
+}
+
+func TestDefaultUseCommandRunner(t *testing.T) {
+	workdir := t.TempDir()
+
+	// 预先创建一个 custom provider 用于测试
+	input := config.SaveCustomProviderInput{
+		Name:                  "my-provider",
+		Driver:                "openaicompat",
+		BaseURL:               "http://mock",
+		APIKeyEnv:             "MOCK_KEY",
+		ModelSource:           "discover",
+		DiscoveryEndpointPath: "/v1/models",
+	}
+	if err := config.SaveCustomProviderWithModels(workdir, input); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("workdir", workdir, "")
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetContext(context.Background())
+
+	// 仅切换 provider
+	err := defaultUseCommandRunner(cmd, "my-provider", useCommandOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	loader := config.NewLoader(workdir, config.StaticDefaults())
+	cfg, err := loader.Load(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.SelectedProvider != "my-provider" {
+		t.Errorf("expected selected provider 'my-provider', got %s", cfg.SelectedProvider)
+	}
+
+	// 切换 provider + model
+	out.Reset()
+	err = defaultUseCommandRunner(cmd, "my-provider", useCommandOptions{Model: "deepseek-chat"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cfg, err = loader.Load(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.CurrentModel != "deepseek-chat" {
+		t.Errorf("expected current model 'deepseek-chat', got %s", cfg.CurrentModel)
+	}
+
+	// 不存在的 provider 应报错
+	err = defaultUseCommandRunner(cmd, "not-found", useCommandOptions{})
+	if err == nil {
+		t.Fatal("expected error for non-existent provider, got nil")
+	}
+}

--- a/internal/cli/use_command_test.go
+++ b/internal/cli/use_command_test.go
@@ -4,116 +4,141 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
-	"neo-code/internal/config"
+
+	configstate "neo-code/internal/config/state"
 )
 
 func TestUseCommand(t *testing.T) {
-	cmd := newUseCommand()
+	svc := &mockSelectionService{}
+	cmd := newUseCommandWithResolver(staticSelectionResolver(svc))
 	if cmd.Use != "use <provider>" {
-		t.Errorf("expected use 'use <provider>', got %s", cmd.Use)
+		t.Fatalf("cmd.Use = %q, want %q", cmd.Use, "use <provider>")
 	}
 
+	originalRunner := runUseCommand
+	t.Cleanup(func() { runUseCommand = originalRunner })
+
 	called := false
-	runUseCommand = func(c *cobra.Command, name string, opts useCommandOptions) error {
+	runUseCommand = func(c *cobra.Command, gotSvc SelectionService, name string, opts useCommandOptions) error {
 		called = true
+		if gotSvc != svc {
+			t.Fatalf("injected service mismatch")
+		}
 		if name != "my-provider" {
-			t.Errorf("expected 'my-provider', got %s", name)
+			t.Fatalf("name = %q, want %q", name, "my-provider")
+		}
+		if opts.Model != "gpt-5.4" {
+			t.Fatalf("opts.Model = %q, want %q", opts.Model, "gpt-5.4")
 		}
 		return errors.New("mock error")
 	}
-	defer func() { runUseCommand = defaultUseCommandRunner }()
 
-	cmd.SetArgs([]string{"my-provider"})
-	if err := cmd.ExecuteContext(context.Background()); err == nil {
+	cmd.SetArgs([]string{"my-provider", "--model", "gpt-5.4"})
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if !called {
-		t.Fatal("runner not called")
-	}
-}
-
-func TestUseCommandWithModelFlag(t *testing.T) {
-	called := false
-	runUseCommand = func(c *cobra.Command, name string, opts useCommandOptions) error {
-		called = true
-		if name != "my-provider" {
-			t.Errorf("expected 'my-provider', got %s", name)
-		}
-		if opts.Model != "gpt-5.4" {
-			t.Errorf("expected model 'gpt-5.4', got %s", opts.Model)
-		}
-		return nil
-	}
-	defer func() { runUseCommand = defaultUseCommandRunner }()
-
-	cmd := newUseCommand()
-	cmd.SetArgs([]string{"my-provider", "--model", "gpt-5.4"})
-	if err := cmd.ExecuteContext(context.Background()); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !called {
-		t.Fatal("runner not called")
+		t.Fatal("expected runUseCommand called")
 	}
 }
 
 func TestDefaultUseCommandRunner(t *testing.T) {
-	workdir := t.TempDir()
+	tests := []struct {
+		name           string
+		provider       string
+		model          string
+		selectProvider func(context.Context, string) (configstate.Selection, error)
+		setCurrent     func(context.Context, string) (configstate.Selection, error)
+		wantErr        string
+		wantOutput     []string
+		wantSetCalled  bool
+	}{
+		{
+			name:     "switch provider only",
+			provider: "openai",
+			selectProvider: func(_ context.Context, provider string) (configstate.Selection, error) {
+				return configstate.Selection{ProviderID: provider, ModelID: "gpt-5.4"}, nil
+			},
+			wantOutput: []string{"已全局切换到供应商: openai"},
+		},
+		{
+			name:     "switch provider and model",
+			provider: "openai",
+			model:    "gpt-4o",
+			selectProvider: func(_ context.Context, provider string) (configstate.Selection, error) {
+				return configstate.Selection{ProviderID: provider, ModelID: "gpt-5.4"}, nil
+			},
+			setCurrent: func(_ context.Context, model string) (configstate.Selection, error) {
+				return configstate.Selection{ProviderID: "openai", ModelID: model}, nil
+			},
+			wantSetCalled: true,
+			wantOutput:    []string{"已全局切换到供应商: openai", "已设置模型: gpt-4o"},
+		},
+		{
+			name:     "select provider error",
+			provider: "missing",
+			selectProvider: func(_ context.Context, provider string) (configstate.Selection, error) {
+				return configstate.Selection{}, errors.New("provider not found")
+			},
+			wantErr: "provider not found",
+		},
+		{
+			name:     "model not found",
+			provider: "openai",
+			model:    "missing-model",
+			selectProvider: func(_ context.Context, provider string) (configstate.Selection, error) {
+				return configstate.Selection{ProviderID: provider, ModelID: "gpt-5.4"}, nil
+			},
+			setCurrent: func(_ context.Context, model string) (configstate.Selection, error) {
+				return configstate.Selection{}, configstate.ErrModelNotFound
+			},
+			wantSetCalled: true,
+			wantErr:       `provider "openai" has no model "missing-model"`,
+		},
+	}
 
-	// 预先创建一个 custom provider 用于测试
-	input := config.SaveCustomProviderInput{
-		Name:                  "my-provider",
-		Driver:                "openaicompat",
-		BaseURL:               "http://mock",
-		APIKeyEnv:             "MOCK_KEY",
-		ModelSource:           "discover",
-		DiscoveryEndpointPath: "/v1/models",
-	}
-	if err := config.SaveCustomProviderWithModels(workdir, input); err != nil {
-		t.Fatal(err)
-	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			output := &bytes.Buffer{}
+			cmd := &cobra.Command{}
+			cmd.SetOut(output)
+			cmd.SetContext(context.Background())
 
-	cmd := &cobra.Command{}
-	cmd.Flags().String("workdir", workdir, "")
-	out := new(bytes.Buffer)
-	cmd.SetOut(out)
-	cmd.SetContext(context.Background())
+			setCalled := false
+			svc := &mockSelectionService{
+				selectProviderFn: tc.selectProvider,
+				setCurrentModelFn: func(ctx context.Context, modelID string) (configstate.Selection, error) {
+					setCalled = true
+					if tc.setCurrent != nil {
+						return tc.setCurrent(ctx, modelID)
+					}
+					return configstate.Selection{}, nil
+				},
+			}
 
-	// 仅切换 provider
-	err := defaultUseCommandRunner(cmd, "my-provider", useCommandOptions{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	loader := config.NewLoader(workdir, config.StaticDefaults())
-	cfg, err := loader.Load(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.SelectedProvider != "my-provider" {
-		t.Errorf("expected selected provider 'my-provider', got %s", cfg.SelectedProvider)
-	}
-
-	// 切换 provider + model
-	out.Reset()
-	err = defaultUseCommandRunner(cmd, "my-provider", useCommandOptions{Model: "deepseek-chat"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	cfg, err = loader.Load(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.CurrentModel != "deepseek-chat" {
-		t.Errorf("expected current model 'deepseek-chat', got %s", cfg.CurrentModel)
-	}
-
-	// 不存在的 provider 应报错
-	err = defaultUseCommandRunner(cmd, "not-found", useCommandOptions{})
-	if err == nil {
-		t.Fatal("expected error for non-existent provider, got nil")
+			err := defaultUseCommandRunner(cmd, svc, tc.provider, useCommandOptions{Model: tc.model})
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want contains %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("defaultUseCommandRunner() error = %v", err)
+			}
+			if setCalled != tc.wantSetCalled {
+				t.Fatalf("setCalled = %v, want %v", setCalled, tc.wantSetCalled)
+			}
+			for _, fragment := range tc.wantOutput {
+				if !strings.Contains(output.String(), fragment) {
+					t.Fatalf("output = %q, want contains %q", output.String(), fragment)
+				}
+			}
+		})
 	}
 }

--- a/internal/cli/use_command_test.go
+++ b/internal/cli/use_command_test.go
@@ -47,6 +47,18 @@ func TestUseCommand(t *testing.T) {
 	}
 }
 
+func TestUseCommandBuilderUsesDefaultResolverWhenNil(t *testing.T) {
+	cmd := newUseCommand()
+	if cmd.Use != "use <provider>" {
+		t.Fatalf("cmd.Use = %q, want %q", cmd.Use, "use <provider>")
+	}
+
+	injected := newUseCommandWithResolver(nil)
+	if injected.Use != "use <provider>" {
+		t.Fatalf("injected.Use = %q, want %q", injected.Use, "use <provider>")
+	}
+}
+
 func TestDefaultUseCommandRunner(t *testing.T) {
 	tests := []struct {
 		name                    string
@@ -135,4 +147,106 @@ func TestDefaultUseCommandRunner(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDefaultUseCommandRunnerExtraBranches(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	if err := defaultUseCommandRunner(cmd, nil, "openai", useCommandOptions{}); err == nil || !strings.Contains(err.Error(), "selection service") {
+		t.Fatalf("defaultUseCommandRunner(nil) err = %v", err)
+	}
+
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	svc := &mockSelectionService{
+		selectProviderFn: func(context.Context, string) (configstate.Selection, error) {
+			return configstate.Selection{ProviderID: "", ModelID: ""}, nil
+		},
+	}
+	if err := defaultUseCommandRunner(cmd, svc, "custom-provider", useCommandOptions{}); err != nil {
+		t.Fatalf("defaultUseCommandRunner() error = %v", err)
+	}
+	if !strings.Contains(output.String(), "custom-provider") {
+		t.Fatalf("output = %q, want fallback provider name", output.String())
+	}
+
+	output.Reset()
+	svc = &mockSelectionService{
+		selectProviderModelFn: func(context.Context, string, string) (configstate.Selection, error) {
+			return configstate.Selection{ProviderID: "openai", ModelID: ""}, nil
+		},
+	}
+	if err := defaultUseCommandRunner(cmd, svc, "openai", useCommandOptions{Model: "gpt-4o"}); err != nil {
+		t.Fatalf("defaultUseCommandRunner(with model) error = %v", err)
+	}
+	if !strings.Contains(output.String(), "gpt-4o") {
+		t.Fatalf("output = %q, want fallback model id", output.String())
+	}
+}
+
+func TestUseCommandExecuteWithoutModelInvokesRunner(t *testing.T) {
+	svc := &mockSelectionService{}
+	cmd := newUseCommandWithResolver(staticSelectionResolver(svc))
+
+	originalRunner := runUseCommand
+	t.Cleanup(func() { runUseCommand = originalRunner })
+
+	called := false
+	runUseCommand = func(c *cobra.Command, gotSvc SelectionService, name string, opts useCommandOptions) error {
+		called = true
+		if gotSvc != svc {
+			t.Fatalf("injected service mismatch")
+		}
+		if name != "only-provider" {
+			t.Fatalf("name = %q, want only-provider", name)
+		}
+		if opts.Model != "" {
+			t.Fatalf("opts.Model = %q, want empty", opts.Model)
+		}
+		return errors.New("mock error")
+	}
+
+	cmd.SetArgs([]string{"only-provider"})
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "mock error") {
+		t.Fatalf("err = %v, want mock error", err)
+	}
+	if !called {
+		t.Fatal("expected runUseCommand called")
+	}
+}
+
+func TestUseCommandResolverErrorAndWhitespaceModel(t *testing.T) {
+	t.Run("resolver returns error", func(t *testing.T) {
+		cmd := newUseCommandWithResolver(selectionServiceResolverFunc(func(*cobra.Command) (SelectionService, error) {
+			return nil, errors.New("resolve failed")
+		}))
+		cmd.SetArgs([]string{"openai"})
+		err := cmd.ExecuteContext(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "resolve failed") {
+			t.Fatalf("err = %v, want resolve failed", err)
+		}
+	})
+
+	t.Run("whitespace model falls back to SelectProvider", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetContext(context.Background())
+
+		selectProviderCalled := false
+		svc := &mockSelectionService{
+			selectProviderFn: func(_ context.Context, providerName string) (configstate.Selection, error) {
+				selectProviderCalled = true
+				return configstate.Selection{ProviderID: providerName}, nil
+			},
+		}
+		err := defaultUseCommandRunner(cmd, svc, "openai", useCommandOptions{Model: "   "})
+		if err != nil {
+			t.Fatalf("defaultUseCommandRunner() error = %v", err)
+		}
+		if !selectProviderCalled {
+			t.Fatal("expected SelectProvider path to be called")
+		}
+	})
 }

--- a/internal/config/state/coverage_gaps_test.go
+++ b/internal/config/state/coverage_gaps_test.go
@@ -1,0 +1,91 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	configpkg "neo-code/internal/config"
+	"neo-code/internal/provider"
+	providertypes "neo-code/internal/provider/types"
+)
+
+func TestStateCoverageGapSelectAndSetBranches(t *testing.T) {
+	manager := newSelectionTestManager(t, testDefaultConfig())
+	service := NewService(manager, newDriverSupporterStub(), newCatalogStub())
+
+	if _, err := service.SelectProvider(context.Background(), OpenAIName); err != nil {
+		t.Fatalf("SelectProvider() error = %v", err)
+	}
+	if _, err := service.SelectProviderWithModel(context.Background(), OpenAIName, OpenAIDefaultModel); err != nil {
+		t.Fatalf("SelectProviderWithModel() error = %v", err)
+	}
+	if _, err := service.selectProviderUnlocked(context.Background(), OpenAIName); err != nil {
+		t.Fatalf("selectProviderUnlocked() error = %v", err)
+	}
+	if _, err := service.setCurrentModelUnlocked(context.Background(), OpenAIDefaultModel); err != nil {
+		t.Fatalf("setCurrentModelUnlocked() error = %v", err)
+	}
+}
+
+func TestStateCoverageGapRemoveCustomProviderContextAndEnvBranches(t *testing.T) {
+	manager := newSelectionTestManager(t, testDefaultConfig())
+	service := NewService(manager, newDriverSupporterStub(), catalogMethodsStub{
+		listModels: []providertypes.ModelDescriptor{{ID: OpenAIDefaultModel, Name: OpenAIDefaultModel}},
+	})
+
+	const providerName = "coverage-removable-provider"
+	const apiKeyEnv = "COVERAGE_REMOVABLE_KEY"
+	if err := configpkg.SaveCustomProviderWithModels(manager.BaseDir(), configpkg.SaveCustomProviderInput{
+		Name:                  providerName,
+		Driver:                provider.DriverOpenAICompat,
+		BaseURL:               "https://llm.example.com/v1",
+		APIKeyEnv:             apiKeyEnv,
+		ModelSource:           configpkg.ModelSourceDiscover,
+		DiscoveryEndpointPath: provider.DiscoveryEndpointPathModels,
+	}); err != nil {
+		t.Fatalf("SaveCustomProviderWithModels() error = %v", err)
+	}
+	if _, err := manager.Load(context.Background()); err != nil {
+		t.Fatalf("manager.Load() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := service.RemoveCustomProvider(ctx, providerName); !errors.Is(err, context.Canceled) {
+		t.Fatalf("RemoveCustomProvider(canceled) err = %v, want context.Canceled", err)
+	}
+
+	originalDelete := deleteUserEnvVarForCreate
+	t.Cleanup(func() { deleteUserEnvVarForCreate = originalDelete })
+	called := false
+	deleteUserEnvVarForCreate = func(name string) error {
+		called = true
+		if name != apiKeyEnv {
+			t.Fatalf("delete env name = %q, want %q", name, apiKeyEnv)
+		}
+		return nil
+	}
+
+	if err := service.RemoveCustomProvider(context.Background(), providerName); err != nil {
+		t.Fatalf("RemoveCustomProvider() error = %v", err)
+	}
+	if !called {
+		t.Fatal("expected deleteUserEnvVarForCreate to be called")
+	}
+}
+
+func TestStateCoverageGapNormalizeCreateInputEntry(t *testing.T) {
+	_, err := normalizeCreateCustomProviderInput(CreateCustomProviderInput{
+		Name:                  "cov-provider",
+		Driver:                provider.DriverOpenAICompat,
+		BaseURL:               "https://llm.example.com/v1",
+		APIKeyEnv:             "COV_PROVIDER_KEY",
+		APIKey:                "sk-test",
+		ModelSource:           configpkg.ModelSourceDiscover,
+		DiscoveryEndpointPath: provider.DiscoveryEndpointPathModels,
+	})
+	if err != nil {
+		t.Fatalf("normalizeCreateCustomProviderInput() error = %v", err)
+	}
+}

--- a/internal/config/state/model.go
+++ b/internal/config/state/model.go
@@ -21,6 +21,8 @@ type Selection struct {
 type ProviderOption struct {
 	ID     string                          `json:"id"`
 	Name   string                          `json:"name"`
+	Driver string                          `json:"driver,omitempty"`
+	Source string                          `json:"source,omitempty"`
 	Models []providertypes.ModelDescriptor `json:"models,omitempty"`
 }
 
@@ -81,6 +83,8 @@ func providerOption(cfg config.ProviderConfig, models []providertypes.ModelDescr
 	return ProviderOption{
 		ID:     strings.TrimSpace(cfg.Name),
 		Name:   strings.TrimSpace(cfg.Name),
+		Driver: strings.TrimSpace(cfg.Driver),
+		Source: strings.TrimSpace(string(cfg.Source)),
 		Models: providertypes.MergeModelDescriptors(models),
 	}
 }

--- a/internal/config/state/service.go
+++ b/internal/config/state/service.go
@@ -3,6 +3,7 @@ package state
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"neo-code/internal/config"
@@ -93,7 +94,14 @@ func (s *Service) SelectProviderWithModel(ctx context.Context, providerName stri
 	if _, err := s.selectProviderUnlocked(ctx, providerName); err != nil {
 		return Selection{}, err
 	}
-	return s.setCurrentModelUnlocked(ctx, modelID)
+	selection, err := s.setCurrentModelUnlocked(ctx, modelID)
+	if err != nil {
+		if errors.Is(err, ErrProviderNotFound) {
+			return Selection{}, fmt.Errorf("selection: provider %q was removed during selection: %w", providerName, err)
+		}
+		return Selection{}, err
+	}
+	return selection, nil
 }
 
 // selectProviderUnlocked 在调用方已完成锁控制时执行 provider 切换核心逻辑。

--- a/internal/config/state/service.go
+++ b/internal/config/state/service.go
@@ -63,7 +63,41 @@ func (s *Service) SelectProvider(ctx context.Context, providerName string) (Sele
 	if err := s.validate(); err != nil {
 		return Selection{}, err
 	}
+	if err := ctx.Err(); err != nil {
+		return Selection{}, err
+	}
 
+	release := s.manager.AcquireProviderCreateLock()
+	defer release()
+
+	return s.selectProviderUnlocked(ctx, providerName)
+}
+
+// SelectProviderWithModel 在同一临界区内完成 provider 切换与模型覆盖，避免两次写入之间被并发插入。
+func (s *Service) SelectProviderWithModel(ctx context.Context, providerName string, modelID string) (Selection, error) {
+	if err := s.validate(); err != nil {
+		return Selection{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return Selection{}, err
+	}
+
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return Selection{}, ErrModelNotFound
+	}
+
+	release := s.manager.AcquireProviderCreateLock()
+	defer release()
+
+	if _, err := s.selectProviderUnlocked(ctx, providerName); err != nil {
+		return Selection{}, err
+	}
+	return s.setCurrentModelUnlocked(ctx, modelID)
+}
+
+// selectProviderUnlocked 在调用方已完成锁控制时执行 provider 切换核心逻辑。
+func (s *Service) selectProviderUnlocked(ctx context.Context, providerName string) (Selection, error) {
 	cfgSnapshot := s.manager.Get()
 	providerCfg, err := cfgSnapshot.ProviderByName(providerName)
 	if err != nil {
@@ -80,6 +114,13 @@ func (s *Service) SelectProvider(ctx context.Context, providerName string) (Sele
 	var models []providertypes.ModelDescriptor
 	if providerCfg.Source == config.ProviderSourceCustom {
 		models, err = s.catalogs.ListProviderModels(ctx, input)
+		if err != nil {
+			snapshotModels, snapshotErr := s.catalogs.ListProviderModelsSnapshot(ctx, input)
+			if snapshotErr != nil {
+				return Selection{}, err
+			}
+			models = snapshotModels
+		}
 	} else {
 		models, err = s.catalogs.ListProviderModelsSnapshot(ctx, input)
 		if len(models) == 0 {
@@ -216,7 +257,18 @@ func (s *Service) SetCurrentModel(ctx context.Context, modelID string) (Selectio
 	if err := s.validate(); err != nil {
 		return Selection{}, err
 	}
+	if err := ctx.Err(); err != nil {
+		return Selection{}, err
+	}
 
+	release := s.manager.AcquireProviderCreateLock()
+	defer release()
+
+	return s.setCurrentModelUnlocked(ctx, modelID)
+}
+
+// setCurrentModelUnlocked 在调用方已完成锁控制时执行模型校验与持久化。
+func (s *Service) setCurrentModelUnlocked(ctx context.Context, modelID string) (Selection, error) {
 	modelID = strings.TrimSpace(modelID)
 	if modelID == "" {
 		return Selection{}, ErrModelNotFound

--- a/internal/config/state/service.go
+++ b/internal/config/state/service.go
@@ -236,7 +236,11 @@ func (s *Service) SetCurrentModel(ctx context.Context, modelID string) (Selectio
 	}
 	models, err := s.catalogs.ListProviderModels(ctx, input)
 	if err != nil {
-		return Selection{}, err
+		snapshotModels, snapshotErr := s.catalogs.ListProviderModelsSnapshot(ctx, input)
+		if snapshotErr != nil {
+			return Selection{}, err
+		}
+		models = snapshotModels
 	}
 	if len(models) == 0 {
 		return Selection{}, ErrNoModelsAvailable

--- a/internal/config/state/service_provider_create.go
+++ b/internal/config/state/service_provider_create.go
@@ -169,6 +169,7 @@ func (s *Service) CreateCustomProvider(ctx context.Context, input CreateCustomPr
 }
 
 // RemoveCustomProvider 删除指定的自定义 provider，并在必要时修复当前选中项。
+//
 //go:noinline
 func (s *Service) RemoveCustomProvider(ctx context.Context, name string) error {
 	if err := s.validate(); err != nil {
@@ -211,9 +212,10 @@ func (s *Service) RemoveCustomProvider(ctx context.Context, name string) error {
 		return err
 	}
 
+	var envCleanupErr error
 	if apiKeyEnv != "" {
 		if envErr := deleteUserEnvVarForCreate(apiKeyEnv); envErr != nil {
-			return fmt.Errorf("selection: remove provider env: %w", envErr)
+			envCleanupErr = fmt.Errorf("selection: remove provider env: %w", envErr)
 		}
 	}
 
@@ -230,14 +232,21 @@ func (s *Service) RemoveCustomProvider(ctx context.Context, name string) error {
 	}
 
 	if _, err := s.manager.Load(ctx); err != nil {
+		if envCleanupErr != nil {
+			return errors.Join(envCleanupErr, err)
+		}
 		return err
 	}
 
 	if wasSelected {
-		_, err := s.EnsureSelection(ctx)
-		return err
+		if _, err := s.EnsureSelection(ctx); err != nil {
+			if envCleanupErr != nil {
+				return errors.Join(envCleanupErr, err)
+			}
+			return err
+		}
 	}
-	return nil
+	return envCleanupErr
 }
 
 // normalizeCreateCustomProviderInput 统一裁剪新增 Provider 输入并执行基础字段校验。

--- a/internal/config/state/service_provider_create.go
+++ b/internal/config/state/service_provider_create.go
@@ -201,11 +201,19 @@ func (s *Service) RemoveCustomProvider(ctx context.Context, name string) error {
 		return nil
 	}
 	if providerCfg.Source != config.ProviderSourceCustom {
-		return nil
+		return fmt.Errorf("selection: provider %q is builtin and cannot be removed", providerName)
 	}
+
+	apiKeyEnv := strings.TrimSpace(providerCfg.APIKeyEnv)
 
 	if err := config.DeleteCustomProvider(s.manager.BaseDir(), providerName); err != nil {
 		return err
+	}
+
+	if apiKeyEnv != "" {
+		if envErr := deleteUserEnvVarForCreate(apiKeyEnv); envErr != nil {
+			return fmt.Errorf("selection: remove provider env: %w", envErr)
+		}
 	}
 
 	if wasSelected {

--- a/internal/config/state/service_provider_create.go
+++ b/internal/config/state/service_provider_create.go
@@ -169,6 +169,7 @@ func (s *Service) CreateCustomProvider(ctx context.Context, input CreateCustomPr
 }
 
 // RemoveCustomProvider 删除指定的自定义 provider，并在必要时修复当前选中项。
+//go:noinline
 func (s *Service) RemoveCustomProvider(ctx context.Context, name string) error {
 	if err := s.validate(); err != nil {
 		return err

--- a/internal/config/state/service_provider_create.go
+++ b/internal/config/state/service_provider_create.go
@@ -26,7 +26,7 @@ const providerCreateRollbackReloadTimeout = 3 * time.Second
 const providerCreateCrossProcessLockName = ".provider-create.lock"
 const providerCreateCrossProcessLockLeaseName = ".lease"
 const providerCreateCrossProcessLockRetryInterval = 50 * time.Millisecond
-const providerCreateCrossProcessLockStaleThreshold = 30 * time.Second
+const providerCreateCrossProcessLockStaleThreshold = 60 * time.Second
 const providerCreateCrossProcessLockHeartbeatInterval = 2 * time.Second
 
 // CreateCustomProviderInput 定义新增自定义 Provider 所需的输入参数。
@@ -160,12 +160,75 @@ func (s *Service) CreateCustomProvider(ctx context.Context, input CreateCustomPr
 		return Selection{}, rollback(fmt.Errorf("selection: reload config snapshot: %w", err))
 	}
 
-	selection, err := s.SelectProvider(ctx, normalized.Name)
+	selection, err := s.selectProviderUnlocked(ctx, normalized.Name)
 	if err != nil {
 		return Selection{}, rollback(fmt.Errorf("selection: select provider: %w", err))
 	}
 
 	return selection, nil
+}
+
+// RemoveCustomProvider 删除指定的自定义 provider，并在必要时修复当前选中项。
+func (s *Service) RemoveCustomProvider(ctx context.Context, name string) error {
+	if err := s.validate(); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	providerName := strings.TrimSpace(name)
+	if providerName == "" {
+		return ErrProviderNotFound
+	}
+	if err := config.ValidateCustomProviderName(providerName); err != nil {
+		return err
+	}
+
+	releaseProviderLock := s.manager.AcquireProviderCreateLock()
+	defer releaseProviderLock()
+
+	releaseCrossProcessLock, err := lockProviderCreateCrossProcess(ctx, s.manager.BaseDir())
+	if err != nil {
+		return err
+	}
+	defer releaseCrossProcessLock()
+
+	cfgSnapshot := s.manager.Get()
+	wasSelected := strings.EqualFold(strings.TrimSpace(cfgSnapshot.SelectedProvider), providerName)
+	providerCfg, err := cfgSnapshot.ProviderByName(providerName)
+	if err != nil {
+		return nil
+	}
+	if providerCfg.Source != config.ProviderSourceCustom {
+		return nil
+	}
+
+	if err := config.DeleteCustomProvider(s.manager.BaseDir(), providerName); err != nil {
+		return err
+	}
+
+	if wasSelected {
+		if err := s.manager.Update(ctx, func(cfg *config.Config) error {
+			if strings.EqualFold(strings.TrimSpace(cfg.SelectedProvider), providerName) {
+				cfg.SelectedProvider = ""
+				cfg.CurrentModel = ""
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+
+	if _, err := s.manager.Load(ctx); err != nil {
+		return err
+	}
+
+	if wasSelected {
+		_, err := s.EnsureSelection(ctx)
+		return err
+	}
+	return nil
 }
 
 // normalizeCreateCustomProviderInput 统一裁剪新增 Provider 输入并执行基础字段校验。

--- a/internal/config/state/service_provider_create_test.go
+++ b/internal/config/state/service_provider_create_test.go
@@ -895,6 +895,60 @@ func TestRemoveCustomProviderEnvDeleteFailure(t *testing.T) {
 	}
 }
 
+func TestRemoveCustomProviderEnvDeleteFailureStillRepairsSelection(t *testing.T) {
+	restorePersist, restoreDelete, restoreLookup, restoreSaveWithModels := stubUserEnvOpsForCreateProvider(t)
+	defer restorePersist()
+	defer restoreDelete()
+	defer restoreLookup()
+	defer restoreSaveWithModels()
+
+	manager := newSelectionTestManager(t, testDefaultConfig())
+	service := NewService(manager, newDriverSupporterStub(), newCatalogStub())
+
+	const providerName = "env-delete-failed-selected-provider"
+	if err := configpkg.SaveCustomProviderWithModels(manager.BaseDir(), configpkg.SaveCustomProviderInput{
+		Name:                  providerName,
+		Driver:                provider.DriverOpenAICompat,
+		BaseURL:               "https://llm.example.com/v1",
+		APIKeyEnv:             "ENV_DELETE_FAILED_SELECTED_PROVIDER_API_KEY",
+		ModelSource:           configpkg.ModelSourceDiscover,
+		DiscoveryEndpointPath: provider.DiscoveryEndpointPathModels,
+	}); err != nil {
+		t.Fatalf("SaveCustomProviderWithModels() error = %v", err)
+	}
+	if _, err := manager.Load(context.Background()); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if err := manager.Update(context.Background(), func(cfg *configpkg.Config) error {
+		cfg.SelectedProvider = providerName
+		cfg.CurrentModel = "custom-model"
+		return nil
+	}); err != nil {
+		t.Fatalf("seed selected provider: %v", err)
+	}
+
+	deleteUserEnvVarForCreate = func(string) error { return errors.New("delete env failed") }
+	err := service.RemoveCustomProvider(context.Background(), providerName)
+	if err == nil || !strings.Contains(err.Error(), "remove provider env") {
+		t.Fatalf("err = %v, want remove provider env", err)
+	}
+
+	cfg := manager.Get()
+	if strings.EqualFold(strings.TrimSpace(cfg.SelectedProvider), providerName) {
+		t.Fatalf("selected provider still points to removed provider %q", providerName)
+	}
+	if strings.TrimSpace(cfg.SelectedProvider) == "" {
+		t.Fatalf("selected provider should be repaired to a valid provider, got empty")
+	}
+	if _, providerErr := cfg.ProviderByName(cfg.SelectedProvider); providerErr != nil {
+		t.Fatalf("selected provider %q is invalid: %v", cfg.SelectedProvider, providerErr)
+	}
+	removedConfigPath := filepath.Join(manager.BaseDir(), "providers", providerName, "provider.yaml")
+	if _, statErr := os.Stat(removedConfigPath); !os.IsNotExist(statErr) {
+		t.Fatalf("provider config should be removed, stat err = %v", statErr)
+	}
+}
+
 func TestRemoveCustomProviderSelectedEnsureSelectionFailure(t *testing.T) {
 	restorePersist, restoreDelete, restoreLookup, restoreSaveWithModels := stubUserEnvOpsForCreateProvider(t)
 	defer restorePersist()

--- a/internal/config/state/service_provider_create_test.go
+++ b/internal/config/state/service_provider_create_test.go
@@ -67,6 +67,57 @@ func TestCreateCustomProviderSuccess(t *testing.T) {
 	}
 }
 
+func TestRemoveCustomProviderSelectedProvider(t *testing.T) {
+	manager := newSelectionTestManager(t, testDefaultConfig())
+	service := NewService(manager, newDriverSupporterStub(), newCatalogStub())
+
+	const providerName = "removable-provider"
+	if err := configpkg.SaveCustomProviderWithModels(manager.BaseDir(), configpkg.SaveCustomProviderInput{
+		Name:                  providerName,
+		Driver:                provider.DriverOpenAICompat,
+		BaseURL:               "https://llm.example.com/v1",
+		APIKeyEnv:             "REMOVABLE_PROVIDER_KEY",
+		ModelSource:           configpkg.ModelSourceDiscover,
+		DiscoveryEndpointPath: provider.DiscoveryEndpointPathModels,
+	}); err != nil {
+		t.Fatalf("SaveCustomProviderWithModels() error = %v", err)
+	}
+	if _, err := manager.Load(context.Background()); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if err := manager.Update(context.Background(), func(cfg *configpkg.Config) error {
+		cfg.SelectedProvider = providerName
+		cfg.CurrentModel = "custom-model"
+		return nil
+	}); err != nil {
+		t.Fatalf("seed selected custom provider: %v", err)
+	}
+
+	if err := service.RemoveCustomProvider(context.Background(), providerName); err != nil {
+		t.Fatalf("RemoveCustomProvider() error = %v", err)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(manager.BaseDir(), "providers", providerName)); !os.IsNotExist(statErr) {
+		t.Fatalf("expected provider dir removed, stat err = %v", statErr)
+	}
+	cfg := manager.Get()
+	if strings.EqualFold(strings.TrimSpace(cfg.SelectedProvider), providerName) {
+		t.Fatalf("expected selected provider repaired after removal, got %q", cfg.SelectedProvider)
+	}
+}
+
+func TestRemoveCustomProviderNoopCases(t *testing.T) {
+	manager := newSelectionTestManager(t, testDefaultConfig())
+	service := NewService(manager, newDriverSupporterStub(), newCatalogStub())
+
+	if err := service.RemoveCustomProvider(context.Background(), "missing-provider"); err != nil {
+		t.Fatalf("expected missing provider remove to be noop, got %v", err)
+	}
+	if err := service.RemoveCustomProvider(context.Background(), configpkg.OpenAIName); err != nil {
+		t.Fatalf("expected builtin provider remove to be noop, got %v", err)
+	}
+}
+
 func TestCreateCustomProviderPreservesExplicitCustomChatEndpoint(t *testing.T) {
 	restorePersist, restoreDelete, restoreLookup, restoreSaveWithModels := stubUserEnvOpsForCreateProvider(t)
 	defer restorePersist()

--- a/internal/config/state/service_provider_create_test.go
+++ b/internal/config/state/service_provider_create_test.go
@@ -829,6 +829,191 @@ func TestTryReclaimStaleProviderCreateLockKeepsActiveLeaseWhenDirIsOld(t *testin
 	}
 }
 
+func TestRemoveCustomProviderValidationBranches(t *testing.T) {
+	restorePersist, restoreDelete, restoreLookup, restoreSaveWithModels := stubUserEnvOpsForCreateProvider(t)
+	defer restorePersist()
+	defer restoreDelete()
+	defer restoreLookup()
+	defer restoreSaveWithModels()
+
+	manager := newSelectionTestManager(t, testDefaultConfig())
+	service := NewService(manager, newDriverSupporterStub(), newCatalogStub())
+
+	t.Run("context canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := service.RemoveCustomProvider(ctx, "custom")
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+	})
+
+	t.Run("empty provider name", func(t *testing.T) {
+		err := service.RemoveCustomProvider(context.Background(), "   ")
+		if !errors.Is(err, ErrProviderNotFound) {
+			t.Fatalf("err = %v, want ErrProviderNotFound", err)
+		}
+	})
+
+	t.Run("invalid provider name", func(t *testing.T) {
+		err := service.RemoveCustomProvider(context.Background(), "../bad")
+		if err == nil {
+			t.Fatal("expected invalid provider name error")
+		}
+	})
+}
+
+func TestRemoveCustomProviderEnvDeleteFailure(t *testing.T) {
+	restorePersist, restoreDelete, restoreLookup, restoreSaveWithModels := stubUserEnvOpsForCreateProvider(t)
+	defer restorePersist()
+	defer restoreDelete()
+	defer restoreLookup()
+	defer restoreSaveWithModels()
+
+	manager := newSelectionTestManager(t, testDefaultConfig())
+	service := NewService(manager, newDriverSupporterStub(), newCatalogStub())
+
+	const providerName = "env-delete-failed-provider"
+	if err := configpkg.SaveCustomProviderWithModels(manager.BaseDir(), configpkg.SaveCustomProviderInput{
+		Name:                  providerName,
+		Driver:                provider.DriverOpenAICompat,
+		BaseURL:               "https://llm.example.com/v1",
+		APIKeyEnv:             "ENV_DELETE_FAILED_PROVIDER_API_KEY",
+		ModelSource:           configpkg.ModelSourceDiscover,
+		DiscoveryEndpointPath: provider.DiscoveryEndpointPathModels,
+	}); err != nil {
+		t.Fatalf("SaveCustomProviderWithModels() error = %v", err)
+	}
+	if _, err := manager.Load(context.Background()); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	deleteUserEnvVarForCreate = func(string) error { return errors.New("delete env failed") }
+	err := service.RemoveCustomProvider(context.Background(), providerName)
+	if err == nil || !strings.Contains(err.Error(), "remove provider env") {
+		t.Fatalf("err = %v, want remove provider env", err)
+	}
+}
+
+func TestRemoveCustomProviderSelectedEnsureSelectionFailure(t *testing.T) {
+	restorePersist, restoreDelete, restoreLookup, restoreSaveWithModels := stubUserEnvOpsForCreateProvider(t)
+	defer restorePersist()
+	defer restoreDelete()
+	defer restoreLookup()
+	defer restoreSaveWithModels()
+
+	defaults := testDefaultConfig()
+	manager := newSelectionTestManager(t, defaults)
+	supporters := &selectiveDriverSupporter{supported: map[string]bool{"anthropic": true}}
+	service := NewService(manager, supporters, newCatalogStub())
+
+	const providerName = "selected-provider-for-failed-ensure"
+	if err := configpkg.SaveCustomProviderWithModels(manager.BaseDir(), configpkg.SaveCustomProviderInput{
+		Name:                  providerName,
+		Driver:                provider.DriverOpenAICompat,
+		BaseURL:               "https://llm.example.com/v1",
+		APIKeyEnv:             "FAILED_ENSURE_SELECTION_API_KEY",
+		ModelSource:           configpkg.ModelSourceDiscover,
+		DiscoveryEndpointPath: provider.DiscoveryEndpointPathModels,
+	}); err != nil {
+		t.Fatalf("SaveCustomProviderWithModels() error = %v", err)
+	}
+	if _, err := manager.Load(context.Background()); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if err := manager.Update(context.Background(), func(cfg *configpkg.Config) error {
+		cfg.SelectedProvider = providerName
+		cfg.CurrentModel = "custom-model"
+		return nil
+	}); err != nil {
+		t.Fatalf("seed selected provider: %v", err)
+	}
+
+	err := service.RemoveCustomProvider(context.Background(), providerName)
+	if !errors.Is(err, ErrProviderNotFound) {
+		t.Fatalf("err = %v, want ErrProviderNotFound", err)
+	}
+}
+
+func TestRemoveCustomProviderContextCancellationDuringUpdate(t *testing.T) {
+	restorePersist, restoreDelete, restoreLookup, restoreSaveWithModels := stubUserEnvOpsForCreateProvider(t)
+	defer restorePersist()
+	defer restoreDelete()
+	defer restoreLookup()
+	defer restoreSaveWithModels()
+
+	manager := newSelectionTestManager(t, testDefaultConfig())
+	service := NewService(manager, newDriverSupporterStub(), newCatalogStub())
+
+	const providerName = "cancel-during-update-provider"
+	if err := configpkg.SaveCustomProviderWithModels(manager.BaseDir(), configpkg.SaveCustomProviderInput{
+		Name:                  providerName,
+		Driver:                provider.DriverOpenAICompat,
+		BaseURL:               "https://llm.example.com/v1",
+		APIKeyEnv:             "CANCEL_DURING_UPDATE_PROVIDER_API_KEY",
+		ModelSource:           configpkg.ModelSourceDiscover,
+		DiscoveryEndpointPath: provider.DiscoveryEndpointPathModels,
+	}); err != nil {
+		t.Fatalf("SaveCustomProviderWithModels() error = %v", err)
+	}
+	if _, err := manager.Load(context.Background()); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if err := manager.Update(context.Background(), func(cfg *configpkg.Config) error {
+		cfg.SelectedProvider = providerName
+		cfg.CurrentModel = "custom-model"
+		return nil
+	}); err != nil {
+		t.Fatalf("seed selected provider: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	deleteUserEnvVarForCreate = func(string) error {
+		cancel()
+		return nil
+	}
+	err := service.RemoveCustomProvider(ctx, providerName)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
+func TestRemoveCustomProviderContextCancellationBeforeReload(t *testing.T) {
+	restorePersist, restoreDelete, restoreLookup, restoreSaveWithModels := stubUserEnvOpsForCreateProvider(t)
+	defer restorePersist()
+	defer restoreDelete()
+	defer restoreLookup()
+	defer restoreSaveWithModels()
+
+	manager := newSelectionTestManager(t, testDefaultConfig())
+	service := NewService(manager, newDriverSupporterStub(), newCatalogStub())
+
+	const providerName = "cancel-before-reload-provider"
+	if err := configpkg.SaveCustomProviderWithModels(manager.BaseDir(), configpkg.SaveCustomProviderInput{
+		Name:                  providerName,
+		Driver:                provider.DriverOpenAICompat,
+		BaseURL:               "https://llm.example.com/v1",
+		APIKeyEnv:             "CANCEL_BEFORE_RELOAD_PROVIDER_API_KEY",
+		ModelSource:           configpkg.ModelSourceDiscover,
+		DiscoveryEndpointPath: provider.DiscoveryEndpointPathModels,
+	}); err != nil {
+		t.Fatalf("SaveCustomProviderWithModels() error = %v", err)
+	}
+	if _, err := manager.Load(context.Background()); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	deleteUserEnvVarForCreate = func(string) error {
+		cancel()
+		return nil
+	}
+	err := service.RemoveCustomProvider(ctx, providerName)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
 func captureEnvForCreateProvider(t *testing.T, key string) func() {
 	t.Helper()
 

--- a/internal/config/state/service_provider_create_test.go
+++ b/internal/config/state/service_provider_create_test.go
@@ -113,8 +113,8 @@ func TestRemoveCustomProviderNoopCases(t *testing.T) {
 	if err := service.RemoveCustomProvider(context.Background(), "missing-provider"); err != nil {
 		t.Fatalf("expected missing provider remove to be noop, got %v", err)
 	}
-	if err := service.RemoveCustomProvider(context.Background(), configpkg.OpenAIName); err != nil {
-		t.Fatalf("expected builtin provider remove to be noop, got %v", err)
+	if err := service.RemoveCustomProvider(context.Background(), configpkg.OpenAIName); err == nil {
+		t.Fatal("expected builtin provider remove to fail with error")
 	}
 }
 

--- a/internal/config/state/service_test.go
+++ b/internal/config/state/service_test.go
@@ -279,6 +279,41 @@ func TestSelectionServiceSelectProviderAndSetCurrentModel(t *testing.T) {
 	}
 }
 
+func TestSelectionServiceSelectProviderWithModel(t *testing.T) {
+	t.Parallel()
+
+	manager := newSelectionTestManager(t, testDefaultConfig())
+	service := NewService(manager, newDriverSupporterStub(), newCatalogStub())
+
+	selection, err := service.SelectProviderWithModel(context.Background(), QiniuName, QiniuDefaultModel+"-alt")
+	if err != nil {
+		t.Fatalf("SelectProviderWithModel() error = %v", err)
+	}
+	if selection.ProviderID != QiniuName || selection.ModelID != QiniuDefaultModel+"-alt" {
+		t.Fatalf("unexpected selection after atomic switch: %+v", selection)
+	}
+
+	cfg := manager.Get()
+	if cfg.SelectedProvider != QiniuName {
+		t.Fatalf("expected selected provider %q, got %q", QiniuName, cfg.SelectedProvider)
+	}
+	if cfg.CurrentModel != QiniuDefaultModel+"-alt" {
+		t.Fatalf("expected selected model %q, got %q", QiniuDefaultModel+"-alt", cfg.CurrentModel)
+	}
+}
+
+func TestSelectionServiceSelectProviderWithModelEmptyModel(t *testing.T) {
+	t.Parallel()
+
+	manager := newSelectionTestManager(t, testDefaultConfig())
+	service := NewService(manager, newDriverSupporterStub(), newCatalogStub())
+
+	_, err := service.SelectProviderWithModel(context.Background(), QiniuName, "   ")
+	if !errors.Is(err, ErrModelNotFound) {
+		t.Fatalf("expected ErrModelNotFound, got %v", err)
+	}
+}
+
 func TestSelectionServiceSetCurrentModelRejectsUnsupportedDriver(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/state/service_test.go
+++ b/internal/config/state/service_test.go
@@ -1202,6 +1202,117 @@ func TestResolveCurrentModelHelper(t *testing.T) {
 
 // ---- 婵炴潙顑堥惁顖涙綇閸涱厼袠 ----
 
+func TestSelectionServiceSelectProviderWithModelWrapsProviderRemovedError(t *testing.T) {
+	t.Parallel()
+
+	manager := newSelectionTestManager(t, testDefaultConfig())
+	service := NewService(manager, newDriverSupporterStub(), &mutatingCatalog{
+		listModels: []providertypes.ModelDescriptor{
+			{ID: OpenAIDefaultModel, Name: OpenAIDefaultModel},
+		},
+		onList: func(ctx context.Context) error {
+			return manager.Update(ctx, func(cfg *configpkg.Config) error {
+				cfg.SelectedProvider = ""
+				cfg.CurrentModel = ""
+				return nil
+			})
+		},
+	})
+
+	_, err := service.SelectProviderWithModel(context.Background(), OpenAIName, OpenAIDefaultModel)
+	if err == nil || !strings.Contains(err.Error(), "was removed during selection") {
+		t.Fatalf("err = %v, want wrapped provider removed error", err)
+	}
+	if !errors.Is(err, ErrProviderNotFound) {
+		t.Fatalf("err = %v, want ErrProviderNotFound", err)
+	}
+}
+
+func TestSelectionServiceSelectProviderUnlockedBuiltinSnapshotFallback(t *testing.T) {
+	t.Parallel()
+
+	manager := newSelectionTestManager(t, testDefaultConfig())
+	service := NewService(manager, newDriverSupporterStub(), catalogMethodsStub{
+		snapshotModels: nil,
+	})
+
+	selection, err := service.selectProviderUnlocked(context.Background(), QiniuName)
+	if err != nil {
+		t.Fatalf("selectProviderUnlocked() error = %v", err)
+	}
+	if selection.ProviderID != QiniuName {
+		t.Fatalf("selection.ProviderID = %q, want %q", selection.ProviderID, QiniuName)
+	}
+	if selection.ModelID != QiniuDefaultModel {
+		t.Fatalf("selection.ModelID = %q, want %q", selection.ModelID, QiniuDefaultModel)
+	}
+}
+
+func TestSelectionServiceSetCurrentModelUnlockedTrimmedEmpty(t *testing.T) {
+	t.Parallel()
+
+	manager := newSelectionTestManager(t, testDefaultConfig())
+	service := NewService(manager, newDriverSupporterStub(), newCatalogStub())
+
+	_, err := service.setCurrentModelUnlocked(context.Background(), "   ")
+	if !errors.Is(err, ErrModelNotFound) {
+		t.Fatalf("expected ErrModelNotFound, got %v", err)
+	}
+}
+
+func TestSelectionServiceSelectProviderAndModelContextBranches(t *testing.T) {
+	t.Parallel()
+
+	manager := newSelectionTestManager(t, testDefaultConfig())
+	service := NewService(manager, newDriverSupporterStub(), newCatalogStub())
+
+	t.Run("SelectProviderWithModel context canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := service.SelectProviderWithModel(ctx, OpenAIName, OpenAIDefaultModel)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+	})
+
+	t.Run("SelectProvider success path", func(t *testing.T) {
+		selection, err := service.SelectProvider(context.Background(), OpenAIName)
+		if err != nil {
+			t.Fatalf("SelectProvider() error = %v", err)
+		}
+		if selection.ProviderID != OpenAIName {
+			t.Fatalf("selection.ProviderID = %q, want %q", selection.ProviderID, OpenAIName)
+		}
+	})
+
+	t.Run("SelectProviderWithModel empty model", func(t *testing.T) {
+		_, err := service.SelectProviderWithModel(context.Background(), OpenAIName, " ")
+		if !errors.Is(err, ErrModelNotFound) {
+			t.Fatalf("err = %v, want ErrModelNotFound", err)
+		}
+	})
+
+	t.Run("setCurrentModelUnlocked update validation drift", func(t *testing.T) {
+		driftManager := newSelectionTestManager(t, testDefaultConfig())
+		driftService := NewService(driftManager, newDriverSupporterStub(), &mutatingCatalog{
+			listModels: []providertypes.ModelDescriptor{
+				{ID: OpenAIDefaultModel, Name: OpenAIDefaultModel},
+			},
+			onList: func(ctx context.Context) error {
+				return driftManager.Update(ctx, func(cfg *configpkg.Config) error {
+					cfg.SelectedProvider = ""
+					cfg.CurrentModel = ""
+					return nil
+				})
+			},
+		})
+		_, err := driftService.setCurrentModelUnlocked(context.Background(), OpenAIDefaultModel)
+		if !errors.Is(err, ErrProviderNotFound) {
+			t.Fatalf("err = %v, want ErrProviderNotFound", err)
+		}
+	})
+}
+
 type driverSupporterAll struct{}
 
 func (*driverSupporterAll) Supports(_ string) bool { return true }

--- a/internal/ptyproxy/coverage_gaps_test.go
+++ b/internal/ptyproxy/coverage_gaps_test.go
@@ -1,0 +1,41 @@
+package ptyproxy
+
+import "testing"
+
+func TestPTYProxyCoverageGapBranches(t *testing.T) {
+	t.Run("command exemption verb branch", func(t *testing.T) {
+		if !isCommandExempted("   GrEp   keyword file.txt") {
+			t.Fatal("expected grep command to be exempted")
+		}
+	})
+
+	t.Run("fold carriage returns join branch", func(t *testing.T) {
+		got := foldCarriageReturns("old\rnew\nline")
+		if got != "new\nline" {
+			t.Fatalf("foldCarriageReturns() = %q, want %q", got, "new\nline")
+		}
+	})
+
+	t.Run("tmux inner osc payload branch", func(t *testing.T) {
+		parser := &OSC133Parser{}
+		raw := []byte("x\x1bPtmux;\x1b]133;C\a\x1b\\y")
+		clean, events := parser.Feed(raw)
+		if string(clean) != "xy" {
+			t.Fatalf("clean = %q, want %q", clean, "xy")
+		}
+		if len(events) != 1 || events[0].Type != ShellEventCommandStart {
+			t.Fatalf("events = %#v, want one command_start event", events)
+		}
+	})
+
+	t.Run("keep leftover truncates over max", func(t *testing.T) {
+		raw := make([]byte, maxOSCLeftover+128)
+		for i := range raw {
+			raw[i] = 'a'
+		}
+		kept := keepOSCLeftover(raw)
+		if len(kept) != maxOSCLeftover {
+			t.Fatalf("len(kept) = %d, want %d", len(kept), maxOSCLeftover)
+		}
+	})
+}

--- a/internal/ptyproxy/filter.go
+++ b/internal/ptyproxy/filter.go
@@ -1,0 +1,67 @@
+package ptyproxy
+
+import (
+	"strings"
+)
+
+var autoTriggerCommandExemptions = map[string]struct{}{
+	"grep":  {},
+	"find":  {},
+	"test":  {},
+	"false": {},
+}
+
+// ShouldTriggerAutoDiagnosis 根据退出码、命令词和输出质量判断是否应进入自动诊断。
+func ShouldTriggerAutoDiagnosis(exitCode int, commandText string, outputText string) bool {
+	if exitCode == 0 {
+		return false
+	}
+	if exitCode == 130 || exitCode == 137 {
+		return false
+	}
+	if isCommandExempted(commandText) {
+		return false
+	}
+	return hasMeaningfulOutput(outputText)
+}
+
+// isCommandExempted 判断命令首词是否处于本地豁免名单。
+func isCommandExempted(commandText string) bool {
+	trimmed := strings.TrimSpace(commandText)
+	if trimmed == "" {
+		return false
+	}
+	fields := strings.Fields(trimmed)
+	if len(fields) == 0 {
+		return false
+	}
+	verb := strings.ToLower(strings.TrimSpace(fields[0]))
+	_, exempted := autoTriggerCommandExemptions[verb]
+	return exempted
+}
+
+// hasMeaningfulOutput 判断输出是否包含足够有效的报错信息，避免空输出误触发。
+func hasMeaningfulOutput(outputText string) bool {
+	trimmed := strings.TrimSpace(outputText)
+	if len(trimmed) < 12 {
+		return false
+	}
+	lower := strings.ToLower(trimmed)
+	keywords := []string{
+		"error",
+		"failed",
+		"fatal",
+		"exception",
+		"denied",
+		"not found",
+		"no such file",
+		"timeout",
+	}
+	for _, keyword := range keywords {
+		if strings.Contains(lower, keyword) {
+			return true
+		}
+	}
+	// 关键字缺失时，只要输出长度足够大也认为有排查价值。
+	return len(lower) >= 48
+}

--- a/internal/ptyproxy/filter_test.go
+++ b/internal/ptyproxy/filter_test.go
@@ -1,0 +1,83 @@
+package ptyproxy
+
+import "testing"
+
+func TestShouldTriggerAutoDiagnosis(t *testing.T) {
+	tests := []struct {
+		name        string
+		exitCode    int
+		commandText string
+		outputText  string
+		want        bool
+	}{
+		{
+			name:       "success exit skipped",
+			exitCode:   0,
+			outputText: "fatal: file not found",
+			want:       false,
+		},
+		{
+			name:       "ctrl c skipped",
+			exitCode:   130,
+			outputText: "error timeout",
+			want:       false,
+		},
+		{
+			name:       "sigkill skipped",
+			exitCode:   137,
+			outputText: "killed",
+			want:       false,
+		},
+		{
+			name:        "command exemption grep",
+			exitCode:    1,
+			commandText: "grep foo file.txt",
+			outputText:  "foo not found",
+			want:        false,
+		},
+		{
+			name:        "command exemption find",
+			exitCode:    1,
+			commandText: "find . -name x",
+			outputText:  "find: nothing",
+			want:        false,
+		},
+		{
+			name:        "output too short skipped",
+			exitCode:    1,
+			commandText: "go test ./...",
+			outputText:  "failed",
+			want:        false,
+		},
+		{
+			name:        "keyword hit triggers",
+			exitCode:    2,
+			commandText: "go test ./...",
+			outputText:  "fatal: module not found in current directory",
+			want:        true,
+		},
+		{
+			name:        "long output without keyword still triggers",
+			exitCode:    1,
+			commandText: "make build",
+			outputText:  "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			want:        true,
+		},
+	}
+
+	for _, tc := range tests {
+		got := ShouldTriggerAutoDiagnosis(tc.exitCode, tc.commandText, tc.outputText)
+		if got != tc.want {
+			t.Fatalf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestIsCommandExempted(t *testing.T) {
+	if !isCommandExempted("  TEST foo  ") {
+		t.Fatal("TEST should be exempted")
+	}
+	if isCommandExempted("go test ./...") {
+		t.Fatal("go should not be exempted")
+	}
+}

--- a/internal/ptyproxy/filter_test.go
+++ b/internal/ptyproxy/filter_test.go
@@ -81,3 +81,15 @@ func TestIsCommandExempted(t *testing.T) {
 		t.Fatal("go should not be exempted")
 	}
 }
+
+func TestFilterHelperBranches(t *testing.T) {
+	if isCommandExempted("   ") {
+		t.Fatal("empty command should not be exempted")
+	}
+	if hasMeaningfulOutput("tiny") {
+		t.Fatal("short output should not be meaningful")
+	}
+	if !hasMeaningfulOutput("permission denied while opening file") {
+		t.Fatal("keyword-based output should be meaningful")
+	}
+}

--- a/internal/ptyproxy/ipc_protocol.go
+++ b/internal/ptyproxy/ipc_protocol.go
@@ -6,9 +6,10 @@ import (
 )
 
 const (
-	diagCommandDiagnose = "diagnose"
-	diagCommandAutoOn   = "auto_on"
-	diagCommandAutoOff  = "auto_off"
+	diagCommandDiagnose   = "diagnose"
+	diagCommandAutoOn     = "auto_on"
+	diagCommandAutoOff    = "auto_off"
+	diagCommandAutoStatus = "auto_status"
 )
 
 type diagIPCRequest struct {

--- a/internal/ptyproxy/ipc_protocol.go
+++ b/internal/ptyproxy/ipc_protocol.go
@@ -1,0 +1,28 @@
+package ptyproxy
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+const (
+	diagCommandDiagnose = "diagnose"
+	diagCommandAutoOn   = "auto_on"
+	diagCommandAutoOff  = "auto_off"
+)
+
+type diagIPCRequest struct {
+	Cmd     string          `json:"cmd"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+}
+
+type diagIPCResponse struct {
+	OK          bool   `json:"ok"`
+	Message     string `json:"message,omitempty"`
+	AutoEnabled bool   `json:"auto_enabled,omitempty"`
+}
+
+// normalizeDiagIPCCommand 归一化 IPC 指令名，避免大小写或空白导致分支漂移。
+func normalizeDiagIPCCommand(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
+}

--- a/internal/ptyproxy/proxy_unix.go
+++ b/internal/ptyproxy/proxy_unix.go
@@ -422,6 +422,15 @@ func SendAutoModeSignal(ctx context.Context, socketPath string, enabled bool) er
 	return err
 }
 
+// QueryAutoMode 查询当前代理 shell 的 Auto 诊断模式开关状态。
+func QueryAutoMode(ctx context.Context, socketPath string) (bool, error) {
+	response, err := sendDiagIPCCommand(ctx, socketPath, diagIPCRequest{Cmd: diagCommandAutoStatus})
+	if err != nil {
+		return false, err
+	}
+	return response.AutoEnabled, nil
+}
+
 // sendDiagIPCCommand 通过 JSON-Lines 发送控制命令，并在必要时回退到旧版 tmp socket。
 func sendDiagIPCCommand(ctx context.Context, socketPath string, request diagIPCRequest) (diagIPCResponse, error) {
 	primaryPath := filepath.Clean(strings.TrimSpace(socketPath))
@@ -668,6 +677,12 @@ func handleDiagSocketConnection(
 	case diagCommandAutoOff:
 		autoState.Enabled.Store(false)
 		writeDiagIPCResponse(connection, diagIPCResponse{OK: true, AutoEnabled: false, Message: "auto mode disabled"})
+	case diagCommandAutoStatus:
+		writeDiagIPCResponse(connection, diagIPCResponse{
+			OK:          true,
+			AutoEnabled: autoState.Enabled.Load(),
+			Message:     "auto mode status",
+		})
 	default:
 		writeDiagIPCResponse(connection, diagIPCResponse{OK: false, Message: "unsupported command"})
 	}

--- a/internal/ptyproxy/proxy_unix.go
+++ b/internal/ptyproxy/proxy_unix.go
@@ -202,7 +202,6 @@ func RunManualShell(ctx context.Context, options ManualShellOptions) error {
 		defer probeTimer.Stop()
 		<-probeTimer.C
 		if !autoState.OSCReady.Load() {
-			autoState.Enabled.Store(false)
 			writeProxyf(normalized.Stderr, "neocode shell: OSC133 probe timed out, fallback to manual mode\n")
 		}
 	}()
@@ -1020,7 +1019,6 @@ func streamPTYOutput(
 				switch event.Type {
 				case ShellEventPromptReady:
 					autoState.OSCReady.Store(true)
-					autoState.Enabled.Store(true)
 					if pendingTrigger != nil && autoState.Enabled.Load() {
 						select {
 						case autoTriggerCh <- *pendingTrigger:

--- a/internal/ptyproxy/proxy_unix.go
+++ b/internal/ptyproxy/proxy_unix.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	diagnoseCallTimeout    = 10 * time.Second
+	diagnoseCallTimeout    = 60 * time.Second
 	diagSocketReadDeadline = 3 * time.Second
 	autoProbeTimeout       = 1500 * time.Millisecond
 
@@ -122,7 +122,8 @@ func RunManualShell(ctx context.Context, options ManualShellOptions) error {
 		_ = restoreRawTerminal()
 	}()
 
-	command := buildShellCommand(shellPath, normalized, socketPath)
+	command, cleanupRC := buildShellCommand(shellPath, normalized, socketPath)
+	defer cleanupRC()
 	ptyFile, err := pty.Start(command)
 	if err != nil {
 		return fmt.Errorf("ptyproxy: start pty shell: %w", err)
@@ -143,6 +144,25 @@ func RunManualShell(ctx context.Context, options ManualShellOptions) error {
 	var outputMu sync.Mutex
 	synchronizedOutput := &serializedWriter{writer: normalized.Stdout, lock: &outputMu}
 	printProxyInitializedBanner(synchronizedOutput)
+	printWelcomeBanner(synchronizedOutput)
+
+	// 预建立 Gateway RPC 长连接：若 gateway 已运行则直接复用，否则自动拉起。
+	gwRPCClient, gwErr := gatewayclient.NewGatewayRPCClient(gatewayclient.GatewayRPCClientOptions{
+		ListenAddress: normalized.GatewayListenAddress,
+		TokenFile:     normalized.GatewayTokenFile,
+	})
+	if gwErr != nil {
+		writeProxyf(normalized.Stderr, "neocode shell: gateway client init failed: %v\n", gwErr)
+	} else {
+		authCtx, authCancel := context.WithTimeout(context.Background(), diagnoseCallTimeout)
+		if authErr := gwRPCClient.Authenticate(authCtx); authErr != nil {
+			writeProxyf(normalized.Stderr, "neocode shell: gateway auth failed: %v\n", authErr)
+		}
+		authCancel()
+	}
+	if gwRPCClient != nil {
+		defer gwRPCClient.Close()
+	}
 
 	logBuffer := NewUTF8RingBuffer(DefaultRingBufferCapacity)
 	outputSink := io.MultiWriter(synchronizedOutput, logBuffer)
@@ -151,6 +171,8 @@ func RunManualShell(ctx context.Context, options ManualShellOptions) error {
 	autoState := &autoRuntimeState{}
 	autoState.Enabled.Store(true)
 	autoState.OSCReady.Store(false)
+
+	printAutoModeBanner(synchronizedOutput, autoState)
 
 	diagnoseJobCh := make(chan diagnoseJob, 4)
 	acceptCtx, cancelAccept := context.WithCancel(context.Background())
@@ -166,7 +188,7 @@ func RunManualShell(ctx context.Context, options ManualShellOptions) error {
 	diagWG.Add(1)
 	go func() {
 		defer diagWG.Done()
-		consumeDiagSignals(diagCtx, diagnoseJobCh, synchronizedOutput, logBuffer, normalized, socketPath, autoState)
+		consumeDiagSignals(diagCtx, gwRPCClient, diagnoseJobCh, synchronizedOutput, logBuffer, normalized, socketPath, autoState)
 	}()
 
 	inputTracker := &commandTracker{}
@@ -180,6 +202,7 @@ func RunManualShell(ctx context.Context, options ManualShellOptions) error {
 		defer probeTimer.Stop()
 		<-probeTimer.C
 		if !autoState.OSCReady.Load() {
+			autoState.Enabled.Store(false)
 			writeProxyf(normalized.Stderr, "neocode shell: OSC133 probe timed out, fallback to manual mode\n")
 		}
 	}()
@@ -250,6 +273,37 @@ func printProxyInitializedBanner(writer io.Writer) {
 		return
 	}
 	writeProxyLine(writer, proxyInitializedBanner)
+}
+
+// printWelcomeBanner 在 PTY 会话启动后输出指引与提示，帮助用户了解诊断功能的使用方式。
+func printWelcomeBanner(writer io.Writer) {
+	if writer == nil {
+		return
+	}
+	lines := []string{
+		"[ 💡 欢迎使用终端诊断代理！您可以像往常一样在终端里工作。 ]",
+		"[ 常用指引: ]",
+		"[ - 自动诊断: 报错时原位自动输出解析。开关控制: `neocode diag auto off` / `neocode diag auto on` ]",
+		"[ - 手动诊断: 报错后输入 `neocode diag` 随时分析。 ]",
+		"[ - 沙盒排查: 输入 `neocode diag -i` 进入 IDM 模式，排查完毕后输入 `exit` 退出沙盒。 ]",
+		"[ - 帮助手册: 输入 `neocode -h` 查看所有命令与配置项。 ]",
+		"[ - 退出代理: 输入 `exit` 或按 `Ctrl+D` 退出 NeoCode 代理外壳，回到系统原生 Shell。 ]",
+	}
+	for _, line := range lines {
+		writeProxyLine(writer, line)
+	}
+}
+
+// printAutoModeBanner 根据当前 auto 诊断开关状态输出对应提示。
+func printAutoModeBanner(writer io.Writer, autoState *autoRuntimeState) {
+	if writer == nil {
+		return
+	}
+	if autoState != nil && autoState.Enabled.Load() {
+		writeProxyLine(writer, "[ ✅ 自动诊断模式已开启，执行命令出错时将自动分析根因。 ]")
+	} else {
+		writeProxyLine(writer, "[ ⚠ 自动诊断模式未开启，报错后请手动输入 `neocode diag` 进行分析。 ]")
+	}
 }
 
 // printProxyExitedBanner 在 PTY 会话结束后输出代理退出提示。
@@ -539,12 +593,71 @@ func sendDiagIPCCommandToPath(ctx context.Context, socketPath string, request di
 }
 
 // buildShellCommand 构建真实 shell 进程，并在子进程环境中注入诊断 socket 变量。
-func buildShellCommand(shellPath string, options ManualShellOptions, socketPath string) *exec.Cmd {
+// 对 bash 自动注入 OSC133 init 脚本（--rcfile），使 shell 集成立即可用。
+// 返回的 cleanup 函数必须在调用方 defer 中执行，用于清理临时 RC 文件。
+func buildShellCommand(shellPath string, options ManualShellOptions, socketPath string) (*exec.Cmd, func()) {
 	command := exec.Command(shellPath)
 	command.Dir = options.Workdir
 	command.Env = MergeEnvVar(os.Environ(), DiagSocketEnv, socketPath)
-	//command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	return command
+	cleanup := func() {}
+	if rcFile := prepareBashInitRC(shellPath); rcFile != "" {
+		command.Args = append(command.Args, "--rcfile", rcFile)
+		cleanup = func() { deleteBashInitRCFile(rcFile) }
+	}
+	return command, cleanup
+}
+
+// prepareBashInitRC 当 shell 为 bash 时创建包含 OSC133 init 脚本 + 用户 ~/.bashrc 的临时文件。
+// 返回空字符串表示跳过（非 bash 或创建失败）。
+// 调用方需确保在进程退出后用 deleteBashInitRC 清理。
+var (
+	createBashInitRCFile = defaultCreateBashInitRCFile
+	deleteBashInitRCFile = defaultDeleteBashInitRCFile
+)
+
+func prepareBashInitRC(shellPath string) string {
+	if !isBashShell(shellPath) {
+		return ""
+	}
+	path, err := createBashInitRCFile()
+	if err != nil {
+		return ""
+	}
+	return path
+}
+
+func isBashShell(shellPath string) bool {
+	base := strings.ToLower(filepath.Base(shellPath))
+	return base == "bash"
+}
+
+func defaultCreateBashInitRCFile() (string, error) {
+	content := shellInitScript + `
+# Load user's original bashrc to preserve custom prompt, aliases, etc.
+if [ -f ~/.bashrc ]; then
+	. ~/.bashrc
+fi
+`
+	tmpFile, err := os.CreateTemp("", "neocode-bash-rc-*.sh")
+	if err != nil {
+		return "", fmt.Errorf("ptyproxy: create bash rc file: %w", err)
+	}
+	if _, err := tmpFile.WriteString(content); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
+		return "", fmt.Errorf("ptyproxy: write bash rc file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpFile.Name())
+		return "", fmt.Errorf("ptyproxy: close bash rc file: %w", err)
+	}
+	return tmpFile.Name(), nil
+}
+
+func defaultDeleteBashInitRCFile(path string) {
+	if path != "" {
+		_ = os.Remove(path)
+	}
 }
 
 // resolveShellPath 按“显式参数 -> SHELL 环境变量 -> /bin/bash”顺序选择实际 shell。
@@ -701,9 +814,10 @@ func writeDiagIPCResponse(connection net.Conn, response diagIPCResponse) {
 	_, _ = connection.Write(encoded)
 }
 
-// consumeDiagSignals 串行消费诊断任务，避免输出相互覆盖。
+// consumeDiagSignals 串行消费诊断任务，复用预建立的 Gateway RPC 长连接。
 func consumeDiagSignals(
 	ctx context.Context,
+	rpcClient *gatewayclient.GatewayRPCClient,
 	jobCh <-chan diagnoseJob,
 	output io.Writer,
 	buffer *UTF8RingBuffer,
@@ -719,7 +833,7 @@ func consumeDiagSignals(
 			if !ok {
 				return
 			}
-			runSingleDiagnosis(output, buffer, options, socketPath, job.Trigger, job.IsAuto, autoState)
+			runSingleDiagnosis(rpcClient, output, buffer, options, socketPath, job.Trigger, job.IsAuto, autoState)
 			if job.Done != nil {
 				job.Done <- diagIPCResponse{OK: true, AutoEnabled: autoState.Enabled.Load(), Message: "diagnosis completed"}
 			}
@@ -729,6 +843,7 @@ func consumeDiagSignals(
 
 // runSingleDiagnosis 执行一次诊断调用，并根据 Auto 开关决定是否渲染结果。
 func runSingleDiagnosis(
+	rpcClient *gatewayclient.GatewayRPCClient,
 	output io.Writer,
 	buffer *UTF8RingBuffer,
 	options ManualShellOptions,
@@ -741,7 +856,7 @@ func runSingleDiagnosis(
 		return
 	}
 
-	result, err := callDiagnoseTool(buffer, options, socketPath, trigger)
+	result, err := callDiagnoseTool(rpcClient, buffer, options, socketPath, trigger)
 	if err != nil {
 		writeProxyf(output, "\n\033[31m[NeoCode Diagnosis]\033[0m %s\n", strings.TrimSpace(err.Error()))
 		return
@@ -752,13 +867,18 @@ func runSingleDiagnosis(
 	renderDiagnosis(output, result.Content, result.IsError)
 }
 
-// callDiagnoseTool 组装参数并调用 gateway.executeSystemTool(diagnose)。
+// callDiagnoseTool 使用 RunManualShell 预建立的 Gateway RPC 长连接调用 executeSystemTool(diagnose)。
 func callDiagnoseTool(
+	rpcClient *gatewayclient.GatewayRPCClient,
 	buffer *UTF8RingBuffer,
 	options ManualShellOptions,
 	socketPath string,
 	trigger diagnoseTrigger,
 ) (tools.ToolResult, error) {
+	if rpcClient == nil {
+		return tools.ToolResult{}, fmt.Errorf("网关客户端未就绪，请检查 gateway 服务状态")
+	}
+
 	logSnapshot := buffer.SnapshotString()
 	if strings.TrimSpace(trigger.OutputText) != "" {
 		logSnapshot = trigger.OutputText
@@ -781,21 +901,8 @@ func callDiagnoseTool(
 		return tools.ToolResult{}, fmt.Errorf("请求构建失败: %w", err)
 	}
 
-	rpcClient, err := gatewayclient.NewGatewayRPCClient(gatewayclient.GatewayRPCClientOptions{
-		ListenAddress: options.GatewayListenAddress,
-		TokenFile:     options.GatewayTokenFile,
-	})
-	if err != nil {
-		return tools.ToolResult{}, fmt.Errorf("网关客户端初始化失败: %w", err)
-	}
-	defer rpcClient.Close()
-
 	callContext, cancel := context.WithTimeout(context.Background(), diagnoseCallTimeout)
 	defer cancel()
-
-	if err := rpcClient.Authenticate(callContext); err != nil {
-		return tools.ToolResult{}, fmt.Errorf("网关认证失败: %w", err)
-	}
 
 	var frame gateway.MessageFrame
 	if err := rpcClient.CallWithOptions(
@@ -913,6 +1020,7 @@ func streamPTYOutput(
 				switch event.Type {
 				case ShellEventPromptReady:
 					autoState.OSCReady.Store(true)
+					autoState.Enabled.Store(true)
 					if pendingTrigger != nil && autoState.Enabled.Load() {
 						select {
 						case autoTriggerCh <- *pendingTrigger:

--- a/internal/ptyproxy/proxy_unix.go
+++ b/internal/ptyproxy/proxy_unix.go
@@ -499,7 +499,7 @@ func sendDiagIPCCommand(ctx context.Context, socketPath string, request diagIPCR
 		return diagIPCResponse{}, err
 	}
 
-	legacyPath, fallbackErr := ResolveLegacyTmpDiagSocketPath()
+	legacyPath, fallbackErr := resolveValidatedLegacyDiagSocketPath(primaryPath)
 	if fallbackErr != nil {
 		return diagIPCResponse{}, err
 	}
@@ -517,6 +517,26 @@ func sendDiagIPCCommand(ctx context.Context, socketPath string, request diagIPCR
 		strings.TrimSpace(primaryPath),
 	)
 	return fallbackResponse, nil
+}
+
+// resolveValidatedLegacyDiagSocketPath 基于主 socket 的 PID 选择并校验 legacy socket，避免误连其他会话。
+func resolveValidatedLegacyDiagSocketPath(primaryPath string) (string, error) {
+	expectedPID, err := parseDiagSocketPIDFromPath(primaryPath)
+	if err != nil {
+		return "", err
+	}
+	legacyPath, err := ResolveLegacyTmpDiagSocketPathForPID(expectedPID)
+	if err != nil {
+		return "", err
+	}
+	legacyPID, err := parseDiagSocketPIDFromPath(legacyPath)
+	if err != nil {
+		return "", err
+	}
+	if legacyPID != expectedPID {
+		return "", fmt.Errorf("ptyproxy: legacy diag socket pid mismatch, want %d got %d", expectedPID, legacyPID)
+	}
+	return legacyPath, nil
 }
 
 // sendDiagIPCCommandToPath 在指定 socket 路径上执行一次 JSON-Lines 请求响应。

--- a/internal/ptyproxy/proxy_unix.go
+++ b/internal/ptyproxy/proxy_unix.go
@@ -598,10 +598,20 @@ func buildShellCommand(shellPath string, options ManualShellOptions, socketPath 
 	command := exec.Command(shellPath)
 	command.Dir = options.Workdir
 	command.Env = MergeEnvVar(os.Environ(), DiagSocketEnv, socketPath)
-	cleanup := func() {}
+
+	cleanupTasks := make([]func(), 0, 2)
+	cleanup := func() {
+		for index := len(cleanupTasks) - 1; index >= 0; index-- {
+			cleanupTasks[index]()
+		}
+	}
 	if rcFile := prepareBashInitRC(shellPath); rcFile != "" {
 		command.Args = append(command.Args, "--rcfile", rcFile)
-		cleanup = func() { deleteBashInitRCFile(rcFile) }
+		cleanupTasks = append(cleanupTasks, func() { deleteBashInitRCFile(rcFile) })
+	}
+	if zdotDir := prepareZshInitDir(shellPath); zdotDir != "" {
+		command.Env = MergeEnvVar(command.Env, "ZDOTDIR", zdotDir)
+		cleanupTasks = append(cleanupTasks, func() { deleteZshInitDir(zdotDir) })
 	}
 	return command, cleanup
 }
@@ -612,6 +622,8 @@ func buildShellCommand(shellPath string, options ManualShellOptions, socketPath 
 var (
 	createBashInitRCFile = defaultCreateBashInitRCFile
 	deleteBashInitRCFile = defaultDeleteBashInitRCFile
+	createZshInitDir     = defaultCreateZshInitDir
+	deleteZshInitDir     = defaultDeleteZshInitDir
 )
 
 func prepareBashInitRC(shellPath string) string {
@@ -625,9 +637,28 @@ func prepareBashInitRC(shellPath string) string {
 	return path
 }
 
+// prepareZshInitDir 当 shell 为 zsh 时创建临时 ZDOTDIR 目录并注入 .zshrc。
+// 返回空字符串表示跳过（非 zsh 或创建失败）。
+func prepareZshInitDir(shellPath string) string {
+	if !isZshShell(shellPath) {
+		return ""
+	}
+	path, err := createZshInitDir()
+	if err != nil {
+		return ""
+	}
+	return path
+}
+
 func isBashShell(shellPath string) bool {
 	base := strings.ToLower(filepath.Base(shellPath))
 	return base == "bash"
+}
+
+// isZshShell 判断给定 shell 路径是否为 zsh。
+func isZshShell(shellPath string) bool {
+	base := strings.ToLower(filepath.Base(shellPath))
+	return base == "zsh"
 }
 
 func defaultCreateBashInitRCFile() (string, error) {
@@ -656,6 +687,33 @@ fi
 func defaultDeleteBashInitRCFile(path string) {
 	if path != "" {
 		_ = os.Remove(path)
+	}
+}
+
+// defaultCreateZshInitDir 创建临时 ZDOTDIR，并写入注入脚本到 .zshrc。
+func defaultCreateZshInitDir() (string, error) {
+	content := shellInitScript + `
+# Load user's original zshrc to preserve custom prompt, aliases, etc.
+if [ -f "${HOME}/.zshrc" ]; then
+	. "${HOME}/.zshrc"
+fi
+`
+	directory, err := os.MkdirTemp("", "neocode-zsh-*")
+	if err != nil {
+		return "", fmt.Errorf("ptyproxy: create zsh init directory: %w", err)
+	}
+	rcPath := filepath.Join(directory, ".zshrc")
+	if writeErr := os.WriteFile(rcPath, []byte(content), 0o600); writeErr != nil {
+		_ = os.RemoveAll(directory)
+		return "", fmt.Errorf("ptyproxy: write zsh rc file: %w", writeErr)
+	}
+	return directory, nil
+}
+
+// defaultDeleteZshInitDir 删除临时 ZDOTDIR 目录及其注入文件。
+func defaultDeleteZshInitDir(path string) {
+	if path != "" {
+		_ = os.RemoveAll(path)
 	}
 }
 

--- a/internal/ptyproxy/proxy_unix.go
+++ b/internal/ptyproxy/proxy_unix.go
@@ -17,6 +17,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -30,10 +31,10 @@ import (
 )
 
 const (
-	diagSignalPayload      = "diagnose\n"
-	diagSignalAckPayload   = "1"
 	diagnoseCallTimeout    = 10 * time.Second
-	diagSocketReadDeadline = 2 * time.Second
+	diagSocketReadDeadline = 3 * time.Second
+	autoProbeTimeout       = 1500 * time.Millisecond
+
 	proxyInitializedBanner = "[ NeoCode Proxy initialized ]"
 	proxyExitedBanner      = "[ NeoCode Proxy exited ]"
 )
@@ -65,11 +66,30 @@ type diagnoseToolResult struct {
 	InvestigationCommands []string `json:"investigation_commands"`
 }
 
-type diagSignalRequest struct {
-	done chan struct{}
+type diagnoseTrigger struct {
+	CommandText string
+	ExitCode    int
+	OutputText  string
 }
 
-// RunManualShell 启动 Manual 模式终端代理，提供 PTY 透明透传与诊断触发能力。
+type diagnoseJob struct {
+	Trigger diagnoseTrigger
+	Done    chan diagIPCResponse
+	IsAuto  bool
+}
+
+type autoRuntimeState struct {
+	Enabled  atomic.Bool
+	OSCReady atomic.Bool
+}
+
+type commandTracker struct {
+	mu          sync.Mutex
+	lineBuffer  []byte
+	lastCommand string
+}
+
+// RunManualShell 启动 Phase2 终端代理，提供 Manual/Auto 诊断闭环与 OSC133 事件驱动能力。
 func RunManualShell(ctx context.Context, options ManualShellOptions) error {
 	normalized, err := NormalizeShellOptions(options)
 	if err != nil {
@@ -90,35 +110,12 @@ func RunManualShell(ctx context.Context, options ManualShellOptions) error {
 		_ = os.Remove(socketPath)
 	}()
 
-	var outputMu sync.Mutex
-	synchronizedOutput := &serializedWriter{writer: normalized.Stdout, lock: &outputMu}
-	buffer := NewUTF8RingBuffer(DefaultRingBufferCapacity)
-	outputSink := io.MultiWriter(synchronizedOutput, buffer)
-
-	triggerCh := make(chan diagSignalRequest, 1)
-	acceptCtx, cancelAccept := context.WithCancel(context.Background())
-	var acceptWG sync.WaitGroup
-	acceptWG.Add(1)
-	go func() {
-		defer acceptWG.Done()
-		serveDiagSocket(acceptCtx, listener, triggerCh, normalized.Stderr)
-	}()
-
-	diagCtx, cancelDiag := context.WithCancel(context.Background())
-	var diagWG sync.WaitGroup
-	diagWG.Add(1)
-	go func() {
-		defer diagWG.Done()
-		consumeDiagSignals(diagCtx, triggerCh, synchronizedOutput, buffer, normalized, socketPath)
-	}()
+	// 兜底恢复：即使后续流程异常退出，也尽量恢复宿主终端状态。
+	restoreGuard := installHostTerminalRestoreGuard()
+	defer restoreGuard()
 
 	restoreRawTerminal, err := enableHostTerminalRawMode()
 	if err != nil {
-		cancelAccept()
-		_ = listener.Close()
-		cancelDiag()
-		acceptWG.Wait()
-		diagWG.Wait()
 		return err
 	}
 	defer func() {
@@ -126,14 +123,8 @@ func RunManualShell(ctx context.Context, options ManualShellOptions) error {
 	}()
 
 	command := buildShellCommand(shellPath, normalized, socketPath)
-
 	ptyFile, err := pty.Start(command)
 	if err != nil {
-		cancelAccept()
-		_ = listener.Close()
-		cancelDiag()
-		acceptWG.Wait()
-		diagWG.Wait()
 		return fmt.Errorf("ptyproxy: start pty shell: %w", err)
 	}
 	defer func() {
@@ -146,13 +137,71 @@ func RunManualShell(ctx context.Context, options ManualShellOptions) error {
 	stopResizeWatcher := watchPTYWindowResize(normalized.Stderr, ptyFile)
 	defer stopResizeWatcher()
 
+	stopSignalForwarder := watchForwardSignals(command.Process, normalized.Stderr)
+	defer stopSignalForwarder()
+
+	var outputMu sync.Mutex
+	synchronizedOutput := &serializedWriter{writer: normalized.Stdout, lock: &outputMu}
 	printProxyInitializedBanner(synchronizedOutput)
 
+	logBuffer := NewUTF8RingBuffer(DefaultRingBufferCapacity)
+	outputSink := io.MultiWriter(synchronizedOutput, logBuffer)
+	commandLogBuffer := NewUTF8RingBuffer(DefaultRingBufferCapacity / 2)
+
+	autoState := &autoRuntimeState{}
+	autoState.Enabled.Store(true)
+	autoState.OSCReady.Store(false)
+
+	diagnoseJobCh := make(chan diagnoseJob, 4)
+	acceptCtx, cancelAccept := context.WithCancel(context.Background())
+	var acceptWG sync.WaitGroup
+	acceptWG.Add(1)
 	go func() {
-		_, _ = io.Copy(ptyFile, normalized.Stdin)
+		defer acceptWG.Done()
+		serveDiagSocket(acceptCtx, listener, diagnoseJobCh, autoState, normalized.Stderr)
 	}()
+
+	diagCtx, cancelDiag := context.WithCancel(context.Background())
+	var diagWG sync.WaitGroup
+	diagWG.Add(1)
 	go func() {
-		_, _ = io.Copy(outputSink, ptyFile)
+		defer diagWG.Done()
+		consumeDiagSignals(diagCtx, diagnoseJobCh, synchronizedOutput, logBuffer, normalized, socketPath, autoState)
+	}()
+
+	inputTracker := &commandTracker{}
+	go func() {
+		_, _ = copyInputWithTracker(ptyFile, normalized.Stdin, inputTracker)
+	}()
+
+	autoTriggerCh := make(chan diagnoseTrigger, 2)
+	go func() {
+		probeTimer := time.NewTimer(autoProbeTimeout)
+		defer probeTimer.Stop()
+		<-probeTimer.C
+		if !autoState.OSCReady.Load() {
+			writeProxyf(normalized.Stderr, "neocode shell: OSC133 probe timed out, fallback to manual mode\n")
+		}
+	}()
+
+	var streamWG sync.WaitGroup
+	streamWG.Add(1)
+	go func() {
+		defer streamWG.Done()
+		streamPTYOutput(ptyFile, outputSink, commandLogBuffer, inputTracker, autoTriggerCh, autoState)
+	}()
+
+	var triggerWG sync.WaitGroup
+	triggerWG.Add(1)
+	go func() {
+		defer triggerWG.Done()
+		for trigger := range autoTriggerCh {
+			select {
+			case <-diagCtx.Done():
+				return
+			case diagnoseJobCh <- diagnoseJob{Trigger: trigger, IsAuto: true}:
+			}
+		}
 	}()
 
 	waitDone := make(chan error, 1)
@@ -171,12 +220,16 @@ func RunManualShell(ctx context.Context, options ManualShellOptions) error {
 	}
 
 	printProxyExitedBanner(synchronizedOutput)
-
 	_ = ptyFile.Close()
+
 	cancelAccept()
 	_ = listener.Close()
 	acceptWG.Wait()
+
 	cancelDiag()
+	streamWG.Wait()
+	close(autoTriggerCh)
+	triggerWG.Wait()
 	diagWG.Wait()
 
 	if waitErr != nil {
@@ -230,6 +283,24 @@ func enableHostTerminalRawMode() (func() error, error) {
 	}, nil
 }
 
+// installHostTerminalRestoreGuard 提前抓取终端状态并在退出时兜底恢复。
+func installHostTerminalRestoreGuard() func() {
+	if hostTerminalInput == nil {
+		return func() {}
+	}
+	fd := int(hostTerminalInput.Fd())
+	if !isTerminalFD(fd) {
+		return func() {}
+	}
+	state, err := term.GetState(fd)
+	if err != nil {
+		return func() {}
+	}
+	return func() {
+		_ = restoreTerminal(fd, state)
+	}
+}
+
 // syncPTYWindowSize 将宿主终端窗口尺寸同步到 PTY，避免默认 80 列导致的提示符错位。
 func syncPTYWindowSize(errWriter io.Writer, ptyFile *os.File) {
 	if ptyFile == nil {
@@ -277,6 +348,46 @@ func watchPTYWindowResize(errWriter io.Writer, ptyFile *os.File) func() {
 	}
 }
 
+// watchForwardSignals 拦截关键信号并透传给 shell 进程组，确保作业控制语义一致。
+func watchForwardSignals(process *os.Process, errWriter io.Writer) func() {
+	if process == nil {
+		return func() {}
+	}
+	proxySignals := make(chan os.Signal, 1)
+	signal.Notify(proxySignals, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTSTP, syscall.SIGCONT)
+	stopCh := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stopCh:
+				return
+			case signalValue, ok := <-proxySignals:
+				if !ok {
+					return
+				}
+				sysSignal, ok := signalValue.(syscall.Signal)
+				if !ok {
+					continue
+				}
+				if process.Pid <= 0 {
+					continue
+				}
+				if err := syscall.Kill(-process.Pid, sysSignal); err != nil && errWriter != nil {
+					writeProxyf(errWriter, "neocode shell: forward signal %d failed: %v\n", sysSignal, err)
+				}
+			}
+		}
+	}()
+	return func() {
+		signal.Stop(proxySignals)
+		close(stopCh)
+		wg.Wait()
+	}
+}
+
 // writeProxyText 统一将代理自输出的换行规范化为 CRLF，适配 Raw Mode 下的终端显示。
 func writeProxyText(writer io.Writer, text string) {
 	if writer == nil || text == "" {
@@ -295,43 +406,127 @@ func writeProxyf(writer io.Writer, format string, args ...any) {
 	writeProxyText(writer, fmt.Sprintf(format, args...))
 }
 
-// SendDiagnoseSignal 连接 shell 代理暴露的本地 socket，并发送一次诊断触发信令。
+// SendDiagnoseSignal 连接本地 socket 并触发一次手动诊断请求。
 func SendDiagnoseSignal(ctx context.Context, socketPath string) error {
-	normalizedSocket := strings.TrimSpace(socketPath)
-	if normalizedSocket == "" {
-		return errors.New("ptyproxy: diagnose socket path is empty")
+	_, err := sendDiagIPCCommand(ctx, socketPath, diagIPCRequest{Cmd: diagCommandDiagnose})
+	return err
+}
+
+// SendAutoModeSignal 向代理 shell 发送 Auto 模式开关信令。
+func SendAutoModeSignal(ctx context.Context, socketPath string, enabled bool) error {
+	command := diagCommandAutoOff
+	if enabled {
+		command = diagCommandAutoOn
+	}
+	_, err := sendDiagIPCCommand(ctx, socketPath, diagIPCRequest{Cmd: command})
+	return err
+}
+
+// sendDiagIPCCommand 通过 JSON-Lines 发送控制命令，并在必要时回退到旧版 tmp socket。
+func sendDiagIPCCommand(ctx context.Context, socketPath string, request diagIPCRequest) (diagIPCResponse, error) {
+	primaryPath := filepath.Clean(strings.TrimSpace(socketPath))
+	if primaryPath == "." || strings.TrimSpace(primaryPath) == "" {
+		return diagIPCResponse{}, errors.New("ptyproxy: diagnose socket path is empty")
 	}
 
+	response, err := sendDiagIPCCommandToPath(ctx, primaryPath, request)
+	if err == nil {
+		return response, nil
+	}
+	if !strings.Contains(filepath.ToSlash(primaryPath), "/.neocode/run/") {
+		return diagIPCResponse{}, err
+	}
+
+	legacyPath, fallbackErr := ResolveLegacyTmpDiagSocketPath()
+	if fallbackErr != nil {
+		return diagIPCResponse{}, err
+	}
+	if strings.EqualFold(filepath.Clean(legacyPath), primaryPath) {
+		return diagIPCResponse{}, err
+	}
+	fallbackResponse, fallbackCallErr := sendDiagIPCCommandToPath(ctx, legacyPath, request)
+	if fallbackCallErr != nil {
+		return diagIPCResponse{}, err
+	}
+	_, _ = fmt.Fprintf(
+		os.Stderr,
+		"warning: diagnose socket fallback to legacy tmp path: %s (from %s)\n",
+		strings.TrimSpace(legacyPath),
+		strings.TrimSpace(primaryPath),
+	)
+	return fallbackResponse, nil
+}
+
+// sendDiagIPCCommandToPath 在指定 socket 路径上执行一次 JSON-Lines 请求响应。
+func sendDiagIPCCommandToPath(ctx context.Context, socketPath string, request diagIPCRequest) (diagIPCResponse, error) {
 	dialer := net.Dialer{}
-	connection, err := dialer.DialContext(ctx, "unix", normalizedSocket)
+	connection, err := dialer.DialContext(ctx, "unix", strings.TrimSpace(socketPath))
 	if err != nil {
-		return fmt.Errorf("ptyproxy: connect diagnose socket: %w", err)
+		return diagIPCResponse{}, fmt.Errorf("ptyproxy: connect diagnose socket: %w", err)
 	}
 	defer connection.Close()
 
-	_ = connection.SetWriteDeadline(time.Now().Add(diagSocketReadDeadline))
-	_, err = connection.Write([]byte(diagSignalPayload))
+	payload, err := json.Marshal(request)
 	if err != nil {
-		return fmt.Errorf("ptyproxy: send diagnose signal: %w", err)
+		return diagIPCResponse{}, fmt.Errorf("ptyproxy: encode diag request: %w", err)
 	}
+	payload = append(payload, '\n')
+	_ = connection.SetWriteDeadline(time.Now().Add(diagSocketReadDeadline))
+	if _, err := connection.Write(payload); err != nil {
+		return diagIPCResponse{}, fmt.Errorf("ptyproxy: send diag request: %w", err)
+	}
+	_ = connection.SetWriteDeadline(time.Time{})
 
-	waitDone := make(chan error, 1)
+	readDone := make(chan struct {
+		response diagIPCResponse
+		err      error
+	}, 1)
 	go func() {
-		_, readErr := io.ReadAll(connection)
-		waitDone <- readErr
+		reader := bufio.NewReader(connection)
+		line, readErr := reader.ReadBytes('\n')
+		if readErr != nil {
+			readDone <- struct {
+				response diagIPCResponse
+				err      error
+			}{err: readErr}
+			return
+		}
+		var response diagIPCResponse
+		if unmarshalErr := json.Unmarshal(line, &response); unmarshalErr != nil {
+			readDone <- struct {
+				response diagIPCResponse
+				err      error
+			}{err: fmt.Errorf("decode diag response: %w", unmarshalErr)}
+			return
+		}
+		if !response.OK {
+			message := strings.TrimSpace(response.Message)
+			if message == "" {
+				message = "diagnose command rejected"
+			}
+			readDone <- struct {
+				response diagIPCResponse
+				err      error
+			}{response: response, err: errors.New("ptyproxy: " + message)}
+			return
+		}
+		readDone <- struct {
+			response diagIPCResponse
+			err      error
+		}{response: response}
 	}()
 
 	select {
 	case <-ctx.Done():
 		_ = connection.SetReadDeadline(time.Now())
-		<-waitDone
-		return fmt.Errorf("ptyproxy: wait diagnose completion: %w", ctx.Err())
-	case readErr := <-waitDone:
-		if readErr != nil && !isClosedNetworkError(readErr) {
-			return fmt.Errorf("ptyproxy: wait diagnose completion: %w", readErr)
+		<-readDone
+		return diagIPCResponse{}, fmt.Errorf("ptyproxy: wait diagnose completion: %w", ctx.Err())
+	case result := <-readDone:
+		if result.err != nil && !isClosedNetworkError(result.err) {
+			return diagIPCResponse{}, fmt.Errorf("ptyproxy: wait diagnose completion: %w", result.err)
 		}
+		return result.response, nil
 	}
-	return nil
 }
 
 // buildShellCommand 构建真实 shell 进程，并在子进程环境中注入诊断 socket 变量。
@@ -339,6 +534,7 @@ func buildShellCommand(shellPath string, options ManualShellOptions, socketPath 
 	command := exec.Command(shellPath)
 	command.Dir = options.Workdir
 	command.Env = MergeEnvVar(os.Environ(), DiagSocketEnv, socketPath)
+	//command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	return command
 }
 
@@ -353,11 +549,15 @@ func resolveShellPath(shellOption string) string {
 	return "/bin/bash"
 }
 
-// listenDiagSocket 创建并监听 Unix socket；路径为空时按进程生成默认地址。
+// listenDiagSocket 创建并监听 Unix socket；路径为空时使用 ~/.neocode/run 的统一地址。
 func listenDiagSocket(socketOption string) (net.Listener, string, error) {
 	socketPath := strings.TrimSpace(socketOption)
 	if socketPath == "" {
-		socketPath = filepath.Join(os.TempDir(), fmt.Sprintf("neocode-diag-%d.sock", os.Getpid()))
+		resolved, err := ResolveDefaultDiagSocketPath()
+		if err != nil {
+			return nil, "", err
+		}
+		socketPath = resolved
 	}
 	socketPath = filepath.Clean(socketPath)
 	if err := os.MkdirAll(filepath.Dir(socketPath), 0o700); err != nil {
@@ -396,8 +596,14 @@ func cleanupStaleSocket(socketPath string) error {
 	return nil
 }
 
-// serveDiagSocket 接收本地诊断触发连接，并向消费协程投递触发信号。
-func serveDiagSocket(ctx context.Context, listener net.Listener, triggerCh chan<- diagSignalRequest, errWriter io.Writer) {
+// serveDiagSocket 接收 JSON-Lines 信令，转发手动诊断或即时切换 Auto 开关。
+func serveDiagSocket(
+	ctx context.Context,
+	listener net.Listener,
+	jobCh chan<- diagnoseJob,
+	autoState *autoRuntimeState,
+	errWriter io.Writer,
+) {
 	for {
 		connection, err := listener.Accept()
 		if err != nil {
@@ -409,87 +615,155 @@ func serveDiagSocket(ctx context.Context, listener net.Listener, triggerCh chan<
 			}
 			continue
 		}
-		handleDiagSocketConnection(ctx, connection, triggerCh)
+		handleDiagSocketConnection(ctx, connection, jobCh, autoState)
 	}
 }
 
-// handleDiagSocketConnection 处理单个诊断请求连接，并在对应诊断渲染结束后返回 ACK 后断开连接。
-func handleDiagSocketConnection(ctx context.Context, connection net.Conn, triggerCh chan<- diagSignalRequest) {
+// handleDiagSocketConnection 处理单连接请求并返回单行 JSON 响应。
+func handleDiagSocketConnection(
+	ctx context.Context,
+	connection net.Conn,
+	jobCh chan<- diagnoseJob,
+	autoState *autoRuntimeState,
+) {
 	if connection == nil {
 		return
 	}
 	defer connection.Close()
 
 	_ = connection.SetReadDeadline(time.Now().Add(diagSocketReadDeadline))
-	reader := bufio.NewReader(io.LimitReader(connection, 1024))
-	_, _ = reader.ReadString('\n')
+	reader := bufio.NewReader(io.LimitReader(connection, 8*1024))
+	line, err := reader.ReadBytes('\n')
+	if err != nil {
+		writeDiagIPCResponse(connection, diagIPCResponse{OK: false, Message: "read request failed"})
+		return
+	}
 	_ = connection.SetReadDeadline(time.Time{})
 
-	request := diagSignalRequest{
-		done: make(chan struct{}),
-	}
-	select {
-	case <-ctx.Done():
+	var request diagIPCRequest
+	if unmarshalErr := json.Unmarshal(line, &request); unmarshalErr != nil {
+		writeDiagIPCResponse(connection, diagIPCResponse{OK: false, Message: "invalid request"})
 		return
-	case triggerCh <- request:
 	}
 
-	select {
-	case <-ctx.Done():
-		return
-	case <-request.done:
-		_, _ = connection.Write([]byte(diagSignalAckPayload))
+	switch normalizeDiagIPCCommand(request.Cmd) {
+	case diagCommandDiagnose:
+		done := make(chan diagIPCResponse, 1)
+		job := diagnoseJob{Done: done, IsAuto: false}
+		select {
+		case <-ctx.Done():
+			writeDiagIPCResponse(connection, diagIPCResponse{OK: false, Message: "proxy shutting down"})
+			return
+		case jobCh <- job:
+		}
+		select {
+		case <-ctx.Done():
+			writeDiagIPCResponse(connection, diagIPCResponse{OK: false, Message: "proxy shutting down"})
+		case response := <-done:
+			writeDiagIPCResponse(connection, response)
+		}
+	case diagCommandAutoOn:
+		autoState.Enabled.Store(true)
+		writeDiagIPCResponse(connection, diagIPCResponse{OK: true, AutoEnabled: true, Message: "auto mode enabled"})
+	case diagCommandAutoOff:
+		autoState.Enabled.Store(false)
+		writeDiagIPCResponse(connection, diagIPCResponse{OK: true, AutoEnabled: false, Message: "auto mode disabled"})
+	default:
+		writeDiagIPCResponse(connection, diagIPCResponse{OK: false, Message: "unsupported command"})
 	}
 }
 
-// consumeDiagSignals 串行消费触发信号并执行诊断调用，避免并发请求互相覆盖终端输出。
+// writeDiagIPCResponse 写入单行 JSON 响应。
+func writeDiagIPCResponse(connection net.Conn, response diagIPCResponse) {
+	if connection == nil {
+		return
+	}
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		encoded = []byte(`{"ok":false,"message":"encode response failed"}`)
+	}
+	encoded = append(encoded, '\n')
+	_, _ = connection.Write(encoded)
+}
+
+// consumeDiagSignals 串行消费诊断任务，避免输出相互覆盖。
 func consumeDiagSignals(
 	ctx context.Context,
-	triggerCh <-chan diagSignalRequest,
+	jobCh <-chan diagnoseJob,
 	output io.Writer,
 	buffer *UTF8RingBuffer,
 	options ManualShellOptions,
 	socketPath string,
+	autoState *autoRuntimeState,
 ) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case request, ok := <-triggerCh:
+		case job, ok := <-jobCh:
 			if !ok {
 				return
 			}
-			runSingleDiagnosis(output, buffer, options, socketPath)
-			if request.done != nil {
-				close(request.done)
+			runSingleDiagnosis(output, buffer, options, socketPath, job.Trigger, job.IsAuto, autoState)
+			if job.Done != nil {
+				job.Done <- diagIPCResponse{OK: true, AutoEnabled: autoState.Enabled.Load(), Message: "diagnosis completed"}
 			}
 		}
 	}
 }
 
-// runSingleDiagnosis 读取最近日志并调用 gateway.executeSystemTool(diagnose) 获取诊断结果。
-func runSingleDiagnosis(output io.Writer, buffer *UTF8RingBuffer, options ManualShellOptions, socketPath string) {
+// runSingleDiagnosis 执行一次诊断调用，并根据 Auto 开关决定是否渲染结果。
+func runSingleDiagnosis(
+	output io.Writer,
+	buffer *UTF8RingBuffer,
+	options ManualShellOptions,
+	socketPath string,
+	trigger diagnoseTrigger,
+	isAuto bool,
+	autoState *autoRuntimeState,
+) {
 	if output == nil {
 		return
 	}
 
+	result, err := callDiagnoseTool(buffer, options, socketPath, trigger)
+	if err != nil {
+		writeProxyf(output, "\n\033[31m[NeoCode Diagnosis]\033[0m %s\n", strings.TrimSpace(err.Error()))
+		return
+	}
+	if isAuto && autoState != nil && !autoState.Enabled.Load() {
+		return
+	}
+	renderDiagnosis(output, result.Content, result.IsError)
+}
+
+// callDiagnoseTool 组装参数并调用 gateway.executeSystemTool(diagnose)。
+func callDiagnoseTool(
+	buffer *UTF8RingBuffer,
+	options ManualShellOptions,
+	socketPath string,
+	trigger diagnoseTrigger,
+) (tools.ToolResult, error) {
 	logSnapshot := buffer.SnapshotString()
+	if strings.TrimSpace(trigger.OutputText) != "" {
+		logSnapshot = trigger.OutputText
+	}
+
 	requestArgs := diagnoseToolArgs{
-		ErrorLog: logSnapshot,
+		ErrorLog: SanitizeDiagnosisText(logSnapshot, defaultDiagnosisPayloadMaxBytes),
 		OSEnv: map[string]string{
 			"os":     runtime.GOOS,
 			"shell":  resolveShellPath(options.Shell),
 			"cwd":    options.Workdir,
 			"socket": socketPath,
 		},
-		CommandText: "",
-		ExitCode:    0,
+		CommandText: SanitizeDiagnosisText(trigger.CommandText, 1024),
+		ExitCode:    trigger.ExitCode,
 	}
 
 	requestPayload, err := json.Marshal(requestArgs)
 	if err != nil {
-		writeProxyf(output, "\n\033[31m[NeoCode Diagnosis]\033[0m 请求构建失败: %v\n", err)
-		return
+		return tools.ToolResult{}, fmt.Errorf("请求构建失败: %w", err)
 	}
 
 	rpcClient, err := gatewayclient.NewGatewayRPCClient(gatewayclient.GatewayRPCClientOptions{
@@ -497,8 +771,7 @@ func runSingleDiagnosis(output io.Writer, buffer *UTF8RingBuffer, options Manual
 		TokenFile:     options.GatewayTokenFile,
 	})
 	if err != nil {
-		writeProxyf(output, "\n\033[31m[NeoCode Diagnosis]\033[0m 网关客户端初始化失败: %v\n", err)
-		return
+		return tools.ToolResult{}, fmt.Errorf("网关客户端初始化失败: %w", err)
 	}
 	defer rpcClient.Close()
 
@@ -506,8 +779,7 @@ func runSingleDiagnosis(output io.Writer, buffer *UTF8RingBuffer, options Manual
 	defer cancel()
 
 	if err := rpcClient.Authenticate(callContext); err != nil {
-		writeProxyf(output, "\n\033[31m[NeoCode Diagnosis]\033[0m 网关认证失败: %v\n", err)
-		return
+		return tools.ToolResult{}, fmt.Errorf("网关认证失败: %w", err)
 	}
 
 	var frame gateway.MessageFrame
@@ -525,30 +797,25 @@ func runSingleDiagnosis(output io.Writer, buffer *UTF8RingBuffer, options Manual
 			Retries: 0,
 		},
 	); err != nil {
-		writeProxyf(output, "\n\033[31m[NeoCode Diagnosis]\033[0m 诊断调用失败: %v\n", err)
-		return
+		return tools.ToolResult{}, fmt.Errorf("诊断调用失败: %w", err)
 	}
 
 	if frame.Type == gateway.FrameTypeError && frame.Error != nil {
-		writeProxyf(
-			output,
-			"\n\033[31m[NeoCode Diagnosis]\033[0m 网关返回错误 (%s): %s\n",
+		return tools.ToolResult{}, fmt.Errorf(
+			"网关返回错误 (%s): %s",
 			strings.TrimSpace(frame.Error.Code),
 			strings.TrimSpace(frame.Error.Message),
 		)
-		return
 	}
 	if frame.Type != gateway.FrameTypeAck {
-		writeProxyf(output, "\n\033[31m[NeoCode Diagnosis]\033[0m 网关返回未知帧: %s\n", frame.Type)
-		return
+		return tools.ToolResult{}, fmt.Errorf("网关返回未知帧: %s", frame.Type)
 	}
 
 	toolResult, err := decodeToolResult(frame.Payload)
 	if err != nil {
-		writeProxyf(output, "\n\033[31m[NeoCode Diagnosis]\033[0m 诊断结果解析失败: %v\n", err)
-		return
+		return tools.ToolResult{}, fmt.Errorf("诊断结果解析失败: %w", err)
 	}
-	renderDiagnosis(output, toolResult.Content, toolResult.IsError)
+	return toolResult, nil
 }
 
 // decodeToolResult 将网关 payload 反序列化为统一的 ToolResult 结构。
@@ -598,6 +865,137 @@ func renderDiagnosis(output io.Writer, content string, isError bool) {
 			writeProxyf(output, "- %s\n", strings.TrimSpace(command))
 		}
 	}
+}
+
+// streamPTYOutput 解析 PTY 输出并分离 OSC133 事件，按规则触发 Auto 诊断任务。
+func streamPTYOutput(
+	ptyFile *os.File,
+	outputSink io.Writer,
+	commandLogBuffer *UTF8RingBuffer,
+	tracker *commandTracker,
+	autoTriggerCh chan<- diagnoseTrigger,
+	autoState *autoRuntimeState,
+) {
+	if ptyFile == nil || outputSink == nil || commandLogBuffer == nil {
+		return
+	}
+	parser := &OSC133Parser{}
+	collectingCommand := false
+	pendingTrigger := (*diagnoseTrigger)(nil)
+
+	buffer := make([]byte, 4096)
+	for {
+		readBytes, err := ptyFile.Read(buffer)
+		if readBytes > 0 {
+			cleanOutput, events := parser.Feed(buffer[:readBytes])
+			if len(cleanOutput) > 0 {
+				_, _ = outputSink.Write(cleanOutput)
+				if collectingCommand {
+					_, _ = commandLogBuffer.Write(cleanOutput)
+				}
+			}
+			for _, event := range events {
+				switch event.Type {
+				case ShellEventPromptReady:
+					autoState.OSCReady.Store(true)
+					if pendingTrigger != nil && autoState.Enabled.Load() {
+						select {
+						case autoTriggerCh <- *pendingTrigger:
+						default:
+							// 渠道拥塞时直接丢弃本次触发，避免阻塞 PTY 输出主循环。
+						}
+						pendingTrigger = nil
+					}
+				case ShellEventCommandStart:
+					collectingCommand = true
+					commandLogBuffer = NewUTF8RingBuffer(DefaultRingBufferCapacity / 2)
+				case ShellEventCommandDone:
+					collectingCommand = false
+					commandText := ""
+					if tracker != nil {
+						commandText = tracker.LastCommand()
+					}
+					outputText := commandLogBuffer.SnapshotString()
+					if ShouldTriggerAutoDiagnosis(event.ExitCode, commandText, outputText) {
+						pendingTrigger = &diagnoseTrigger{
+							CommandText: commandText,
+							ExitCode:    event.ExitCode,
+							OutputText:  outputText,
+						}
+					}
+				}
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// copyInputWithTracker 在转发用户输入到 PTY 的同时提取最近命令文本。
+func copyInputWithTracker(dst io.Writer, src io.Reader, tracker *commandTracker) (int64, error) {
+	if dst == nil || src == nil {
+		return 0, nil
+	}
+	written := int64(0)
+	buffer := make([]byte, 4096)
+	for {
+		n, err := src.Read(buffer)
+		if n > 0 {
+			payload := buffer[:n]
+			if tracker != nil {
+				tracker.Observe(payload)
+			}
+			m, writeErr := dst.Write(payload)
+			written += int64(m)
+			if writeErr != nil {
+				return written, writeErr
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return written, nil
+			}
+			return written, err
+		}
+	}
+}
+
+// Observe 观察输入字节流并维护最新完整命令行。
+func (t *commandTracker) Observe(payload []byte) {
+	if t == nil || len(payload) == 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, b := range payload {
+		switch b {
+		case '\r', '\n':
+			current := strings.TrimSpace(string(t.lineBuffer))
+			if current != "" {
+				t.lastCommand = current
+			}
+			t.lineBuffer = t.lineBuffer[:0]
+		case 0x08, 0x7f:
+			if len(t.lineBuffer) > 0 {
+				t.lineBuffer = t.lineBuffer[:len(t.lineBuffer)-1]
+			}
+		default:
+			if b >= 0x20 {
+				t.lineBuffer = append(t.lineBuffer, b)
+			}
+		}
+	}
+}
+
+// LastCommand 返回最近一次完成输入的命令文本。
+func (t *commandTracker) LastCommand() string {
+	if t == nil {
+		return ""
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return strings.TrimSpace(t.lastCommand)
 }
 
 // isClosedNetworkError 识别网络连接已关闭类错误，避免重复打印无效噪声。

--- a/internal/ptyproxy/proxy_unix.go
+++ b/internal/ptyproxy/proxy_unix.go
@@ -884,14 +884,14 @@ func renderDiagnosis(output io.Writer, content string, isError bool) {
 
 // streamPTYOutput 解析 PTY 输出并分离 OSC133 事件，按规则触发 Auto 诊断任务。
 func streamPTYOutput(
-	ptyFile *os.File,
+	ptyReader io.Reader,
 	outputSink io.Writer,
 	commandLogBuffer *UTF8RingBuffer,
 	tracker *commandTracker,
 	autoTriggerCh chan<- diagnoseTrigger,
 	autoState *autoRuntimeState,
 ) {
-	if ptyFile == nil || outputSink == nil || commandLogBuffer == nil {
+	if ptyReader == nil || outputSink == nil || commandLogBuffer == nil {
 		return
 	}
 	parser := &OSC133Parser{}
@@ -900,7 +900,7 @@ func streamPTYOutput(
 
 	buffer := make([]byte, 4096)
 	for {
-		readBytes, err := ptyFile.Read(buffer)
+		readBytes, err := ptyReader.Read(buffer)
 		if readBytes > 0 {
 			cleanOutput, events := parser.Feed(buffer[:readBytes])
 			if len(cleanOutput) > 0 {

--- a/internal/ptyproxy/proxy_unix_test.go
+++ b/internal/ptyproxy/proxy_unix_test.go
@@ -949,7 +949,7 @@ func TestStreamPTYOutputSkipsTriggerWhenAutoDisabled(t *testing.T) {
 	}
 }
 
-func TestStreamPTYOutputReenablesAutoOnPromptReady(t *testing.T) {
+func TestStreamPTYOutputPromptReadyKeepsUserAutoSwitch(t *testing.T) {
 	payloadReader, payloadWriter := io.Pipe()
 	defer payloadReader.Close()
 	output := &bytes.Buffer{}
@@ -974,26 +974,21 @@ func TestStreamPTYOutputReenablesAutoOnPromptReady(t *testing.T) {
 		_ = payloadWriter.Close()
 	}()
 
-	var gotTrigger diagnoseTrigger
 	select {
 	case trigger := <-autoTriggers:
-		gotTrigger = trigger
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("expected one auto diagnose trigger after re-enable")
+		t.Fatalf("unexpected trigger when auto is disabled by user: %#v", trigger)
+	default:
 	}
 	select {
 	case <-streamDone:
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("streamPTYOutput did not finish")
 	}
-	if !autoState.Enabled.Load() {
-		t.Fatal("expected auto to be re-enabled after OSC133 PromptReady")
+	if autoState.Enabled.Load() {
+		t.Fatal("expected auto switch to keep disabled after OSC133 PromptReady")
 	}
 	if !autoState.OSCReady.Load() {
 		t.Fatal("expected OSCReady to be set after PromptReady")
-	}
-	if gotTrigger.CommandText != "go test ./..." {
-		t.Fatalf("trigger.CommandText = %q, want %q", gotTrigger.CommandText, "go test ./...")
 	}
 	if !strings.Contains(output.String(), "fatal: build failed") {
 		t.Fatalf("output = %q, want contains fatal text", output.String())

--- a/internal/ptyproxy/proxy_unix_test.go
+++ b/internal/ptyproxy/proxy_unix_test.go
@@ -1212,7 +1212,11 @@ func TestSendDiagIPCCommandFallbackToLegacySocket(t *testing.T) {
 	t.Setenv("HOME", homeDir)
 	t.Setenv("TMPDIR", legacyTmpDir)
 
-	legacySocket := filepath.Join(legacyTmpDir, fmt.Sprintf("%s%d%s", diagSocketFilePrefix, time.Now().UnixNano(), diagSocketFileSuffix))
+	const legacyPID = 48213
+	legacySocket := filepath.Join(
+		legacyTmpDir,
+		fmt.Sprintf("%s%d%s", diagSocketFilePrefix, legacyPID, diagSocketFileSuffix),
+	)
 	listener, resolvedLegacySocket, err := listenDiagSocket(legacySocket)
 	if err != nil {
 		t.Fatalf("listenDiagSocket() error = %v", err)
@@ -1251,7 +1255,12 @@ func TestSendDiagIPCCommandFallbackToLegacySocket(t *testing.T) {
 		serverDone <- writeErr
 	}()
 
-	primarySocket := filepath.Join(homeDir, ".neocode", "run", "missing.sock")
+	primarySocket := filepath.Join(
+		homeDir,
+		".neocode",
+		"run",
+		fmt.Sprintf("%s%d%s", diagSocketFilePrefix, legacyPID, diagSocketFileSuffix),
+	)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	response, err := sendDiagIPCCommand(ctx, primarySocket, diagIPCRequest{Cmd: diagCommandDiagnose})
@@ -1263,6 +1272,38 @@ func TestSendDiagIPCCommandFallbackToLegacySocket(t *testing.T) {
 	}
 	if serverErr := <-serverDone; serverErr != nil {
 		t.Fatalf("legacy socket server error = %v", serverErr)
+	}
+}
+
+func TestSendDiagIPCCommandFallbackRejectsMismatchedLegacyPID(t *testing.T) {
+	homeDir := t.TempDir()
+	legacyTmpDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("TMPDIR", legacyTmpDir)
+
+	const legacyPID = 39101
+	legacySocket := filepath.Join(
+		legacyTmpDir,
+		fmt.Sprintf("%s%d%s", diagSocketFilePrefix, legacyPID, diagSocketFileSuffix),
+	)
+	listener, resolvedLegacySocket, err := listenDiagSocket(legacySocket)
+	if err != nil {
+		t.Fatalf("listenDiagSocket() error = %v", err)
+	}
+	defer func() {
+		_ = listener.Close()
+		_ = os.Remove(resolvedLegacySocket)
+	}()
+
+	primarySocket := filepath.Join(
+		homeDir,
+		".neocode",
+		"run",
+		fmt.Sprintf("%s%d%s", diagSocketFilePrefix, legacyPID+1, diagSocketFileSuffix),
+	)
+	_, err = sendDiagIPCCommand(context.Background(), primarySocket, diagIPCRequest{Cmd: diagCommandDiagnose})
+	if err == nil {
+		t.Fatal("expected sendDiagIPCCommand() to fail when legacy pid mismatches primary pid")
 	}
 }
 

--- a/internal/ptyproxy/proxy_unix_test.go
+++ b/internal/ptyproxy/proxy_unix_test.go
@@ -3,306 +3,25 @@
 package ptyproxy
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"io"
 	"net"
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 	"time"
-
-	"neo-code/internal/gateway"
-	"neo-code/internal/gateway/protocol"
-	"neo-code/internal/tools"
-
-	"golang.org/x/term"
 )
 
 func assertNoBareLineFeed(t *testing.T, text string) {
 	t.Helper()
-	for index := 0; index < len(text); index++ {
-		if text[index] == '\n' && (index == 0 || text[index-1] != '\r') {
-			t.Fatalf("output contains bare LF at index %d: %q", index, text)
+	for i := 0; i < len(text); i++ {
+		if text[i] == '\n' && (i == 0 || text[i-1] != '\r') {
+			t.Fatalf("output contains bare LF at index %d: %q", i, text)
 		}
-	}
-}
-
-func findTestShellPath(t *testing.T) string {
-	t.Helper()
-
-	candidates := []string{
-		"/bin/sh",
-		"/usr/bin/sh",
-		"/bin/bash",
-		"/usr/bin/bash",
-	}
-	for _, candidate := range candidates {
-		info, err := os.Stat(candidate)
-		if err == nil && !info.IsDir() {
-			return candidate
-		}
-	}
-	t.Skip("no usable shell executable found for PTY test")
-	return ""
-}
-
-func writeGatewayRPCResult(responseWriter *json.Encoder, id json.RawMessage, result any) error {
-	response, rpcError := protocol.NewJSONRPCResultResponse(id, result)
-	if rpcError != nil {
-		return fmt.Errorf("build jsonrpc response failed: %s", strings.TrimSpace(rpcError.Message))
-	}
-	if err := responseWriter.Encode(response); err != nil {
-		return fmt.Errorf("encode jsonrpc response failed: %w", err)
-	}
-	return nil
-}
-
-func writeGatewayTokenFile(t *testing.T, tokenPath string, token string) {
-	t.Helper()
-	payload := map[string]any{
-		"version":    1,
-		"token":      token,
-		"created_at": time.Now().UTC(),
-		"updated_at": time.Now().UTC(),
-	}
-	raw, err := json.MarshalIndent(payload, "", "  ")
-	if err != nil {
-		t.Fatalf("marshal token payload error = %v", err)
-	}
-	raw = append(raw, '\n')
-	if err := os.WriteFile(tokenPath, raw, 0o600); err != nil {
-		t.Fatalf("write token file error = %v", err)
-	}
-}
-
-func withRawModeDisabledForTest(t *testing.T) {
-	t.Helper()
-	originalInput := hostTerminalInput
-	originalIsTerminal := isTerminalFD
-	originalMakeRaw := makeRawTerminal
-	originalRestore := restoreTerminal
-	t.Cleanup(func() {
-		hostTerminalInput = originalInput
-		isTerminalFD = originalIsTerminal
-		makeRawTerminal = originalMakeRaw
-		restoreTerminal = originalRestore
-	})
-
-	hostTerminalInput = nil
-	isTerminalFD = func(int) bool { return false }
-	makeRawTerminal = func(int) (*term.State, error) {
-		return nil, errors.New("makeRawTerminal should not be called when hostTerminalInput is nil")
-	}
-	restoreTerminal = func(int, *term.State) error { return nil }
-}
-
-func TestBuildShellCommandInjectsDiagEnv(t *testing.T) {
-	t.Setenv(DiagSocketEnv, "/tmp/old.sock")
-	command := buildShellCommand("/bin/bash", ManualShellOptions{
-		Workdir: "/tmp",
-	}, "/tmp/new.sock")
-
-	if command.Path != "/bin/bash" {
-		t.Fatalf("command.Path = %q, want %q", command.Path, "/bin/bash")
-	}
-	if command.Dir != "/tmp" {
-		t.Fatalf("command.Dir = %q, want %q", command.Dir, "/tmp")
-	}
-
-	var entries []string
-	for _, item := range command.Env {
-		if strings.HasPrefix(item, DiagSocketEnv+"=") {
-			entries = append(entries, item)
-		}
-	}
-	if len(entries) != 1 {
-		t.Fatalf("diag env entries len = %d, want 1", len(entries))
-	}
-	if entries[0] != DiagSocketEnv+"=/tmp/new.sock" {
-		t.Fatalf("diag env entry = %q, want %q", entries[0], DiagSocketEnv+"=/tmp/new.sock")
-	}
-}
-
-func TestRunManualShellSuccess(t *testing.T) {
-	withRawModeDisabledForTest(t)
-
-	stdoutBuffer := &bytes.Buffer{}
-	stderrBuffer := &bytes.Buffer{}
-	workdir := t.TempDir()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	err := RunManualShell(ctx, ManualShellOptions{
-		Workdir:              workdir,
-		Shell:                findTestShellPath(t),
-		SocketPath:           filepath.Join(t.TempDir(), "diag.sock"),
-		GatewayListenAddress: filepath.Join(t.TempDir(), "missing-gateway.sock"),
-		GatewayTokenFile:     filepath.Join(t.TempDir(), "missing-auth.json"),
-		Stdin:                strings.NewReader("exit 0\n"),
-		Stdout:               stdoutBuffer,
-		Stderr:               stderrBuffer,
-	})
-	if err != nil {
-		t.Fatalf("RunManualShell() error = %v", err)
-	}
-
-	output := stdoutBuffer.String()
-	if !strings.Contains(output, proxyInitializedBanner) {
-		t.Fatalf("stdout = %q, want contains %q", output, proxyInitializedBanner)
-	}
-	if !strings.Contains(output, proxyExitedBanner) {
-		t.Fatalf("stdout = %q, want contains %q", output, proxyExitedBanner)
-	}
-	assertNoBareLineFeed(t, output)
-}
-
-func TestRunManualShellFailsOnMissingShell(t *testing.T) {
-	withRawModeDisabledForTest(t)
-
-	err := RunManualShell(context.Background(), ManualShellOptions{
-		Workdir:    t.TempDir(),
-		Shell:      filepath.Join(t.TempDir(), "missing-shell"),
-		SocketPath: filepath.Join(t.TempDir(), "diag.sock"),
-		Stdin:      strings.NewReader("exit 0\n"),
-		Stdout:     &bytes.Buffer{},
-		Stderr:     &bytes.Buffer{},
-	})
-	if err == nil {
-		t.Fatal("expected shell start error")
-	}
-	if !strings.Contains(err.Error(), "start pty shell") {
-		t.Fatalf("error = %v, want contains %q", err, "start pty shell")
-	}
-}
-
-func TestRunManualShellFailsOnInvalidSocketPath(t *testing.T) {
-	withRawModeDisabledForTest(t)
-
-	workspace := t.TempDir()
-	blockingFile := filepath.Join(workspace, "blocking-file")
-	if err := os.WriteFile(blockingFile, []byte("x"), 0o600); err != nil {
-		t.Fatalf("write blocking file error = %v", err)
-	}
-
-	err := RunManualShell(context.Background(), ManualShellOptions{
-		Workdir:    workspace,
-		Shell:      findTestShellPath(t),
-		SocketPath: filepath.Join(blockingFile, "diag.sock"),
-		Stdin:      strings.NewReader("exit 0\n"),
-		Stdout:     &bytes.Buffer{},
-		Stderr:     &bytes.Buffer{},
-	})
-	if err == nil {
-		t.Fatal("expected socket path error")
-	}
-	if !strings.Contains(err.Error(), "create socket directory") {
-		t.Fatalf("error = %v, want contains %q", err, "create socket directory")
-	}
-}
-
-func TestSendDiagnoseSignal(t *testing.T) {
-	socketPath := filepath.Join(t.TempDir(), "diag.sock")
-	listener, resolvedPath, err := listenDiagSocket(socketPath)
-	if err != nil {
-		t.Fatalf("listenDiagSocket() error = %v", err)
-	}
-	t.Cleanup(func() {
-		_ = listener.Close()
-		_ = os.Remove(resolvedPath)
-	})
-
-	payloadCh := make(chan string, 1)
-	go func() {
-		connection, acceptErr := listener.Accept()
-		if acceptErr != nil {
-			payloadCh <- "accept-error:" + acceptErr.Error()
-			return
-		}
-		defer connection.Close()
-		buffer := make([]byte, 128)
-		n, readErr := connection.Read(buffer)
-		if readErr != nil {
-			payloadCh <- "read-error:" + readErr.Error()
-			return
-		}
-		payloadCh <- string(buffer[:n])
-	}()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	if err := SendDiagnoseSignal(ctx, resolvedPath); err != nil {
-		t.Fatalf("SendDiagnoseSignal() error = %v", err)
-	}
-
-	select {
-	case payload := <-payloadCh:
-		if payload != diagSignalPayload {
-			t.Fatalf("payload = %q, want %q", payload, diagSignalPayload)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("timeout waiting for payload")
-	}
-}
-
-func TestSendDiagnoseSignalWaitsForServerCompletion(t *testing.T) {
-	socketPath := filepath.Join(t.TempDir(), "diag-wait.sock")
-	listener, resolvedPath, err := listenDiagSocket(socketPath)
-	if err != nil {
-		t.Fatalf("listenDiagSocket() error = %v", err)
-	}
-	t.Cleanup(func() {
-		_ = listener.Close()
-		_ = os.Remove(resolvedPath)
-	})
-
-	const serverDelay = 120 * time.Millisecond
-	serverErrCh := make(chan error, 1)
-	go func() {
-		connection, acceptErr := listener.Accept()
-		if acceptErr != nil {
-			serverErrCh <- acceptErr
-			return
-		}
-		defer connection.Close()
-		buffer := make([]byte, 128)
-		n, readErr := connection.Read(buffer)
-		if readErr != nil {
-			serverErrCh <- readErr
-			return
-		}
-		if string(buffer[:n]) != diagSignalPayload {
-			serverErrCh <- errors.New("unexpected payload")
-			return
-		}
-		time.Sleep(serverDelay)
-		_, writeErr := connection.Write([]byte(diagSignalAckPayload))
-		serverErrCh <- writeErr
-	}()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	start := time.Now()
-	if err := SendDiagnoseSignal(ctx, resolvedPath); err != nil {
-		t.Fatalf("SendDiagnoseSignal() error = %v", err)
-	}
-	elapsed := time.Since(start)
-	if elapsed < serverDelay {
-		t.Fatalf("SendDiagnoseSignal returned too early: elapsed=%s, want >= %s", elapsed, serverDelay)
-	}
-
-	select {
-	case serverErr := <-serverErrCh:
-		if serverErr != nil {
-			t.Fatalf("server error = %v", serverErr)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("timeout waiting for server completion")
 	}
 }
 
@@ -336,323 +55,180 @@ func TestCleanupStaleSocketRejectsRegularFile(t *testing.T) {
 	}
 }
 
+func TestHandleDiagSocketConnectionAutoMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		command     string
+		wantEnabled bool
+	}{
+		{name: "auto on", command: diagCommandAutoOn, wantEnabled: true},
+		{name: "auto off", command: diagCommandAutoOff, wantEnabled: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			serverConn, clientConn := net.Pipe()
+			defer clientConn.Close()
+
+			jobCh := make(chan diagnoseJob, 1)
+			autoState := &autoRuntimeState{}
+			autoState.Enabled.Store(!tc.wantEnabled)
+			done := make(chan struct{})
+			go func() {
+				handleDiagSocketConnection(context.Background(), serverConn, jobCh, autoState)
+				close(done)
+			}()
+
+			req := diagIPCRequest{Cmd: tc.command}
+			raw, _ := json.Marshal(req)
+			_, _ = clientConn.Write(append(raw, '\n'))
+
+			line, err := bufio.NewReader(clientConn).ReadBytes('\n')
+			if err != nil {
+				t.Fatalf("read response error = %v", err)
+			}
+			var resp diagIPCResponse
+			if err := json.Unmarshal(line, &resp); err != nil {
+				t.Fatalf("unmarshal response error = %v", err)
+			}
+			if !resp.OK {
+				t.Fatalf("response not ok: %#v", resp)
+			}
+			if autoState.Enabled.Load() != tc.wantEnabled {
+				t.Fatalf("enabled = %v, want %v", autoState.Enabled.Load(), tc.wantEnabled)
+			}
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("timeout waiting handler return")
+			}
+		})
+	}
+}
+
+func TestHandleDiagSocketConnectionDiagnose(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	jobCh := make(chan diagnoseJob, 1)
+	autoState := &autoRuntimeState{}
+	done := make(chan struct{})
+	go func() {
+		handleDiagSocketConnection(context.Background(), serverConn, jobCh, autoState)
+		close(done)
+	}()
+
+	raw, _ := json.Marshal(diagIPCRequest{Cmd: diagCommandDiagnose})
+	_, _ = clientConn.Write(append(raw, '\n'))
+
+	var job diagnoseJob
+	select {
+	case job = <-jobCh:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting diagnose job")
+	}
+	if job.Done == nil {
+		t.Fatal("job.Done should not be nil")
+	}
+	job.Done <- diagIPCResponse{OK: true, Message: "done"}
+
+	line, err := bufio.NewReader(clientConn).ReadBytes('\n')
+	if err != nil {
+		t.Fatalf("read response error = %v", err)
+	}
+	var resp diagIPCResponse
+	if err := json.Unmarshal(line, &resp); err != nil {
+		t.Fatalf("unmarshal response error = %v", err)
+	}
+	if !resp.OK {
+		t.Fatalf("response not ok: %#v", resp)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting handler return")
+	}
+}
+
+func TestSendDiagIPCCommandToPath(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "ipc.sock")
+	listener, resolvedPath, err := listenDiagSocket(socketPath)
+	if err != nil {
+		t.Fatalf("listenDiagSocket() error = %v", err)
+	}
+	defer func() {
+		_ = listener.Close()
+		_ = os.Remove(resolvedPath)
+	}()
+
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			serverDone <- acceptErr
+			return
+		}
+		defer conn.Close()
+		line, readErr := bufio.NewReader(conn).ReadBytes('\n')
+		if readErr != nil {
+			serverDone <- readErr
+			return
+		}
+		var req diagIPCRequest
+		if err := json.Unmarshal(line, &req); err != nil {
+			serverDone <- err
+			return
+		}
+		if req.Cmd != diagCommandDiagnose {
+			serverDone <- io.ErrUnexpectedEOF
+			return
+		}
+		resp, _ := json.Marshal(diagIPCResponse{OK: true, Message: "ok"})
+		_, writeErr := conn.Write(append(resp, '\n'))
+		serverDone <- writeErr
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	resp, err := sendDiagIPCCommandToPath(ctx, resolvedPath, diagIPCRequest{Cmd: diagCommandDiagnose})
+	if err != nil {
+		t.Fatalf("sendDiagIPCCommandToPath() error = %v", err)
+	}
+	if !resp.OK {
+		t.Fatalf("resp.OK = false")
+	}
+	if serverErr := <-serverDone; serverErr != nil {
+		t.Fatalf("server error = %v", serverErr)
+	}
+}
+
 func TestRunSingleDiagnosisGatewayUnavailableDoesNotPanic(t *testing.T) {
 	buffer := NewUTF8RingBuffer(1024)
 	_, _ = buffer.Write([]byte("中文日志 + \u001b[31merror\u001b[0m"))
 
 	output := &bytes.Buffer{}
-	runSingleDiagnosis(output, buffer, ManualShellOptions{
-		Workdir:              t.TempDir(),
-		Shell:                "/bin/bash",
-		GatewayListenAddress: filepath.Join(t.TempDir(), "missing-gateway.sock"),
-		GatewayTokenFile:     filepath.Join(t.TempDir(), "missing-auth.json"),
-	}, filepath.Join(t.TempDir(), "diag.sock"))
+	runSingleDiagnosis(
+		output,
+		buffer,
+		ManualShellOptions{
+			Workdir:              t.TempDir(),
+			Shell:                "/bin/bash",
+			GatewayListenAddress: filepath.Join(t.TempDir(), "missing-gateway.sock"),
+			GatewayTokenFile:     filepath.Join(t.TempDir(), "missing-auth.json"),
+		},
+		filepath.Join(t.TempDir(), "diag.sock"),
+		diagnoseTrigger{
+			CommandText: "go test ./...",
+			ExitCode:    1,
+			OutputText:  "fatal: missing module",
+		},
+		false,
+		&autoRuntimeState{},
+	)
 
 	if !strings.Contains(output.String(), "NeoCode Diagnosis") {
 		t.Fatalf("output = %q, want contains %q", output.String(), "NeoCode Diagnosis")
 	}
 	assertNoBareLineFeed(t, output.String())
-}
-
-func TestRunSingleDiagnosisGatewayHappyPath(t *testing.T) {
-	tempDir := t.TempDir()
-	gatewaySocketPath := filepath.Join(tempDir, "gateway.sock")
-	listener, err := net.Listen("unix", gatewaySocketPath)
-	if err != nil {
-		t.Fatalf("listen gateway socket error = %v", err)
-	}
-	t.Cleanup(func() {
-		_ = listener.Close()
-		_ = os.Remove(gatewaySocketPath)
-	})
-
-	tokenFile := filepath.Join(tempDir, "auth.json")
-	const expectedToken = "diag-test-token"
-	writeGatewayTokenFile(t, tokenFile, expectedToken)
-
-	serverErrCh := make(chan error, 1)
-	go func() {
-		connection, acceptErr := listener.Accept()
-		if acceptErr != nil {
-			serverErrCh <- fmt.Errorf("accept gateway connection: %w", acceptErr)
-			return
-		}
-		defer connection.Close()
-
-		requestReader := json.NewDecoder(connection)
-		responseWriter := json.NewEncoder(connection)
-
-		var authRequest protocol.JSONRPCRequest
-		if err := requestReader.Decode(&authRequest); err != nil {
-			serverErrCh <- fmt.Errorf("decode auth request: %w", err)
-			return
-		}
-		if authRequest.Method != protocol.MethodGatewayAuthenticate {
-			serverErrCh <- fmt.Errorf("auth method = %q, want %q", authRequest.Method, protocol.MethodGatewayAuthenticate)
-			return
-		}
-
-		var authParams protocol.AuthenticateParams
-		if err := json.Unmarshal(authRequest.Params, &authParams); err != nil {
-			serverErrCh <- fmt.Errorf("decode auth params: %w", err)
-			return
-		}
-		if authParams.Token != expectedToken {
-			serverErrCh <- fmt.Errorf("auth token = %q, want %q", authParams.Token, expectedToken)
-			return
-		}
-		if err := writeGatewayRPCResult(responseWriter, authRequest.ID, gateway.MessageFrame{
-			Type:   gateway.FrameTypeAck,
-			Action: gateway.FrameActionAuthenticate,
-		}); err != nil {
-			serverErrCh <- err
-			return
-		}
-
-		var executeRequest protocol.JSONRPCRequest
-		if err := requestReader.Decode(&executeRequest); err != nil {
-			serverErrCh <- fmt.Errorf("decode execute request: %w", err)
-			return
-		}
-		if executeRequest.Method != protocol.MethodGatewayExecuteSystemTool {
-			serverErrCh <- fmt.Errorf(
-				"execute method = %q, want %q",
-				executeRequest.Method,
-				protocol.MethodGatewayExecuteSystemTool,
-			)
-			return
-		}
-
-		var executeParams protocol.ExecuteSystemToolParams
-		if err := json.Unmarshal(executeRequest.Params, &executeParams); err != nil {
-			serverErrCh <- fmt.Errorf("decode execute params: %w", err)
-			return
-		}
-		if executeParams.ToolName != tools.ToolNameDiagnose {
-			serverErrCh <- fmt.Errorf("tool_name = %q, want %q", executeParams.ToolName, tools.ToolNameDiagnose)
-			return
-		}
-
-		responsePayload := tools.ToolResult{
-			Content: `{"confidence":0.95,"root_cause":"disk full","investigation_commands":["df -h"],"fix_commands":["rm -rf /tmp/*"]}`,
-			IsError: false,
-		}
-		if err := writeGatewayRPCResult(responseWriter, executeRequest.ID, gateway.MessageFrame{
-			Type:    gateway.FrameTypeAck,
-			Action:  gateway.FrameActionExecuteSystemTool,
-			Payload: responsePayload,
-		}); err != nil {
-			serverErrCh <- err
-			return
-		}
-		serverErrCh <- nil
-	}()
-
-	logBuffer := NewUTF8RingBuffer(1024)
-	_, _ = logBuffer.Write([]byte("诊断样本日志"))
-	outputBuffer := &bytes.Buffer{}
-	runSingleDiagnosis(outputBuffer, logBuffer, ManualShellOptions{
-		Workdir:              tempDir,
-		Shell:                findTestShellPath(t),
-		GatewayListenAddress: gatewaySocketPath,
-		GatewayTokenFile:     tokenFile,
-	}, filepath.Join(tempDir, "diag.sock"))
-
-	select {
-	case serverErr := <-serverErrCh:
-		if serverErr != nil {
-			t.Fatalf("gateway mock server error = %v", serverErr)
-		}
-	case <-time.After(3 * time.Second):
-		t.Fatal("timeout waiting for gateway mock server")
-	}
-
-	output := outputBuffer.String()
-	if !strings.Contains(output, "NeoCode Diagnosis") {
-		t.Fatalf("output = %q, want contains %q", output, "NeoCode Diagnosis")
-	}
-	if !strings.Contains(output, "根因: disk full") {
-		t.Fatalf("output = %q, want contains %q", output, "根因: disk full")
-	}
-	if !strings.Contains(output, "建议排查命令") {
-		t.Fatalf("output = %q, want contains %q", output, "建议排查命令")
-	}
-	if !strings.Contains(output, "建议修复命令") {
-		t.Fatalf("output = %q, want contains %q", output, "建议修复命令")
-	}
-	assertNoBareLineFeed(t, output)
-}
-
-func TestPrintProxyInitializedBanner(t *testing.T) {
-	buffer := &bytes.Buffer{}
-	printProxyInitializedBanner(buffer)
-	if buffer.String() != proxyInitializedBanner+"\r\n" {
-		t.Fatalf("banner output = %q, want %q", buffer.String(), proxyInitializedBanner+"\\r\\n")
-	}
-}
-
-func TestPrintProxyExitedBanner(t *testing.T) {
-	buffer := &bytes.Buffer{}
-	printProxyExitedBanner(buffer)
-	if buffer.String() != "\r\n"+proxyExitedBanner+"\r\n" {
-		t.Fatalf("banner output = %q, want %q", buffer.String(), "\\r\\n"+proxyExitedBanner+"\\r\\n")
-	}
-}
-
-func TestRenderDiagnosisUsesCRLFLineEndings(t *testing.T) {
-	buffer := &bytes.Buffer{}
-	renderDiagnosis(buffer, "", false)
-	output := buffer.String()
-	assertNoBareLineFeed(t, output)
-	if !strings.Contains(output, "\r\n") {
-		t.Fatalf("renderDiagnosis output = %q, want contains CRLF", output)
-	}
-}
-
-func TestEnableHostTerminalRawModeSkipsNonTerminal(t *testing.T) {
-	originalInput := hostTerminalInput
-	originalIsTerminal := isTerminalFD
-	originalMakeRaw := makeRawTerminal
-	originalRestore := restoreTerminal
-	t.Cleanup(func() {
-		hostTerminalInput = originalInput
-		isTerminalFD = originalIsTerminal
-		makeRawTerminal = originalMakeRaw
-		restoreTerminal = originalRestore
-	})
-
-	filePath := filepath.Join(t.TempDir(), "stdin.txt")
-	if err := os.WriteFile(filePath, []byte("stdin"), 0o600); err != nil {
-		t.Fatalf("write stdin file error = %v", err)
-	}
-	inputFile, err := os.Open(filePath)
-	if err != nil {
-		t.Fatalf("open stdin file error = %v", err)
-	}
-	defer inputFile.Close()
-
-	hostTerminalInput = inputFile
-	isTerminalFD = func(int) bool { return false }
-
-	makeRawCalled := false
-	makeRawTerminal = func(int) (*term.State, error) {
-		makeRawCalled = true
-		return &term.State{}, nil
-	}
-	restoreFn, err := enableHostTerminalRawMode()
-	if err != nil {
-		t.Fatalf("enableHostTerminalRawMode() error = %v", err)
-	}
-	if makeRawCalled {
-		t.Fatal("makeRawTerminal should not be called for non-terminal input")
-	}
-	if restoreErr := restoreFn(); restoreErr != nil {
-		t.Fatalf("restoreFn() error = %v", restoreErr)
-	}
-}
-
-func TestEnableHostTerminalRawModeCallsMakeRawAndRestore(t *testing.T) {
-	originalInput := hostTerminalInput
-	originalIsTerminal := isTerminalFD
-	originalMakeRaw := makeRawTerminal
-	originalRestore := restoreTerminal
-	t.Cleanup(func() {
-		hostTerminalInput = originalInput
-		isTerminalFD = originalIsTerminal
-		makeRawTerminal = originalMakeRaw
-		restoreTerminal = originalRestore
-	})
-
-	filePath := filepath.Join(t.TempDir(), "stdin-terminal.txt")
-	if err := os.WriteFile(filePath, []byte("stdin"), 0o600); err != nil {
-		t.Fatalf("write stdin file error = %v", err)
-	}
-	inputFile, err := os.Open(filePath)
-	if err != nil {
-		t.Fatalf("open stdin file error = %v", err)
-	}
-	defer inputFile.Close()
-	hostTerminalInput = inputFile
-
-	expectedFD := int(inputFile.Fd())
-	state := &term.State{}
-	makeRawCalled := false
-	restoreCalled := false
-
-	isTerminalFD = func(fd int) bool {
-		if fd != expectedFD {
-			t.Fatalf("isTerminal fd = %d, want %d", fd, expectedFD)
-		}
-		return true
-	}
-	makeRawTerminal = func(fd int) (*term.State, error) {
-		if fd != expectedFD {
-			t.Fatalf("makeRaw fd = %d, want %d", fd, expectedFD)
-		}
-		makeRawCalled = true
-		return state, nil
-	}
-	restoreTerminal = func(fd int, restored *term.State) error {
-		if fd != expectedFD {
-			t.Fatalf("restore fd = %d, want %d", fd, expectedFD)
-		}
-		if restored != state {
-			t.Fatalf("restore state pointer mismatch")
-		}
-		restoreCalled = true
-		return nil
-	}
-
-	restoreFn, err := enableHostTerminalRawMode()
-	if err != nil {
-		t.Fatalf("enableHostTerminalRawMode() error = %v", err)
-	}
-	if !makeRawCalled {
-		t.Fatal("expected makeRawTerminal to be called")
-	}
-	if restoreErr := restoreFn(); restoreErr != nil {
-		t.Fatalf("restoreFn() error = %v", restoreErr)
-	}
-	if !restoreCalled {
-		t.Fatal("expected restoreTerminal to be called")
-	}
-}
-
-func TestEnableHostTerminalRawModeMakeRawError(t *testing.T) {
-	originalInput := hostTerminalInput
-	originalIsTerminal := isTerminalFD
-	originalMakeRaw := makeRawTerminal
-	originalRestore := restoreTerminal
-	t.Cleanup(func() {
-		hostTerminalInput = originalInput
-		isTerminalFD = originalIsTerminal
-		makeRawTerminal = originalMakeRaw
-		restoreTerminal = originalRestore
-	})
-
-	filePath := filepath.Join(t.TempDir(), "stdin-error.txt")
-	if err := os.WriteFile(filePath, []byte("stdin"), 0o600); err != nil {
-		t.Fatalf("write stdin file error = %v", err)
-	}
-	inputFile, err := os.Open(filePath)
-	if err != nil {
-		t.Fatalf("open stdin file error = %v", err)
-	}
-	defer inputFile.Close()
-	hostTerminalInput = inputFile
-
-	isTerminalFD = func(int) bool { return true }
-	makeRawTerminal = func(int) (*term.State, error) {
-		return nil, errors.New("raw mode failed")
-	}
-
-	_, err = enableHostTerminalRawMode()
-	if err == nil {
-		t.Fatal("expected raw mode error")
-	}
-	if !strings.Contains(err.Error(), "set host terminal raw mode") {
-		t.Fatalf("error = %v, want contains %q", err, "set host terminal raw mode")
-	}
 }
 
 func TestResolveShellPathDefaultsToBinBash(t *testing.T) {
@@ -677,355 +253,4 @@ func TestResolveShellPathPrefersExplicit(t *testing.T) {
 	if path != "/bin/fish" {
 		t.Fatalf("resolveShellPath() = %q, want %q", path, "/bin/fish")
 	}
-}
-
-func TestIsClosedNetworkErrorNil(t *testing.T) {
-	if isClosedNetworkError(nil) {
-		t.Fatal("isClosedNetworkError(nil) should be false")
-	}
-}
-
-func TestIsClosedNetworkErrorDetectsNetErrClosed(t *testing.T) {
-	if !isClosedNetworkError(net.ErrClosed) {
-		t.Fatal("isClosedNetworkError(net.ErrClosed) should be true")
-	}
-}
-
-func TestIsClosedNetworkErrorDetectsStringMatch(t *testing.T) {
-	err := errors.New("use of closed network connection")
-	if !isClosedNetworkError(err) {
-		t.Fatal("isClosedNetworkError() should be true for closed connection string")
-	}
-}
-
-func TestIsClosedNetworkErrorNonMatch(t *testing.T) {
-	err := errors.New("some other error")
-	if isClosedNetworkError(err) {
-		t.Fatal("isClosedNetworkError() should be false for unrelated error")
-	}
-}
-
-func TestSerializedWriterNilWriter(t *testing.T) {
-	var w *serializedWriter
-	n, err := w.Write([]byte("hello"))
-	if err != nil {
-		t.Fatalf("Write() on nil receiver error = %v", err)
-	}
-	if n != len("hello") {
-		t.Fatalf("Write() n = %d, want %d", n, len("hello"))
-	}
-}
-
-func TestSerializedWriterNilLock(t *testing.T) {
-	var buffer bytes.Buffer
-	w := &serializedWriter{writer: &buffer, lock: nil}
-	n, err := w.Write([]byte("data"))
-	if err != nil {
-		t.Fatalf("Write() error = %v", err)
-	}
-	if n != 4 {
-		t.Fatalf("Write() n = %d, want 4", n)
-	}
-	if buffer.String() != "data" {
-		t.Fatalf("buffer = %q, want %q", buffer.String(), "data")
-	}
-}
-
-func TestSerializedWriterWithLock(t *testing.T) {
-	var buffer bytes.Buffer
-	var mu sync.Mutex
-	w := &serializedWriter{writer: &buffer, lock: &mu}
-	n, err := w.Write([]byte("locked-write"))
-	if err != nil {
-		t.Fatalf("Write() error = %v", err)
-	}
-	if n != len("locked-write") {
-		t.Fatalf("Write() n = %d, want %d", n, len("locked-write"))
-	}
-	if buffer.String() != "locked-write" {
-		t.Fatalf("buffer = %q, want %q", buffer.String(), "locked-write")
-	}
-}
-
-func TestWriteProxyTextNilWriter(t *testing.T) {
-	writeProxyText(nil, "text")
-	writeProxyLine(nil, "text")
-}
-
-func TestWriteProxyTextEmptyText(t *testing.T) {
-	var buffer bytes.Buffer
-	writeProxyText(&buffer, "")
-	if buffer.Len() != 0 {
-		t.Fatalf("expected empty output, got %q", buffer.String())
-	}
-}
-
-func TestWriteProxyTextNormalizesLineEndings(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"hello\nworld", "hello\r\nworld"},
-		{"hello\r\nworld", "hello\r\nworld"},
-		{"hello\rworld", "hello\r\nworld"},
-		{"line1\nline2\nline3", "line1\r\nline2\r\nline3"},
-	}
-	for _, tt := range tests {
-		var buffer bytes.Buffer
-		writeProxyText(&buffer, tt.input)
-		if buffer.String() != tt.expected {
-			t.Fatalf("writeProxyText(%q) = %q, want %q", tt.input, buffer.String(), tt.expected)
-		}
-	}
-}
-
-func TestWriteProxyLine(t *testing.T) {
-	var buffer bytes.Buffer
-	writeProxyLine(&buffer, "header")
-	// writeProxyText with "\n" appended → normalized to "\r\n"
-	if buffer.String() != "header\r\n" {
-		t.Fatalf("writeProxyLine output = %q, want %q", buffer.String(), "header\\r\\n")
-	}
-}
-
-func TestWriteProxyf(t *testing.T) {
-	var buffer bytes.Buffer
-	writeProxyf(&buffer, "count=%d, name=%s", 42, "test")
-	expected := "count=42, name=test"
-	// writeProxyf → writeProxyText which normalizes
-	got := buffer.String()
-	if got != expected {
-		t.Fatalf("writeProxyf output = %q, want %q", got, expected)
-	}
-}
-
-func TestSyncPTYWindowSizeNilPTY(t *testing.T) {
-	syncPTYWindowSize(nil, nil)
-}
-
-func TestWatchPTYWindowResizeNilPTY(t *testing.T) {
-	stop := watchPTYWindowResize(nil, nil)
-	stop()
-}
-
-func TestDecodeToolResult(t *testing.T) {
-	result, err := decodeToolResult(map[string]any{
-		"content": "ok",
-		"isError": false,
-	})
-	if err != nil {
-		t.Fatalf("decodeToolResult() error = %v", err)
-	}
-	if result.Content != "ok" {
-		t.Fatalf("Content = %q, want %q", result.Content, "ok")
-	}
-	if result.IsError {
-		t.Fatal("IsError should be false")
-	}
-}
-
-func TestDecodeToolResultInvalidPayload(t *testing.T) {
-	_, err := decodeToolResult([]byte(`not-json`))
-	if err == nil {
-		t.Fatal("expected decode error")
-	}
-}
-
-func TestDecodeToolResultFromStruct(t *testing.T) {
-	result, err := decodeToolResult(map[string]any{"content": "from-map", "isError": true})
-	if err != nil {
-		t.Fatalf("decodeToolResult() error = %v", err)
-	}
-	if result.Content != "from-map" {
-		t.Fatalf("Content = %q, want %q", result.Content, "from-map")
-	}
-	if !result.IsError {
-		t.Fatal("IsError should be true")
-	}
-}
-
-func TestRenderDiagnosisNilOutput(t *testing.T) {
-	renderDiagnosis(nil, "some content", false)
-}
-
-func TestRenderDiagnosisEmptyContent(t *testing.T) {
-	var buffer bytes.Buffer
-	renderDiagnosis(&buffer, "", false)
-	output := buffer.String()
-	if !strings.Contains(output, "无可用诊断内容") {
-		t.Fatalf("output = %q, want contains %q", output, "无可用诊断内容")
-	}
-	assertNoBareLineFeed(t, output)
-}
-
-func TestRenderDiagnosisErrorHeader(t *testing.T) {
-	var buffer bytes.Buffer
-	renderDiagnosis(&buffer, `{"confidence":0.9,"rootCause":"OOM","fixCommands":["free -h"]}`, true)
-	output := buffer.String()
-	assertNoBareLineFeed(t, output)
-	if !strings.Contains(output, "\033[31m") {
-		t.Fatalf("error output should use red color, got %q", output)
-	}
-}
-
-func TestRenderDiagnosisFullContent(t *testing.T) {
-	var buffer bytes.Buffer
-	renderDiagnosis(&buffer, `{"confidence":0.95,"root_cause":"disk full","investigation_commands":["df -h"],"fix_commands":["rm -rf /tmp/*"]}`, false)
-	output := buffer.String()
-	assertNoBareLineFeed(t, output)
-	if !strings.Contains(output, "置信度: 0.95") {
-		t.Fatalf("output = %q, want contains %q", output, "置信度: 0.95")
-	}
-	if !strings.Contains(output, "建议排查命令") {
-		t.Fatalf("output = %q, want contains %q", output, "建议排查命令")
-	}
-	if !strings.Contains(output, "建议修复命令") {
-		t.Fatalf("output = %q, want contains %q", output, "建议修复命令")
-	}
-}
-
-func TestCleanupStaleSocketNotExist(t *testing.T) {
-	socketPath := filepath.Join(t.TempDir(), "nonexistent.sock")
-	err := cleanupStaleSocket(socketPath)
-	if err != nil {
-		t.Fatalf("cleanupStaleSocket() error = %v, want nil", err)
-	}
-}
-
-func TestHandleDiagSocketConnectionNil(t *testing.T) {
-	handleDiagSocketConnection(context.Background(), nil, make(chan diagSignalRequest, 1))
-}
-
-func TestHandleDiagSocketConnectionEmitsTriggerAndAck(t *testing.T) {
-	serverConnection, clientConnection := net.Pipe()
-	defer clientConnection.Close()
-
-	triggerCh := make(chan diagSignalRequest, 1)
-	done := make(chan struct{})
-	go func() {
-		handleDiagSocketConnection(context.Background(), serverConnection, triggerCh)
-		close(done)
-	}()
-
-	if _, err := clientConnection.Write([]byte(diagSignalPayload)); err != nil {
-		t.Fatalf("write payload error = %v", err)
-	}
-
-	var request diagSignalRequest
-	select {
-	case request = <-triggerCh:
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for trigger request")
-	}
-	if request.done == nil {
-		t.Fatal("request.done should not be nil")
-	}
-
-	if err := clientConnection.SetReadDeadline(time.Now().Add(120 * time.Millisecond)); err != nil {
-		t.Fatalf("set read deadline error = %v", err)
-	}
-	ackBuffer := make([]byte, len(diagSignalAckPayload))
-	if _, err := io.ReadFull(clientConnection, ackBuffer); err == nil {
-		t.Fatalf("ack should not be readable before diagnosis completion, got %q", string(ackBuffer))
-	}
-	_ = clientConnection.SetReadDeadline(time.Time{})
-
-	close(request.done)
-	if _, err := io.ReadFull(clientConnection, ackBuffer); err != nil {
-		t.Fatalf("read ack error = %v", err)
-	}
-	if string(ackBuffer) != diagSignalAckPayload {
-		t.Fatalf("ack payload = %q, want %q", string(ackBuffer), diagSignalAckPayload)
-	}
-
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for handleDiagSocketConnection to return")
-	}
-}
-
-func TestServeDiagSocketHandlesUnexpectedAndNormalPayload(t *testing.T) {
-	socketPath := filepath.Join(t.TempDir(), "serve-diag.sock")
-	listener, resolvedPath, err := listenDiagSocket(socketPath)
-	if err != nil {
-		t.Fatalf("listenDiagSocket() error = %v", err)
-	}
-	t.Cleanup(func() {
-		_ = listener.Close()
-		_ = os.Remove(resolvedPath)
-	})
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	triggerCh := make(chan diagSignalRequest, 2)
-	serveDone := make(chan struct{})
-	go func() {
-		serveDiagSocket(ctx, listener, triggerCh, nil)
-		close(serveDone)
-	}()
-
-	sendAndVerify := func(payload string) {
-		t.Helper()
-		connection, err := net.Dial("unix", resolvedPath)
-		if err != nil {
-			t.Fatalf("dial diag socket error = %v", err)
-		}
-		defer connection.Close()
-
-		if _, err := connection.Write([]byte(payload)); err != nil {
-			t.Fatalf("write payload error = %v", err)
-		}
-
-		var request diagSignalRequest
-		select {
-		case request = <-triggerCh:
-		case <-time.After(time.Second):
-			t.Fatalf("timeout waiting for trigger, payload=%q", payload)
-		}
-		if request.done == nil {
-			t.Fatal("request.done should not be nil")
-		}
-		close(request.done)
-
-		ack := make([]byte, len(diagSignalAckPayload))
-		if _, err := io.ReadFull(connection, ack); err != nil {
-			t.Fatalf("read ack error = %v", err)
-		}
-		if string(ack) != diagSignalAckPayload {
-			t.Fatalf("ack payload = %q, want %q", string(ack), diagSignalAckPayload)
-		}
-	}
-
-	sendAndVerify("unexpected-signal\n")
-	sendAndVerify(diagSignalPayload)
-
-	cancel()
-	_ = listener.Close()
-	select {
-	case <-serveDone:
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for serveDiagSocket to stop")
-	}
-}
-
-func TestConsumeDiagSignalsContextCancel(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	consumeDiagSignals(ctx, nil, nil, nil, ManualShellOptions{}, "")
-}
-
-func TestConsumeDiagSignalsChannelClosed(t *testing.T) {
-	ch := make(chan diagSignalRequest)
-	close(ch)
-	consumeDiagSignals(context.Background(), ch, nil, nil, ManualShellOptions{}, "")
-}
-
-func TestPrintProxyFunctionsNilWriter(t *testing.T) {
-	printProxyInitializedBanner(nil)
-	printProxyExitedBanner(nil)
-}
-
-func TestRunSingleDiagnosisNilOutput(t *testing.T) {
-	runSingleDiagnosis(nil, nil, ManualShellOptions{}, "")
 }

--- a/internal/ptyproxy/proxy_unix_test.go
+++ b/internal/ptyproxy/proxy_unix_test.go
@@ -1642,20 +1642,46 @@ func TestPrepareBashInitRCAndBuildShellCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("prepareZshInitDir", func(t *testing.T) {
+		originalCreate := createZshInitDir
+		t.Cleanup(func() { createZshInitDir = originalCreate })
+
+		createZshInitDir = func() (string, error) { return "/tmp/mock-zdotdir", nil }
+		if got := prepareZshInitDir("/bin/zsh"); got != "/tmp/mock-zdotdir" {
+			t.Fatalf("prepareZshInitDir() = %q, want /tmp/mock-zdotdir", got)
+		}
+		if got := prepareZshInitDir("/bin/bash"); got != "" {
+			t.Fatalf("prepareZshInitDir(non-zsh) = %q, want empty", got)
+		}
+
+		createZshInitDir = func() (string, error) { return "", errors.New("mock create error") }
+		if got := prepareZshInitDir("/bin/zsh"); got != "" {
+			t.Fatalf("prepareZshInitDir(create error) = %q, want empty", got)
+		}
+	})
+
 	t.Run("buildShellCommand", func(t *testing.T) {
 		originalCreate := createBashInitRCFile
 		originalDelete := deleteBashInitRCFile
+		originalCreateZsh := createZshInitDir
+		originalDeleteZsh := deleteZshInitDir
 		t.Cleanup(func() { createBashInitRCFile = originalCreate })
 		t.Cleanup(func() { deleteBashInitRCFile = originalDelete })
+		t.Cleanup(func() { createZshInitDir = originalCreateZsh })
+		t.Cleanup(func() { deleteZshInitDir = originalDeleteZsh })
 
 		rcPath := filepath.Join(t.TempDir(), "mock.rc")
 		if err := os.WriteFile(rcPath, []byte("mock"), 0o600); err != nil {
 			t.Fatalf("WriteFile() error = %v", err)
 		}
+		zdotDirPath := t.TempDir()
 
 		deletedPath := ""
+		deletedZdotDir := ""
 		createBashInitRCFile = func() (string, error) { return rcPath, nil }
 		deleteBashInitRCFile = func(path string) { deletedPath = path }
+		createZshInitDir = func() (string, error) { return zdotDirPath, nil }
+		deleteZshInitDir = func(path string) { deletedZdotDir = path }
 
 		cmd, cleanup := buildShellCommand("/bin/bash", ManualShellOptions{Workdir: t.TempDir()}, "/tmp/diag.sock")
 		if cmd.Path != "/bin/bash" {
@@ -1683,7 +1709,20 @@ func TestPrepareBashInitRCAndBuildShellCommand(t *testing.T) {
 		if strings.Contains(strings.Join(cmd.Args, " "), "--rcfile") {
 			t.Fatalf("zsh cmd.Args = %#v, should not contain --rcfile", cmd.Args)
 		}
+		foundZdotDir := false
+		for _, env := range cmd.Env {
+			if env == "ZDOTDIR="+zdotDirPath {
+				foundZdotDir = true
+				break
+			}
+		}
+		if !foundZdotDir {
+			t.Fatalf("zsh cmd.Env = %#v, want contains ZDOTDIR", cmd.Env)
+		}
 		cleanup()
+		if deletedZdotDir != zdotDirPath {
+			t.Fatalf("deletedZdotDir = %q, want %q", deletedZdotDir, zdotDirPath)
+		}
 	})
 }
 
@@ -1710,6 +1749,32 @@ func TestDefaultBashInitRCFileLifecycle(t *testing.T) {
 	}
 
 	defaultDeleteBashInitRCFile("")
+}
+
+func TestDefaultZshInitDirLifecycle(t *testing.T) {
+	path, err := defaultCreateZshInitDir()
+	if err != nil {
+		t.Fatalf("defaultCreateZshInitDir() error = %v", err)
+	}
+	rcPath := filepath.Join(path, ".zshrc")
+	data, readErr := os.ReadFile(rcPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile() error = %v", readErr)
+	}
+	text := string(data)
+	if !strings.Contains(text, "neocode shell integration") {
+		t.Fatalf("zsh rc content missing integration marker: %q", text)
+	}
+	if !strings.Contains(text, ". \"${HOME}/.zshrc\"") {
+		t.Fatalf("zsh rc content missing ${HOME}/.zshrc include: %q", text)
+	}
+
+	defaultDeleteZshInitDir(path)
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("expected zsh init dir removed, stat err = %v", statErr)
+	}
+
+	defaultDeleteZshInitDir("")
 }
 
 func TestResolveShellPathDefaultsToBinBash(t *testing.T) {

--- a/internal/ptyproxy/proxy_unix_test.go
+++ b/internal/ptyproxy/proxy_unix_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"neo-code/internal/gateway"
+	gatewayclient "neo-code/internal/gateway/client"
 	"neo-code/internal/gateway/protocol"
 	"neo-code/internal/tools"
 
@@ -295,6 +296,267 @@ func TestSendDiagIPCCommandToPathRejectsResponse(t *testing.T) {
 	}
 }
 
+func TestSendDiagIPCCommandWithoutRunDirFallback(t *testing.T) {
+	_, err := sendDiagIPCCommand(context.Background(), "/tmp/not-in-run-dir.sock", diagIPCRequest{Cmd: diagCommandDiagnose})
+	if err == nil {
+		t.Fatal("expected sendDiagIPCCommand() to fail")
+	}
+	if strings.Contains(err.Error(), "legacy tmp path") {
+		t.Fatalf("unexpected legacy fallback for non-run path: %v", err)
+	}
+}
+
+func TestSendDiagIPCCommandRunDirFallbackMissingLegacy(t *testing.T) {
+	home := t.TempDir()
+	legacyTmpDir := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("TMPDIR", legacyTmpDir)
+
+	primarySocket := filepath.Join(home, ".neocode", "run", "missing.sock")
+	_, err := sendDiagIPCCommand(context.Background(), primarySocket, diagIPCRequest{Cmd: diagCommandDiagnose})
+	if err == nil {
+		t.Fatal("expected sendDiagIPCCommand() to fail")
+	}
+}
+
+func TestSendDiagIPCCommandToPathResponseReadAndDecodeErrors(t *testing.T) {
+	t.Run("read response failed", func(t *testing.T) {
+		socketPath := filepath.Join(t.TempDir(), "read-failed.sock")
+		listener, resolvedPath, err := listenDiagSocket(socketPath)
+		if err != nil {
+			t.Fatalf("listenDiagSocket() error = %v", err)
+		}
+		defer func() {
+			_ = listener.Close()
+			_ = os.Remove(resolvedPath)
+		}()
+
+		serverDone := make(chan error, 1)
+		go func() {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				serverDone <- acceptErr
+				return
+			}
+			_ = conn.Close()
+			serverDone <- nil
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_, err = sendDiagIPCCommandToPath(ctx, resolvedPath, diagIPCRequest{Cmd: diagCommandDiagnose})
+		if err == nil || !strings.Contains(err.Error(), "wait diagnose completion") {
+			t.Fatalf("err = %v, want wait diagnose completion", err)
+		}
+		if serverErr := <-serverDone; serverErr != nil {
+			t.Fatalf("server error = %v", serverErr)
+		}
+	})
+
+	t.Run("decode response failed", func(t *testing.T) {
+		socketPath := filepath.Join(t.TempDir(), "decode-failed.sock")
+		listener, resolvedPath, err := listenDiagSocket(socketPath)
+		if err != nil {
+			t.Fatalf("listenDiagSocket() error = %v", err)
+		}
+		defer func() {
+			_ = listener.Close()
+			_ = os.Remove(resolvedPath)
+		}()
+
+		serverDone := make(chan error, 1)
+		go func() {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				serverDone <- acceptErr
+				return
+			}
+			defer conn.Close()
+			_, _ = bufio.NewReader(conn).ReadBytes('\n')
+			_, writeErr := conn.Write([]byte("not-json\n"))
+			serverDone <- writeErr
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_, err = sendDiagIPCCommandToPath(ctx, resolvedPath, diagIPCRequest{Cmd: diagCommandDiagnose})
+		if err == nil || !strings.Contains(err.Error(), "decode diag response") {
+			t.Fatalf("err = %v, want decode diag response", err)
+		}
+		if serverErr := <-serverDone; serverErr != nil {
+			t.Fatalf("server error = %v", serverErr)
+		}
+	})
+
+	t.Run("empty rejection message", func(t *testing.T) {
+		socketPath := filepath.Join(t.TempDir(), "empty-reject.sock")
+		listener, resolvedPath, err := listenDiagSocket(socketPath)
+		if err != nil {
+			t.Fatalf("listenDiagSocket() error = %v", err)
+		}
+		defer func() {
+			_ = listener.Close()
+			_ = os.Remove(resolvedPath)
+		}()
+
+		serverDone := make(chan error, 1)
+		go func() {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				serverDone <- acceptErr
+				return
+			}
+			defer conn.Close()
+			_, _ = bufio.NewReader(conn).ReadBytes('\n')
+			resp, _ := json.Marshal(diagIPCResponse{OK: false, Message: ""})
+			_, writeErr := conn.Write(append(resp, '\n'))
+			serverDone <- writeErr
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_, err = sendDiagIPCCommandToPath(ctx, resolvedPath, diagIPCRequest{Cmd: diagCommandDiagnose})
+		if err == nil || !strings.Contains(err.Error(), "diagnose command rejected") {
+			t.Fatalf("err = %v, want default rejection message", err)
+		}
+		if serverErr := <-serverDone; serverErr != nil {
+			t.Fatalf("server error = %v", serverErr)
+		}
+	})
+}
+
+func TestSendDiagIPCCommandToPathContextDone(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "context-done.sock")
+	listener, resolvedPath, err := listenDiagSocket(socketPath)
+	if err != nil {
+		t.Fatalf("listenDiagSocket() error = %v", err)
+	}
+	defer func() {
+		_ = listener.Close()
+		_ = os.Remove(resolvedPath)
+	}()
+
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			serverDone <- acceptErr
+			return
+		}
+		defer conn.Close()
+		_, _ = bufio.NewReader(conn).ReadBytes('\n')
+		time.Sleep(120 * time.Millisecond)
+		resp, _ := json.Marshal(diagIPCResponse{OK: true, Message: "ok"})
+		_, writeErr := conn.Write(append(resp, '\n'))
+		if writeErr != nil && !strings.Contains(strings.ToLower(writeErr.Error()), "broken pipe") {
+			serverDone <- writeErr
+			return
+		}
+		serverDone <- nil
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
+	defer cancel()
+	_, err = sendDiagIPCCommandToPath(ctx, resolvedPath, diagIPCRequest{Cmd: diagCommandDiagnose})
+	if err == nil || !strings.Contains(err.Error(), "wait diagnose completion") {
+		t.Fatalf("err = %v, want context wait diagnose completion", err)
+	}
+	if serverErr := <-serverDone; serverErr != nil {
+		t.Fatalf("server error = %v", serverErr)
+	}
+}
+
+func TestSignalHelpersViaIPC(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "ipc.sock")
+	listener, resolvedPath, err := listenDiagSocket(socketPath)
+	if err != nil {
+		t.Fatalf("listenDiagSocket() error = %v", err)
+	}
+	defer func() {
+		_ = listener.Close()
+		_ = os.Remove(resolvedPath)
+	}()
+
+	receivedCommands := make(chan string, 4)
+	serverDone := make(chan error, 1)
+	go func() {
+		defer close(serverDone)
+		for i := 0; i < 4; i++ {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				serverDone <- acceptErr
+				return
+			}
+			reader := bufio.NewReader(conn)
+			line, readErr := reader.ReadBytes('\n')
+			if readErr != nil {
+				_ = conn.Close()
+				serverDone <- readErr
+				return
+			}
+			var request diagIPCRequest
+			if err := json.Unmarshal(line, &request); err != nil {
+				_ = conn.Close()
+				serverDone <- err
+				return
+			}
+			receivedCommands <- request.Cmd
+
+			response := diagIPCResponse{OK: true, Message: "ok"}
+			if request.Cmd == diagCommandAutoStatus {
+				response.AutoEnabled = true
+			}
+			encoded, _ := json.Marshal(response)
+			if _, writeErr := conn.Write(append(encoded, '\n')); writeErr != nil {
+				_ = conn.Close()
+				serverDone <- writeErr
+				return
+			}
+			_ = conn.Close()
+		}
+		serverDone <- nil
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := SendDiagnoseSignal(ctx, resolvedPath); err != nil {
+		t.Fatalf("SendDiagnoseSignal() error = %v", err)
+	}
+	if err := SendAutoModeSignal(ctx, resolvedPath, true); err != nil {
+		t.Fatalf("SendAutoModeSignal(on) error = %v", err)
+	}
+	if err := SendAutoModeSignal(ctx, resolvedPath, false); err != nil {
+		t.Fatalf("SendAutoModeSignal(off) error = %v", err)
+	}
+	enabled, err := QueryAutoMode(ctx, resolvedPath)
+	if err != nil {
+		t.Fatalf("QueryAutoMode() error = %v", err)
+	}
+	if !enabled {
+		t.Fatal("QueryAutoMode() = false, want true")
+	}
+
+	var commands []string
+	for i := 0; i < 4; i++ {
+		commands = append(commands, <-receivedCommands)
+	}
+	want := []string{
+		diagCommandDiagnose,
+		diagCommandAutoOn,
+		diagCommandAutoOff,
+		diagCommandAutoStatus,
+	}
+	for i := range want {
+		if commands[i] != want[i] {
+			t.Fatalf("command[%d] = %q, want %q", i, commands[i], want[i])
+		}
+	}
+	if serverErr := <-serverDone; serverErr != nil {
+		t.Fatalf("server error = %v", serverErr)
+	}
+}
+
 func TestSendDiagIPCCommandEmptyPath(t *testing.T) {
 	_, err := sendDiagIPCCommand(context.Background(), "   ", diagIPCRequest{Cmd: diagCommandDiagnose})
 	if err == nil {
@@ -560,6 +822,24 @@ func TestInstallHostTerminalRestoreGuardNoop(t *testing.T) {
 	restore()
 }
 
+func TestInstallHostTerminalRestoreGuardNonTerminalNoop(t *testing.T) {
+	originalInput := hostTerminalInput
+	originalIsTerminal := isTerminalFD
+	t.Cleanup(func() { hostTerminalInput = originalInput })
+	t.Cleanup(func() { isTerminalFD = originalIsTerminal })
+
+	file, err := os.CreateTemp(t.TempDir(), "terminal-*")
+	if err != nil {
+		t.Fatalf("CreateTemp() error = %v", err)
+	}
+	defer file.Close()
+
+	hostTerminalInput = file
+	isTerminalFD = func(int) bool { return false }
+	restore := installHostTerminalRestoreGuard()
+	restore()
+}
+
 func TestCopyInputWithTracker(t *testing.T) {
 	tracker := &commandTracker{}
 	input := []byte("go tes\x08st\rnext\r")
@@ -670,12 +950,8 @@ func TestStreamPTYOutputSkipsTriggerWhenAutoDisabled(t *testing.T) {
 }
 
 func TestStreamPTYOutputReenablesAutoOnPromptReady(t *testing.T) {
-	payload := strings.NewReader(
-		"\x1b]133;C\x07" +
-			"fatal: build failed\n" +
-			"\x1b]133;D;1\x07" +
-			"\x1b]133;A\x07",
-	)
+	payloadReader, payloadWriter := io.Pipe()
+	defer payloadReader.Close()
 	output := &bytes.Buffer{}
 	commandLog := NewUTF8RingBuffer(1024)
 	tracker := &commandTracker{}
@@ -685,21 +961,39 @@ func TestStreamPTYOutputReenablesAutoOnPromptReady(t *testing.T) {
 	autoState.Enabled.Store(false)
 	autoState.OSCReady.Store(false)
 
-	streamPTYOutput(payload, output, commandLog, tracker, autoTriggers, autoState)
+	streamDone := make(chan struct{})
+	go func() {
+		defer close(streamDone)
+		streamPTYOutput(payloadReader, output, commandLog, tracker, autoTriggers, autoState)
+	}()
+	go func() {
+		_, _ = payloadWriter.Write([]byte("\x1b]133;C\x07"))
+		_, _ = payloadWriter.Write([]byte("fatal: build failed\n"))
+		_, _ = payloadWriter.Write([]byte("\x1b]133;D;1\x07"))
+		_, _ = payloadWriter.Write([]byte("\x1b]133;A\x07"))
+		_ = payloadWriter.Close()
+	}()
 
+	var gotTrigger diagnoseTrigger
+	select {
+	case trigger := <-autoTriggers:
+		gotTrigger = trigger
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected one auto diagnose trigger after re-enable")
+	}
+	select {
+	case <-streamDone:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("streamPTYOutput did not finish")
+	}
 	if !autoState.Enabled.Load() {
 		t.Fatal("expected auto to be re-enabled after OSC133 PromptReady")
 	}
 	if !autoState.OSCReady.Load() {
 		t.Fatal("expected OSCReady to be set after PromptReady")
 	}
-	select {
-	case trigger := <-autoTriggers:
-		if trigger.CommandText != "go test ./..." {
-			t.Fatalf("trigger.CommandText = %q, want %q", trigger.CommandText, "go test ./...")
-		}
-	default:
-		t.Fatal("expected one auto diagnose trigger after re-enable")
+	if gotTrigger.CommandText != "go test ./..." {
+		t.Fatalf("trigger.CommandText = %q, want %q", gotTrigger.CommandText, "go test ./...")
 	}
 	if !strings.Contains(output.String(), "fatal: build failed") {
 		t.Fatalf("output = %q, want contains fatal text", output.String())
@@ -798,10 +1092,25 @@ func TestCallDiagnoseToolSuccess(t *testing.T) {
 	})
 	defer cleanupServer()
 
+	rpcClient, err := gatewayclient.NewGatewayRPCClient(gatewayclient.GatewayRPCClientOptions{
+		ListenAddress: gatewaySocket,
+		TokenFile:     authTokenFile,
+	})
+	if err != nil {
+		t.Fatalf("NewGatewayRPCClient() error = %v", err)
+	}
+	defer rpcClient.Close()
+	authCtx, authCancel := context.WithTimeout(context.Background(), time.Second)
+	if err := rpcClient.Authenticate(authCtx); err != nil {
+		authCancel()
+		t.Fatalf("Authenticate() error = %v", err)
+	}
+	authCancel()
+
 	buffer := NewUTF8RingBuffer(2048)
 	_, _ = buffer.Write([]byte("fallback log"))
 	result, err := callDiagnoseTool(
-		nil,
+		rpcClient,
 		buffer,
 		ManualShellOptions{
 			Workdir:              baseDir,
@@ -862,10 +1171,25 @@ func TestCallDiagnoseToolGatewayFrameError(t *testing.T) {
 	})
 	defer cleanupServer()
 
+	rpcClient, err := gatewayclient.NewGatewayRPCClient(gatewayclient.GatewayRPCClientOptions{
+		ListenAddress: gatewaySocket,
+		TokenFile:     authTokenFile,
+	})
+	if err != nil {
+		t.Fatalf("NewGatewayRPCClient() error = %v", err)
+	}
+	defer rpcClient.Close()
+	authCtx, authCancel := context.WithTimeout(context.Background(), time.Second)
+	if err := rpcClient.Authenticate(authCtx); err != nil {
+		authCancel()
+		t.Fatalf("Authenticate() error = %v", err)
+	}
+	authCancel()
+
 	buffer := NewUTF8RingBuffer(1024)
 	_, _ = buffer.Write([]byte("fallback log"))
-	_, err := callDiagnoseTool(
-		nil,
+	_, err = callDiagnoseTool(
+		rpcClient,
 		buffer,
 		ManualShellOptions{
 			Workdir:              baseDir,
@@ -1024,6 +1348,375 @@ func TestRunSingleDiagnosisGatewayUnavailableDoesNotPanic(t *testing.T) {
 	assertNoBareLineFeed(t, output.String())
 }
 
+func TestRunSingleDiagnosisAutoDisabledSkipsRender(t *testing.T) {
+	baseDir := t.TempDir()
+	gatewaySocket := filepath.Join(baseDir, "gateway.sock")
+	authTokenFile := filepath.Join(baseDir, "auth.json")
+	writeGatewayAuthTokenFile(t, authTokenFile, "test-token")
+
+	cleanupServer, serverDone := startGatewayRPCMockServer(t, gatewaySocket, func(decoder *json.Decoder, encoder *json.Encoder) error {
+		authenticateRequest, err := readRPCRequest(decoder)
+		if err != nil {
+			return err
+		}
+		if err := writeRPCResult(encoder, authenticateRequest.ID, gateway.MessageFrame{
+			Type:   gateway.FrameTypeAck,
+			Action: gateway.FrameActionAuthenticate,
+		}); err != nil {
+			return err
+		}
+		executeRequest, err := readRPCRequest(decoder)
+		if err != nil {
+			return err
+		}
+		return writeRPCResult(encoder, executeRequest.ID, gateway.MessageFrame{
+			Type:   gateway.FrameTypeAck,
+			Action: gateway.FrameActionExecuteSystemTool,
+			Payload: map[string]any{
+				"Content": `{"confidence":0.8,"root_cause":"ok","fix_commands":["echo fix"],"investigation_commands":["echo inv"]}`,
+				"IsError": false,
+			},
+		})
+	})
+	defer cleanupServer()
+
+	rpcClient, err := gatewayclient.NewGatewayRPCClient(gatewayclient.GatewayRPCClientOptions{
+		ListenAddress: gatewaySocket,
+		TokenFile:     authTokenFile,
+	})
+	if err != nil {
+		t.Fatalf("NewGatewayRPCClient() error = %v", err)
+	}
+	defer rpcClient.Close()
+	authCtx, authCancel := context.WithTimeout(context.Background(), time.Second)
+	if err := rpcClient.Authenticate(authCtx); err != nil {
+		authCancel()
+		t.Fatalf("Authenticate() error = %v", err)
+	}
+	authCancel()
+
+	buffer := NewUTF8RingBuffer(1024)
+	_, _ = buffer.Write([]byte("fallback log"))
+	output := &bytes.Buffer{}
+	autoState := &autoRuntimeState{}
+	autoState.Enabled.Store(false)
+
+	runSingleDiagnosis(
+		rpcClient,
+		output,
+		buffer,
+		ManualShellOptions{Workdir: baseDir, Shell: "/bin/bash"},
+		filepath.Join(baseDir, "diag.sock"),
+		diagnoseTrigger{CommandText: "go test ./...", ExitCode: 1, OutputText: "fatal"},
+		true,
+		autoState,
+	)
+	if strings.Contains(output.String(), "NeoCode Diagnosis") {
+		t.Fatalf("output should be empty when auto mode is disabled, got %q", output.String())
+	}
+	if serverErr := <-serverDone; serverErr != nil {
+		t.Fatalf("server error = %v", serverErr)
+	}
+}
+
+func TestConsumeDiagSignalsAndBannerPaths(t *testing.T) {
+	t.Run("consume job and notify done", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		jobCh := make(chan diagnoseJob, 1)
+		doneCh := make(chan diagIPCResponse, 1)
+		jobCh <- diagnoseJob{
+			Trigger: diagnoseTrigger{CommandText: "go test ./...", ExitCode: 1, OutputText: "fatal"},
+			Done:    doneCh,
+			IsAuto:  false,
+		}
+		close(jobCh)
+
+		output := &bytes.Buffer{}
+		autoState := &autoRuntimeState{}
+		autoState.Enabled.Store(true)
+
+		consumeDiagSignals(ctx, nil, jobCh, output, NewUTF8RingBuffer(1024), ManualShellOptions{}, "/tmp/diag.sock", autoState)
+		select {
+		case response := <-doneCh:
+			if !response.OK {
+				t.Fatalf("response = %#v, want OK", response)
+			}
+		default:
+			t.Fatal("expected consumeDiagSignals to notify job done")
+		}
+	})
+
+	t.Run("banner helpers", func(t *testing.T) {
+		printProxyInitializedBanner(nil)
+		printWelcomeBanner(nil)
+		printAutoModeBanner(nil, nil)
+		printProxyExitedBanner(nil)
+
+		buffer := &bytes.Buffer{}
+		printProxyInitializedBanner(buffer)
+		printWelcomeBanner(buffer)
+		autoOn := &autoRuntimeState{}
+		autoOn.Enabled.Store(true)
+		printAutoModeBanner(buffer, autoOn)
+		autoOff := &autoRuntimeState{}
+		autoOff.Enabled.Store(false)
+		printAutoModeBanner(buffer, autoOff)
+		printProxyExitedBanner(buffer)
+
+		text := buffer.String()
+		if !strings.Contains(text, proxyInitializedBanner) || !strings.Contains(text, proxyExitedBanner) {
+			t.Fatalf("banner output = %q", text)
+		}
+	})
+}
+
+func TestHandleDiagSocketConnectionAutoModeBranches(t *testing.T) {
+	execRequest := func(t *testing.T, cmd string, initialEnabled bool) (diagIPCResponse, bool) {
+		t.Helper()
+		serverConn, clientConn := net.Pipe()
+		defer clientConn.Close()
+
+		autoState := &autoRuntimeState{}
+		autoState.Enabled.Store(initialEnabled)
+		jobCh := make(chan diagnoseJob, 1)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			handleDiagSocketConnection(ctx, serverConn, jobCh, autoState)
+		}()
+
+		raw, err := json.Marshal(diagIPCRequest{Cmd: cmd})
+		if err != nil {
+			t.Fatalf("marshal request: %v", err)
+		}
+		if _, err := clientConn.Write(append(raw, '\n')); err != nil {
+			t.Fatalf("write request: %v", err)
+		}
+
+		line, err := bufio.NewReader(clientConn).ReadBytes('\n')
+		if err != nil {
+			t.Fatalf("read response: %v", err)
+		}
+		var response diagIPCResponse
+		if err := json.Unmarshal(line, &response); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
+		<-done
+		return response, autoState.Enabled.Load()
+	}
+
+	t.Run("auto off", func(t *testing.T) {
+		response, enabled := execRequest(t, diagCommandAutoOff, true)
+		if !response.OK || enabled {
+			t.Fatalf("response=%#v enabled=%v, want ok=true enabled=false", response, enabled)
+		}
+	})
+
+	t.Run("auto status", func(t *testing.T) {
+		response, enabled := execRequest(t, diagCommandAutoStatus, false)
+		if !response.OK || response.Message == "" || response.AutoEnabled != enabled {
+			t.Fatalf("response=%#v enabled=%v", response, enabled)
+		}
+	})
+}
+
+func TestConsumeDiagSignalsClosedChannelReturns(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	jobCh := make(chan diagnoseJob)
+	close(jobCh)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		consumeDiagSignals(ctx, nil, jobCh, &bytes.Buffer{}, NewUTF8RingBuffer(1024), ManualShellOptions{}, "/tmp/diag.sock", &autoRuntimeState{})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("consumeDiagSignals did not return after channel closed")
+	}
+}
+
+func TestCallDiagnoseToolDecodePayloadFailure(t *testing.T) {
+	baseDir := t.TempDir()
+	gatewaySocket := filepath.Join(baseDir, "gateway.sock")
+	authTokenFile := filepath.Join(baseDir, "auth.json")
+	writeGatewayAuthTokenFile(t, authTokenFile, "test-token")
+
+	cleanupServer, serverDone := startGatewayRPCMockServer(t, gatewaySocket, func(decoder *json.Decoder, encoder *json.Encoder) error {
+		authenticateRequest, err := readRPCRequest(decoder)
+		if err != nil {
+			return err
+		}
+		if err := writeRPCResult(encoder, authenticateRequest.ID, gateway.MessageFrame{
+			Type:   gateway.FrameTypeAck,
+			Action: gateway.FrameActionAuthenticate,
+		}); err != nil {
+			return err
+		}
+		executeRequest, err := readRPCRequest(decoder)
+		if err != nil {
+			return err
+		}
+		return writeRPCResult(encoder, executeRequest.ID, gateway.MessageFrame{
+			Type:    gateway.FrameTypeAck,
+			Action:  gateway.FrameActionExecuteSystemTool,
+			Payload: "plain-text-payload",
+		})
+	})
+	defer cleanupServer()
+
+	rpcClient, err := gatewayclient.NewGatewayRPCClient(gatewayclient.GatewayRPCClientOptions{
+		ListenAddress: gatewaySocket,
+		TokenFile:     authTokenFile,
+	})
+	if err != nil {
+		t.Fatalf("NewGatewayRPCClient() error = %v", err)
+	}
+	defer rpcClient.Close()
+
+	authCtx, authCancel := context.WithTimeout(context.Background(), time.Second)
+	if err := rpcClient.Authenticate(authCtx); err != nil {
+		authCancel()
+		t.Fatalf("Authenticate() error = %v", err)
+	}
+	authCancel()
+
+	buffer := NewUTF8RingBuffer(1024)
+	_, _ = buffer.Write([]byte("decode-failure log"))
+	_, err = callDiagnoseTool(
+		rpcClient,
+		buffer,
+		ManualShellOptions{
+			Workdir:              baseDir,
+			Shell:                "/bin/bash",
+			GatewayListenAddress: gatewaySocket,
+			GatewayTokenFile:     authTokenFile,
+		},
+		filepath.Join(baseDir, "diag.sock"),
+		diagnoseTrigger{CommandText: "go test ./...", ExitCode: 1, OutputText: "fatal"},
+	)
+	if err == nil || !strings.Contains(err.Error(), "decode tool payload") {
+		t.Fatalf("expected decode failure error, got %v", err)
+	}
+	if serverErr := <-serverDone; serverErr != nil {
+		t.Fatalf("server error = %v", serverErr)
+	}
+}
+
+func TestSyncPTYWindowSize(t *testing.T) {
+	syncPTYWindowSize(nil, nil)
+
+	file, err := os.CreateTemp(t.TempDir(), "not-pty-*")
+	if err != nil {
+		t.Fatalf("CreateTemp() error = %v", err)
+	}
+	defer file.Close()
+
+	errWriter := &bytes.Buffer{}
+	syncPTYWindowSize(errWriter, file)
+	if !strings.Contains(errWriter.String(), "inherit terminal size failed") {
+		t.Fatalf("errWriter = %q, want contains inherit terminal size failed", errWriter.String())
+	}
+}
+
+func TestPrepareBashInitRCAndBuildShellCommand(t *testing.T) {
+	t.Run("prepareBashInitRC", func(t *testing.T) {
+		originalCreate := createBashInitRCFile
+		t.Cleanup(func() { createBashInitRCFile = originalCreate })
+
+		createBashInitRCFile = func() (string, error) { return "/tmp/mock.rc", nil }
+		if got := prepareBashInitRC("/bin/bash"); got != "/tmp/mock.rc" {
+			t.Fatalf("prepareBashInitRC() = %q, want /tmp/mock.rc", got)
+		}
+		if got := prepareBashInitRC("/bin/zsh"); got != "" {
+			t.Fatalf("prepareBashInitRC(non-bash) = %q, want empty", got)
+		}
+
+		createBashInitRCFile = func() (string, error) { return "", errors.New("mock create error") }
+		if got := prepareBashInitRC("/bin/bash"); got != "" {
+			t.Fatalf("prepareBashInitRC(create error) = %q, want empty", got)
+		}
+	})
+
+	t.Run("buildShellCommand", func(t *testing.T) {
+		originalCreate := createBashInitRCFile
+		originalDelete := deleteBashInitRCFile
+		t.Cleanup(func() { createBashInitRCFile = originalCreate })
+		t.Cleanup(func() { deleteBashInitRCFile = originalDelete })
+
+		rcPath := filepath.Join(t.TempDir(), "mock.rc")
+		if err := os.WriteFile(rcPath, []byte("mock"), 0o600); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+
+		deletedPath := ""
+		createBashInitRCFile = func() (string, error) { return rcPath, nil }
+		deleteBashInitRCFile = func(path string) { deletedPath = path }
+
+		cmd, cleanup := buildShellCommand("/bin/bash", ManualShellOptions{Workdir: t.TempDir()}, "/tmp/diag.sock")
+		if cmd.Path != "/bin/bash" {
+			t.Fatalf("cmd.Path = %q, want /bin/bash", cmd.Path)
+		}
+		if !strings.Contains(strings.Join(cmd.Args, " "), "--rcfile") {
+			t.Fatalf("cmd.Args = %#v, want contains --rcfile", cmd.Args)
+		}
+		foundDiagEnv := false
+		for _, env := range cmd.Env {
+			if strings.HasPrefix(env, DiagSocketEnv+"=") && strings.HasSuffix(env, "/tmp/diag.sock") {
+				foundDiagEnv = true
+				break
+			}
+		}
+		if !foundDiagEnv {
+			t.Fatalf("cmd.Env = %#v, want %s", cmd.Env, DiagSocketEnv)
+		}
+		cleanup()
+		if deletedPath != rcPath {
+			t.Fatalf("deletedPath = %q, want %q", deletedPath, rcPath)
+		}
+
+		cmd, cleanup = buildShellCommand("/bin/zsh", ManualShellOptions{Workdir: t.TempDir()}, "/tmp/diag.sock")
+		if strings.Contains(strings.Join(cmd.Args, " "), "--rcfile") {
+			t.Fatalf("zsh cmd.Args = %#v, should not contain --rcfile", cmd.Args)
+		}
+		cleanup()
+	})
+}
+
+func TestDefaultBashInitRCFileLifecycle(t *testing.T) {
+	path, err := defaultCreateBashInitRCFile()
+	if err != nil {
+		t.Fatalf("defaultCreateBashInitRCFile() error = %v", err)
+	}
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("ReadFile() error = %v", readErr)
+	}
+	text := string(data)
+	if !strings.Contains(text, "neocode shell integration") {
+		t.Fatalf("rc file content missing integration marker: %q", text)
+	}
+	if !strings.Contains(text, ". ~/.bashrc") {
+		t.Fatalf("rc file content missing ~/.bashrc include: %q", text)
+	}
+
+	defaultDeleteBashInitRCFile(path)
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("expected rc file removed, stat err = %v", statErr)
+	}
+
+	defaultDeleteBashInitRCFile("")
+}
+
 func TestResolveShellPathDefaultsToBinBash(t *testing.T) {
 	t.Setenv("SHELL", "")
 	path := resolveShellPath("")
@@ -1049,9 +1742,6 @@ func TestResolveShellPathPrefersExplicit(t *testing.T) {
 }
 
 func TestRunManualShellBasicIntegration(t *testing.T) {
-	if os.Getenv("PTY_INTEGRATION_TEST") != "1" {
-		t.Skip("set PTY_INTEGRATION_TEST=1 to run integration test")
-	}
 	if _, err := os.Stat("/bin/echo"); err != nil {
 		t.Skip("/bin/echo not available")
 	}

--- a/internal/ptyproxy/proxy_unix_test.go
+++ b/internal/ptyproxy/proxy_unix_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -16,6 +17,10 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"neo-code/internal/gateway"
+	"neo-code/internal/gateway/protocol"
+	"neo-code/internal/tools"
 
 	"golang.org/x/term"
 )
@@ -244,6 +249,52 @@ func TestSendDiagIPCCommandToPath(t *testing.T) {
 	}
 }
 
+func TestSendDiagIPCCommandToPathRejectsResponse(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "ipc.sock")
+	listener, resolvedPath, err := listenDiagSocket(socketPath)
+	if err != nil {
+		t.Fatalf("listenDiagSocket() error = %v", err)
+	}
+	defer func() {
+		_ = listener.Close()
+		_ = os.Remove(resolvedPath)
+	}()
+
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			serverDone <- acceptErr
+			return
+		}
+		defer conn.Close()
+
+		line, readErr := bufio.NewReader(conn).ReadBytes('\n')
+		if readErr != nil {
+			serverDone <- readErr
+			return
+		}
+		var request diagIPCRequest
+		if err := json.Unmarshal(line, &request); err != nil {
+			serverDone <- err
+			return
+		}
+		response, _ := json.Marshal(diagIPCResponse{OK: false, Message: "denied"})
+		_, writeErr := conn.Write(append(response, '\n'))
+		serverDone <- writeErr
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err = sendDiagIPCCommandToPath(ctx, resolvedPath, diagIPCRequest{Cmd: diagCommandDiagnose})
+	if err == nil || !strings.Contains(err.Error(), "denied") {
+		t.Fatalf("expected denied error, got %v", err)
+	}
+	if serverErr := <-serverDone; serverErr != nil {
+		t.Fatalf("server error = %v", serverErr)
+	}
+}
+
 func TestSendDiagIPCCommandEmptyPath(t *testing.T) {
 	_, err := sendDiagIPCCommand(context.Background(), "   ", diagIPCRequest{Cmd: diagCommandDiagnose})
 	if err == nil {
@@ -251,6 +302,12 @@ func TestSendDiagIPCCommandEmptyPath(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "empty") {
 		t.Fatalf("err = %v, want contains empty", err)
+	}
+}
+
+func TestNormalizeDiagIPCCommand(t *testing.T) {
+	if got := normalizeDiagIPCCommand("  AUTO_ON  "); got != "auto_on" {
+		t.Fatalf("normalizeDiagIPCCommand() = %q, want %q", got, "auto_on")
 	}
 }
 
@@ -310,7 +367,7 @@ func TestRenderDiagnosis(t *testing.T) {
 		{
 			name:     "empty content",
 			content:  "",
-			contains: []string{"NeoCode Diagnosis", "无可用诊断内容"},
+			contains: []string{"NeoCode Diagnosis", "-"},
 		},
 		{
 			name:     "plain text fallback",
@@ -319,14 +376,13 @@ func TestRenderDiagnosis(t *testing.T) {
 		},
 		{
 			name: "json diagnosis",
-			content: `{"confidence":0.82,"root_cause":"网络不可达","investigation_commands":["ping 1.1.1.1"],` +
+			content: `{"confidence":0.82,"root_cause":"network unreachable","investigation_commands":["ping 1.1.1.1"],` +
 				`"fix_commands":["export HTTPS_PROXY=http://127.0.0.1:7890"]}`,
 			contains: []string{
-				"置信度: 0.82",
-				"根因: 网络不可达",
-				"建议排查命令:",
+				"0.82",
+				"network unreachable",
 				"ping 1.1.1.1",
-				"建议修复命令:",
+				"export HTTPS_PROXY=http://127.0.0.1:7890",
 			},
 		},
 		{
@@ -536,12 +592,8 @@ func TestCopyInputWithTrackerNilIO(t *testing.T) {
 }
 
 func TestStreamPTYOutputEmitsAutoTrigger(t *testing.T) {
-	payload := strings.NewReader(
-		"\x1b]133;C\x07" +
-			"fatal: build failed\n" +
-			"\x1b]133;D;1\x07" +
-			"\x1b]133;A\x07",
-	)
+	payloadReader, payloadWriter := io.Pipe()
+	defer payloadReader.Close()
 	output := &bytes.Buffer{}
 	commandLog := NewUTF8RingBuffer(1024)
 	tracker := &commandTracker{}
@@ -550,7 +602,19 @@ func TestStreamPTYOutputEmitsAutoTrigger(t *testing.T) {
 	autoState := &autoRuntimeState{}
 	autoState.Enabled.Store(true)
 
-	streamPTYOutput(payload, output, commandLog, tracker, autoTriggers, autoState)
+	streamDone := make(chan struct{})
+	go func() {
+		defer close(streamDone)
+		streamPTYOutput(payloadReader, output, commandLog, tracker, autoTriggers, autoState)
+	}()
+	go func() {
+		// Write OSC133 events in lifecycle order to avoid chunk-order timing flakiness.
+		_, _ = payloadWriter.Write([]byte("\x1b]133;C\x07"))
+		_, _ = payloadWriter.Write([]byte("fatal: build failed\n"))
+		_, _ = payloadWriter.Write([]byte("\x1b]133;D;1\x07"))
+		_, _ = payloadWriter.Write([]byte("\x1b]133;A\x07"))
+		_ = payloadWriter.Close()
+	}()
 
 	select {
 	case trigger := <-autoTriggers:
@@ -563,8 +627,14 @@ func TestStreamPTYOutputEmitsAutoTrigger(t *testing.T) {
 		if !strings.Contains(trigger.OutputText, "fatal: build failed") {
 			t.Fatalf("trigger.OutputText = %q, want contains fatal message", trigger.OutputText)
 		}
-	default:
+	case <-time.After(500 * time.Millisecond):
 		t.Fatal("expected one auto diagnose trigger")
+	}
+
+	select {
+	case <-streamDone:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("streamPTYOutput did not finish")
 	}
 
 	if !strings.Contains(output.String(), "fatal: build failed") {
@@ -573,11 +643,11 @@ func TestStreamPTYOutputEmitsAutoTrigger(t *testing.T) {
 }
 
 func TestStreamPTYOutputSkipsTriggerWhenAutoDisabled(t *testing.T) {
+	// Without OSC133 A (PromptReady): auto stays disabled, pendingTrigger is never sent.
 	payload := strings.NewReader(
 		"\x1b]133;C\x07" +
 			"fatal: build failed\n" +
-			"\x1b]133;D;1\x07" +
-			"\x1b]133;A\x07",
+			"\x1b]133;D;1\x07",
 	)
 	output := &bytes.Buffer{}
 	commandLog := NewUTF8RingBuffer(1024)
@@ -593,6 +663,43 @@ func TestStreamPTYOutputSkipsTriggerWhenAutoDisabled(t *testing.T) {
 	case trigger := <-autoTriggers:
 		t.Fatalf("unexpected trigger: %#v", trigger)
 	default:
+	}
+	if !strings.Contains(output.String(), "fatal: build failed") {
+		t.Fatalf("output = %q, want contains fatal text", output.String())
+	}
+}
+
+func TestStreamPTYOutputReenablesAutoOnPromptReady(t *testing.T) {
+	payload := strings.NewReader(
+		"\x1b]133;C\x07" +
+			"fatal: build failed\n" +
+			"\x1b]133;D;1\x07" +
+			"\x1b]133;A\x07",
+	)
+	output := &bytes.Buffer{}
+	commandLog := NewUTF8RingBuffer(1024)
+	tracker := &commandTracker{}
+	tracker.Observe([]byte("go test ./...\r"))
+	autoTriggers := make(chan diagnoseTrigger, 1)
+	autoState := &autoRuntimeState{}
+	autoState.Enabled.Store(false)
+	autoState.OSCReady.Store(false)
+
+	streamPTYOutput(payload, output, commandLog, tracker, autoTriggers, autoState)
+
+	if !autoState.Enabled.Load() {
+		t.Fatal("expected auto to be re-enabled after OSC133 PromptReady")
+	}
+	if !autoState.OSCReady.Load() {
+		t.Fatal("expected OSCReady to be set after PromptReady")
+	}
+	select {
+	case trigger := <-autoTriggers:
+		if trigger.CommandText != "go test ./..." {
+			t.Fatalf("trigger.CommandText = %q, want %q", trigger.CommandText, "go test ./...")
+		}
+	default:
+		t.Fatal("expected one auto diagnose trigger after re-enable")
 	}
 	if !strings.Contains(output.String(), "fatal: build failed") {
 		t.Fatalf("output = %q, want contains fatal text", output.String())
@@ -615,12 +722,284 @@ func TestDecodeToolResult(t *testing.T) {
 	}
 }
 
+func TestDecodeToolResultErrors(t *testing.T) {
+	_, err := decodeToolResult(func() {})
+	if err == nil || !strings.Contains(err.Error(), "encode tool payload") {
+		t.Fatalf("expected encode tool payload error, got %v", err)
+	}
+
+	_, err = decodeToolResult("plain-text")
+	if err == nil || !strings.Contains(err.Error(), "decode tool payload") {
+		t.Fatalf("expected decode tool payload error, got %v", err)
+	}
+}
+
+func TestCallDiagnoseToolSuccess(t *testing.T) {
+	baseDir := t.TempDir()
+	gatewaySocket := filepath.Join(baseDir, "gateway.sock")
+	authTokenFile := filepath.Join(baseDir, "auth.json")
+	writeGatewayAuthTokenFile(t, authTokenFile, "test-token")
+
+	cleanupServer, serverDone := startGatewayRPCMockServer(t, gatewaySocket, func(decoder *json.Decoder, encoder *json.Encoder) error {
+		authenticateRequest, err := readRPCRequest(decoder)
+		if err != nil {
+			return err
+		}
+		if authenticateRequest.Method != protocol.MethodGatewayAuthenticate {
+			return fmt.Errorf("authenticate method = %q", authenticateRequest.Method)
+		}
+		var authenticateParams protocol.AuthenticateParams
+		if err := json.Unmarshal(authenticateRequest.Params, &authenticateParams); err != nil {
+			return fmt.Errorf("decode authenticate params: %w", err)
+		}
+		if authenticateParams.Token != "test-token" {
+			return fmt.Errorf("authenticate token = %q", authenticateParams.Token)
+		}
+		if err := writeRPCResult(encoder, authenticateRequest.ID, gateway.MessageFrame{
+			Type:   gateway.FrameTypeAck,
+			Action: gateway.FrameActionAuthenticate,
+		}); err != nil {
+			return err
+		}
+
+		executeRequest, err := readRPCRequest(decoder)
+		if err != nil {
+			return err
+		}
+		if executeRequest.Method != protocol.MethodGatewayExecuteSystemTool {
+			return fmt.Errorf("execute method = %q", executeRequest.Method)
+		}
+		var executeParams protocol.ExecuteSystemToolParams
+		if err := json.Unmarshal(executeRequest.Params, &executeParams); err != nil {
+			return fmt.Errorf("decode execute params: %w", err)
+		}
+		if executeParams.ToolName != tools.ToolNameDiagnose {
+			return fmt.Errorf("tool name = %q", executeParams.ToolName)
+		}
+		var diagnoseArgs diagnoseToolArgs
+		if err := json.Unmarshal(executeParams.Arguments, &diagnoseArgs); err != nil {
+			return fmt.Errorf("decode diagnose args: %w", err)
+		}
+		if diagnoseArgs.CommandText != "go test ./..." {
+			return fmt.Errorf("command text = %q", diagnoseArgs.CommandText)
+		}
+		if diagnoseArgs.ExitCode != 1 {
+			return fmt.Errorf("exit code = %d", diagnoseArgs.ExitCode)
+		}
+
+		return writeRPCResult(encoder, executeRequest.ID, gateway.MessageFrame{
+			Type:   gateway.FrameTypeAck,
+			Action: gateway.FrameActionExecuteSystemTool,
+			Payload: map[string]any{
+				"Content": "diagnosis ok",
+				"IsError": false,
+			},
+		})
+	})
+	defer cleanupServer()
+
+	buffer := NewUTF8RingBuffer(2048)
+	_, _ = buffer.Write([]byte("fallback log"))
+	result, err := callDiagnoseTool(
+		nil,
+		buffer,
+		ManualShellOptions{
+			Workdir:              baseDir,
+			Shell:                "/bin/bash",
+			GatewayListenAddress: gatewaySocket,
+			GatewayTokenFile:     authTokenFile,
+		},
+		filepath.Join(baseDir, "diag.sock"),
+		diagnoseTrigger{
+			CommandText: "go test ./...",
+			ExitCode:    1,
+			OutputText:  "fatal: build failed",
+		},
+	)
+	if err != nil {
+		t.Fatalf("callDiagnoseTool() error = %v", err)
+	}
+	if result.Content != "diagnosis ok" {
+		t.Fatalf("result.Content = %q, want diagnosis ok", result.Content)
+	}
+	if result.IsError {
+		t.Fatal("result.IsError = true, want false")
+	}
+	if serverErr := <-serverDone; serverErr != nil {
+		t.Fatalf("mock gateway server error = %v", serverErr)
+	}
+}
+
+func TestCallDiagnoseToolGatewayFrameError(t *testing.T) {
+	baseDir := t.TempDir()
+	gatewaySocket := filepath.Join(baseDir, "gateway.sock")
+	authTokenFile := filepath.Join(baseDir, "auth.json")
+	writeGatewayAuthTokenFile(t, authTokenFile, "test-token")
+
+	cleanupServer, serverDone := startGatewayRPCMockServer(t, gatewaySocket, func(decoder *json.Decoder, encoder *json.Encoder) error {
+		authenticateRequest, err := readRPCRequest(decoder)
+		if err != nil {
+			return err
+		}
+		if err := writeRPCResult(encoder, authenticateRequest.ID, gateway.MessageFrame{
+			Type:   gateway.FrameTypeAck,
+			Action: gateway.FrameActionAuthenticate,
+		}); err != nil {
+			return err
+		}
+
+		executeRequest, err := readRPCRequest(decoder)
+		if err != nil {
+			return err
+		}
+		return writeRPCResult(encoder, executeRequest.ID, gateway.MessageFrame{
+			Type: gateway.FrameTypeError,
+			Error: &gateway.FrameError{
+				Code:    "mock_failed",
+				Message: "boom",
+			},
+		})
+	})
+	defer cleanupServer()
+
+	buffer := NewUTF8RingBuffer(1024)
+	_, _ = buffer.Write([]byte("fallback log"))
+	_, err := callDiagnoseTool(
+		nil,
+		buffer,
+		ManualShellOptions{
+			Workdir:              baseDir,
+			Shell:                "/bin/bash",
+			GatewayListenAddress: gatewaySocket,
+			GatewayTokenFile:     authTokenFile,
+		},
+		filepath.Join(baseDir, "diag.sock"),
+		diagnoseTrigger{CommandText: "go test ./...", ExitCode: 1, OutputText: "fatal"},
+	)
+	if err == nil {
+		t.Fatal("expected gateway frame error")
+	}
+	if !strings.Contains(err.Error(), "mock_failed") || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("unexpected error = %v", err)
+	}
+	if serverErr := <-serverDone; serverErr != nil {
+		t.Fatalf("mock gateway server error = %v", serverErr)
+	}
+}
+
+func TestSendDiagIPCCommandFallbackToLegacySocket(t *testing.T) {
+	homeDir := t.TempDir()
+	legacyTmpDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("TMPDIR", legacyTmpDir)
+
+	legacySocket := filepath.Join(legacyTmpDir, fmt.Sprintf("%s%d%s", diagSocketFilePrefix, time.Now().UnixNano(), diagSocketFileSuffix))
+	listener, resolvedLegacySocket, err := listenDiagSocket(legacySocket)
+	if err != nil {
+		t.Fatalf("listenDiagSocket() error = %v", err)
+	}
+	defer func() {
+		_ = listener.Close()
+		_ = os.Remove(resolvedLegacySocket)
+	}()
+
+	serverDone := make(chan error, 1)
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			serverDone <- acceptErr
+			return
+		}
+		defer connection.Close()
+
+		request, readErr := bufio.NewReader(connection).ReadBytes('\n')
+		if readErr != nil {
+			serverDone <- readErr
+			return
+		}
+
+		var payload diagIPCRequest
+		if err := json.Unmarshal(request, &payload); err != nil {
+			serverDone <- err
+			return
+		}
+		if payload.Cmd != diagCommandDiagnose {
+			serverDone <- fmt.Errorf("cmd = %q", payload.Cmd)
+			return
+		}
+		response, _ := json.Marshal(diagIPCResponse{OK: true, Message: "ok"})
+		_, writeErr := connection.Write(append(response, '\n'))
+		serverDone <- writeErr
+	}()
+
+	primarySocket := filepath.Join(homeDir, ".neocode", "run", "missing.sock")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	response, err := sendDiagIPCCommand(ctx, primarySocket, diagIPCRequest{Cmd: diagCommandDiagnose})
+	if err != nil {
+		t.Fatalf("sendDiagIPCCommand() error = %v", err)
+	}
+	if !response.OK {
+		t.Fatalf("response = %#v, want ok=true", response)
+	}
+	if serverErr := <-serverDone; serverErr != nil {
+		t.Fatalf("legacy socket server error = %v", serverErr)
+	}
+}
+
+func TestServeDiagSocketAcceptError(t *testing.T) {
+	releaseAccept := make(chan struct{})
+	listener := &scriptedListener{
+		acceptSteps: []func() (net.Conn, error){
+			func() (net.Conn, error) { return nil, errors.New("accept failed") },
+			func() (net.Conn, error) {
+				<-releaseAccept
+				return nil, net.ErrClosed
+			},
+		},
+	}
+
+	output := &bytes.Buffer{}
+	jobCh := make(chan diagnoseJob, 1)
+	autoState := &autoRuntimeState{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		serveDiagSocket(ctx, listener, jobCh, autoState, output)
+	}()
+
+	deadline := time.After(500 * time.Millisecond)
+	for {
+		if strings.Contains(output.String(), "accept signal error") {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("expected accept error output, got %q", output.String())
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	cancel()
+	close(releaseAccept)
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("serveDiagSocket did not exit after context cancellation")
+	}
+}
+
 func TestRunSingleDiagnosisGatewayUnavailableDoesNotPanic(t *testing.T) {
 	buffer := NewUTF8RingBuffer(1024)
-	_, _ = buffer.Write([]byte("中文日志 + \u001b[31merror\u001b[0m"))
+	_, _ = buffer.Write([]byte("diagnose log + \u001b[31merror\u001b[0m"))
 
 	output := &bytes.Buffer{}
 	runSingleDiagnosis(
+		nil,
 		output,
 		buffer,
 		ManualShellOptions{
@@ -670,7 +1049,7 @@ func TestResolveShellPathPrefersExplicit(t *testing.T) {
 }
 
 func TestRunManualShellBasicIntegration(t *testing.T) {
-	if os.Getenv("PTY_INTEGRATION_TEST") == "" {
+	if os.Getenv("PTY_INTEGRATION_TEST") != "1" {
 		t.Skip("set PTY_INTEGRATION_TEST=1 to run integration test")
 	}
 	if _, err := os.Stat("/bin/echo"); err != nil {
@@ -702,4 +1081,97 @@ func TestRunManualShellBasicIntegration(t *testing.T) {
 	if !strings.Contains(stdout.String(), proxyExitedBanner) {
 		t.Fatalf("stdout = %q, want contains exited banner", stdout.String())
 	}
+}
+
+func writeGatewayAuthTokenFile(t *testing.T, path string, token string) {
+	t.Helper()
+	payload := map[string]any{
+		"version":    1,
+		"token":      token,
+		"created_at": time.Now().UTC(),
+		"updated_at": time.Now().UTC(),
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal auth token payload error = %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write auth token file error = %v", err)
+	}
+}
+
+func startGatewayRPCMockServer(
+	t *testing.T,
+	socketPath string,
+	handler func(decoder *json.Decoder, encoder *json.Encoder) error,
+) (func(), <-chan error) {
+	t.Helper()
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen gateway socket error = %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			done <- acceptErr
+			return
+		}
+		defer connection.Close()
+
+		decoder := json.NewDecoder(connection)
+		encoder := json.NewEncoder(connection)
+		done <- handler(decoder, encoder)
+	}()
+
+	cleanup := func() {
+		_ = listener.Close()
+		_ = os.Remove(socketPath)
+	}
+	return cleanup, done
+}
+
+func readRPCRequest(decoder *json.Decoder) (protocol.JSONRPCRequest, error) {
+	var request protocol.JSONRPCRequest
+	if err := decoder.Decode(&request); err != nil {
+		return protocol.JSONRPCRequest{}, err
+	}
+	return request, nil
+}
+
+func writeRPCResult(encoder *json.Encoder, id json.RawMessage, result any) error {
+	response, rpcErr := protocol.NewJSONRPCResultResponse(id, result)
+	if rpcErr != nil {
+		return fmt.Errorf("new jsonrpc result response: %v", rpcErr)
+	}
+	if err := encoder.Encode(response); err != nil {
+		return fmt.Errorf("encode jsonrpc result: %w", err)
+	}
+	return nil
+}
+
+type scriptedListener struct {
+	mu          sync.Mutex
+	acceptSteps []func() (net.Conn, error)
+	index       int
+}
+
+func (s *scriptedListener) Accept() (net.Conn, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.index >= len(s.acceptSteps) {
+		return nil, net.ErrClosed
+	}
+	step := s.acceptSteps[s.index]
+	s.index++
+	return step()
+}
+
+func (s *scriptedListener) Close() error {
+	return nil
+}
+
+func (s *scriptedListener) Addr() net.Addr {
+	return &net.UnixAddr{Name: "scripted-listener", Net: "unix"}
 }

--- a/internal/ptyproxy/proxy_unix_test.go
+++ b/internal/ptyproxy/proxy_unix_test.go
@@ -7,20 +7,24 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"golang.org/x/term"
 )
 
 func assertNoBareLineFeed(t *testing.T, text string) {
 	t.Helper()
-	for i := 0; i < len(text); i++ {
-		if text[i] == '\n' && (i == 0 || text[i-1] != '\r') {
-			t.Fatalf("output contains bare LF at index %d: %q", i, text)
+	for index := 0; index < len(text); index++ {
+		if text[index] == '\n' && (index == 0 || text[index-1] != '\r') {
+			t.Fatalf("output contains bare LF at index %d: %q", index, text)
 		}
 	}
 }
@@ -46,6 +50,7 @@ func TestCleanupStaleSocketRejectsRegularFile(t *testing.T) {
 	if err := os.WriteFile(socketPath, []byte("x"), 0o600); err != nil {
 		t.Fatalf("write file error = %v", err)
 	}
+
 	err := cleanupStaleSocket(socketPath)
 	if err == nil {
 		t.Fatal("expected non-socket error")
@@ -78,20 +83,20 @@ func TestHandleDiagSocketConnectionAutoMode(t *testing.T) {
 				close(done)
 			}()
 
-			req := diagIPCRequest{Cmd: tc.command}
-			raw, _ := json.Marshal(req)
+			request := diagIPCRequest{Cmd: tc.command}
+			raw, _ := json.Marshal(request)
 			_, _ = clientConn.Write(append(raw, '\n'))
 
 			line, err := bufio.NewReader(clientConn).ReadBytes('\n')
 			if err != nil {
 				t.Fatalf("read response error = %v", err)
 			}
-			var resp diagIPCResponse
-			if err := json.Unmarshal(line, &resp); err != nil {
+			var response diagIPCResponse
+			if err := json.Unmarshal(line, &response); err != nil {
 				t.Fatalf("unmarshal response error = %v", err)
 			}
-			if !resp.OK {
-				t.Fatalf("response not ok: %#v", resp)
+			if !response.OK {
+				t.Fatalf("response not ok: %#v", response)
 			}
 			if autoState.Enabled.Load() != tc.wantEnabled {
 				t.Fatalf("enabled = %v, want %v", autoState.Enabled.Load(), tc.wantEnabled)
@@ -102,6 +107,42 @@ func TestHandleDiagSocketConnectionAutoMode(t *testing.T) {
 				t.Fatal("timeout waiting handler return")
 			}
 		})
+	}
+}
+
+func TestHandleDiagSocketConnectionAutoStatus(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	jobCh := make(chan diagnoseJob, 1)
+	autoState := &autoRuntimeState{}
+	autoState.Enabled.Store(true)
+
+	done := make(chan struct{})
+	go func() {
+		handleDiagSocketConnection(context.Background(), serverConn, jobCh, autoState)
+		close(done)
+	}()
+
+	request := diagIPCRequest{Cmd: diagCommandAutoStatus}
+	raw, _ := json.Marshal(request)
+	_, _ = clientConn.Write(append(raw, '\n'))
+
+	line, err := bufio.NewReader(clientConn).ReadBytes('\n')
+	if err != nil {
+		t.Fatalf("read response error = %v", err)
+	}
+	var response diagIPCResponse
+	if err := json.Unmarshal(line, &response); err != nil {
+		t.Fatalf("unmarshal response error = %v", err)
+	}
+	if !response.OK || !response.AutoEnabled {
+		t.Fatalf("response = %#v, want ok and auto_enabled=true", response)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting handler return")
 	}
 }
 
@@ -135,12 +176,12 @@ func TestHandleDiagSocketConnectionDiagnose(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read response error = %v", err)
 	}
-	var resp diagIPCResponse
-	if err := json.Unmarshal(line, &resp); err != nil {
+	var response diagIPCResponse
+	if err := json.Unmarshal(line, &response); err != nil {
 		t.Fatalf("unmarshal response error = %v", err)
 	}
-	if !resp.OK {
-		t.Fatalf("response not ok: %#v", resp)
+	if !response.OK {
+		t.Fatalf("response not ok: %#v", response)
 	}
 	select {
 	case <-done:
@@ -168,36 +209,409 @@ func TestSendDiagIPCCommandToPath(t *testing.T) {
 			return
 		}
 		defer conn.Close()
+
 		line, readErr := bufio.NewReader(conn).ReadBytes('\n')
 		if readErr != nil {
 			serverDone <- readErr
 			return
 		}
-		var req diagIPCRequest
-		if err := json.Unmarshal(line, &req); err != nil {
+
+		var request diagIPCRequest
+		if err := json.Unmarshal(line, &request); err != nil {
 			serverDone <- err
 			return
 		}
-		if req.Cmd != diagCommandDiagnose {
+		if request.Cmd != diagCommandDiagnose {
 			serverDone <- io.ErrUnexpectedEOF
 			return
 		}
-		resp, _ := json.Marshal(diagIPCResponse{OK: true, Message: "ok"})
-		_, writeErr := conn.Write(append(resp, '\n'))
+		response, _ := json.Marshal(diagIPCResponse{OK: true, Message: "ok"})
+		_, writeErr := conn.Write(append(response, '\n'))
 		serverDone <- writeErr
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	resp, err := sendDiagIPCCommandToPath(ctx, resolvedPath, diagIPCRequest{Cmd: diagCommandDiagnose})
+	response, err := sendDiagIPCCommandToPath(ctx, resolvedPath, diagIPCRequest{Cmd: diagCommandDiagnose})
 	if err != nil {
 		t.Fatalf("sendDiagIPCCommandToPath() error = %v", err)
 	}
-	if !resp.OK {
-		t.Fatalf("resp.OK = false")
+	if !response.OK {
+		t.Fatal("response.OK = false")
 	}
 	if serverErr := <-serverDone; serverErr != nil {
 		t.Fatalf("server error = %v", serverErr)
+	}
+}
+
+func TestSendDiagIPCCommandEmptyPath(t *testing.T) {
+	_, err := sendDiagIPCCommand(context.Background(), "   ", diagIPCRequest{Cmd: diagCommandDiagnose})
+	if err == nil {
+		t.Fatal("expected empty socket path error")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("err = %v, want contains empty", err)
+	}
+}
+
+func TestCommandTrackerObserve(t *testing.T) {
+	tests := []struct {
+		name   string
+		inputs [][]byte
+		want   string
+	}{
+		{
+			name:   "single command",
+			inputs: [][]byte{[]byte("go test\r")},
+			want:   "go test",
+		},
+		{
+			name:   "backspace handling",
+			inputs: [][]byte{[]byte("go tes\x08st\r")},
+			want:   "go test",
+		},
+		{
+			name:   "multiple commands",
+			inputs: [][]byte{[]byte("ls\r"), []byte("cd ..\r")},
+			want:   "cd ..",
+		},
+		{
+			name:   "line feed split",
+			inputs: [][]byte{[]byte("echo 1\n"), []byte("echo 2\r")},
+			want:   "echo 2",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tracker := &commandTracker{}
+			for _, input := range tc.inputs {
+				tracker.Observe(input)
+			}
+			if got := tracker.LastCommand(); got != tc.want {
+				t.Fatalf("LastCommand() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	var nilTracker *commandTracker
+	nilTracker.Observe([]byte("ignored\r"))
+	if got := nilTracker.LastCommand(); got != "" {
+		t.Fatalf("nil tracker LastCommand() = %q, want empty", got)
+	}
+}
+
+func TestRenderDiagnosis(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		isError  bool
+		contains []string
+	}{
+		{
+			name:     "empty content",
+			content:  "",
+			contains: []string{"NeoCode Diagnosis", "无可用诊断内容"},
+		},
+		{
+			name:     "plain text fallback",
+			content:  "raw diagnose output",
+			contains: []string{"NeoCode Diagnosis", "raw diagnose output"},
+		},
+		{
+			name: "json diagnosis",
+			content: `{"confidence":0.82,"root_cause":"网络不可达","investigation_commands":["ping 1.1.1.1"],` +
+				`"fix_commands":["export HTTPS_PROXY=http://127.0.0.1:7890"]}`,
+			contains: []string{
+				"置信度: 0.82",
+				"根因: 网络不可达",
+				"建议排查命令:",
+				"ping 1.1.1.1",
+				"建议修复命令:",
+			},
+		},
+		{
+			name:     "error header color",
+			content:  "fatal error",
+			isError:  true,
+			contains: []string{"\u001b[31m[NeoCode Diagnosis]\u001b[0m"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			output := &bytes.Buffer{}
+			renderDiagnosis(output, tc.content, tc.isError)
+			text := output.String()
+			for _, fragment := range tc.contains {
+				if !strings.Contains(text, fragment) {
+					t.Fatalf("output = %q, want contains %q", text, fragment)
+				}
+			}
+			assertNoBareLineFeed(t, text)
+		})
+	}
+}
+
+func TestSerializedWriterConcurrent(t *testing.T) {
+	target := &bytes.Buffer{}
+	lock := &sync.Mutex{}
+	writer := &serializedWriter{writer: target, lock: lock}
+
+	const count = 64
+	var wg sync.WaitGroup
+	wg.Add(count)
+	for index := 0; index < count; index++ {
+		go func() {
+			defer wg.Done()
+			_, _ = writer.Write([]byte("x"))
+		}()
+	}
+	wg.Wait()
+
+	if got := len(target.String()); got != count {
+		t.Fatalf("len(output) = %d, want %d", got, count)
+	}
+}
+
+func TestIsClosedNetworkError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "net err closed", err: net.ErrClosed, want: true},
+		{name: "closed message", err: errors.New("use of closed network connection"), want: true},
+		{name: "other error", err: errors.New("permission denied"), want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isClosedNetworkError(tc.err); got != tc.want {
+				t.Fatalf("isClosedNetworkError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWriteProxyTextCRLF(t *testing.T) {
+	buffer := &bytes.Buffer{}
+	writeProxyText(buffer, "a\nb\rc\r\nd")
+	writeProxyLine(buffer, "line")
+	writeProxyf(buffer, "fmt:%s\n", "ok")
+	text := buffer.String()
+	if !strings.Contains(text, "a\r\nb\r\nc\r\nd") {
+		t.Fatalf("text = %q, want normalized CRLF content", text)
+	}
+	if !strings.Contains(text, "line\r\n") {
+		t.Fatalf("text = %q, want line with CRLF", text)
+	}
+	if !strings.Contains(text, "fmt:ok\r\n") {
+		t.Fatalf("text = %q, want formatted CRLF line", text)
+	}
+	assertNoBareLineFeed(t, text)
+
+	writeProxyText(nil, "ignored")
+	writeProxyLine(nil, "ignored")
+	writeProxyf(nil, "ignored")
+}
+
+func TestEnableHostTerminalRawMode(t *testing.T) {
+	originalInput := hostTerminalInput
+	originalIsTerminal := isTerminalFD
+	originalMakeRaw := makeRawTerminal
+	originalRestore := restoreTerminal
+	t.Cleanup(func() { hostTerminalInput = originalInput })
+	t.Cleanup(func() { isTerminalFD = originalIsTerminal })
+	t.Cleanup(func() { makeRawTerminal = originalMakeRaw })
+	t.Cleanup(func() { restoreTerminal = originalRestore })
+
+	file, err := os.CreateTemp(t.TempDir(), "terminal-*")
+	if err != nil {
+		t.Fatalf("CreateTemp() error = %v", err)
+	}
+	defer file.Close()
+
+	hostTerminalInput = file
+	isTerminalFD = func(int) bool { return true }
+	makeRawTerminal = func(int) (*term.State, error) { return &term.State{}, nil }
+
+	restoreCalled := false
+	restoreTerminal = func(int, *term.State) error {
+		restoreCalled = true
+		return nil
+	}
+
+	restoreFn, err := enableHostTerminalRawMode()
+	if err != nil {
+		t.Fatalf("enableHostTerminalRawMode() error = %v", err)
+	}
+	if restoreFn == nil {
+		t.Fatal("restore function should not be nil")
+	}
+	if err := restoreFn(); err != nil {
+		t.Fatalf("restoreFn() error = %v", err)
+	}
+	if !restoreCalled {
+		t.Fatal("expected restoreTerminal called")
+	}
+}
+
+func TestEnableHostTerminalRawModeFallbacks(t *testing.T) {
+	originalInput := hostTerminalInput
+	originalIsTerminal := isTerminalFD
+	originalMakeRaw := makeRawTerminal
+	t.Cleanup(func() { hostTerminalInput = originalInput })
+	t.Cleanup(func() { isTerminalFD = originalIsTerminal })
+	t.Cleanup(func() { makeRawTerminal = originalMakeRaw })
+
+	hostTerminalInput = nil
+	restoreFn, err := enableHostTerminalRawMode()
+	if err != nil {
+		t.Fatalf("enableHostTerminalRawMode() with nil input error = %v", err)
+	}
+	if err := restoreFn(); err != nil {
+		t.Fatalf("restoreFn() error = %v", err)
+	}
+
+	file, err := os.CreateTemp(t.TempDir(), "terminal-*")
+	if err != nil {
+		t.Fatalf("CreateTemp() error = %v", err)
+	}
+	defer file.Close()
+	hostTerminalInput = file
+	isTerminalFD = func(int) bool { return false }
+	restoreFn, err = enableHostTerminalRawMode()
+	if err != nil {
+		t.Fatalf("enableHostTerminalRawMode() non-terminal error = %v", err)
+	}
+	if err := restoreFn(); err != nil {
+		t.Fatalf("restoreFn() error = %v", err)
+	}
+
+	isTerminalFD = func(int) bool { return true }
+	makeRawTerminal = func(int) (*term.State, error) { return nil, errors.New("make raw failed") }
+	_, err = enableHostTerminalRawMode()
+	if err == nil || !strings.Contains(err.Error(), "set host terminal raw mode") {
+		t.Fatalf("err = %v, want wrapped make raw error", err)
+	}
+}
+
+func TestInstallHostTerminalRestoreGuardNoop(t *testing.T) {
+	originalInput := hostTerminalInput
+	t.Cleanup(func() { hostTerminalInput = originalInput })
+	hostTerminalInput = nil
+	restore := installHostTerminalRestoreGuard()
+	restore()
+}
+
+func TestCopyInputWithTracker(t *testing.T) {
+	tracker := &commandTracker{}
+	input := []byte("go tes\x08st\rnext\r")
+	reader := bytes.NewReader(input)
+	output := &bytes.Buffer{}
+
+	written, err := copyInputWithTracker(output, reader, tracker)
+	if err != nil {
+		t.Fatalf("copyInputWithTracker() error = %v", err)
+	}
+	if written != int64(len(input)) {
+		t.Fatalf("written = %d, want %d", written, len(input))
+	}
+	if output.String() != string(input) {
+		t.Fatalf("output = %q, want %q", output.String(), string(input))
+	}
+	if tracker.LastCommand() != "next" {
+		t.Fatalf("LastCommand() = %q, want %q", tracker.LastCommand(), "next")
+	}
+}
+
+func TestCopyInputWithTrackerNilIO(t *testing.T) {
+	written, err := copyInputWithTracker(nil, nil, &commandTracker{})
+	if err != nil {
+		t.Fatalf("copyInputWithTracker(nil,nil) error = %v", err)
+	}
+	if written != 0 {
+		t.Fatalf("written = %d, want 0", written)
+	}
+}
+
+func TestStreamPTYOutputEmitsAutoTrigger(t *testing.T) {
+	payload := strings.NewReader(
+		"\x1b]133;C\x07" +
+			"fatal: build failed\n" +
+			"\x1b]133;D;1\x07" +
+			"\x1b]133;A\x07",
+	)
+	output := &bytes.Buffer{}
+	commandLog := NewUTF8RingBuffer(1024)
+	tracker := &commandTracker{}
+	tracker.Observe([]byte("go test ./...\r"))
+	autoTriggers := make(chan diagnoseTrigger, 1)
+	autoState := &autoRuntimeState{}
+	autoState.Enabled.Store(true)
+
+	streamPTYOutput(payload, output, commandLog, tracker, autoTriggers, autoState)
+
+	select {
+	case trigger := <-autoTriggers:
+		if trigger.CommandText != "go test ./..." {
+			t.Fatalf("trigger.CommandText = %q, want %q", trigger.CommandText, "go test ./...")
+		}
+		if trigger.ExitCode != 1 {
+			t.Fatalf("trigger.ExitCode = %d, want 1", trigger.ExitCode)
+		}
+		if !strings.Contains(trigger.OutputText, "fatal: build failed") {
+			t.Fatalf("trigger.OutputText = %q, want contains fatal message", trigger.OutputText)
+		}
+	default:
+		t.Fatal("expected one auto diagnose trigger")
+	}
+
+	if !strings.Contains(output.String(), "fatal: build failed") {
+		t.Fatalf("output = %q, want contains visible command output", output.String())
+	}
+}
+
+func TestStreamPTYOutputSkipsTriggerWhenAutoDisabled(t *testing.T) {
+	payload := strings.NewReader(
+		"\x1b]133;C\x07" +
+			"fatal: build failed\n" +
+			"\x1b]133;D;1\x07" +
+			"\x1b]133;A\x07",
+	)
+	output := &bytes.Buffer{}
+	commandLog := NewUTF8RingBuffer(1024)
+	tracker := &commandTracker{}
+	tracker.Observe([]byte("go test ./...\r"))
+	autoTriggers := make(chan diagnoseTrigger, 1)
+	autoState := &autoRuntimeState{}
+	autoState.Enabled.Store(false)
+
+	streamPTYOutput(payload, output, commandLog, tracker, autoTriggers, autoState)
+
+	select {
+	case trigger := <-autoTriggers:
+		t.Fatalf("unexpected trigger: %#v", trigger)
+	default:
+	}
+	if !strings.Contains(output.String(), "fatal: build failed") {
+		t.Fatalf("output = %q, want contains fatal text", output.String())
+	}
+}
+
+func TestDecodeToolResult(t *testing.T) {
+	result, err := decodeToolResult(map[string]any{
+		"Content": "ok",
+		"IsError": false,
+	})
+	if err != nil {
+		t.Fatalf("decodeToolResult() error = %v", err)
+	}
+	if result.Content != "ok" {
+		t.Fatalf("result.Content = %q, want %q", result.Content, "ok")
+	}
+	if result.IsError {
+		t.Fatal("result.IsError = true, want false")
 	}
 }
 
@@ -252,5 +666,40 @@ func TestResolveShellPathPrefersExplicit(t *testing.T) {
 	path := resolveShellPath("/bin/fish")
 	if path != "/bin/fish" {
 		t.Fatalf("resolveShellPath() = %q, want %q", path, "/bin/fish")
+	}
+}
+
+func TestRunManualShellBasicIntegration(t *testing.T) {
+	if os.Getenv("PTY_INTEGRATION_TEST") == "" {
+		t.Skip("set PTY_INTEGRATION_TEST=1 to run integration test")
+	}
+	if _, err := os.Stat("/bin/echo"); err != nil {
+		t.Skip("/bin/echo not available")
+	}
+
+	originalInput := hostTerminalInput
+	t.Cleanup(func() { hostTerminalInput = originalInput })
+	hostTerminalInput = nil
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := RunManualShell(ctx, ManualShellOptions{
+		Workdir: t.TempDir(),
+		Shell:   "/bin/echo",
+		Stdin:   bytes.NewReader(nil),
+		Stdout:  stdout,
+		Stderr:  stderr,
+	})
+	if err != nil {
+		t.Fatalf("RunManualShell() error = %v, stderr=%q", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), proxyInitializedBanner) {
+		t.Fatalf("stdout = %q, want contains initialized banner", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), proxyExitedBanner) {
+		t.Fatalf("stdout = %q, want contains exited banner", stdout.String())
 	}
 }

--- a/internal/ptyproxy/proxy_windows.go
+++ b/internal/ptyproxy/proxy_windows.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 )
 
-var errUnsupportedPlatform = errors.New("ptyproxy: manual shell mode is only supported on unix-like systems in phase1")
+var errUnsupportedPlatform = errors.New("ptyproxy: manual shell mode is only supported on unix-like systems")
 
 // RunManualShell 在 Windows 平台返回明确不支持错误，避免误判为静默失败。
 func RunManualShell(context.Context, ManualShellOptions) error {
@@ -16,5 +16,10 @@ func RunManualShell(context.Context, ManualShellOptions) error {
 
 // SendDiagnoseSignal 在 Windows 平台返回明确不支持错误。
 func SendDiagnoseSignal(context.Context, string) error {
+	return errUnsupportedPlatform
+}
+
+// SendAutoModeSignal 在 Windows 平台返回明确不支持错误。
+func SendAutoModeSignal(context.Context, string, bool) error {
 	return errUnsupportedPlatform
 }

--- a/internal/ptyproxy/proxy_windows.go
+++ b/internal/ptyproxy/proxy_windows.go
@@ -23,3 +23,8 @@ func SendDiagnoseSignal(context.Context, string) error {
 func SendAutoModeSignal(context.Context, string, bool) error {
 	return errUnsupportedPlatform
 }
+
+// QueryAutoMode 在 Windows 平台返回明确不支持错误。
+func QueryAutoMode(context.Context, string) (bool, error) {
+	return false, errUnsupportedPlatform
+}

--- a/internal/ptyproxy/sanitizer.go
+++ b/internal/ptyproxy/sanitizer.go
@@ -1,0 +1,102 @@
+package ptyproxy
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+const defaultDiagnosisPayloadMaxBytes = 8 * 1024
+
+var (
+	ansiSequencePattern = regexp.MustCompile(`\x1b(?:\[[0-?]*[ -/]*[@-~]|][^\x07]*(?:\x07|\x1b\\)|[@-Z\\-_])`)
+
+	awsAccessKeyPattern = regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`)
+	jwtPattern          = regexp.MustCompile(`\beyJ[a-zA-Z0-9_-]{8,}\.[a-zA-Z0-9_-]{8,}\.[a-zA-Z0-9_-]{8,}\b`)
+	bearerTokenPattern  = regexp.MustCompile(`(?i)\bbearer\s+([a-z0-9\-._~+/]+=*)`)
+	apiKeyPattern       = regexp.MustCompile(`(?i)\b(api[_-]?key|token|password|secret)\b\s*[:=]\s*([^\s,;]+)`)
+	privateKeyPattern   = regexp.MustCompile(`(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----`)
+)
+
+// SanitizeDiagnosisText 对诊断载荷执行降噪、截断和脱敏，必须只在 RPC 发起前一刻调用。
+// 性能约束：禁止把该函数放入实时终端 I/O 热路径，避免高频正则导致 CPU 抖动。
+func SanitizeDiagnosisText(raw string, maxBytes int) string {
+	if maxBytes <= 0 {
+		maxBytes = defaultDiagnosisPayloadMaxBytes
+	}
+	trimmed := normalizeWhitespace(foldCarriageReturns(stripANSI(raw)))
+	trimmed = TruncateUTF8HeadTail(trimmed, maxBytes)
+	return redactSensitive(trimmed)
+}
+
+// stripANSI 去除 ANSI 控制序列，避免颜色编码污染模型输入。
+func stripANSI(raw string) string {
+	if strings.TrimSpace(raw) == "" {
+		return ""
+	}
+	return ansiSequencePattern.ReplaceAllString(raw, "")
+}
+
+// foldCarriageReturns 折叠 \r 覆盖输出，仅保留每行最终可见内容。
+func foldCarriageReturns(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	lines := strings.Split(raw, "\n")
+	for index, line := range lines {
+		if strings.Contains(line, "\r") {
+			line = strings.TrimRight(line, "\r")
+			parts := strings.Split(line, "\r")
+			if len(parts) > 0 {
+				lines[index] = parts[len(parts)-1]
+			} else {
+				lines[index] = ""
+			}
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// normalizeWhitespace 清理不可打印字符并折叠多余空白。
+func normalizeWhitespace(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	var builder strings.Builder
+	builder.Grow(len(raw))
+	lastSpace := false
+	for _, char := range raw {
+		if char == '\n' {
+			builder.WriteRune(char)
+			lastSpace = false
+			continue
+		}
+		if unicode.IsSpace(char) {
+			if lastSpace {
+				continue
+			}
+			builder.WriteRune(' ')
+			lastSpace = true
+			continue
+		}
+		if !unicode.IsPrint(char) {
+			continue
+		}
+		builder.WriteRune(char)
+		lastSpace = false
+	}
+	return strings.TrimSpace(builder.String())
+}
+
+// redactSensitive 对常见高危凭证做强制打码。
+func redactSensitive(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	redacted := awsAccessKeyPattern.ReplaceAllString(raw, "AKIA[REDACTED]")
+	redacted = jwtPattern.ReplaceAllString(redacted, "[JWT_REDACTED]")
+	redacted = bearerTokenPattern.ReplaceAllString(redacted, "Bearer [REDACTED]")
+	redacted = apiKeyPattern.ReplaceAllString(redacted, "$1=[REDACTED]")
+	redacted = privateKeyPattern.ReplaceAllString(redacted, "-----BEGIN PRIVATE KEY-----[REDACTED]-----END PRIVATE KEY-----")
+	return redacted
+}

--- a/internal/ptyproxy/sanitizer_test.go
+++ b/internal/ptyproxy/sanitizer_test.go
@@ -1,0 +1,58 @@
+package ptyproxy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeDiagnosisTextANSIAndCRFold(t *testing.T) {
+	raw := "step1\rstep2\n\x1b[31merror\x1b[0m happened"
+	got := SanitizeDiagnosisText(raw, 1024)
+	if strings.Contains(got, "\x1b[31m") {
+		t.Fatalf("ansi should be removed: %q", got)
+	}
+	if strings.Contains(got, "step1") {
+		t.Fatalf("carriage-return overwritten text should be folded: %q", got)
+	}
+	if !strings.Contains(got, "step2") {
+		t.Fatalf("want folded line tail kept: %q", got)
+	}
+}
+
+func TestSanitizeDiagnosisTextRedactsSecrets(t *testing.T) {
+	raw := strings.Join([]string{
+		"AKIAABCDEFGHIJKLMNOP",
+		"Bearer super-secret-token",
+		"password=abc123",
+		"api_key: key-xyz",
+		"-----BEGIN PRIVATE KEY-----abc-----END PRIVATE KEY-----",
+		"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTYifQ.signaturepart",
+	}, "\n")
+	got := SanitizeDiagnosisText(raw, 4096)
+	for _, leaked := range []string{
+		"AKIAABCDEFGHIJKLMNOP",
+		"super-secret-token",
+		"abc123",
+		"key-xyz",
+		"signaturepart",
+	} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("secret leaked %q in %q", leaked, got)
+		}
+	}
+	if !strings.Contains(got, "[REDACTED]") && !strings.Contains(got, "[JWT_REDACTED]") {
+		t.Fatalf("redaction marker missing: %q", got)
+	}
+}
+
+func TestSanitizeDiagnosisTextTruncatesBeforeRedactionStage(t *testing.T) {
+	// 构造超长文本，验证结果长度受 maxBytes 限制并保持可解析。
+	raw := strings.Repeat("x", 8192) + "\npassword=abcdef"
+	got := SanitizeDiagnosisText(raw, 256)
+	if len(got) > 256+len(truncationMarker) {
+		t.Fatalf("sanitized payload too large: %d", len(got))
+	}
+	if strings.Contains(got, "abcdef") {
+		t.Fatalf("secret should be redacted even after truncation: %q", got)
+	}
+}

--- a/internal/ptyproxy/sanitizer_test.go
+++ b/internal/ptyproxy/sanitizer_test.go
@@ -56,3 +56,22 @@ func TestSanitizeDiagnosisTextTruncatesBeforeRedactionStage(t *testing.T) {
 		t.Fatalf("secret should be redacted even after truncation: %q", got)
 	}
 }
+
+func TestSanitizerHelperBranches(t *testing.T) {
+	if got := SanitizeDiagnosisText("", 0); got != "" {
+		t.Fatalf("SanitizeDiagnosisText(empty) = %q, want empty", got)
+	}
+	if got := stripANSI(" "); got != "" {
+		t.Fatalf("stripANSI(whitespace) = %q, want empty", got)
+	}
+	if got := foldCarriageReturns(""); got != "" {
+		t.Fatalf("foldCarriageReturns(empty) = %q, want empty", got)
+	}
+	normalized := normalizeWhitespace("a \t\tb\u0001\u0002\n c")
+	if normalized != "a b\n c" {
+		t.Fatalf("normalizeWhitespace() = %q, want %q", normalized, "a b\n c")
+	}
+	if got := redactSensitive(""); got != "" {
+		t.Fatalf("redactSensitive(empty) = %q, want empty", got)
+	}
+}

--- a/internal/ptyproxy/shell_events.go
+++ b/internal/ptyproxy/shell_events.go
@@ -1,0 +1,170 @@
+package ptyproxy
+
+import (
+	"strconv"
+	"strings"
+)
+
+const (
+	oscBEL         = byte('\a')
+	oscEscape      = byte(0x1b)
+	oscCloseByte   = byte('\\')
+	oscPrefix      = "\x1b]133;"
+	tmuxDCSOpen    = "\x1bPtmux;"
+	maxOSCLeftover = 4096
+)
+
+// ShellEventType 表示代理捕获到的 Shell Integration 事件类型。
+type ShellEventType string
+
+const (
+	// ShellEventPromptReady 对应 OSC 133;A，表示 prompt 已就绪。
+	ShellEventPromptReady ShellEventType = "prompt_ready"
+	// ShellEventCommandStart 对应 OSC 133;C，表示命令开始执行。
+	ShellEventCommandStart ShellEventType = "command_start"
+	// ShellEventCommandDone 对应 OSC 133;D;<exit_code>，表示命令结束。
+	ShellEventCommandDone ShellEventType = "command_done"
+)
+
+// ShellEvent 描述从输出字节流中提取的结构化 shell 事件。
+type ShellEvent struct {
+	Type     ShellEventType
+	ExitCode int
+}
+
+// OSC133Parser 负责从 PTY 字节流中剥离 OSC 133 并产出结构化事件。
+type OSC133Parser struct {
+	leftover []byte
+}
+
+// Feed 解析新输入分片，返回去除控制序列后的可显示字节与提取出的事件。
+func (p *OSC133Parser) Feed(chunk []byte) ([]byte, []ShellEvent) {
+	if len(chunk) == 0 {
+		return nil, nil
+	}
+	buffer := append(append([]byte(nil), p.leftover...), chunk...)
+	p.leftover = nil
+
+	output := make([]byte, 0, len(buffer))
+	events := make([]ShellEvent, 0, 4)
+
+	for index := 0; index < len(buffer); {
+		// 尝试剥离 tmux passthrough 包裹。
+		if hasPrefixAt(buffer, index, tmuxDCSOpen) {
+			end, ok := findESCBackslash(buffer, index+len(tmuxDCSOpen))
+			if !ok {
+				p.leftover = keepOSCLeftover(buffer[index:])
+				break
+			}
+			inner := buffer[index+len(tmuxDCSOpen) : end]
+			// tmux 透传会将 ESC 转义为双 ESC，这里先做一次解包还原。
+			if len(inner) > 1 && inner[0] == oscEscape && hasPrefixAt(inner, 1, oscPrefix) {
+				inner = inner[1:]
+			}
+			if hasPrefixAt(inner, 0, oscPrefix) {
+				payload, payloadOK := parseOSCPayload(inner)
+				if payloadOK {
+					if event, matched := parseOSC133Event(payload); matched {
+						events = append(events, event)
+					}
+					index = end + 2
+					continue
+				}
+			}
+		}
+
+		// 直接解析 OSC 133。
+		if hasPrefixAt(buffer, index, oscPrefix) {
+			payload, next, ok := parseOSCFromBuffer(buffer, index)
+			if !ok {
+				p.leftover = keepOSCLeftover(buffer[index:])
+				break
+			}
+			if event, matched := parseOSC133Event(payload); matched {
+				events = append(events, event)
+			}
+			index = next
+			continue
+		}
+
+		output = append(output, buffer[index])
+		index++
+	}
+
+	return output, events
+}
+
+// parseOSCFromBuffer 从完整缓冲区中读取一个 OSC payload。
+func parseOSCFromBuffer(buffer []byte, start int) (string, int, bool) {
+	cursor := start + len(oscPrefix)
+	for cursor < len(buffer) {
+		if buffer[cursor] == oscBEL {
+			return string(buffer[start+len(oscPrefix) : cursor]), cursor + 1, true
+		}
+		if cursor+1 < len(buffer) && buffer[cursor] == oscEscape && buffer[cursor+1] == oscCloseByte {
+			return string(buffer[start+len(oscPrefix) : cursor]), cursor + 2, true
+		}
+		cursor++
+	}
+	return "", start, false
+}
+
+// parseOSCPayload 解析独立 payload 片段（用于 tmux 内嵌场景）。
+func parseOSCPayload(raw []byte) (string, bool) {
+	payload, _, ok := parseOSCFromBuffer(raw, 0)
+	return payload, ok
+}
+
+// parseOSC133Event 将 OSC payload 转换为结构化 shell 事件。
+func parseOSC133Event(payload string) (ShellEvent, bool) {
+	trimmed := strings.TrimSpace(payload)
+	if trimmed == "" {
+		return ShellEvent{}, false
+	}
+	switch {
+	case strings.HasPrefix(trimmed, "A"):
+		return ShellEvent{Type: ShellEventPromptReady}, true
+	case strings.HasPrefix(trimmed, "C"):
+		return ShellEvent{Type: ShellEventCommandStart}, true
+	case strings.HasPrefix(trimmed, "D"):
+		parts := strings.Split(trimmed, ";")
+		exitCode := 0
+		if len(parts) >= 2 {
+			if parsed, err := strconv.Atoi(strings.TrimSpace(parts[1])); err == nil {
+				exitCode = parsed
+			}
+		}
+		return ShellEvent{
+			Type:     ShellEventCommandDone,
+			ExitCode: exitCode,
+		}, true
+	default:
+		return ShellEvent{}, false
+	}
+}
+
+// findESCBackslash 在缓冲区中查找 ESC\ 结束序列。
+func findESCBackslash(buffer []byte, start int) (int, bool) {
+	for index := start; index+1 < len(buffer); index++ {
+		if buffer[index] == oscEscape && buffer[index+1] == oscCloseByte {
+			return index, true
+		}
+	}
+	return 0, false
+}
+
+// hasPrefixAt 判断给定下标处是否命中指定前缀。
+func hasPrefixAt(buffer []byte, start int, prefix string) bool {
+	if start < 0 || start+len(prefix) > len(buffer) {
+		return false
+	}
+	return string(buffer[start:start+len(prefix)]) == prefix
+}
+
+// keepOSCLeftover 控制未完成片段缓存上限，防止异常流导致内存无限增长。
+func keepOSCLeftover(raw []byte) []byte {
+	if len(raw) <= maxOSCLeftover {
+		return append([]byte(nil), raw...)
+	}
+	return append([]byte(nil), raw[len(raw)-maxOSCLeftover:]...)
+}

--- a/internal/ptyproxy/shell_events_test.go
+++ b/internal/ptyproxy/shell_events_test.go
@@ -1,0 +1,79 @@
+package ptyproxy
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestOSC133ParserExtractsEventsAndStripsControlBytes(t *testing.T) {
+	parser := &OSC133Parser{}
+	payload := []byte("hello\x1b]133;C\aerr\n\x1b]133;D;2\aworld\x1b]133;A\a!")
+	clean, events := parser.Feed(payload)
+
+	if string(clean) != "helloerr\nworld!" {
+		t.Fatalf("clean = %q, want %q", string(clean), "helloerr\nworld!")
+	}
+	if len(events) != 3 {
+		t.Fatalf("events len = %d, want 3", len(events))
+	}
+	if events[0].Type != ShellEventCommandStart {
+		t.Fatalf("events[0].Type = %q", events[0].Type)
+	}
+	if events[1].Type != ShellEventCommandDone || events[1].ExitCode != 2 {
+		t.Fatalf("events[1] = %#v, want command_done/2", events[1])
+	}
+	if events[2].Type != ShellEventPromptReady {
+		t.Fatalf("events[2].Type = %q", events[2].Type)
+	}
+}
+
+func TestOSC133ParserSupportsChunkedInput(t *testing.T) {
+	parser := &OSC133Parser{}
+	part1 := []byte("before\x1b]133;D;")
+	part2 := []byte("137\amiddle\x1b]133;A\aafter")
+
+	clean1, events1 := parser.Feed(part1)
+	clean2, events2 := parser.Feed(part2)
+
+	if string(clean1) != "before" {
+		t.Fatalf("clean1 = %q, want %q", string(clean1), "before")
+	}
+	if len(events1) != 0 {
+		t.Fatalf("events1 len = %d, want 0", len(events1))
+	}
+	if string(clean2) != "middleafter" {
+		t.Fatalf("clean2 = %q, want %q", string(clean2), "middleafter")
+	}
+	if len(events2) != 2 {
+		t.Fatalf("events2 len = %d, want 2", len(events2))
+	}
+	if events2[0].Type != ShellEventCommandDone || events2[0].ExitCode != 137 {
+		t.Fatalf("events2[0] = %#v", events2[0])
+	}
+	if events2[1].Type != ShellEventPromptReady {
+		t.Fatalf("events2[1] = %#v", events2[1])
+	}
+}
+
+func TestOSC133ParserSupportsTmuxPassthrough(t *testing.T) {
+	parser := &OSC133Parser{}
+	raw := []byte("x\x1bPtmux;\x1b\x1b]133;C\a\x1b\\y")
+	clean, events := parser.Feed(raw)
+	if string(clean) != "xy" {
+		t.Fatalf("clean = %q, want %q", string(clean), "xy")
+	}
+	if len(events) != 1 || events[0].Type != ShellEventCommandStart {
+		t.Fatalf("events = %#v", events)
+	}
+}
+
+func TestOSC133ParserLeftoverBounded(t *testing.T) {
+	parser := &OSC133Parser{}
+	noise := bytes.Repeat([]byte("a"), maxOSCLeftover+128)
+	// 制造一个不完整的 OSC 前缀，确保 leftover 会被上限裁剪。
+	chunk := append([]byte("\x1b]133;"), noise...)
+	_, _ = parser.Feed(chunk)
+	if len(parser.leftover) > maxOSCLeftover {
+		t.Fatalf("leftover len = %d, want <= %d", len(parser.leftover), maxOSCLeftover)
+	}
+}

--- a/internal/ptyproxy/shell_events_test.go
+++ b/internal/ptyproxy/shell_events_test.go
@@ -77,3 +77,79 @@ func TestOSC133ParserLeftoverBounded(t *testing.T) {
 		t.Fatalf("leftover len = %d, want <= %d", len(parser.leftover), maxOSCLeftover)
 	}
 }
+
+func TestOSC133ParserAndHelpersAdditionalBranches(t *testing.T) {
+	t.Run("feed empty chunk", func(t *testing.T) {
+		parser := &OSC133Parser{}
+		clean, events := parser.Feed(nil)
+		if clean != nil || events != nil {
+			t.Fatalf("Feed(nil) = (%v, %v), want (nil, nil)", clean, events)
+		}
+	})
+
+	t.Run("tmux passthrough unknown event", func(t *testing.T) {
+		parser := &OSC133Parser{}
+		raw := []byte("x\x1bPtmux;\x1b\x1b]133;X\a\x1b\\y")
+		clean, events := parser.Feed(raw)
+		if string(clean) != "xy" {
+			t.Fatalf("clean = %q, want xy", clean)
+		}
+		if len(events) != 0 {
+			t.Fatalf("events = %#v, want empty", events)
+		}
+	})
+
+	t.Run("command done with invalid exit code", func(t *testing.T) {
+		event, ok := parseOSC133Event("D;not-a-number")
+		if !ok {
+			t.Fatal("expected parseOSC133Event to match D payload")
+		}
+		if event.Type != ShellEventCommandDone || event.ExitCode != 0 {
+			t.Fatalf("event = %#v, want command_done with exit 0", event)
+		}
+	})
+
+	t.Run("hasPrefixAt bounds and keep leftover short", func(t *testing.T) {
+		if hasPrefixAt([]byte("abc"), -1, "a") {
+			t.Fatal("hasPrefixAt should return false for negative index")
+		}
+		if hasPrefixAt([]byte("abc"), 3, "a") {
+			t.Fatal("hasPrefixAt should return false for out of range index")
+		}
+		if !hasPrefixAt([]byte("abc"), 0, "ab") {
+			t.Fatal("hasPrefixAt should return true for matching prefix")
+		}
+
+		raw := []byte("short")
+		kept := keepOSCLeftover(raw)
+		if string(kept) != "short" {
+			t.Fatalf("keepOSCLeftover(short) = %q, want short", kept)
+		}
+	})
+}
+
+func TestOSC133ParseHelpers(t *testing.T) {
+	t.Run("parse osc payload and esc terminator", func(t *testing.T) {
+		payload, next, ok := parseOSCFromBuffer([]byte("\x1b]133;D;7\x1b\\tail"), 0)
+		if !ok {
+			t.Fatal("parseOSCFromBuffer should parse ESC terminator payload")
+		}
+		if payload != "D;7" {
+			t.Fatalf("payload = %q, want D;7", payload)
+		}
+		if next <= 0 {
+			t.Fatalf("next = %d, want >0", next)
+		}
+
+		parsed, ok := parseOSCPayload([]byte("\x1b]133;C\a"))
+		if !ok || parsed != "C" {
+			t.Fatalf("parseOSCPayload() = (%q, %v), want (C, true)", parsed, ok)
+		}
+	})
+
+	t.Run("parse osc event empty payload", func(t *testing.T) {
+		if _, ok := parseOSC133Event("   "); ok {
+			t.Fatal("parseOSC133Event should reject empty payload")
+		}
+	})
+}

--- a/internal/ptyproxy/shell_init.go
+++ b/internal/ptyproxy/shell_init.go
@@ -1,0 +1,68 @@
+package ptyproxy
+
+import (
+	"fmt"
+	"strings"
+)
+
+const shellInitScript = `# >>> neocode shell integration >>>
+if [ -n "${NEOCODE_SHELL_INIT_LOADED:-}" ]; then
+	return 0 2>/dev/null || exit 0
+fi
+export NEOCODE_SHELL_INIT_LOADED=1
+
+__neocode_emit_osc133() {
+	local _payload="$1"
+	if [ -n "${TMUX:-}" ]; then
+		printf '\033Ptmux;\033\033]133;%s\007\033\\' "$_payload"
+	else
+		printf '\033]133;%s\007' "$_payload"
+	fi
+}
+
+if [ -n "${ZSH_VERSION:-}" ]; then
+	autoload -Uz add-zsh-hook
+	__neocode_preexec() {
+		__neocode_emit_osc133 "C"
+	}
+	__neocode_precmd() {
+		local _exit="$?"
+		__neocode_emit_osc133 "D;${_exit}"
+		__neocode_emit_osc133 "A"
+	}
+	add-zsh-hook preexec __neocode_preexec
+	add-zsh-hook precmd __neocode_precmd
+elif [ -n "${BASH_VERSION:-}" ]; then
+	__neocode_last_cmd=""
+	__neocode_preexec() {
+		local _current="$BASH_COMMAND"
+		if [ "${_current}" = "${__neocode_last_cmd}" ]; then
+			return
+		fi
+		__neocode_last_cmd="${_current}"
+		__neocode_emit_osc133 "C"
+	}
+	trap '__neocode_preexec' DEBUG
+
+	__neocode_precmd() {
+		local _exit="$?"
+		__neocode_emit_osc133 "D;${_exit}"
+		__neocode_emit_osc133 "A"
+	}
+	if [ -n "${PROMPT_COMMAND:-}" ]; then
+		PROMPT_COMMAND="__neocode_precmd;${PROMPT_COMMAND}"
+	else
+		PROMPT_COMMAND="__neocode_precmd"
+	fi
+fi
+# <<< neocode shell integration <<<
+`
+
+// BuildShellInitScript 返回可直接 source 的 shell integration 脚本内容。
+func BuildShellInitScript(shellOption string) string {
+	trimmed := strings.TrimSpace(shellOption)
+	if trimmed == "" {
+		return shellInitScript
+	}
+	return fmt.Sprintf("# target shell: %s\n%s", trimmed, shellInitScript)
+}

--- a/internal/ptyproxy/shell_init_test.go
+++ b/internal/ptyproxy/shell_init_test.go
@@ -1,0 +1,24 @@
+package ptyproxy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildShellInitScript(t *testing.T) {
+	defaultScript := BuildShellInitScript("")
+	if !strings.Contains(defaultScript, "neocode shell integration") {
+		t.Fatalf("default script missing marker: %q", defaultScript)
+	}
+	if strings.HasPrefix(defaultScript, "# target shell:") {
+		t.Fatalf("default script should not contain target header: %q", defaultScript)
+	}
+
+	annotated := BuildShellInitScript(" /bin/zsh ")
+	if !strings.HasPrefix(annotated, "# target shell: /bin/zsh\n") {
+		t.Fatalf("annotated script header = %q", annotated)
+	}
+	if !strings.Contains(annotated, "neocode shell integration") {
+		t.Fatalf("annotated script missing marker: %q", annotated)
+	}
+}

--- a/internal/ptyproxy/socket_paths.go
+++ b/internal/ptyproxy/socket_paths.go
@@ -35,6 +35,15 @@ func ResolveLegacyTmpDiagSocketPath() (string, error) {
 	return findLatestSocketByPattern(os.TempDir(), diagSocketFilePrefix+"*"+diagSocketFileSuffix)
 }
 
+// ResolveLegacyTmpDiagSocketPathForPID 返回临时目录下与指定 PID 匹配的遗留诊断 socket 路径。
+func ResolveLegacyTmpDiagSocketPathForPID(pid int) (string, error) {
+	if pid <= 0 {
+		return "", fmt.Errorf("ptyproxy: invalid diag socket pid %d", pid)
+	}
+	pattern := diagSocketFilePrefix + strconv.Itoa(pid) + diagSocketFileSuffix
+	return findLatestSocketByPattern(os.TempDir(), pattern)
+}
+
 // resolveDiagSocketPathForPID 按约定生成带 PID 的诊断 socket 路径。
 func resolveDiagSocketPathForPID(pid int) (string, error) {
 	runDir, err := resolveDiagSocketRunDir()
@@ -45,6 +54,24 @@ func resolveDiagSocketPathForPID(pid int) (string, error) {
 		pid = os.Getpid()
 	}
 	return filepath.Join(runDir, diagSocketFilePrefix+strconv.Itoa(pid)+diagSocketFileSuffix), nil
+}
+
+// parseDiagSocketPIDFromPath 从诊断 socket 文件名中解析 PID。
+func parseDiagSocketPIDFromPath(socketPath string) (int, error) {
+	base := strings.TrimSpace(filepath.Base(strings.TrimSpace(socketPath)))
+	if base == "." || base == "" {
+		return 0, fmt.Errorf("ptyproxy: diag socket path is empty")
+	}
+	if !strings.HasPrefix(base, diagSocketFilePrefix) || !strings.HasSuffix(base, diagSocketFileSuffix) {
+		return 0, fmt.Errorf("ptyproxy: diag socket filename is invalid: %s", base)
+	}
+	rawPID := strings.TrimPrefix(base, diagSocketFilePrefix)
+	rawPID = strings.TrimSuffix(rawPID, diagSocketFileSuffix)
+	pid, err := strconv.Atoi(rawPID)
+	if err != nil || pid <= 0 {
+		return 0, fmt.Errorf("ptyproxy: diag socket pid is invalid: %s", rawPID)
+	}
+	return pid, nil
 }
 
 // resolveDiagSocketRunDir 解析诊断 socket 的统一运行目录。

--- a/internal/ptyproxy/socket_paths.go
+++ b/internal/ptyproxy/socket_paths.go
@@ -1,0 +1,95 @@
+package ptyproxy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	diagSocketRunRelativeDir = ".neocode/run"
+	diagSocketFilePrefix     = "neocode-diag-"
+	diagSocketFileSuffix     = ".sock"
+)
+
+// ResolveDefaultDiagSocketPath 解析当前进程默认诊断 socket 路径。
+func ResolveDefaultDiagSocketPath() (string, error) {
+	return resolveDiagSocketPathForPID(os.Getpid())
+}
+
+// ResolveLatestRunDiagSocketPath 返回 ~/.neocode/run 下最近修改的诊断 socket 路径。
+func ResolveLatestRunDiagSocketPath() (string, error) {
+	runDir, err := resolveDiagSocketRunDir()
+	if err != nil {
+		return "", err
+	}
+	return findLatestSocketByPattern(runDir, diagSocketFilePrefix+"*"+diagSocketFileSuffix)
+}
+
+// ResolveLegacyTmpDiagSocketPath 返回临时目录下最近修改的遗留诊断 socket 路径。
+func ResolveLegacyTmpDiagSocketPath() (string, error) {
+	return findLatestSocketByPattern(os.TempDir(), diagSocketFilePrefix+"*"+diagSocketFileSuffix)
+}
+
+// resolveDiagSocketPathForPID 按约定生成带 PID 的诊断 socket 路径。
+func resolveDiagSocketPathForPID(pid int) (string, error) {
+	runDir, err := resolveDiagSocketRunDir()
+	if err != nil {
+		return "", err
+	}
+	if pid <= 0 {
+		pid = os.Getpid()
+	}
+	return filepath.Join(runDir, diagSocketFilePrefix+strconv.Itoa(pid)+diagSocketFileSuffix), nil
+}
+
+// resolveDiagSocketRunDir 解析诊断 socket 的统一运行目录。
+func resolveDiagSocketRunDir() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("ptyproxy: resolve user home dir: %w", err)
+	}
+	return filepath.Join(homeDir, diagSocketRunRelativeDir), nil
+}
+
+// findLatestSocketByPattern 从目录中挑选最新的匹配 socket 文件。
+func findLatestSocketByPattern(root string, pattern string) (string, error) {
+	matches, err := filepath.Glob(filepath.Join(root, pattern))
+	if err != nil {
+		return "", fmt.Errorf("ptyproxy: glob diag socket path: %w", err)
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("ptyproxy: no diag socket found in %s", strings.TrimSpace(root))
+	}
+
+	type candidate struct {
+		path    string
+		modTime time.Time
+	}
+	candidates := make([]candidate, 0, len(matches))
+	for _, matchedPath := range matches {
+		info, statErr := os.Stat(matchedPath)
+		if statErr != nil {
+			continue
+		}
+		if info.Mode()&os.ModeSocket == 0 {
+			continue
+		}
+		candidates = append(candidates, candidate{
+			path:    matchedPath,
+			modTime: info.ModTime(),
+		})
+	}
+	if len(candidates) == 0 {
+		return "", fmt.Errorf("ptyproxy: no socket candidate found in %s", strings.TrimSpace(root))
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].modTime.After(candidates[j].modTime)
+	})
+	return filepath.Clean(candidates[0].path), nil
+}

--- a/internal/ptyproxy/socket_paths_coverage_test.go
+++ b/internal/ptyproxy/socket_paths_coverage_test.go
@@ -1,0 +1,64 @@
+//go:build !windows
+
+package ptyproxy
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSocketPathCoverageGapResolveLatestRunAndFind(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	runDir := filepath.Join(home, ".neocode", "run")
+	if err := os.MkdirAll(runDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	socketPath := filepath.Join(runDir, diagSocketFilePrefix+"30001"+diagSocketFileSuffix)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("net.Listen() error = %v", err)
+	}
+	defer listener.Close()
+
+	got, err := ResolveLatestRunDiagSocketPath()
+	if err != nil {
+		t.Fatalf("ResolveLatestRunDiagSocketPath() error = %v", err)
+	}
+	if filepath.Clean(got) != filepath.Clean(socketPath) {
+		t.Fatalf("got = %q, want %q", got, socketPath)
+	}
+}
+
+func TestSocketPathCoverageGapResolvePIDAndFindFunctionEntry(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path, err := resolveDiagSocketPathForPID(0)
+	if err != nil {
+		t.Fatalf("resolveDiagSocketPathForPID() error = %v", err)
+	}
+	if !strings.Contains(path, diagSocketFilePrefix) || !strings.HasSuffix(path, diagSocketFileSuffix) {
+		t.Fatalf("path = %q, want diag socket naming", path)
+	}
+
+	root := t.TempDir()
+	socketPath := filepath.Join(root, diagSocketFilePrefix+"70001"+diagSocketFileSuffix)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("net.Listen() error = %v", err)
+	}
+	defer listener.Close()
+
+	found, err := findLatestSocketByPattern(root, diagSocketFilePrefix+"*"+diagSocketFileSuffix)
+	if err != nil {
+		t.Fatalf("findLatestSocketByPattern() error = %v", err)
+	}
+	if filepath.Clean(found) != filepath.Clean(socketPath) {
+		t.Fatalf("found = %q, want %q", found, socketPath)
+	}
+}

--- a/internal/ptyproxy/socket_paths_test.go
+++ b/internal/ptyproxy/socket_paths_test.go
@@ -119,3 +119,54 @@ func TestResolveLegacyTmpDiagSocketPath(t *testing.T) {
 		t.Fatalf("legacy = %q, want %q", legacy, socketPath)
 	}
 }
+
+func TestResolveLegacyTmpDiagSocketPathForPID(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp)
+
+	firstPath := filepath.Join(tmp, diagSocketFilePrefix+"34567"+diagSocketFileSuffix)
+	firstListener, err := net.Listen("unix", firstPath)
+	if err != nil {
+		t.Fatalf("net.Listen(first) error = %v", err)
+	}
+	defer firstListener.Close()
+
+	secondPath := filepath.Join(tmp, diagSocketFilePrefix+"45678"+diagSocketFileSuffix)
+	secondListener, err := net.Listen("unix", secondPath)
+	if err != nil {
+		t.Fatalf("net.Listen(second) error = %v", err)
+	}
+	defer secondListener.Close()
+
+	legacy, err := ResolveLegacyTmpDiagSocketPathForPID(45678)
+	if err != nil {
+		t.Fatalf("ResolveLegacyTmpDiagSocketPathForPID() error = %v", err)
+	}
+	if filepath.Clean(legacy) != filepath.Clean(secondPath) {
+		t.Fatalf("legacy = %q, want %q", legacy, secondPath)
+	}
+}
+
+func TestResolveLegacyTmpDiagSocketPathForPIDRejectsInvalidPID(t *testing.T) {
+	_, err := ResolveLegacyTmpDiagSocketPathForPID(0)
+	if err == nil || !strings.Contains(err.Error(), "invalid diag socket pid") {
+		t.Fatalf("err = %v, want invalid diag socket pid", err)
+	}
+}
+
+func TestParseDiagSocketPIDFromPath(t *testing.T) {
+	pid, err := parseDiagSocketPIDFromPath("/tmp/" + diagSocketFilePrefix + "12345" + diagSocketFileSuffix)
+	if err != nil {
+		t.Fatalf("parseDiagSocketPIDFromPath() error = %v", err)
+	}
+	if pid != 12345 {
+		t.Fatalf("pid = %d, want 12345", pid)
+	}
+}
+
+func TestParseDiagSocketPIDFromPathRejectsInvalidName(t *testing.T) {
+	_, err := parseDiagSocketPIDFromPath("/tmp/diag.sock")
+	if err == nil || !strings.Contains(err.Error(), "diag socket filename is invalid") {
+		t.Fatalf("err = %v, want invalid filename error", err)
+	}
+}

--- a/internal/ptyproxy/socket_paths_test.go
+++ b/internal/ptyproxy/socket_paths_test.go
@@ -1,0 +1,121 @@
+//go:build !windows
+
+package ptyproxy
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestResolveLatestRunDiagSocketPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	runDir := filepath.Join(home, ".neocode", "run")
+	if err := os.MkdirAll(runDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	firstPath := filepath.Join(runDir, diagSocketFilePrefix+"111"+diagSocketFileSuffix)
+	firstListener, err := net.Listen("unix", firstPath)
+	if err != nil {
+		t.Fatalf("net.Listen(first) error = %v", err)
+	}
+	defer firstListener.Close()
+
+	time.Sleep(20 * time.Millisecond)
+
+	secondPath := filepath.Join(runDir, diagSocketFilePrefix+"222"+diagSocketFileSuffix)
+	secondListener, err := net.Listen("unix", secondPath)
+	if err != nil {
+		t.Fatalf("net.Listen(second) error = %v", err)
+	}
+	defer secondListener.Close()
+
+	latest, err := ResolveLatestRunDiagSocketPath()
+	if err != nil {
+		t.Fatalf("ResolveLatestRunDiagSocketPath() error = %v", err)
+	}
+	if filepath.Clean(latest) != filepath.Clean(secondPath) {
+		t.Fatalf("latest = %q, want %q", latest, secondPath)
+	}
+}
+
+func TestResolveLatestRunDiagSocketPathNoSocketCandidate(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	runDir := filepath.Join(home, ".neocode", "run")
+	if err := os.MkdirAll(runDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	regularFile := filepath.Join(runDir, diagSocketFilePrefix+"not-socket"+diagSocketFileSuffix)
+	if err := os.WriteFile(regularFile, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	_, err := ResolveLatestRunDiagSocketPath()
+	if err == nil || !strings.Contains(err.Error(), "no socket candidate found") {
+		t.Fatalf("ResolveLatestRunDiagSocketPath() err = %v, want no socket candidate", err)
+	}
+}
+
+func TestResolveDiagSocketPathForPIDFallback(t *testing.T) {
+	path, err := resolveDiagSocketPathForPID(0)
+	if err != nil {
+		t.Fatalf("resolveDiagSocketPathForPID() error = %v", err)
+	}
+	if !strings.Contains(path, diagSocketFilePrefix) || !strings.HasSuffix(path, diagSocketFileSuffix) {
+		t.Fatalf("path = %q, want diag socket naming", path)
+	}
+}
+
+func TestResolveDiagSocketPathForPIDExplicit(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path, err := resolveDiagSocketPathForPID(12345)
+	if err != nil {
+		t.Fatalf("resolveDiagSocketPathForPID() error = %v", err)
+	}
+	if !strings.Contains(path, diagSocketFilePrefix+"12345"+diagSocketFileSuffix) {
+		t.Fatalf("path = %q, want contains explicit pid suffix", path)
+	}
+}
+
+func TestFindLatestSocketByPatternGlobError(t *testing.T) {
+	_, err := findLatestSocketByPattern(t.TempDir(), "[")
+	if err == nil || !strings.Contains(err.Error(), "glob diag socket path") {
+		t.Fatalf("err = %v, want glob error", err)
+	}
+}
+
+func TestResolveLatestRunDiagSocketPathMissingRunDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	_, err := ResolveLatestRunDiagSocketPath()
+	if err == nil || !strings.Contains(err.Error(), "no diag socket found") {
+		t.Fatalf("err = %v, want no diag socket found", err)
+	}
+}
+
+func TestResolveLegacyTmpDiagSocketPath(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp)
+
+	socketPath := filepath.Join(tmp, diagSocketFilePrefix+"legacy"+diagSocketFileSuffix)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("net.Listen() error = %v", err)
+	}
+	defer listener.Close()
+
+	legacy, err := ResolveLegacyTmpDiagSocketPath()
+	if err != nil {
+		t.Fatalf("ResolveLegacyTmpDiagSocketPath() error = %v", err)
+	}
+	if filepath.Clean(legacy) != filepath.Clean(socketPath) {
+		t.Fatalf("legacy = %q, want %q", legacy, socketPath)
+	}
+}

--- a/internal/ptyproxy/truncator.go
+++ b/internal/ptyproxy/truncator.go
@@ -1,0 +1,55 @@
+package ptyproxy
+
+import "unicode/utf8"
+
+const truncationMarker = "\n...[truncated]...\n"
+
+// TruncateUTF8HeadTail 对文本执行 UTF-8 安全的首尾截断，避免长日志撑爆 token。
+func TruncateUTF8HeadTail(text string, maxBytes int) string {
+	if maxBytes <= 0 || len(text) <= maxBytes {
+		return text
+	}
+	if maxBytes <= len(truncationMarker)+2 {
+		return utf8SafePrefix(text, maxBytes)
+	}
+
+	budget := maxBytes - len(truncationMarker)
+	headBudget := budget / 2
+	tailBudget := budget - headBudget
+	head := utf8SafePrefix(text, headBudget)
+	tail := utf8SafeSuffix(text, tailBudget)
+	return head + truncationMarker + tail
+}
+
+// utf8SafePrefix 按字节预算截取合法 UTF-8 前缀。
+func utf8SafePrefix(text string, bytes int) string {
+	if bytes <= 0 {
+		return ""
+	}
+	raw := []byte(text)
+	if len(raw) <= bytes {
+		return text
+	}
+	candidate := raw[:bytes]
+	for len(candidate) > 0 && !utf8.Valid(candidate) {
+		candidate = candidate[:len(candidate)-1]
+	}
+	return string(candidate)
+}
+
+// utf8SafeSuffix 按字节预算截取合法 UTF-8 后缀。
+func utf8SafeSuffix(text string, bytes int) string {
+	if bytes <= 0 {
+		return ""
+	}
+	raw := []byte(text)
+	if len(raw) <= bytes {
+		return text
+	}
+	start := len(raw) - bytes
+	candidate := raw[start:]
+	for len(candidate) > 0 && !utf8.Valid(candidate) {
+		candidate = candidate[1:]
+	}
+	return string(candidate)
+}

--- a/internal/ptyproxy/truncator_test.go
+++ b/internal/ptyproxy/truncator_test.go
@@ -1,0 +1,37 @@
+package ptyproxy
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncateUTF8HeadTailNoTruncation(t *testing.T) {
+	text := "hello 世界"
+	got := TruncateUTF8HeadTail(text, len(text)+16)
+	if got != text {
+		t.Fatalf("got %q, want %q", got, text)
+	}
+}
+
+func TestTruncateUTF8HeadTailKeepsUTF8Validity(t *testing.T) {
+	text := strings.Repeat("中", 120) + "tail"
+	got := TruncateUTF8HeadTail(text, 64)
+	if !utf8.ValidString(got) {
+		t.Fatalf("result is invalid utf-8: %q", got)
+	}
+	if !strings.Contains(got, truncationMarker) {
+		t.Fatalf("result should contain truncation marker: %q", got)
+	}
+}
+
+func TestTruncateUTF8HeadTailTinyBudget(t *testing.T) {
+	text := "你好，世界，这是一个很长的字符串。"
+	got := TruncateUTF8HeadTail(text, 6)
+	if !utf8.ValidString(got) {
+		t.Fatalf("result is invalid utf-8: %q", got)
+	}
+	if len(got) > 6 {
+		t.Fatalf("len(result) = %d, want <= 6", len(got))
+	}
+}

--- a/internal/ptyproxy/truncator_test.go
+++ b/internal/ptyproxy/truncator_test.go
@@ -35,3 +35,22 @@ func TestTruncateUTF8HeadTailTinyBudget(t *testing.T) {
 		t.Fatalf("len(result) = %d, want <= 6", len(got))
 	}
 }
+
+func TestUTF8SafePrefixSuffixBranchCoverage(t *testing.T) {
+	text := "hello"
+	if got := utf8SafePrefix(text, 0); got != "" {
+		t.Fatalf("utf8SafePrefix(bytes=0) = %q, want empty", got)
+	}
+	if got := utf8SafePrefix(text, len(text)+1); got != text {
+		t.Fatalf("utf8SafePrefix(full) = %q, want %q", got, text)
+	}
+	if got := utf8SafeSuffix(text, 0); got != "" {
+		t.Fatalf("utf8SafeSuffix(bytes=0) = %q, want empty", got)
+	}
+	if got := utf8SafeSuffix(text, len(text)+1); got != text {
+		t.Fatalf("utf8SafeSuffix(full) = %q, want %q", got, text)
+	}
+	if got := TruncateUTF8HeadTail(text, 0); got != text {
+		t.Fatalf("TruncateUTF8HeadTail(max=0) = %q, want %q", got, text)
+	}
+}

--- a/internal/tools/diagnose/agent_test.go
+++ b/internal/tools/diagnose/agent_test.go
@@ -1,0 +1,188 @@
+package diagnose
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"neo-code/internal/subagent"
+	"neo-code/internal/tools"
+)
+
+type stubDiagnoseSubAgentInvoker struct {
+	runFunc func(ctx context.Context, input tools.SubAgentRunInput) (tools.SubAgentRunResult, error)
+}
+
+func (s stubDiagnoseSubAgentInvoker) Run(ctx context.Context, input tools.SubAgentRunInput) (tools.SubAgentRunResult, error) {
+	if s.runFunc == nil {
+		return tools.SubAgentRunResult{}, nil
+	}
+	return s.runFunc(ctx, input)
+}
+
+func TestDiagnoseToolSubAgentSuccess(t *testing.T) {
+	tool := New()
+	invoker := stubDiagnoseSubAgentInvoker{
+		runFunc: func(_ context.Context, input tools.SubAgentRunInput) (tools.SubAgentRunResult, error) {
+			if input.TaskID != diagnoseSubAgentTaskID {
+				t.Fatalf("TaskID = %q, want %q", input.TaskID, diagnoseSubAgentTaskID)
+			}
+			return tools.SubAgentRunResult{
+				State:      subagent.StateSucceeded,
+				StopReason: subagent.StopReasonCompleted,
+				StepCount:  2,
+				Output: subagent.Output{
+					Summary:     "missing dependency in go.mod",
+					Findings:    []string{"confidence=0.83", "go.sum lacks package checksum"},
+					Patches:     []string{"go get github.com/example/pkg@latest"},
+					NextActions: []string{"go mod tidy", "go test ./..."},
+				},
+			}, nil
+		},
+	}
+
+	result, err := tool.Execute(context.Background(), tools.ToolCallInput{
+		Arguments: []byte(`{
+			"error_log":"build failed",
+			"os_env":{"os":"linux","shell":"/bin/bash","cwd":"/repo"},
+			"command_text":"go test ./...",
+			"exit_code":1
+		}`),
+		SubAgentInvoker: invoker,
+		Workdir:         "/repo",
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("result.IsError = true, want false")
+	}
+	var parsed diagnoseOutput
+	if unmarshalErr := json.Unmarshal([]byte(result.Content), &parsed); unmarshalErr != nil {
+		t.Fatalf("content should be diagnose JSON: %v", unmarshalErr)
+	}
+	if parsed.RootCause != "missing dependency in go.mod" {
+		t.Fatalf("RootCause = %q, want %q", parsed.RootCause, "missing dependency in go.mod")
+	}
+	if parsed.Confidence != 0.83 {
+		t.Fatalf("Confidence = %v, want 0.83", parsed.Confidence)
+	}
+	if len(parsed.FixCommands) == 0 || parsed.FixCommands[0] != "go get github.com/example/pkg@latest" {
+		t.Fatalf("FixCommands = %#v", parsed.FixCommands)
+	}
+}
+
+func TestDiagnoseToolSubAgentTimeoutFallback(t *testing.T) {
+	tool := New()
+	invoker := stubDiagnoseSubAgentInvoker{
+		runFunc: func(_ context.Context, _ tools.SubAgentRunInput) (tools.SubAgentRunResult, error) {
+			return tools.SubAgentRunResult{}, context.DeadlineExceeded
+		},
+	}
+
+	result, err := tool.Execute(context.Background(), tools.ToolCallInput{
+		Arguments: []byte(`{
+			"error_log":"timeout while calling provider",
+			"os_env":{"os":"linux","shell":"/bin/bash","cwd":"/repo"},
+			"command_text":"curl https://example.com",
+			"exit_code":28
+		}`),
+		SubAgentInvoker: invoker,
+		Workdir:         "/repo",
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v, want nil for graceful degrade", err)
+	}
+	if result.IsError {
+		t.Fatalf("result.IsError = true, want graceful fallback")
+	}
+	var parsed diagnoseOutput
+	if unmarshalErr := json.Unmarshal([]byte(result.Content), &parsed); unmarshalErr != nil {
+		t.Fatalf("content should be diagnose JSON: %v", unmarshalErr)
+	}
+	if parsed.Confidence >= 0.5 {
+		t.Fatalf("fallback confidence = %v, want low confidence", parsed.Confidence)
+	}
+	if len(parsed.InvestigationCommands) == 0 {
+		t.Fatalf("fallback investigation should not be empty")
+	}
+}
+
+func TestDiagnoseToolSubAgentDirtyOutputFallback(t *testing.T) {
+	tool := New()
+	invoker := stubDiagnoseSubAgentInvoker{
+		runFunc: func(_ context.Context, _ tools.SubAgentRunInput) (tools.SubAgentRunResult, error) {
+			return tools.SubAgentRunResult{
+				State:      subagent.StateSucceeded,
+				StopReason: subagent.StopReasonCompleted,
+				Output: subagent.Output{
+					Summary: "   ",
+				},
+			}, nil
+		},
+	}
+
+	result, err := tool.Execute(context.Background(), tools.ToolCallInput{
+		Arguments: []byte(`{
+			"error_log":"garbled provider output",
+			"os_env":{"os":"linux","shell":"/bin/bash"},
+			"command_text":"make build",
+			"exit_code":2
+		}`),
+		SubAgentInvoker: invoker,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v, want nil for graceful degrade", err)
+	}
+	var parsed diagnoseOutput
+	if unmarshalErr := json.Unmarshal([]byte(result.Content), &parsed); unmarshalErr != nil {
+		t.Fatalf("content should be diagnose JSON: %v", unmarshalErr)
+	}
+	if parsed.RootCause == "" {
+		t.Fatal("fallback root_cause should not be empty")
+	}
+}
+
+func TestDiagnoseToolSubAgentFailedStateFallback(t *testing.T) {
+	tool := New()
+	invoker := stubDiagnoseSubAgentInvoker{
+		runFunc: func(_ context.Context, _ tools.SubAgentRunInput) (tools.SubAgentRunResult, error) {
+			return tools.SubAgentRunResult{
+				State:      subagent.StateFailed,
+				StopReason: subagent.StopReasonError,
+				Error:      "provider disconnected",
+			}, nil
+		},
+	}
+
+	result, err := tool.Execute(context.Background(), tools.ToolCallInput{
+		Arguments: []byte(`{
+			"error_log":"provider disconnected",
+			"os_env":{"os":"linux","shell":"/bin/bash"},
+			"command_text":"npm run build",
+			"exit_code":1
+		}`),
+		SubAgentInvoker: invoker,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v, want graceful fallback", err)
+	}
+	var parsed diagnoseOutput
+	if unmarshalErr := json.Unmarshal([]byte(result.Content), &parsed); unmarshalErr != nil {
+		t.Fatalf("content should be diagnose JSON: %v", unmarshalErr)
+	}
+	if parsed.RootCause == "" {
+		t.Fatal("fallback root_cause should not be empty")
+	}
+}
+
+func TestParseSubAgentDiagnosisRejectsEmptySummary(t *testing.T) {
+	_, err := parseSubAgentDiagnosis(subagent.Output{Summary: ""})
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !errors.Is(err, errors.New("empty summary")) && err.Error() != "empty summary" {
+		t.Fatalf("err = %v", err)
+	}
+}

--- a/internal/tools/diagnose/agent_test.go
+++ b/internal/tools/diagnose/agent_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"neo-code/internal/subagent"
@@ -184,5 +185,46 @@ func TestParseSubAgentDiagnosisRejectsEmptySummary(t *testing.T) {
 	}
 	if !errors.Is(err, errors.New("empty summary")) && err.Error() != "empty summary" {
 		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestParseSubAgentDiagnosisFromSummaryJSON(t *testing.T) {
+	parsed, err := parseSubAgentDiagnosis(subagent.Output{
+		Summary: `{"confidence":1.4,"root_cause":"disk full","fix_commands":["  rm -rf /tmp/cache  "],"investigation_commands":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("parseSubAgentDiagnosis() error = %v", err)
+	}
+	if parsed.RootCause != "disk full" {
+		t.Fatalf("RootCause = %q, want disk full", parsed.RootCause)
+	}
+	if parsed.Confidence != 1 {
+		t.Fatalf("Confidence = %v, want 1", parsed.Confidence)
+	}
+	if len(parsed.FixCommands) != 1 || parsed.FixCommands[0] != "rm -rf /tmp/cache" {
+		t.Fatalf("FixCommands = %#v", parsed.FixCommands)
+	}
+}
+
+func TestParseSubAgentDiagnosisFallbacks(t *testing.T) {
+	parsed, err := parseSubAgentDiagnosis(subagent.Output{
+		Summary:  "network timeout",
+		Findings: []string{"  run: ping 1.1.1.1  ", "run: ping 1.1.1.1"},
+		Patches:  []string{"  export HTTPS_PROXY=http://127.0.0.1:7890  "},
+	})
+	if err != nil {
+		t.Fatalf("parseSubAgentDiagnosis() error = %v", err)
+	}
+	if !strings.Contains(parsed.RootCause, "network timeout") {
+		t.Fatalf("RootCause = %q", parsed.RootCause)
+	}
+	if parsed.Confidence != 0.56 {
+		t.Fatalf("Confidence = %v, want 0.56 fallback", parsed.Confidence)
+	}
+	if len(parsed.InvestigationCommands) != 1 || parsed.InvestigationCommands[0] != "run: ping 1.1.1.1" {
+		t.Fatalf("InvestigationCommands = %#v", parsed.InvestigationCommands)
+	}
+	if len(parsed.FixCommands) != 1 || parsed.FixCommands[0] != "export HTTPS_PROXY=http://127.0.0.1:7890" {
+		t.Fatalf("FixCommands = %#v", parsed.FixCommands)
 	}
 }

--- a/internal/tools/diagnose/coverage_gaps_test.go
+++ b/internal/tools/diagnose/coverage_gaps_test.go
@@ -1,0 +1,26 @@
+package diagnose
+
+import "testing"
+
+func TestDiagnoseCoverageGapFallbackAndPathListBranches(t *testing.T) {
+	output := buildFallbackDiagnosis(diagnoseInput{
+		ErrorLog:    "fatal: sample",
+		CommandText: "",
+		OSEnv:       map[string]string{"os": "linux"},
+		ExitCode:    1,
+	}, "")
+	if len(output.InvestigationCommands) < 2 {
+		t.Fatalf("InvestigationCommands = %#v, want default commands", output.InvestigationCommands)
+	}
+	if output.InvestigationCommands[0] != "pwd" {
+		t.Fatalf("first investigation command = %q, want pwd", output.InvestigationCommands[0])
+	}
+
+	if got := normalizePathList("   "); got != nil {
+		t.Fatalf("normalizePathList(empty) = %#v, want nil", got)
+	}
+	got := normalizePathList(" /repo ")
+	if len(got) != 1 || got[0] != "/repo" {
+		t.Fatalf("normalizePathList(non-empty) = %#v, want [/repo]", got)
+	}
+}

--- a/internal/tools/diagnose/tool.go
+++ b/internal/tools/diagnose/tool.go
@@ -146,7 +146,7 @@ func runDiagnoseWithSpawnSubAgent(
 		Workdir:               workdir,
 		MaxSteps:              diagnoseSubAgentSteps,
 		Timeout:               diagnoseSubAgentTimeout,
-		AllowedTools:          []string{tools.ToolNameFilesystemReadFile},
+		AllowedTools:          []string{tools.ToolNameFilesystemReadFile, tools.ToolNameFilesystemGlob},
 		AllowedPaths:          allowedPaths,
 	})
 	if runErr != nil {

--- a/internal/tools/diagnose/tool.go
+++ b/internal/tools/diagnose/tool.go
@@ -5,12 +5,27 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
+	"neo-code/internal/subagent"
 	"neo-code/internal/tools"
 )
 
-const diagnoseToolName = tools.ToolNameDiagnose
+const (
+	diagnoseToolName = tools.ToolNameDiagnose
+
+	diagnoseSubAgentTaskID  = "terminal-diagnose"
+	diagnoseSubAgentTimeout = 25 * time.Second
+	diagnoseSubAgentSteps   = 4
+
+	diagnoseGoalLogMaxRunes     = 6000
+	diagnoseGoalCommandMaxRunes = 512
+)
+
+var confidencePattern = regexp.MustCompile(`(?i)\bconfidence\s*[:=]\s*([0-9]+(?:\.[0-9]+)?)\b`)
 
 type diagnoseInput struct {
 	ErrorLog    string            `json:"error_log"`
@@ -26,7 +41,7 @@ type diagnoseOutput struct {
 	InvestigationCommands []string `json:"investigation_commands"`
 }
 
-// Tool 提供 gateway.executeSystemTool(diagnose) 的最小可用实现。
+// Tool 提供 gateway.executeSystemTool(diagnose) 的真实诊断实现。
 type Tool struct{}
 
 // New 创建 diagnose 工具实例。
@@ -67,12 +82,12 @@ func (t *Tool) Schema() map[string]any {
 	}
 }
 
-// MicroCompactPolicy 保留诊断结果，避免在短期压缩时丢失排障上下文。
+// MicroCompactPolicy 保留诊断结果，避免短期压缩时丢失排障上下文。
 func (t *Tool) MicroCompactPolicy() tools.MicroCompactPolicy {
 	return tools.MicroCompactPolicyPreserveHistory
 }
 
-// Execute 校验输入并返回 Mock 诊断结构，供 Phase1 链路联调。
+// Execute 校验输入并通过 SpawnSubAgent 能力链路执行真实诊断，失败时静默降级。
 func (t *Tool) Execute(ctx context.Context, call tools.ToolCallInput) (tools.ToolResult, error) {
 	if err := ctx.Err(); err != nil {
 		return tools.NewErrorResult(diagnoseToolName, tools.NormalizeErrorReason(diagnoseToolName, err), "", nil), err
@@ -82,35 +97,287 @@ func (t *Tool) Execute(ctx context.Context, call tools.ToolCallInput) (tools.Too
 		return tools.NewErrorResult(diagnoseToolName, tools.NormalizeErrorReason(diagnoseToolName, err), "", nil), err
 	}
 
-	result := diagnoseOutput{
-		Confidence: 0.62,
-		RootCause:  "mock: diagnose tool wiring is active; please replace with real analyzer in next phase",
-		FixCommands: []string{
-			"neocode diag",
-		},
-		InvestigationCommands: []string{
-			"pwd",
-			"env | grep -E 'NEOCODE_DIAG_SOCKET|SHELL'",
-		},
-	}
-	if strings.TrimSpace(input.CommandText) != "" {
-		result.InvestigationCommands = append(result.InvestigationCommands, strings.TrimSpace(input.CommandText))
-	}
+	output, metadata := runDiagnoseWithSpawnSubAgent(ctx, call, input)
+	output = normalizeDiagnosisOutput(output)
 
-	raw, marshalErr := json.Marshal(result)
+	raw, marshalErr := json.Marshal(output)
 	if marshalErr != nil {
-		wrapped := fmt.Errorf("%s: encode mock result: %w", diagnoseToolName, marshalErr)
-		return tools.NewErrorResult(diagnoseToolName, tools.NormalizeErrorReason(diagnoseToolName, wrapped), "", nil), wrapped
+		fallback := normalizeDiagnosisOutput(buildFallbackDiagnosis(input, "diagnose output marshal failed"))
+		raw, _ = json.Marshal(fallback)
+		metadata["degraded"] = true
+		metadata["degraded_reason"] = "marshal_failed"
 	}
 
-	return tools.ToolResult{
-		Name:    diagnoseToolName,
-		Content: string(raw),
-		Metadata: map[string]any{
-			"mock":            true,
-			"error_log_bytes": len(input.ErrorLog),
-		},
-	}, nil
+	result := tools.ToolResult{
+		Name:     diagnoseToolName,
+		Content:  string(raw),
+		IsError:  false,
+		Metadata: metadata,
+	}
+	result = tools.ApplyOutputLimit(result, tools.DefaultOutputLimitBytes)
+	return result, nil
+}
+
+// runDiagnoseWithSpawnSubAgent 复用 runtime 注入的 SpawnSubAgent 执行桥接完成真实诊断。
+func runDiagnoseWithSpawnSubAgent(
+	ctx context.Context,
+	call tools.ToolCallInput,
+	input diagnoseInput,
+) (diagnoseOutput, map[string]any) {
+	metadata := map[string]any{
+		"backend":      "spawn_subagent",
+		"backend_tool": tools.ToolNameSpawnSubAgent,
+	}
+	if call.SubAgentInvoker == nil {
+		metadata["degraded"] = true
+		metadata["degraded_reason"] = "subagent_invoker_unavailable"
+		return buildFallbackDiagnosis(input, "subagent invoker unavailable"), metadata
+	}
+
+	workdir := resolveDiagnoseWorkdir(call.Workdir, input.OSEnv)
+	allowedPaths := normalizePathList(workdir)
+	runResult, runErr := call.SubAgentInvoker.Run(ctx, tools.SubAgentRunInput{
+		CallerAgent:           strings.TrimSpace(call.AgentID),
+		ParentCapabilityToken: call.CapabilityToken,
+		Role:                  subagent.RoleReviewer,
+		TaskID:                diagnoseSubAgentTaskID,
+		Goal:                  buildDiagnoseGoal(input, workdir),
+		ExpectedOut:           buildDiagnoseExpectedOutput(),
+		Workdir:               workdir,
+		MaxSteps:              diagnoseSubAgentSteps,
+		Timeout:               diagnoseSubAgentTimeout,
+		AllowedTools:          []string{tools.ToolNameFilesystemReadFile},
+		AllowedPaths:          allowedPaths,
+	})
+	if runErr != nil {
+		metadata["degraded"] = true
+		metadata["degraded_reason"] = "subagent_run_error"
+		metadata["subagent_error"] = strings.TrimSpace(runErr.Error())
+		return buildFallbackDiagnosis(input, runErr.Error()), metadata
+	}
+	if runResult.State != subagent.StateSucceeded {
+		metadata["degraded"] = true
+		metadata["degraded_reason"] = "subagent_state_not_succeeded"
+		metadata["subagent_state"] = string(runResult.State)
+		metadata["subagent_stop_reason"] = string(runResult.StopReason)
+		metadata["subagent_error"] = strings.TrimSpace(runResult.Error)
+		return buildFallbackDiagnosis(input, runResult.Error), metadata
+	}
+
+	parsed, parseErr := parseSubAgentDiagnosis(runResult.Output)
+	if parseErr != nil {
+		metadata["degraded"] = true
+		metadata["degraded_reason"] = "subagent_output_unparseable"
+		metadata["subagent_error"] = strings.TrimSpace(parseErr.Error())
+		return buildFallbackDiagnosis(input, parseErr.Error()), metadata
+	}
+	metadata["degraded"] = false
+	metadata["subagent_state"] = string(runResult.State)
+	metadata["subagent_stop_reason"] = string(runResult.StopReason)
+	metadata["subagent_step_count"] = runResult.StepCount
+	return parsed, metadata
+}
+
+// buildDiagnoseGoal 构造发送给子代理的任务文本，限制上下文规模并强调输出约束。
+func buildDiagnoseGoal(input diagnoseInput, workdir string) string {
+	goal := []string{
+		"你是终端故障诊断代理。请只基于给定日志和环境做根因判断，禁止臆测不存在的文件内容。",
+		"输出必须可执行、可落地，命令尽量短小；不确定时要在 risks 中说明。",
+	}
+
+	commandText := truncateRunes(strings.TrimSpace(input.CommandText), diagnoseGoalCommandMaxRunes)
+	if commandText != "" {
+		goal = append(goal, "失败命令: "+commandText)
+	}
+	goal = append(goal, fmt.Sprintf("退出码: %d", input.ExitCode))
+	if strings.TrimSpace(workdir) != "" {
+		goal = append(goal, "工作目录: "+strings.TrimSpace(workdir))
+	}
+	if shell := strings.TrimSpace(input.OSEnv["shell"]); shell != "" {
+		goal = append(goal, "Shell: "+shell)
+	}
+	if osName := strings.TrimSpace(input.OSEnv["os"]); osName != "" {
+		goal = append(goal, "OS: "+osName)
+	}
+
+	goal = append(goal, "", "错误日志片段:")
+	goal = append(goal, truncateRunes(strings.TrimSpace(input.ErrorLog), diagnoseGoalLogMaxRunes))
+	return strings.Join(goal, "\n")
+}
+
+// buildDiagnoseExpectedOutput 声明子代理 contract 字段如何映射到 diagnose JSON 契约。
+func buildDiagnoseExpectedOutput() string {
+	return strings.Join([]string{
+		"请返回 subagent 标准 JSON 对象（summary/findings/patches/risks/next_actions/artifacts）。",
+		"字段映射要求：",
+		"1) summary: 仅一条根因结论（root_cause）。",
+		"2) findings: 第一条必须写成 confidence=<0~1>，其余写证据。",
+		"3) patches: 仅放修复命令（fix_commands）。",
+		"4) next_actions: 仅放进一步排查命令（investigation_commands）。",
+		"5) 若信息不足，confidence 要降低并在 risks 解释。",
+	}, "\n")
+}
+
+// parseSubAgentDiagnosis 将子代理输出映射为 diagnose 的固定 JSON 契约结构。
+func parseSubAgentDiagnosis(output subagent.Output) (diagnoseOutput, error) {
+	summary := strings.TrimSpace(output.Summary)
+	if summary == "" {
+		return diagnoseOutput{}, errors.New("empty summary")
+	}
+
+	// 优先兼容“summary 内直接输出 diagnose JSON”的情况。
+	if decoded, ok := decodeDiagnosisJSON(summary); ok {
+		return normalizeDiagnosisOutput(decoded), nil
+	}
+
+	parsed := diagnoseOutput{
+		Confidence:            parseConfidence(output.Findings),
+		RootCause:             summary,
+		FixCommands:           normalizeCommandList(output.Patches),
+		InvestigationCommands: normalizeCommandList(output.NextActions),
+	}
+	if parsed.Confidence <= 0 {
+		parsed.Confidence = 0.56
+	}
+	if len(parsed.InvestigationCommands) == 0 {
+		parsed.InvestigationCommands = normalizeCommandList(output.Findings)
+	}
+	return normalizeDiagnosisOutput(parsed), nil
+}
+
+// decodeDiagnosisJSON 解析 summary 中潜在的 diagnose JSON 对象并校验关键字段。
+func decodeDiagnosisJSON(raw string) (diagnoseOutput, bool) {
+	var output diagnoseOutput
+	if err := json.Unmarshal([]byte(raw), &output); err != nil {
+		return diagnoseOutput{}, false
+	}
+	if strings.TrimSpace(output.RootCause) == "" {
+		return diagnoseOutput{}, false
+	}
+	return normalizeDiagnosisOutput(output), true
+}
+
+// parseConfidence 从 findings 中提取 confidence=0.0~1.0，缺失时返回 0。
+func parseConfidence(findings []string) float64 {
+	for _, finding := range findings {
+		match := confidencePattern.FindStringSubmatch(strings.TrimSpace(finding))
+		if len(match) != 2 {
+			continue
+		}
+		value, err := strconv.ParseFloat(match[1], 64)
+		if err != nil {
+			continue
+		}
+		return clampConfidence(value)
+	}
+	return 0
+}
+
+// buildFallbackDiagnosis 构造静默降级结果，保证输出契约完整且无 panic。
+func buildFallbackDiagnosis(input diagnoseInput, reason string) diagnoseOutput {
+	rootCause := "当前诊断服务不可用，已降级为保守建议。"
+	if strings.TrimSpace(reason) != "" {
+		rootCause = rootCause + " (" + strings.TrimSpace(reason) + ")"
+	}
+	investigation := []string{
+		"pwd",
+		"echo $SHELL",
+	}
+	if cmd := strings.TrimSpace(input.CommandText); cmd != "" {
+		investigation = append(investigation, cmd)
+	}
+	return normalizeDiagnosisOutput(diagnoseOutput{
+		Confidence:            0.18,
+		RootCause:             rootCause,
+		FixCommands:           []string{},
+		InvestigationCommands: investigation,
+	})
+}
+
+// normalizeDiagnosisOutput 统一收敛字段内容，确保 JSON 契约稳定可解析。
+func normalizeDiagnosisOutput(output diagnoseOutput) diagnoseOutput {
+	output.Confidence = clampConfidence(output.Confidence)
+	output.RootCause = strings.TrimSpace(output.RootCause)
+	if output.RootCause == "" {
+		output.RootCause = "未获得有效根因，请先执行 investigation_commands 收集更多信息。"
+	}
+	output.FixCommands = normalizeCommandList(output.FixCommands)
+	output.InvestigationCommands = normalizeCommandList(output.InvestigationCommands)
+	if output.FixCommands == nil {
+		output.FixCommands = []string{}
+	}
+	if output.InvestigationCommands == nil {
+		output.InvestigationCommands = []string{}
+	}
+	return output
+}
+
+// normalizeCommandList 清洗命令列表并去重，保留首个出现顺序。
+func normalizeCommandList(commands []string) []string {
+	if len(commands) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(commands))
+	normalized := make([]string, 0, len(commands))
+	for _, command := range commands {
+		trimmed := strings.TrimSpace(command)
+		if trimmed == "" {
+			continue
+		}
+		if _, duplicated := seen[trimmed]; duplicated {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		normalized = append(normalized, trimmed)
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
+}
+
+// resolveDiagnoseWorkdir 统一诊断工作目录来源，优先调用方再回退到 os_env.cwd。
+func resolveDiagnoseWorkdir(callWorkdir string, osEnv map[string]string) string {
+	if trimmed := strings.TrimSpace(callWorkdir); trimmed != "" {
+		return trimmed
+	}
+	if trimmed := strings.TrimSpace(osEnv["cwd"]); trimmed != "" {
+		return trimmed
+	}
+	return ""
+}
+
+// normalizePathList 规整 allowed_paths 参数，空值时返回 nil。
+func normalizePathList(path string) []string {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return nil
+	}
+	return []string{trimmed}
+}
+
+// clampConfidence 将置信度约束在 [0,1] 区间内。
+func clampConfidence(value float64) float64 {
+	if value < 0 {
+		return 0
+	}
+	if value > 1 {
+		return 1
+	}
+	return value
+}
+
+// truncateRunes 按 rune 长度截断文本，避免上下文过大导致子代理超时。
+func truncateRunes(text string, maxRunes int) string {
+	trimmed := strings.TrimSpace(text)
+	if maxRunes <= 0 || trimmed == "" {
+		return ""
+	}
+	runes := []rune(trimmed)
+	if len(runes) <= maxRunes {
+		return trimmed
+	}
+	return string(runes[:maxRunes]) + "\n...[truncated]"
 }
 
 // parseDiagnoseInput 解析并校验 diagnose 工具输入参数。

--- a/internal/tools/diagnose/tool_test.go
+++ b/internal/tools/diagnose/tool_test.go
@@ -25,12 +25,12 @@ func TestToolMetadata(t *testing.T) {
 	}
 }
 
-func TestToolExecuteSuccess(t *testing.T) {
+func TestToolExecuteFallbackWhenInvokerUnavailable(t *testing.T) {
 	tool := New()
 	result, err := tool.Execute(context.Background(), tools.ToolCallInput{
 		Arguments: []byte(`{
 			"error_log":"fatal: example",
-			"os_env":{"os":"linux","shell":"/bin/bash"},
+			"os_env":{"os":"linux","shell":"/bin/bash","cwd":"/repo"},
 			"command_text":"go test ./...",
 			"exit_code":1
 		}`),
@@ -39,21 +39,24 @@ func TestToolExecuteSuccess(t *testing.T) {
 		t.Fatalf("Execute() error = %v", err)
 	}
 	if result.IsError {
-		t.Fatalf("result.IsError = true, want false; result = %+v", result)
+		t.Fatalf("result.IsError = true, want false: %+v", result)
 	}
 	if result.Name != tools.ToolNameDiagnose {
 		t.Fatalf("result.Name = %q, want %q", result.Name, tools.ToolNameDiagnose)
 	}
 
-	var decoded map[string]any
+	var decoded diagnoseOutput
 	if unmarshalErr := json.Unmarshal([]byte(result.Content), &decoded); unmarshalErr != nil {
-		t.Fatalf("content should be valid JSON, got err = %v", unmarshalErr)
+		t.Fatalf("content should be valid diagnose JSON, got err = %v", unmarshalErr)
 	}
-	if strings.TrimSpace(toString(decoded["root_cause"])) == "" {
-		t.Fatalf("root_cause should not be empty: %v", decoded)
+	if strings.TrimSpace(decoded.RootCause) == "" {
+		t.Fatalf("root_cause should not be empty: %#v", decoded)
 	}
-	if mock, _ := result.Metadata["mock"].(bool); !mock {
-		t.Fatalf("metadata.mock = %#v, want true", result.Metadata["mock"])
+	if len(decoded.InvestigationCommands) == 0 {
+		t.Fatalf("investigation_commands should not be empty: %#v", decoded)
+	}
+	if degraded, ok := result.Metadata["degraded"].(bool); !ok || !degraded {
+		t.Fatalf("metadata.degraded = %#v, want true", result.Metadata["degraded"])
 	}
 }
 
@@ -125,37 +128,6 @@ func TestToolExecuteMissingOSEnv(t *testing.T) {
 	}
 }
 
-func TestToolExecuteWithCommandText(t *testing.T) {
-	tool := New()
-	result, err := tool.Execute(context.Background(), tools.ToolCallInput{
-		Arguments: []byte(`{"error_log":"err","os_env":{"os":"linux"},"command_text":"go test"}`),
-	})
-	if err != nil {
-		t.Fatalf("Execute() error = %v", err)
-	}
-	if result.IsError {
-		t.Fatalf("result.IsError = true, want false")
-	}
-	var decoded map[string]any
-	if err := json.Unmarshal([]byte(result.Content), &decoded); err != nil {
-		t.Fatalf("content should be valid JSON: %v", err)
-	}
-	investigation, ok := decoded["investigation_commands"].([]any)
-	if !ok || len(investigation) == 0 {
-		t.Fatalf("expected non-empty investigation_commands when command_text is set")
-	}
-	// "go test" should be appended to investigation commands
-	found := false
-	for _, cmd := range investigation {
-		if cmd == "go test" {
-			found = true
-		}
-	}
-	if !found {
-		t.Fatalf("investigation_commands = %v, should contain 'go test'", investigation)
-	}
-}
-
 func TestToolExecuteContextCancelled(t *testing.T) {
 	tool := New()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -194,9 +166,4 @@ func TestParseDiagnoseInputMissingOSEnv(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty os_env")
 	}
-}
-
-func toString(value any) string {
-	text, _ := value.(string)
-	return text
 }

--- a/internal/tools/diagnose/tool_test.go
+++ b/internal/tools/diagnose/tool_test.go
@@ -167,3 +167,90 @@ func TestParseDiagnoseInputMissingOSEnv(t *testing.T) {
 		t.Fatal("expected error for empty os_env")
 	}
 }
+
+func TestDecodeDiagnosisJSON(t *testing.T) {
+	if _, ok := decodeDiagnosisJSON(`{"confidence":0.9}`); ok {
+		t.Fatal("expected decodeDiagnosisJSON() to reject missing root_cause")
+	}
+	if _, ok := decodeDiagnosisJSON(`not-json`); ok {
+		t.Fatal("expected decodeDiagnosisJSON() to reject invalid json")
+	}
+
+	decoded, ok := decodeDiagnosisJSON(`{"confidence":1.2,"root_cause":"proxy mismatch","fix_commands":["  export HTTPS_PROXY=http://127.0.0.1:7890  "],"investigation_commands":["curl -v https://example.com"]}`)
+	if !ok {
+		t.Fatal("expected decodeDiagnosisJSON() success")
+	}
+	if decoded.Confidence != 1 {
+		t.Fatalf("decoded.Confidence = %v, want 1", decoded.Confidence)
+	}
+	if decoded.RootCause != "proxy mismatch" {
+		t.Fatalf("decoded.RootCause = %q, want proxy mismatch", decoded.RootCause)
+	}
+	if len(decoded.FixCommands) != 1 || decoded.FixCommands[0] != "export HTTPS_PROXY=http://127.0.0.1:7890" {
+		t.Fatalf("decoded.FixCommands = %#v", decoded.FixCommands)
+	}
+}
+
+func TestConfidenceAndNormalizationHelpers(t *testing.T) {
+	if got := parseConfidence([]string{"confidence=0.72"}); got != 0.72 {
+		t.Fatalf("parseConfidence() = %v, want 0.72", got)
+	}
+	if got := parseConfidence([]string{"confidence=3.14"}); got != 1 {
+		t.Fatalf("parseConfidence(clamp high) = %v, want 1", got)
+	}
+	if got := parseConfidence([]string{"confidence=bad"}); got != 0 {
+		t.Fatalf("parseConfidence(invalid) = %v, want 0", got)
+	}
+
+	if got := clampConfidence(-2); got != 0 {
+		t.Fatalf("clampConfidence(-2) = %v, want 0", got)
+	}
+	if got := clampConfidence(2); got != 1 {
+		t.Fatalf("clampConfidence(2) = %v, want 1", got)
+	}
+
+	normalized := normalizeDiagnosisOutput(diagnoseOutput{
+		Confidence:            -1,
+		RootCause:             "   ",
+		FixCommands:           []string{" go mod tidy ", "go mod tidy", " "},
+		InvestigationCommands: nil,
+	})
+	if normalized.Confidence != 0 {
+		t.Fatalf("normalized.Confidence = %v, want 0", normalized.Confidence)
+	}
+	if !strings.Contains(normalized.RootCause, "未获得有效根因") {
+		t.Fatalf("normalized.RootCause = %q", normalized.RootCause)
+	}
+	if len(normalized.FixCommands) != 1 || normalized.FixCommands[0] != "go mod tidy" {
+		t.Fatalf("normalized.FixCommands = %#v", normalized.FixCommands)
+	}
+	if normalized.InvestigationCommands == nil {
+		t.Fatal("normalized.InvestigationCommands should be an empty list, not nil")
+	}
+}
+
+func TestWorkdirAndTruncateHelpers(t *testing.T) {
+	if got := resolveDiagnoseWorkdir("/repo", map[string]string{"cwd": "/tmp"}); got != "/repo" {
+		t.Fatalf("resolveDiagnoseWorkdir(callWorkdir) = %q, want /repo", got)
+	}
+	if got := resolveDiagnoseWorkdir(" ", map[string]string{"cwd": " /tmp/work "}); got != "/tmp/work" {
+		t.Fatalf("resolveDiagnoseWorkdir(os env) = %q, want /tmp/work", got)
+	}
+	if got := resolveDiagnoseWorkdir("", nil); got != "" {
+		t.Fatalf("resolveDiagnoseWorkdir(empty) = %q, want empty", got)
+	}
+
+	if got := normalizePathList(" "); got != nil {
+		t.Fatalf("normalizePathList(empty) = %#v, want nil", got)
+	}
+	if got := normalizePathList(" /repo "); len(got) != 1 || got[0] != "/repo" {
+		t.Fatalf("normalizePathList() = %#v, want [/repo]", got)
+	}
+
+	if got := truncateRunes("abc", 0); got != "" {
+		t.Fatalf("truncateRunes(max=0) = %q, want empty", got)
+	}
+	if got := truncateRunes("  你好世界  ", 2); !strings.HasPrefix(got, "你好") || !strings.Contains(got, "[truncated]") {
+		t.Fatalf("truncateRunes() = %q, want truncated prefix", got)
+	}
+}


### PR DESCRIPTION

## 概述

本 PR 基于 #512、#525，继续推进终端诊断链路，并把 Provider / Model 选择能力补齐到可直接落盘、可切换、可回退的状态管理闭环。

相对 `origin/main...HEAD`，当前实际变更为 **44 files / +7480 / -1010**。变更不只包含“终端诊断 Phase 2 + Provider / Model 管理”，还额外带入了：

- `provider rm` 删除能力
- CLI 侧统一的 selection service resolver / 缓存层
- provider / model 选择路径上的并发锁与 snapshot fallback 语义调整
- `diag auto status`、`diag diagnose`、socket 自动发现等诊断命令面扩展
- PTY 代理的超时、banner、gateway RPC 连接复用等运行时行为升级

Close #525

---

## 一、这个 PR 解决了什么问题

### 1.1 Phase 1 终端诊断仍然不够“可持续使用”

Phase 1 只能手动触发诊断，存在几个明显问题：

- shell 代理异常退出时，宿主终端状态可能残留，影响后续命令输入
- `Ctrl+C` / `SIGTSTP` / `SIGCONT` / `SIGWINCH` 等信号在 PTY 转发链路上不完整，容易出现中断吞噬、分页器排版异常或僵尸子进程
- 代理不知道“什么时候用户真正开始执行命令、什么时候命令结束”，因此 Auto 模式无法稳定落地
- 原始报错日志未经清洗直接喂给诊断工具，噪声大、凭证泄漏风险高、长输出也不利于模型分析
- 旧版简单文本 IPC 协议扩展性弱，无法承载后续多种诊断指令和状态查询

### 1.2 Provider / Model 选择还停留在“配置存在”，缺少完整运维闭环

在本 PR 之前，Provider / Model 相关能力还不完整：

- 缺少从 CLI 直接新增 / 删除自定义 provider 的入口
- 缺少当前 provider 下模型列表查看与显式切换命令
- provider 切换和 model 切换分离，容易出现两次写配置之间被并发插入、导致状态漂移
- 自定义 provider 远程模型发现失败时，缺少快照兜底，容易让切换流程直接失败
- 删除 provider 后，当前选择、用户环境变量和本地状态的一致性修复不够完整

### 1.3 需要把“诊断工具”从 demo 变成真实闭环

手动 / 自动诊断的最终目标，不是打印占位文案，而是把终端错误日志真正接入 NeoCode 的工具体系，通过 gateway -> system tool -> sub-agent 完成根因分析，并在失败时具备可预期的降级路径。

---

## 二、核心设计思路

### 2.1 终端诊断仍然沿主链路收敛，不在 TUI / runtime 侧散落逻辑

本 PR 延续仓库既有边界：

`用户输入(TUI/CLI) -> Gateway -> Runtime / Tool Manager -> diagnose tool -> 结果回传`

其中：

- PTY 代理负责采集 shell 行为、维护交互体验、透传信号、触发诊断请求
- `internal/tools/diagnose` 负责真正的诊断执行与降级策略
- CLI 只负责命令入口与状态切换，不直接承载分析逻辑

这样做的原因是把“终端交互细节”和“模型可调用能力”继续隔离，避免把诊断逻辑塞回 runtime 或 UI。

### 2.2 用 Shell Integration + OSC 133 建立“可观测的命令生命周期”

Auto 诊断能否可靠，关键不在关键词匹配，而在于能否知道：

- Prompt 何时 ready
- 命令何时开始执行
- 命令何时结束以及退出码是多少

因此本 PR 引入 shell integration 注入脚本，并统一发射 / 解析 `OSC 133;A/C/D` 事件，把命令生命周期结构化成 `prompt_ready / command_start / command_done`。这样 Auto 模式不再依赖脆弱的文本猜测，而是建立在 shell 事件流上。

### 2.3 用“探针 + 动态降级 / 升级”兼容真实终端环境

不同 shell、tmux、SSH、终端模拟器对 OSC 的实现并不稳定，所以这里没有把 Auto 模式当成硬依赖，而是采用：

- 启动后 1.5s 主动探针
- 未收到 `prompt_ready` 时自动降级为 Manual
- 后续一旦捕获到完整事件序列，再动态升级回 Auto

目标是优先保证 shell 可用性，而不是为了 Auto 模式牺牲兼容性。

### 2.4 Provider / Model 选择统一收敛到 SelectionService

Provider、Model、Use 三组命令本质上都在操作同一份“当前选择状态”。本 PR 新增 CLI 侧的 resolver / 缓存层，把三组命令统一接到同一个 `SelectionService`，避免重复 bootstrap，也让后续命令行为更一致。

同时，`SelectProvider`、`SetCurrentModel`、`SelectProviderWithModel` 都纳入 provider create lock 保护，并对跨进程 provider create/remove 引入更稳健的锁语义，减少状态写入竞争。

---

## 三、终端诊断 Phase 2：PTY 代理与自动诊断闭环

### 3.1 PTY 代理稳定性升级

为保证代理 shell 可长期使用，本 PR 在 `internal/ptyproxy/proxy_unix.go` 中补上了多层稳定性防线：

- 增加 `defer term.Restore()` 兜底恢复宿主终端状态
- 转发 `SIGHUP`、`SIGINT`、`SIGTSTP`、`SIGCONT`
- 同步 `SIGWINCH` 窗口尺寸，保证 `less` / `vim` 等全屏程序显示正常
- 启动与退出时输出 banner，明确代理状态

此外，代理在启动阶段会预建并复用 gateway RPC 长连接，避免每次诊断再重复做一次完整连接与鉴权。

### 3.2 Shell Integration 注入与 OSC 133 事件流

新增：

- `internal/ptyproxy/shell_init.go`
- `internal/ptyproxy/shell_events.go`

能力包括：

- `neocode shell --init` 输出 shell integration 脚本
- 兼容 bash 与 zsh
- 在 tmux 环境下自动进行控制序列包裹透传
- 从 PTY 字节流中剥离并解析 `OSC 133` 序列
- 支持 chunked 输入和 tmux 双层包络
- 对 leftover 缓冲设置上限，避免异常流导致内存持续膨胀

### 3.3 Auto 模式触发过滤

为了避免“命令非零退出就一律诊断”的误报，本 PR新增过滤引擎：

- 信号类退出码如 `130`、`137` 不触发 Auto
- `grep`、`find`、`test`、`false` 等常见命令豁免
- 输出过短、无错误语义、信息量不足时不触发

这样做的目的是把 Auto 诊断聚焦在“值得分析的失败”上，而不是把正常 shell 行为误判成异常。

### 3.4 日志清洗、脱敏与 UTF-8 安全截断

新增：

- `internal/ptyproxy/sanitizer.go`
- `internal/ptyproxy/truncator.go`

诊断 RPC 发起前会统一执行：

- ANSI / 控制字符降噪
- `\r` 覆盖输出折叠
- 空白归一化
- 高危凭证打码（如 AKIA、JWT、Bearer Token、API key / password / secret、private key）
- Head / Tail 截断，并保证 UTF-8 字符边界安全

这样既提高模型可读性，也降低把真实密钥送入模型上下文的风险。

### 3.5 IPC 协议升级为 JSON-Lines

新增 `internal/ptyproxy/ipc_protocol.go`，将原先简单的行文本协议升级为 JSON-Lines：

```json
{"cmd":"diagnose","payload":"..."}
{"cmd":"auto","enabled":true}
{"ok":true,"message":"diagnosis completed","auto_enabled":true}
```

升级原因：

- 支持 Manual 诊断、Auto on/off、Auto status 等多种动作
- 让错误响应和状态响应都可结构化表达
- 为后续 Phase 3 的多轮/多消息交互留下协议扩展空间

### 3.6 Socket 路径规范化与自动发现

新增 `internal/ptyproxy/socket_paths.go`，并把 socket 路径统一收敛到 `~/.neocode/run/`。同时补充：

- 启动前先清理残留 socket，降低 `EADDRINUSE` 风险
- 兼容探测旧 `$TMPDIR` 路径并给出 warning
- `diag` 命令侧支持 `--socket > NEOCODE_DIAG_SOCKET > 最近一次运行目录 socket` 的自动发现回退链路

这解决了用户每次都要手动记 socket 路径的问题，也提高了命令行诊断入口的可达性。

### 3.7 真实 diagnose 工具闭环

`internal/tools/diagnose/tool.go` 不再是占位实现，而是接到真实 system tool 闭环：

- 通过 gateway 执行 `diagnose` 系统工具
- 使用 `SpawnSubAgent` 做根因分析
- 解析 JSON 结构化输出
- 渲染 ANSI 彩色诊断结果
- 对 sub-agent 不可用、超时、返回损坏等情况做 graceful fallback

目标不是“始终成功调用 AI”，而是在失败时仍然返回保守建议，避免 panic 或空白结果。

---

## 四、Provider / Model 管理闭环

### 4.1 `provider add` / `provider rm` / `provider ls`

本 PR 实际补齐了完整的 provider 管理命令面，而不只是新增 `provider add`：

- `neocode provider add <name> --driver --url --api-key-env [--discovery-endpoint]`
- `neocode provider ls`
- `neocode provider rm <name>`

其中 `provider add` 会：

- 校验输入参数
- 从环境变量读取 API key
- 原子写入 provider YAML
- 持久化用户环境变量
- 触发配置 reload
- 自动切换到新 provider，并修正当前模型

`provider rm` 会：

- 删除自定义 provider 配置
- 清理对应用户环境变量
- 如果删除的是当前 provider，则重置当前选择并重新 `EnsureSelection`

### 4.2 `use` 命令与 provider+model 原子切换

新增 `neocode use <provider> [--model <model-id>]`。

如果只切 provider，会自动修正到该 provider 下的可用模型；如果同时指定 `--model`，则通过 `SelectProviderWithModel` 在同一临界区内完成切换，避免先切 provider 再切 model 的两次写入间隙被并发插入。

### 4.3 `model ls` / `model set`

新增：

- `neocode model ls`
- `neocode model set <model-id>`

其中 `model ls` 优先读取 snapshot，必要时再触发同步发现；`model set` 会校验模型归属关系，避免把不属于当前 provider 的模型写进配置。

### 4.4 SelectionService 与状态一致性改造

除了命令本身，本 PR 还调整了 state 层语义：

- 新增 CLI 侧 `selectionServiceResolver`，按 workdir 缓存 selection service
- `SelectProvider` / `SetCurrentModel` 纳入 provider create lock
- 新增 `SelectProviderWithModel`
- 自定义 provider 远程模型发现失败时，回退到 snapshot models
- provider create/remove 跨进程锁的 stale threshold 从 `30s` 调整到 `60s`

这些调整的目标是减少并发切换、配置热更新和远程发现失败时的状态漂移问题。

---

## 五、CLI 结构调整

诊断与选择能力的命令面现在更清晰：

```bash
neocode shell
neocode shell --init bash
neocode shell --init zsh

neocode diag
neocode diag diagnose
neocode diag auto on
neocode diag auto off
neocode diag auto status

neocode provider add ...
neocode provider ls
neocode provider rm ...

neocode model ls
neocode model set ...

neocode use <provider> [--model <id>]
```

同时，诊断命令继续保持 skip preload / skip update check，保证错误现场下的响应尽可能直接。

---

## 六、测试与验证

本 PR 为以下模块补充了大量测试：

- `internal/ptyproxy`
- `internal/tools/diagnose`
- `internal/cli`
- `internal/config/state`

覆盖重点包括：

- OSC 133 解析与 tmux 包络
- Auto 过滤规则
- 日志清洗、脱敏、UTF-8 截断
- socket 路径规范化与自动发现
- JSON-Lines IPC 读写
- provider add/remove 回滚与并发锁语义
- provider / model / use 命令输出与异常分支
- diagnose sub-agent 成功 / 失败 / fallback 链路

实测方面，PR 也验证了：

- Gateway IPC 通信
- shell proxy 启动与降级路径
- manual / auto 诊断信令
- `gateway.executeSystemTool(diagnose)`
- sub-agent 诊断输出渲染
- OpenAI / Anthropic 协议兼容路径

---

## 七、风险与注意事项

1. Auto 模式依赖 shell integration 与终端对 OSC 的支持；探针失败时会自动回退到 Manual，不影响基础 shell 使用。
2. SSH / tmux / 深度定制终端下，事件到达时序可能更不稳定，因此本 PR 采取“可降级优先”的设计。
3. 当前 shell 代理主实现仍聚焦 Unix-like；Windows ConPTY 不在本 PR 范围内。
4. 本 PR 不包含 Phase 3 IDM 交互沙盒、Phase 4 TUI 全屏兼容、Phase 5 Windows ConPTY，这些仍属于后续迭代。

---

## 关联 Issue / 文档

- Close #525
- #512
- [Runtime 事件流与 Usage 对账](docs/runtime-provider-event-flow.md)
- [Skills 系统设计](docs/skills-system-design.md)

