### PR TITLE
refactor(runtime): P7 收敛 before_completion_decision 到 AcceptanceService 单一裁决 (#495)

### DIFF
--- a/internal/runtime/acceptance/types.go
+++ b/internal/runtime/acceptance/types.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"neo-code/internal/runtime/controlplane"
+	"neo-code/internal/runtime/decider"
 	"neo-code/internal/runtime/verify"
 )
 
@@ -26,7 +27,11 @@ type AcceptanceDecision struct {
 	Status                  AcceptanceStatus            `json:"status"`
 	StopReason              controlplane.StopReason     `json:"stop_reason,omitempty"`
 	ErrorClass              verify.ErrorClass           `json:"error_class,omitempty"`
+	CompletionPassed        bool                        `json:"completion_passed,omitempty"`
+	VerificationPassed      bool                        `json:"verification_passed,omitempty"`
 	CompletionBlockedReason string                      `json:"completion_blocked_reason,omitempty"`
+	MissingFacts            []decider.MissingFact       `json:"missing_facts,omitempty"`
+	RequiredNextActions     []decider.RequiredAction    `json:"required_next_actions,omitempty"`
 	UserVisibleSummary      string                      `json:"user_visible_summary,omitempty"`
 	InternalSummary         string                      `json:"internal_summary,omitempty"`
 	ContinueHint            string                      `json:"continue_hint,omitempty"`

--- a/internal/runtime/acceptance/types.go
+++ b/internal/runtime/acceptance/types.go
@@ -32,6 +32,9 @@ type AcceptanceDecision struct {
 	CompletionBlockedReason string                      `json:"completion_blocked_reason,omitempty"`
 	MissingFacts            []decider.MissingFact       `json:"missing_facts,omitempty"`
 	RequiredNextActions     []decider.RequiredAction    `json:"required_next_actions,omitempty"`
+	RequiredInput           *decider.RequiredInput      `json:"required_input,omitempty"`
+	IntentHint              decider.TaskKind            `json:"intent_hint,omitempty"`
+	EffectiveTaskKind       decider.TaskKind            `json:"effective_task_kind,omitempty"`
 	UserVisibleSummary      string                      `json:"user_visible_summary,omitempty"`
 	InternalSummary         string                      `json:"internal_summary,omitempty"`
 	ContinueHint            string                      `json:"continue_hint,omitempty"`

--- a/internal/runtime/acceptance_events.go
+++ b/internal/runtime/acceptance_events.go
@@ -1,0 +1,34 @@
+package runtime
+
+import (
+	"strings"
+
+	"neo-code/internal/runtime/acceptance"
+)
+
+// emitAcceptanceDecisionEvents 将验收决策及其 verifier 轨迹统一转换为运行时事件，保证观测链路一致。
+func (s *Service) emitAcceptanceDecisionEvents(state *runState, decision acceptance.AcceptanceDecision) {
+	for _, result := range decision.VerifierResults {
+		s.emitRunScopedOptional(EventVerificationStageFinished, state, VerificationStageFinishedPayload{
+			Name:       result.Name,
+			Status:     result.Status,
+			Summary:    result.Summary,
+			Reason:     result.Reason,
+			ErrorClass: result.ErrorClass,
+		})
+	}
+	s.emitRunScopedOptional(EventVerificationFinished, state, VerificationFinishedPayload{
+		AcceptanceStatus: decision.Status,
+		StopReason:       decision.StopReason,
+		ErrorClass:       decision.ErrorClass,
+	})
+	s.emitRunScopedOptional(EventAcceptanceDecided, state, AcceptanceDecidedPayload{
+		Status:                  decision.Status,
+		StopReason:              decision.StopReason,
+		ErrorClass:              decision.ErrorClass,
+		CompletionBlockedReason: strings.TrimSpace(decision.CompletionBlockedReason),
+		UserVisibleSummary:      decision.UserVisibleSummary,
+		InternalSummary:         decision.InternalSummary,
+		ContinueHint:            decision.ContinueHint,
+	})
+}

--- a/internal/runtime/acceptance_service.go
+++ b/internal/runtime/acceptance_service.go
@@ -119,6 +119,7 @@ func (s *acceptanceService) Decide(ctx context.Context, input acceptanceServiceI
 	if output.Status == acceptance.AcceptanceContinue && output.ContinueHint == "" {
 		output.ContinueHint = finalContinueReminder
 	}
+	output.ErrorClass = normalizeAcceptanceErrorClass(output.ErrorClass, input, output)
 	return output, nil
 }
 
@@ -208,7 +209,66 @@ func mergeVerificationFailure(
 			out.ErrorClass = verify.ErrorClassUnknown
 		}
 	}
+	out.ErrorClass = normalizeAcceptanceErrorClass(out.ErrorClass, acceptanceServiceInput{}, out)
 	return out
+}
+
+// normalizeAcceptanceErrorClass 统一补齐终态 error_class，避免 TUI/Gateway 出现 unknown/empty 推断歧义。
+func normalizeAcceptanceErrorClass(
+	current verify.ErrorClass,
+	input acceptanceServiceInput,
+	decision acceptance.AcceptanceDecision,
+) verify.ErrorClass {
+	if current != "" {
+		return current
+	}
+	switch decision.StopReason {
+	case controlplane.StopReasonVerificationConfigMissing:
+		return verify.ErrorClassEnvMissing
+	case controlplane.StopReasonVerificationExecutionDenied:
+		return verify.ErrorClassPermissionDenied
+	case controlplane.StopReasonVerificationExecutionError:
+		return verify.ErrorClassUnknown
+	case controlplane.StopReasonRequiredTodoFailed:
+		return verify.ErrorClassUnknown
+	case controlplane.StopReasonNoProgressAfterFinalIntercept:
+		return verify.ErrorClassUnknown
+	case controlplane.StopReasonVerificationFailed:
+		if input.TaskKind == decider.TaskKindSubAgent && len(input.Facts.SubAgents.Failed) > 0 {
+			return verify.ErrorClass("subagent_failed")
+		}
+		if input.TaskKind == decider.TaskKindWorkspaceWrite {
+			if errClass := latestToolErrorClass(input.Facts.Errors.ToolErrors, "filesystem_write_file"); errClass != "" {
+				return verify.ErrorClass(errClass)
+			}
+		}
+		if errClass := latestToolErrorClass(input.Facts.Errors.ToolErrors, "spawn_subagent"); errClass != "" {
+			return verify.ErrorClass(errClass)
+		}
+		if errClass := latestToolErrorClass(input.Facts.Errors.ToolErrors, "filesystem_write_file"); errClass != "" {
+			return verify.ErrorClass(errClass)
+		}
+	}
+	if decision.Status == acceptance.AcceptanceFailed || decision.Status == acceptance.AcceptanceIncomplete {
+		return verify.ErrorClassUnknown
+	}
+	return ""
+}
+
+// latestToolErrorClass 返回目标工具最近一次非空错误分类。
+func latestToolErrorClass(errors []runtimefacts.ToolErrorFact, tool string) string {
+	target := strings.TrimSpace(tool)
+	for i := len(errors) - 1; i >= 0; i-- {
+		entry := errors[i]
+		if target != "" && !strings.EqualFold(strings.TrimSpace(entry.Tool), target) {
+			continue
+		}
+		errClass := strings.TrimSpace(entry.ErrorClass)
+		if errClass != "" {
+			return errClass
+		}
+	}
+	return ""
 }
 
 func firstNonPassVerifierResult(results []verify.VerificationResult) *verify.VerificationResult {

--- a/internal/runtime/acceptance_service.go
+++ b/internal/runtime/acceptance_service.go
@@ -1,0 +1,251 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"neo-code/internal/config"
+	"neo-code/internal/runtime/acceptance"
+	"neo-code/internal/runtime/controlplane"
+	"neo-code/internal/runtime/decider"
+	runtimefacts "neo-code/internal/runtime/facts"
+	"neo-code/internal/runtime/verify"
+	agentsession "neo-code/internal/session"
+)
+
+// acceptanceServiceInput 收敛一次最终验收裁决所需的最小输入。
+type acceptanceServiceInput struct {
+	RunID                   string
+	SessionID               string
+	TaskKind                decider.TaskKind
+	UserGoal                string
+	CompletionPassed        bool
+	CompletionBlockedReason string
+	Facts                   runtimefacts.RuntimeFacts
+	Todos                   decider.TodoSnapshot
+	Progress                decider.ProgressSnapshot
+	LastAssistantText       string
+	HookAnnotations         []string
+	HookGuards              []decider.HookGuardSignal
+	NoProgressStreak        int
+	MaxNoProgress           int
+	VerificationProfile     agentsession.VerificationProfile
+	VerificationInput       verify.FinalVerifyInput
+}
+
+// acceptanceService 负责生成 runtime 唯一终态裁决输出。
+type acceptanceService struct{}
+
+// Decide 统一执行 completion/verification/decider 聚合，并输出 AcceptanceDecision。
+func (s *acceptanceService) Decide(ctx context.Context, input acceptanceServiceInput) (acceptance.AcceptanceDecision, error) {
+	output := acceptance.AcceptanceDecision{
+		Status:                  acceptance.AcceptanceContinue,
+		StopReason:              controlplane.StopReasonTodoNotConverged,
+		CompletionPassed:        input.CompletionPassed,
+		VerificationPassed:      false,
+		CompletionBlockedReason: strings.TrimSpace(input.CompletionBlockedReason),
+	}
+	verificationGate, err := runVerificationGate(ctx, input)
+	if err != nil {
+		return acceptance.AcceptanceDecision{}, err
+	}
+	output.VerificationPassed = verificationGate.Passed
+	output.VerifierResults = append([]verify.VerificationResult(nil), verificationGate.Results...)
+
+	noProgressExceeded := input.MaxNoProgress > 0 && input.NoProgressStreak >= input.MaxNoProgress
+	decision := decider.Decide(decider.DecisionInput{
+		RunID:              strings.TrimSpace(input.RunID),
+		SessionID:          strings.TrimSpace(input.SessionID),
+		TaskKind:           input.TaskKind,
+		UserGoal:           strings.TrimSpace(input.UserGoal),
+		Facts:              input.Facts,
+		Todos:              input.Todos,
+		Progress:           input.Progress,
+		LastAssistantText:  strings.TrimSpace(input.LastAssistantText),
+		CompletionPassed:   input.CompletionPassed,
+		CompletionReason:   strings.TrimSpace(input.CompletionBlockedReason),
+		NoProgressExceeded: noProgressExceeded,
+		HookAnnotations:    append([]string(nil), input.HookAnnotations...),
+		HookGuards:         append([]decider.HookGuardSignal(nil), input.HookGuards...),
+	})
+
+	output.MissingFacts = append([]decider.MissingFact(nil), decision.MissingFacts...)
+	output.RequiredNextActions = append([]decider.RequiredAction(nil), decision.RequiredNextActions...)
+	output.UserVisibleSummary = strings.TrimSpace(decision.UserVisibleSummary)
+	output.InternalSummary = strings.TrimSpace(decision.InternalSummary)
+	output.ContinueHint = strings.TrimSpace(buildDeciderContinueHint(decision))
+	output.StopReason = toControlplaneStopReason(decision.StopReason)
+	output.ErrorClass = ""
+
+	if output.StopReason == "" {
+		output.StopReason = controlplane.StopReasonTodoNotConverged
+	}
+	if noProgressExceeded && decision.Status == decider.DecisionIncomplete {
+		output.StopReason = controlplane.StopReasonNoProgressAfterFinalIntercept
+	}
+
+	// accepted 必须同时通过 completion 与 verification gate。
+	if input.CompletionPassed && verificationGate.Passed && decision.Status == decider.DecisionAccepted {
+		output.Status = acceptance.AcceptanceAccepted
+		output.StopReason = controlplane.StopReasonAccepted
+		output.ContinueHint = ""
+		output.CompletionPassed = true
+		output.VerificationPassed = true
+		return output, nil
+	}
+
+	if input.CompletionPassed && !verificationGate.Passed {
+		return mergeVerificationFailure(output, verificationGate), nil
+	}
+
+	switch decision.Status {
+	case decider.DecisionAccepted:
+		// completion 不通过时即便 decider accepted，也必须继续。
+		output.Status = acceptance.AcceptanceContinue
+	case decider.DecisionFailed, decider.DecisionBlocked:
+		output.Status = acceptance.AcceptanceFailed
+		if output.StopReason == "" {
+			output.StopReason = controlplane.StopReasonVerificationFailed
+		}
+	case decider.DecisionIncomplete:
+		output.Status = acceptance.AcceptanceIncomplete
+		if output.StopReason == "" {
+			output.StopReason = controlplane.StopReasonNoProgressAfterFinalIntercept
+		}
+	default:
+		output.Status = acceptance.AcceptanceContinue
+	}
+	if output.Status == acceptance.AcceptanceContinue && output.ContinueHint == "" {
+		output.ContinueHint = finalContinueReminder
+	}
+	return output, nil
+}
+
+// runVerificationGate 执行 verifier gate；completion 未通过时仅回填必要证据，不执行重 verifier。
+func runVerificationGate(ctx context.Context, input acceptanceServiceInput) (verify.VerificationGateDecision, error) {
+	if !input.VerificationProfile.Valid() {
+		return verify.VerificationGateDecision{
+			Passed: false,
+			Reason: controlplane.StopReasonVerificationConfigMissing,
+			Results: []verify.VerificationResult{{
+				Name:       "verification_profile",
+				Status:     verify.VerificationFail,
+				Summary:    "verification profile invalid",
+				Reason:     fmt.Sprintf("invalid verification profile %q", input.VerificationProfile),
+				ErrorClass: verify.ErrorClassEnvMissing,
+			}},
+		}, nil
+	}
+	if !input.CompletionPassed {
+		results := make([]verify.VerificationResult, 0, 1)
+		if strings.EqualFold(strings.TrimSpace(input.CompletionBlockedReason), string(controlplane.CompletionBlockedReasonPendingTodo)) {
+			if synthetic := synthesizeTodoConvergenceEvidence(toSessionTodos(input.Todos)); synthetic != nil {
+				results = append(results, *synthetic)
+			}
+		}
+		return verify.VerificationGateDecision{
+			Passed:  false,
+			Reason:  controlplane.StopReasonTodoNotConverged,
+			Results: results,
+		}, nil
+	}
+
+	policy := acceptance.DefaultPolicy{Executor: verify.PolicyCommandExecutor{}}
+	verifiers, err := policy.ResolveVerifiers(input.VerificationInput)
+	if err != nil {
+		return verify.VerificationGateDecision{
+			Passed: false,
+			Reason: controlplane.StopReasonVerificationConfigMissing,
+			Results: []verify.VerificationResult{{
+				Name:       "verification_profile",
+				Status:     verify.VerificationFail,
+				Summary:    "verification profile resolution failed",
+				Reason:     err.Error(),
+				ErrorClass: verify.ErrorClassEnvMissing,
+			}},
+		}, nil
+	}
+	orch := verify.Orchestrator{Verifiers: verifiers}
+	return orch.RunFinalVerification(ctx, input.VerificationInput)
+}
+
+// mergeVerificationFailure 统一把 verification gate 非通过映射到终态决策。
+func mergeVerificationFailure(
+	base acceptance.AcceptanceDecision,
+	gate verify.VerificationGateDecision,
+) acceptance.AcceptanceDecision {
+	out := base
+	out.VerificationPassed = gate.Passed
+	out.VerifierResults = append([]verify.VerificationResult(nil), gate.Results...)
+	out.StopReason = gate.Reason
+
+	first := firstNonPassVerifierResult(gate.Results)
+	if gate.Passed || first == nil {
+		return out
+	}
+	out.ErrorClass = first.ErrorClass
+	switch first.Status {
+	case verify.VerificationSoftBlock:
+		out.Status = acceptance.AcceptanceContinue
+		if out.StopReason == "" {
+			out.StopReason = controlplane.StopReasonTodoNotConverged
+		}
+		if out.ContinueHint == "" {
+			out.ContinueHint = finalContinueReminder
+		}
+	case verify.VerificationHardBlock:
+		out.Status = acceptance.AcceptanceIncomplete
+		if first.WaitingExternal {
+			out.StopReason = controlplane.StopReasonTodoWaitingExternal
+		}
+	default:
+		out.Status = acceptance.AcceptanceFailed
+		if out.StopReason == "" || out.StopReason == controlplane.StopReasonAccepted {
+			out.StopReason = controlplane.StopReasonVerificationFailed
+		}
+		if out.ErrorClass == "" {
+			out.ErrorClass = verify.ErrorClassUnknown
+		}
+	}
+	return out
+}
+
+func firstNonPassVerifierResult(results []verify.VerificationResult) *verify.VerificationResult {
+	for _, result := range results {
+		if result.Status == verify.VerificationPass {
+			continue
+		}
+		cloned := result
+		return &cloned
+	}
+	return nil
+}
+
+func toSessionTodos(snapshot decider.TodoSnapshot) []agentsession.TodoItem {
+	if len(snapshot.Items) == 0 {
+		return nil
+	}
+	out := make([]agentsession.TodoItem, 0, len(snapshot.Items))
+	for _, item := range snapshot.Items {
+		required := item.Required
+		status := agentsession.TodoStatus(strings.TrimSpace(item.Status))
+		out = append(out, agentsession.TodoItem{
+			ID:            strings.TrimSpace(item.ID),
+			Content:       strings.TrimSpace(item.Content),
+			Status:        status,
+			Required:      &required,
+			Artifacts:     append([]string(nil), item.Artifacts...),
+			FailureReason: strings.TrimSpace(item.FailureReason),
+		})
+	}
+	return out
+}
+
+func resolveAcceptanceMaxNoProgress(cfg config.VerificationConfig) int {
+	limit := cfg.MaxNoProgress
+	if limit <= 0 {
+		return 3
+	}
+	return limit
+}

--- a/internal/runtime/acceptance_service.go
+++ b/internal/runtime/acceptance_service.go
@@ -72,6 +72,19 @@ func (s *acceptanceService) Decide(ctx context.Context, input acceptanceServiceI
 
 	output.MissingFacts = append([]decider.MissingFact(nil), decision.MissingFacts...)
 	output.RequiredNextActions = append([]decider.RequiredAction(nil), decision.RequiredNextActions...)
+	if decision.RequiredInput != nil {
+		cloned := *decision.RequiredInput
+		if len(cloned.Details) > 0 {
+			details := make(map[string]any, len(cloned.Details))
+			for k, v := range cloned.Details {
+				details[k] = v
+			}
+			cloned.Details = details
+		}
+		output.RequiredInput = &cloned
+	}
+	output.IntentHint = decision.IntentHint
+	output.EffectiveTaskKind = decision.EffectiveTaskKind
 	output.UserVisibleSummary = strings.TrimSpace(decision.UserVisibleSummary)
 	output.InternalSummary = strings.TrimSpace(decision.InternalSummary)
 	output.ContinueHint = strings.TrimSpace(buildDeciderContinueHint(decision))
@@ -119,25 +132,20 @@ func (s *acceptanceService) Decide(ctx context.Context, input acceptanceServiceI
 	if output.Status == acceptance.AcceptanceContinue && output.ContinueHint == "" {
 		output.ContinueHint = finalContinueReminder
 	}
+	if input.VerificationInput.RuntimeState.MaxTurnsReached && output.Status == acceptance.AcceptanceContinue {
+		output.Status = acceptance.AcceptanceIncomplete
+		if output.StopReason == controlplane.StopReasonVerificationFailed {
+			output.StopReason = controlplane.StopReasonMaxTurnExceededWithFailedVerification
+		} else {
+			output.StopReason = controlplane.StopReasonMaxTurnExceededWithUnconvergedTodos
+		}
+	}
 	output.ErrorClass = normalizeAcceptanceErrorClass(output.ErrorClass, input, output)
 	return output, nil
 }
 
 // runVerificationGate 执行 verifier gate；completion 未通过时仅回填必要证据，不执行重 verifier。
 func runVerificationGate(ctx context.Context, input acceptanceServiceInput) (verify.VerificationGateDecision, error) {
-	if !input.VerificationProfile.Valid() {
-		return verify.VerificationGateDecision{
-			Passed: false,
-			Reason: controlplane.StopReasonVerificationConfigMissing,
-			Results: []verify.VerificationResult{{
-				Name:       "verification_profile",
-				Status:     verify.VerificationFail,
-				Summary:    "verification profile invalid",
-				Reason:     fmt.Sprintf("invalid verification profile %q", input.VerificationProfile),
-				ErrorClass: verify.ErrorClassEnvMissing,
-			}},
-		}, nil
-	}
 	if !input.CompletionPassed {
 		results := make([]verify.VerificationResult, 0, 1)
 		if strings.EqualFold(strings.TrimSpace(input.CompletionBlockedReason), string(controlplane.CompletionBlockedReasonPendingTodo)) {
@@ -149,6 +157,19 @@ func runVerificationGate(ctx context.Context, input acceptanceServiceInput) (ver
 			Passed:  false,
 			Reason:  controlplane.StopReasonTodoNotConverged,
 			Results: results,
+		}, nil
+	}
+	if !input.VerificationProfile.Valid() {
+		return verify.VerificationGateDecision{
+			Passed: false,
+			Reason: controlplane.StopReasonVerificationConfigMissing,
+			Results: []verify.VerificationResult{{
+				Name:       "verification_profile",
+				Status:     verify.VerificationFail,
+				Summary:    "verification profile invalid",
+				Reason:     fmt.Sprintf("invalid verification profile %q", input.VerificationProfile),
+				ErrorClass: verify.ErrorClassEnvMissing,
+			}},
 		}, nil
 	}
 

--- a/internal/runtime/acceptance_service_test.go
+++ b/internal/runtime/acceptance_service_test.go
@@ -391,3 +391,33 @@ func TestNormalizeAcceptanceErrorClassCoverage(t *testing.T) {
 		})
 	}
 }
+
+func TestNoProgressThresholdProducesIncomplete(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{events: make(chan RuntimeEvent, 16)}
+	state := newRunState("run-no-progress", agentsession.New("no-progress"))
+	state.session.TaskState.VerificationProfile = agentsession.VerificationProfileTaskOnly
+	state.finalInterceptStreak = 3
+	state.mustUseToolAfterFinalContinue = true
+	state.noToolAfterFinalContinueStreak = 3
+
+	snapshot := TurnBudgetSnapshot{Config: config.StaticDefaults().Clone(), Workdir: t.TempDir()}
+	decision, err := service.beforeAcceptFinal(
+		context.Background(),
+		&state,
+		snapshot,
+		providertypes.Message{Role: providertypes.RoleAssistant, Parts: []providertypes.ContentPart{providertypes.NewTextPart("已完成")}},
+		false,
+		beforeCompletionHookSignals{},
+	)
+	if err != nil {
+		t.Fatalf("beforeAcceptFinal error = %v", err)
+	}
+	if decision.Status != acceptance.AcceptanceIncomplete {
+		t.Fatalf("status=%q want incomplete", decision.Status)
+	}
+	if decision.StopReason != controlplane.StopReasonNoProgressAfterFinalIntercept {
+		t.Fatalf("stop_reason=%q want no_progress_after_final_intercept", decision.StopReason)
+	}
+}

--- a/internal/runtime/acceptance_service_test.go
+++ b/internal/runtime/acceptance_service_test.go
@@ -1,0 +1,248 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"neo-code/internal/config"
+	providertypes "neo-code/internal/provider/types"
+	"neo-code/internal/runtime/acceptance"
+	"neo-code/internal/runtime/controlplane"
+	runtimehooks "neo-code/internal/runtime/hooks"
+	"neo-code/internal/runtime/verify"
+	agentsession "neo-code/internal/session"
+)
+
+func TestBeforeCompletionDecisionAcceptanceHooksOnOffParity(t *testing.T) {
+	t.Parallel()
+
+	snapshot := TurnBudgetSnapshot{Config: config.StaticDefaults().Clone(), Workdir: t.TempDir()}
+	assistant := providertypes.Message{
+		Role:  providertypes.RoleAssistant,
+		Parts: []providertypes.ContentPart{providertypes.NewTextPart("done")},
+	}
+
+	offService := &Service{events: make(chan RuntimeEvent, 16)}
+	offState := newRunState("run-hooks-off", agentsession.New("hooks-off"))
+	offState.session.TaskState.VerificationProfile = agentsession.VerificationProfileTaskOnly
+	offDecision, err := offService.runBeforeCompletionDecisionAcceptance(
+		context.Background(),
+		&offState,
+		snapshot,
+		assistant,
+		snapshot.Workdir,
+		true,
+		false,
+		providertypes.RoleAssistant,
+	)
+	if err != nil {
+		t.Fatalf("hooks-off decision error = %v", err)
+	}
+
+	onService := &Service{events: make(chan RuntimeEvent, 16)}
+	baseRegistry := runtimehooks.NewRegistry()
+	userRegistry := runtimehooks.NewRegistry()
+	repoRegistry := runtimehooks.NewRegistry()
+	if err := userRegistry.Register(runtimehooks.HookSpec{
+		ID:     "user-note",
+		Point:  runtimehooks.HookPointBeforeCompletionDecision,
+		Scope:  runtimehooks.HookScopeUser,
+		Source: runtimehooks.HookSourceUser,
+		Handler: func(_ context.Context, _ runtimehooks.HookContext) runtimehooks.HookResult {
+			return runtimehooks.HookResult{Status: runtimehooks.HookResultPass, Message: "note"}
+		},
+	}); err != nil {
+		t.Fatalf("register user hook: %v", err)
+	}
+	onService.SetHookExecutor(composeRuntimeHookExecutors(
+		runtimehooks.NewExecutor(baseRegistry, nil, time.Second),
+		runtimehooks.NewExecutor(userRegistry, nil, time.Second),
+		runtimehooks.NewExecutor(repoRegistry, nil, time.Second),
+	))
+	onState := newRunState("run-hooks-on", agentsession.New("hooks-on"))
+	onState.session.TaskState.VerificationProfile = agentsession.VerificationProfileTaskOnly
+	onDecision, err := onService.runBeforeCompletionDecisionAcceptance(
+		context.Background(),
+		&onState,
+		snapshot,
+		assistant,
+		snapshot.Workdir,
+		true,
+		false,
+		providertypes.RoleAssistant,
+	)
+	if err != nil {
+		t.Fatalf("hooks-on decision error = %v", err)
+	}
+
+	if offDecision.Status != onDecision.Status || offDecision.StopReason != onDecision.StopReason {
+		t.Fatalf("hooks parity mismatch: off=%+v on=%+v", offDecision, onDecision)
+	}
+}
+
+func TestAcceptanceDecisionRequiresCompletionAndVerification(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{events: make(chan RuntimeEvent, 16)}
+	snapshot := TurnBudgetSnapshot{Config: config.StaticDefaults().Clone(), Workdir: t.TempDir()}
+	assistant := providertypes.Message{Role: providertypes.RoleAssistant, Parts: []providertypes.ContentPart{providertypes.NewTextPart("done")}}
+
+	t.Run("completion_pass_but_verification_fail_not_accepted", func(t *testing.T) {
+		state := newRunState("run-verify-fail", agentsession.New("verify-fail"))
+		state.session.TaskState.VerificationProfile = agentsession.VerificationProfileCreateFile
+		state.session.TaskState.KeyArtifacts = []string{"missing.txt"}
+		decision, err := service.beforeAcceptFinal(context.Background(), &state, snapshot, assistant, true, beforeCompletionHookSignals{})
+		if err != nil {
+			t.Fatalf("beforeAcceptFinal error = %v", err)
+		}
+		if decision.Status == acceptance.AcceptanceAccepted {
+			t.Fatalf("unexpected accepted decision: %+v", decision)
+		}
+		if !decision.CompletionPassed || decision.VerificationPassed {
+			t.Fatalf("expected completion=true verification=false, got %+v", decision)
+		}
+		if len(decision.VerifierResults) == 0 {
+			t.Fatalf("expected verification trace in decision")
+		}
+	})
+
+	t.Run("completion_fail_not_accepted_even_if_task_only", func(t *testing.T) {
+		state := newRunState("run-completion-fail", agentsession.New("completion-fail"))
+		state.session.TaskState.VerificationProfile = agentsession.VerificationProfileTaskOnly
+		decision, err := service.beforeAcceptFinal(context.Background(), &state, snapshot, assistant, false, beforeCompletionHookSignals{})
+		if err != nil {
+			t.Fatalf("beforeAcceptFinal error = %v", err)
+		}
+		if decision.Status == acceptance.AcceptanceAccepted {
+			t.Fatalf("unexpected accepted decision: %+v", decision)
+		}
+		if decision.CompletionPassed {
+			t.Fatalf("expected completion=false, got %+v", decision)
+		}
+	})
+
+	t.Run("accepted_requires_both_true", func(t *testing.T) {
+		state := newRunState("run-accepted", agentsession.New("accepted"))
+		state.session.TaskState.VerificationProfile = agentsession.VerificationProfileTaskOnly
+		decision, err := service.beforeAcceptFinal(context.Background(), &state, snapshot, assistant, true, beforeCompletionHookSignals{})
+		if err != nil {
+			t.Fatalf("beforeAcceptFinal error = %v", err)
+		}
+		if decision.Status != acceptance.AcceptanceAccepted {
+			t.Fatalf("status=%q want accepted", decision.Status)
+		}
+		if !decision.CompletionPassed || !decision.VerificationPassed {
+			t.Fatalf("accepted must satisfy completion+verification, got %+v", decision)
+		}
+	})
+}
+
+func TestBeforeCompletionDecisionUserRepoCannotDirectlyTerminal(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{events: make(chan RuntimeEvent, 16)}
+	baseRegistry := runtimehooks.NewRegistry()
+	userRegistry := runtimehooks.NewRegistry()
+	if err := userRegistry.Register(runtimehooks.HookSpec{
+		ID:     "user-guard",
+		Point:  runtimehooks.HookPointBeforeCompletionDecision,
+		Scope:  runtimehooks.HookScopeUser,
+		Source: runtimehooks.HookSourceUser,
+		Handler: func(_ context.Context, _ runtimehooks.HookContext) runtimehooks.HookResult {
+			return runtimehooks.HookResult{Status: runtimehooks.HookResultFailed, Message: "guard"}
+		},
+	}); err != nil {
+		t.Fatalf("register user guard hook: %v", err)
+	}
+	service.SetHookExecutor(composeRuntimeHookExecutors(
+		runtimehooks.NewExecutor(baseRegistry, nil, time.Second),
+		runtimehooks.NewExecutor(userRegistry, nil, time.Second),
+		nil,
+	))
+
+	state := newRunState("run-user-guard", agentsession.New("user-guard"))
+	state.session.TaskState.VerificationProfile = agentsession.VerificationProfileTaskOnly
+	snapshot := TurnBudgetSnapshot{Config: config.StaticDefaults().Clone(), Workdir: t.TempDir()}
+	decision, err := service.runBeforeCompletionDecisionAcceptance(
+		context.Background(),
+		&state,
+		snapshot,
+		providertypes.Message{Role: providertypes.RoleAssistant, Parts: []providertypes.ContentPart{providertypes.NewTextPart("done")}},
+		snapshot.Workdir,
+		true,
+		false,
+		providertypes.RoleAssistant,
+	)
+	if err != nil {
+		t.Fatalf("runBeforeCompletionDecisionAcceptance error = %v", err)
+	}
+	if decision.Status != acceptance.AcceptanceAccepted {
+		t.Fatalf("user guard should not directly terminal-block acceptance path, got %+v", decision)
+	}
+	if !strings.Contains(decision.InternalSummary, "hook signals consumed") {
+		t.Fatalf("expected hook signal to be consumed by acceptance input, got %q", decision.InternalSummary)
+	}
+}
+
+func TestVerificationTraceEmitsStageEvents(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{events: make(chan RuntimeEvent, 32)}
+	state := newRunState("run-verify-stage-events", agentsession.New("verify-stage-events"))
+	decision := acceptance.AcceptanceDecision{
+		Status:     acceptance.AcceptanceContinue,
+		StopReason: controlplane.StopReasonVerificationFailed,
+		ErrorClass: "content_mismatch",
+		VerifierResults: []verify.VerificationResult{
+			{
+				Name:       "content_match",
+				Status:     verify.VerificationSoftBlock,
+				Summary:    "missing expected token",
+				Reason:     "content mismatch",
+				ErrorClass: "content_mismatch",
+			},
+		},
+	}
+	service.emitAcceptanceDecisionEvents(&state, decision)
+	events := collectRuntimeEvents(service.Events())
+	stageCount := 0
+	for _, evt := range events {
+		if evt.Type == EventVerificationStageFinished {
+			stageCount++
+		}
+	}
+	if stageCount == 0 {
+		t.Fatal("expected verification_stage_finished events from acceptance decision trace")
+	}
+}
+
+func TestVerificationFailureProducesStopReasonAndErrorClass(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{events: make(chan RuntimeEvent, 16)}
+	state := newRunState("run-invalid-profile", agentsession.New("invalid-profile"))
+	state.session.TaskState.VerificationProfile = "bad_profile"
+	snapshot := TurnBudgetSnapshot{Config: config.StaticDefaults().Clone(), Workdir: t.TempDir()}
+	decision, err := service.beforeAcceptFinal(
+		context.Background(),
+		&state,
+		snapshot,
+		providertypes.Message{Role: providertypes.RoleAssistant, Parts: []providertypes.ContentPart{providertypes.NewTextPart("done")}},
+		true,
+		beforeCompletionHookSignals{},
+	)
+	if err != nil {
+		t.Fatalf("beforeAcceptFinal error = %v", err)
+	}
+	if decision.Status != acceptance.AcceptanceFailed {
+		t.Fatalf("status=%q want failed", decision.Status)
+	}
+	if decision.StopReason != controlplane.StopReasonVerificationConfigMissing {
+		t.Fatalf("stop reason=%q want verification_config_missing", decision.StopReason)
+	}
+	if decision.ErrorClass == "" {
+		t.Fatalf("verification failure must keep non-empty error_class: %+v", decision)
+	}
+}

--- a/internal/runtime/acceptance_service_test.go
+++ b/internal/runtime/acceptance_service_test.go
@@ -421,3 +421,71 @@ func TestNoProgressThresholdProducesIncomplete(t *testing.T) {
 		t.Fatalf("stop_reason=%q want no_progress_after_final_intercept", decision.StopReason)
 	}
 }
+
+func TestRunVerificationGateSkipsProfileValidationWhenCompletionBlocked(t *testing.T) {
+	t.Parallel()
+
+	gate, err := runVerificationGate(context.Background(), acceptanceServiceInput{
+		CompletionPassed:        false,
+		CompletionBlockedReason: string(controlplane.CompletionBlockedReasonPendingTodo),
+		VerificationProfile:     "invalid_profile",
+		Todos: decider.TodoSnapshot{
+			Items: []decider.TodoViewItem{{
+				ID:       "todo-1",
+				Content:  "x",
+				Status:   "pending",
+				Required: true,
+			}},
+			Summary: decider.TodoSummary{
+				RequiredTotal: 1,
+				RequiredOpen:  1,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runVerificationGate error = %v", err)
+	}
+	if gate.Reason != controlplane.StopReasonTodoNotConverged {
+		t.Fatalf("reason=%q want todo_not_converged", gate.Reason)
+	}
+	if len(gate.Results) == 0 {
+		t.Fatal("expected synthetic todo convergence evidence when completion is blocked")
+	}
+}
+
+func TestBeforeAcceptFinalMarksIncompleteWhenFinalInterceptHitsMaxTurns(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{events: make(chan RuntimeEvent, 16)}
+	cfg := config.StaticDefaults().Clone()
+	cfg.Runtime.MaxTurns = 1
+	snapshot := TurnBudgetSnapshot{Config: cfg, Workdir: t.TempDir()}
+
+	state := newRunState("run-max-turn-final-intercept", agentsession.New("max-turn-final-intercept"))
+	state.session.TaskState.VerificationProfile = agentsession.VerificationProfileTaskOnly
+	required := true
+	state.session.Todos = []agentsession.TodoItem{{
+		ID:       "todo-1",
+		Content:  "pending",
+		Status:   agentsession.TodoStatusPending,
+		Required: &required,
+	}}
+
+	decision, err := service.beforeAcceptFinal(
+		context.Background(),
+		&state,
+		snapshot,
+		providertypes.Message{Role: providertypes.RoleAssistant, Parts: []providertypes.ContentPart{providertypes.NewTextPart("done")}},
+		true,
+		beforeCompletionHookSignals{},
+	)
+	if err != nil {
+		t.Fatalf("beforeAcceptFinal error = %v", err)
+	}
+	if decision.Status != acceptance.AcceptanceIncomplete {
+		t.Fatalf("status=%q want incomplete", decision.Status)
+	}
+	if decision.StopReason != controlplane.StopReasonMaxTurnExceededWithUnconvergedTodos {
+		t.Fatalf("stop_reason=%q want max_turn_exceeded_with_unconverged_todos", decision.StopReason)
+	}
+}

--- a/internal/runtime/acceptance_service_test.go
+++ b/internal/runtime/acceptance_service_test.go
@@ -10,6 +10,8 @@ import (
 	providertypes "neo-code/internal/provider/types"
 	"neo-code/internal/runtime/acceptance"
 	"neo-code/internal/runtime/controlplane"
+	"neo-code/internal/runtime/decider"
+	runtimefacts "neo-code/internal/runtime/facts"
 	runtimehooks "neo-code/internal/runtime/hooks"
 	"neo-code/internal/runtime/verify"
 	agentsession "neo-code/internal/session"
@@ -79,6 +81,36 @@ func TestBeforeCompletionDecisionAcceptanceHooksOnOffParity(t *testing.T) {
 
 	if offDecision.Status != onDecision.Status || offDecision.StopReason != onDecision.StopReason {
 		t.Fatalf("hooks parity mismatch: off=%+v on=%+v", offDecision, onDecision)
+	}
+
+	offContinue, err := offService.runBeforeCompletionDecisionAcceptance(
+		context.Background(),
+		&offState,
+		snapshot,
+		assistant,
+		snapshot.Workdir,
+		false,
+		false,
+		providertypes.RoleAssistant,
+	)
+	if err != nil {
+		t.Fatalf("hooks-off continue decision error = %v", err)
+	}
+	onContinue, err := onService.runBeforeCompletionDecisionAcceptance(
+		context.Background(),
+		&onState,
+		snapshot,
+		assistant,
+		snapshot.Workdir,
+		false,
+		false,
+		providertypes.RoleAssistant,
+	)
+	if err != nil {
+		t.Fatalf("hooks-on continue decision error = %v", err)
+	}
+	if offContinue.Status != onContinue.Status || offContinue.StopReason != onContinue.StopReason {
+		t.Fatalf("hooks continue parity mismatch: off=%+v on=%+v", offContinue, onContinue)
 	}
 }
 
@@ -244,5 +276,118 @@ func TestVerificationFailureProducesStopReasonAndErrorClass(t *testing.T) {
 	}
 	if decision.ErrorClass == "" {
 		t.Fatalf("verification failure must keep non-empty error_class: %+v", decision)
+	}
+}
+
+func TestChatAnswerAcceptancePassesWithoutHeavyVerification(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{events: make(chan RuntimeEvent, 16)}
+	state := newRunState("run-chat-answer", agentsession.New("chat-answer"))
+	state.taskKind = decider.TaskKindChatAnswer
+	state.userGoal = "你好"
+	state.session.TaskState.VerificationProfile = agentsession.VerificationProfileTaskOnly
+
+	snapshot := TurnBudgetSnapshot{Config: config.StaticDefaults().Clone(), Workdir: t.TempDir()}
+	decision, err := service.beforeAcceptFinal(
+		context.Background(),
+		&state,
+		snapshot,
+		providertypes.Message{Role: providertypes.RoleAssistant, Parts: []providertypes.ContentPart{providertypes.NewTextPart("你好")}},
+		true,
+		beforeCompletionHookSignals{},
+	)
+	if err != nil {
+		t.Fatalf("beforeAcceptFinal error = %v", err)
+	}
+	if !decision.CompletionPassed || !decision.VerificationPassed {
+		t.Fatalf("chat answer should pass completion+verification gate, got %+v", decision)
+	}
+	if decision.Status != acceptance.AcceptanceAccepted {
+		t.Fatalf("status=%q want accepted", decision.Status)
+	}
+	if decision.StopReason != controlplane.StopReasonAccepted {
+		t.Fatalf("stop reason=%q want accepted", decision.StopReason)
+	}
+}
+
+func TestNormalizeAcceptanceErrorClassCoverage(t *testing.T) {
+	t.Parallel()
+
+	testInput := acceptanceServiceInput{
+		TaskKind: decider.TaskKindWorkspaceWrite,
+		Facts: runtimefacts.RuntimeFacts{
+			Errors: runtimefacts.ErrorFacts{
+				ToolErrors: []runtimefacts.ToolErrorFact{{
+					Tool:       "filesystem_write_file",
+					ErrorClass: "permission_denied",
+				}},
+			},
+		},
+	}
+	cases := []struct {
+		name     string
+		input    acceptanceServiceInput
+		decision acceptance.AcceptanceDecision
+		want     verify.ErrorClass
+	}{
+		{
+			name:     "verification_config_missing",
+			input:    acceptanceServiceInput{},
+			decision: acceptance.AcceptanceDecision{StopReason: controlplane.StopReasonVerificationConfigMissing, Status: acceptance.AcceptanceFailed},
+			want:     verify.ErrorClassEnvMissing,
+		},
+		{
+			name:     "verification_execution_denied",
+			input:    acceptanceServiceInput{},
+			decision: acceptance.AcceptanceDecision{StopReason: controlplane.StopReasonVerificationExecutionDenied, Status: acceptance.AcceptanceFailed},
+			want:     verify.ErrorClassPermissionDenied,
+		},
+		{
+			name:     "verification_execution_error",
+			input:    acceptanceServiceInput{},
+			decision: acceptance.AcceptanceDecision{StopReason: controlplane.StopReasonVerificationExecutionError, Status: acceptance.AcceptanceFailed},
+			want:     verify.ErrorClassUnknown,
+		},
+		{
+			name:     "required_todo_failed",
+			input:    acceptanceServiceInput{},
+			decision: acceptance.AcceptanceDecision{StopReason: controlplane.StopReasonRequiredTodoFailed, Status: acceptance.AcceptanceFailed},
+			want:     verify.ErrorClassUnknown,
+		},
+		{
+			name:     "no_progress_after_final_intercept",
+			input:    acceptanceServiceInput{},
+			decision: acceptance.AcceptanceDecision{StopReason: controlplane.StopReasonNoProgressAfterFinalIntercept, Status: acceptance.AcceptanceIncomplete},
+			want:     verify.ErrorClassUnknown,
+		},
+		{
+			name: "subagent failed",
+			input: acceptanceServiceInput{
+				TaskKind: decider.TaskKindSubAgent,
+				Facts: runtimefacts.RuntimeFacts{
+					SubAgents: runtimefacts.SubAgentFacts{
+						Failed: []runtimefacts.SubAgentFact{{TaskID: "sa-1"}},
+					},
+				},
+			},
+			decision: acceptance.AcceptanceDecision{StopReason: controlplane.StopReasonVerificationFailed, Status: acceptance.AcceptanceFailed},
+			want:     verify.ErrorClass("subagent_failed"),
+		},
+		{
+			name:     "workspace_write_hard_failure",
+			input:    testInput,
+			decision: acceptance.AcceptanceDecision{StopReason: controlplane.StopReasonVerificationFailed, Status: acceptance.AcceptanceFailed},
+			want:     verify.ErrorClass("permission_denied"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeAcceptanceErrorClass("", tc.input, tc.decision)
+			if got != tc.want {
+				t.Fatalf("normalizeAcceptanceErrorClass() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/runtime/before_completion_orchestrator.go
+++ b/internal/runtime/before_completion_orchestrator.go
@@ -1,0 +1,152 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+
+	"neo-code/internal/runtime/decider"
+	runtimehooks "neo-code/internal/runtime/hooks"
+)
+
+// beforeCompletionHookSignals 收敛 before_completion_decision 阶段 user/repo hook 的可消费信号。
+type beforeCompletionHookSignals struct {
+	Annotations []string
+	Guards      []decider.HookGuardSignal
+}
+
+// runBeforeCompletionDecisionOrchestrator 执行 before_completion_decision 专用编排：
+// 1) 先执行 user/repo hooks 收集 signal；2) 再执行 internal hooks；3) 仅返回信号，不直接裁决终态。
+func (s *Service) runBeforeCompletionDecisionOrchestrator(
+	ctx context.Context,
+	state *runState,
+	workdir string,
+	completionPassed bool,
+	hasToolCalls bool,
+	assistantRole string,
+) beforeCompletionHookSignals {
+	if s == nil || s.hookExecutor == nil {
+		return beforeCompletionHookSignals{}
+	}
+
+	point := runtimehooks.HookPointBeforeCompletionDecision
+	hookInput := s.buildRunHookContext(
+		state,
+		runtimehooks.HookContext{
+			Metadata: map[string]any{
+				"completion_passed": completionPassed,
+				"has_tool_calls":    hasToolCalls,
+				"assistant_role":    strings.TrimSpace(assistantRole),
+				"workdir":           strings.TrimSpace(workdir),
+			},
+		},
+	)
+	scopedCtx := withRuntimeHookEnvelope(ctx, hookRuntimeEnvelope{
+		RunID:     firstNonBlank(hookRunIDFromState(state), hookInput.RunID),
+		SessionID: firstNonBlank(hookSessionIDFromState(state), hookInput.SessionID),
+		Turn:      hookTurnFromState(state),
+		Phase:     hookPhaseFromState(state),
+	})
+
+	baseExecutor, userExecutor, repoExecutor := splitHookExecutors(s.hookExecutor)
+	signals := beforeCompletionHookSignals{}
+
+	for _, item := range []struct {
+		executor HookExecutor
+		source   runtimehooks.HookSource
+	}{
+		{executor: userExecutor, source: runtimehooks.HookSourceUser},
+		{executor: repoExecutor, source: runtimehooks.HookSourceRepo},
+	} {
+		if item.executor == nil {
+			continue
+		}
+		output := item.executor.Run(scopedCtx, point, hookInput.Clone())
+		annotations, guards := collectBeforeCompletionSignals(output, item.source)
+		signals.Annotations = append(signals.Annotations, annotations...)
+		signals.Guards = append(signals.Guards, guards...)
+		s.recordUserHookAnnotations(state, output)
+	}
+
+	// internal hooks 在该点位最后执行；其结果仅用于观测，不参与 user/repo signal 收集。
+	if baseExecutor != nil {
+		output := baseExecutor.Run(scopedCtx, point, hookInput.Clone())
+		s.recordUserHookAnnotations(state, output)
+	}
+	return signals
+}
+
+// buildRunHookContext 构造带 run/session 元数据的 hook 输入。
+func (s *Service) buildRunHookContext(state *runState, input runtimehooks.HookContext) runtimehooks.HookContext {
+	runID := firstNonBlank(hookRunIDFromState(state), input.RunID)
+	sessionID := firstNonBlank(hookSessionIDFromState(state), input.SessionID)
+	input.RunID = firstNonBlank(input.RunID, runID)
+	input.SessionID = firstNonBlank(input.SessionID, sessionID)
+	if input.Metadata == nil {
+		input.Metadata = make(map[string]any, 8)
+	}
+	input.Metadata["run_id"] = input.RunID
+	input.Metadata["session_id"] = input.SessionID
+	if state != nil {
+		input.Metadata["runtime_run_token"] = state.runToken
+		if _, exists := input.Metadata["phase"]; !exists {
+			input.Metadata["phase"] = hookPhaseFromState(state)
+		}
+		input.Metadata["turn"] = hookTurnFromState(state)
+	}
+	return input
+}
+
+// splitHookExecutors 拆解 composeRuntimeHookExecutors 形成的链，恢复 internal/user/repo 三段执行器。
+func splitHookExecutors(executor HookExecutor) (base HookExecutor, user HookExecutor, repo HookExecutor) {
+	switch typed := executor.(type) {
+	case *repoComposedHookExecutor:
+		subBase, subUser, _ := splitHookExecutors(typed.base)
+		return subBase, subUser, typed.repo
+	case *userComposedHookExecutor:
+		subBase, _, subRepo := splitHookExecutors(typed.base)
+		return subBase, typed.user, subRepo
+	default:
+		return executor, nil, nil
+	}
+}
+
+// collectBeforeCompletionSignals 从 user/repo hook 结果提取 annotation 与 guard 信号。
+func collectBeforeCompletionSignals(
+	output runtimehooks.RunOutput,
+	defaultSource runtimehooks.HookSource,
+) ([]string, []decider.HookGuardSignal) {
+	if len(output.Results) == 0 {
+		return nil, nil
+	}
+	annotations := make([]string, 0, len(output.Results))
+	guards := make([]decider.HookGuardSignal, 0, len(output.Results))
+	for _, result := range output.Results {
+		source := strings.TrimSpace(string(result.Source))
+		if source == "" {
+			source = strings.TrimSpace(string(defaultSource))
+		}
+		message := strings.TrimSpace(result.Message)
+		errText := strings.TrimSpace(result.Error)
+		if message != "" {
+			annotations = append(annotations, message)
+		}
+
+		isGuard := result.Status == runtimehooks.HookResultFailed
+		if !isGuard && strings.Contains(strings.ToLower(errText), "block downgraded") {
+			isGuard = true
+		}
+		if !isGuard && strings.Contains(strings.ToLower(message), "block downgraded") {
+			isGuard = true
+		}
+		if !isGuard {
+			continue
+		}
+		guard := decider.HookGuardSignal{
+			HookID:  strings.TrimSpace(result.HookID),
+			Source:  source,
+			Message: firstNonBlank(message, errText),
+		}
+		guards = append(guards, guard)
+	}
+	return annotations, guards
+}

--- a/internal/runtime/before_completion_orchestrator.go
+++ b/internal/runtime/before_completion_orchestrator.go
@@ -17,7 +17,10 @@ type beforeCompletionHookSignals struct {
 }
 
 // runBeforeCompletionDecisionAcceptance 执行 before_completion_decision 专用编排：
-// 1) 先执行 user/repo hooks 收集 signal；2) 再执行 internal hooks；3) 由 internal acceptance hook 产出唯一裁决。
+// 1) 先执行 user/repo hooks 收集 annotation/guard signal；
+// 2) 再执行普通 internal hooks 用于观测；
+// 3) 最后由 runtime 内部 AcceptanceService 进入收口裁决阶段，产出唯一 AcceptanceDecision。
+// 当前 AcceptanceService 走强类型 runtime 内部路径，不通过通用 HookResult metadata 承载。
 func (s *Service) runBeforeCompletionDecisionAcceptance(
 	ctx context.Context,
 	state *runState,
@@ -82,7 +85,7 @@ func (s *Service) runBeforeCompletionDecisionAcceptance(
 		CompletionPassed:        completionPassed,
 		CompletionBlockedReason: strings.TrimSpace(string(state.completion.CompletionBlockedReason)),
 	})
-	// internal acceptance hook：消费 completion/facts/todo/verification/user-repo signals，生成唯一终态裁决。
+	// 收口裁决阶段：消费 completion/facts/todo/verification/user-repo signals，生成唯一终态裁决。
 	return s.beforeAcceptFinal(ctx, state, snapshot, assistant, completionPassed, signals)
 }
 

--- a/internal/runtime/before_completion_orchestrator.go
+++ b/internal/runtime/before_completion_orchestrator.go
@@ -19,8 +19,8 @@ type beforeCompletionHookSignals struct {
 // runBeforeCompletionDecisionAcceptance 执行 before_completion_decision 专用编排：
 // 1) 先执行 user/repo hooks 收集 annotation/guard signal；
 // 2) 再执行普通 internal hooks 用于观测；
-// 3) 最后由 runtime 内部 AcceptanceService 进入收口裁决阶段，产出唯一 AcceptanceDecision。
-// 当前 AcceptanceService 走强类型 runtime 内部路径，不通过通用 HookResult metadata 承载。
+// 3) 最后由 runtime 内部 AcceptanceService 作为 before_completion_decision 的收口裁决阶段，生成唯一 AcceptanceDecision。
+// AcceptanceDecision 走强类型 runtime 内部路径，不通过通用 HookResult metadata 承载。
 func (s *Service) runBeforeCompletionDecisionAcceptance(
 	ctx context.Context,
 	state *runState,

--- a/internal/runtime/before_completion_orchestrator.go
+++ b/internal/runtime/before_completion_orchestrator.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"strings"
 
+	providertypes "neo-code/internal/provider/types"
+	"neo-code/internal/runtime/acceptance"
 	"neo-code/internal/runtime/decider"
 	runtimehooks "neo-code/internal/runtime/hooks"
 )
@@ -14,18 +16,20 @@ type beforeCompletionHookSignals struct {
 	Guards      []decider.HookGuardSignal
 }
 
-// runBeforeCompletionDecisionOrchestrator 执行 before_completion_decision 专用编排：
-// 1) 先执行 user/repo hooks 收集 signal；2) 再执行 internal hooks；3) 仅返回信号，不直接裁决终态。
-func (s *Service) runBeforeCompletionDecisionOrchestrator(
+// runBeforeCompletionDecisionAcceptance 执行 before_completion_decision 专用编排：
+// 1) 先执行 user/repo hooks 收集 signal；2) 再执行 internal hooks；3) 由 internal acceptance hook 产出唯一裁决。
+func (s *Service) runBeforeCompletionDecisionAcceptance(
 	ctx context.Context,
 	state *runState,
+	snapshot TurnBudgetSnapshot,
+	assistant providertypes.Message,
 	workdir string,
 	completionPassed bool,
 	hasToolCalls bool,
 	assistantRole string,
-) beforeCompletionHookSignals {
-	if s == nil || s.hookExecutor == nil {
-		return beforeCompletionHookSignals{}
+) (acceptance.AcceptanceDecision, error) {
+	if s == nil {
+		return acceptance.AcceptanceDecision{}, nil
 	}
 
 	point := runtimehooks.HookPointBeforeCompletionDecision
@@ -47,32 +51,39 @@ func (s *Service) runBeforeCompletionDecisionOrchestrator(
 		Phase:     hookPhaseFromState(state),
 	})
 
-	baseExecutor, userExecutor, repoExecutor := splitHookExecutors(s.hookExecutor)
 	signals := beforeCompletionHookSignals{}
+	if s.hookExecutor != nil {
+		baseExecutor, userExecutor, repoExecutor := splitHookExecutors(s.hookExecutor)
 
-	for _, item := range []struct {
-		executor HookExecutor
-		source   runtimehooks.HookSource
-	}{
-		{executor: userExecutor, source: runtimehooks.HookSourceUser},
-		{executor: repoExecutor, source: runtimehooks.HookSourceRepo},
-	} {
-		if item.executor == nil {
-			continue
+		for _, item := range []struct {
+			executor HookExecutor
+			source   runtimehooks.HookSource
+		}{
+			{executor: userExecutor, source: runtimehooks.HookSourceUser},
+			{executor: repoExecutor, source: runtimehooks.HookSourceRepo},
+		} {
+			if item.executor == nil {
+				continue
+			}
+			output := item.executor.Run(scopedCtx, point, hookInput.Clone())
+			annotations, guards := collectBeforeCompletionSignals(output, item.source)
+			signals.Annotations = append(signals.Annotations, annotations...)
+			signals.Guards = append(signals.Guards, guards...)
+			s.recordUserHookAnnotations(state, output)
 		}
-		output := item.executor.Run(scopedCtx, point, hookInput.Clone())
-		annotations, guards := collectBeforeCompletionSignals(output, item.source)
-		signals.Annotations = append(signals.Annotations, annotations...)
-		signals.Guards = append(signals.Guards, guards...)
-		s.recordUserHookAnnotations(state, output)
-	}
 
-	// internal hooks 在该点位最后执行；其结果仅用于观测，不参与 user/repo signal 收集。
-	if baseExecutor != nil {
-		output := baseExecutor.Run(scopedCtx, point, hookInput.Clone())
-		s.recordUserHookAnnotations(state, output)
+		// internal hooks 在该点位最后执行；其结果仅用于观测，不参与 user/repo signal 收集。
+		if baseExecutor != nil {
+			output := baseExecutor.Run(scopedCtx, point, hookInput.Clone())
+			s.recordUserHookAnnotations(state, output)
+		}
 	}
-	return signals
+	s.emitRunScopedOptional(EventVerificationStarted, state, VerificationStartedPayload{
+		CompletionPassed:        completionPassed,
+		CompletionBlockedReason: strings.TrimSpace(string(state.completion.CompletionBlockedReason)),
+	})
+	// internal acceptance hook：消费 completion/facts/todo/verification/user-repo signals，生成唯一终态裁决。
+	return s.beforeAcceptFinal(ctx, state, snapshot, assistant, completionPassed, signals)
 }
 
 // buildRunHookContext 构造带 run/session 元数据的 hook 输入。
@@ -131,13 +142,7 @@ func collectBeforeCompletionSignals(
 			annotations = append(annotations, message)
 		}
 
-		isGuard := result.Status == runtimehooks.HookResultFailed
-		if !isGuard && strings.Contains(strings.ToLower(errText), "block downgraded") {
-			isGuard = true
-		}
-		if !isGuard && strings.Contains(strings.ToLower(message), "block downgraded") {
-			isGuard = true
-		}
+		isGuard := result.Status == runtimehooks.HookResultFailed || result.Metadata.GuardSignal
 		if !isGuard {
 			continue
 		}

--- a/internal/runtime/decider/decide.go
+++ b/internal/runtime/decider/decide.go
@@ -30,7 +30,7 @@ func Decide(input DecisionInput) Decision {
 			UserVisibleSummary: "存在 required todo 失败，任务已终止。",
 			InternalSummary:    "required todo entered failed terminal state",
 		}
-		return finalizeDecision(decision, hint, effectiveTaskKind)
+		return finalizeDecision(decision, hint, effectiveTaskKind, input)
 	}
 	if input.NoProgressExceeded {
 		decision = Decision{
@@ -39,11 +39,11 @@ func Decide(input DecisionInput) Decision {
 			UserVisibleSummary: "连续多轮缺少新事实，任务以未完成结束。",
 			InternalSummary:    "no progress exceeded while final intercepted",
 		}
-		return finalizeDecision(decision, hint, effectiveTaskKind)
+		return finalizeDecision(decision, hint, effectiveTaskKind, input)
 	}
 	if !input.CompletionPassed {
 		decision = continueWithCompletionReason(input)
-		return finalizeDecision(decision, hint, effectiveTaskKind)
+		return finalizeDecision(decision, hint, effectiveTaskKind, input)
 	}
 
 	switch effectiveTaskKind {
@@ -67,7 +67,7 @@ func Decide(input DecisionInput) Decision {
 			InternalSummary:    "chat answer accepted by completion gate",
 		}
 	}
-	return finalizeDecision(decision, hint, effectiveTaskKind)
+	return finalizeDecision(decision, hint, effectiveTaskKind, input)
 }
 
 // continueWithCompletionReason 把 completion gate 阻塞转成可执行缺失事实提示。
@@ -613,7 +613,19 @@ func latestWriteVerificationHint(allFacts facts.RuntimeFacts, preferredPath stri
 }
 
 // finalizeDecision 统一补全决策元信息，确保快照可观测 hint 与 effective kind。
-func finalizeDecision(decision Decision, intentHint TaskKind, effective TaskKind) Decision {
+func finalizeDecision(decision Decision, intentHint TaskKind, effective TaskKind, input DecisionInput) Decision {
+	if len(input.HookAnnotations) > 0 || len(input.HookGuards) > 0 {
+		detail := fmt.Sprintf(
+			"hook signals consumed (annotations=%d guards=%d)",
+			len(input.HookAnnotations),
+			len(input.HookGuards),
+		)
+		if strings.TrimSpace(decision.InternalSummary) == "" {
+			decision.InternalSummary = detail
+		} else {
+			decision.InternalSummary = strings.TrimSpace(decision.InternalSummary) + "; " + detail
+		}
+	}
 	decision.IntentHint = intentHint
 	decision.EffectiveTaskKind = effective
 	return decision

--- a/internal/runtime/decider/types.go
+++ b/internal/runtime/decider/types.go
@@ -57,6 +57,13 @@ type RequiredInput struct {
 	Details map[string]any `json:"details,omitempty"`
 }
 
+// HookGuardSignal 描述 before_completion_decision user/repo hook 产生的守卫信号。
+type HookGuardSignal struct {
+	HookID  string `json:"hook_id,omitempty"`
+	Source  string `json:"source,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
 // TaskIntent 描述由用户文本推断出的弱意图线索。
 type TaskIntent struct {
 	Hint       TaskKind `json:"hint,omitempty"`
@@ -122,4 +129,6 @@ type DecisionInput struct {
 	CompletionPassed   bool
 	CompletionReason   string
 	NoProgressExceeded bool
+	HookAnnotations    []string
+	HookGuards         []HookGuardSignal
 }

--- a/internal/runtime/final_acceptance.go
+++ b/internal/runtime/final_acceptance.go
@@ -251,6 +251,14 @@ func toControlplaneStopReason(reason string) controlplane.StopReason {
 		return controlplane.StopReasonRequiredTodoFailed
 	case string(controlplane.StopReasonVerificationFailed):
 		return controlplane.StopReasonVerificationFailed
+	case string(controlplane.StopReasonTodoWaitingExternal):
+		return controlplane.StopReasonTodoWaitingExternal
+	case string(controlplane.StopReasonVerificationConfigMissing):
+		return controlplane.StopReasonVerificationConfigMissing
+	case string(controlplane.StopReasonVerificationExecutionDenied):
+		return controlplane.StopReasonVerificationExecutionDenied
+	case string(controlplane.StopReasonVerificationExecutionError):
+		return controlplane.StopReasonVerificationExecutionError
 	default:
 		return ""
 	}
@@ -296,7 +304,8 @@ func buildDeciderContinueHint(decision decider.Decision) string {
 	return strings.TrimSpace(builder.String())
 }
 
-// beforeAcceptFinalLegacy 保留历史 acceptance/verify 执行逻辑，作为兼容后备路径。
+// beforeAcceptFinalLegacy 是历史 acceptance/verify 实现，仅用于回滚对照与测试覆盖。
+// Deprecated: P7 主链不再调用该路径，最终裁决统一走 beforeAcceptFinal -> AcceptanceService。
 func (s *Service) beforeAcceptFinalLegacy(
 	ctx context.Context,
 	state *runState,

--- a/internal/runtime/final_acceptance.go
+++ b/internal/runtime/final_acceptance.go
@@ -167,7 +167,8 @@ func toDeciderDecisionFromAcceptance(decision acceptance.AcceptanceDecision) dec
 	}
 }
 
-// mapDeciderDecisionToAcceptance 把 FinalDecider 裁决映射到现有 acceptance 协议，保证主链兼容。
+// mapDeciderDecisionToAcceptance 把 FinalDecider 裁决映射到 acceptance 协议。
+// Deprecated: 仅保留给 legacy 回滚对照与测试使用；P7 主链直接消费 AcceptanceService.Decide 产物。
 func mapDeciderDecisionToAcceptance(decision decider.Decision) acceptance.AcceptanceDecision {
 	out := acceptance.AcceptanceDecision{
 		StopReason:         toControlplaneStopReason(decision.StopReason),

--- a/internal/runtime/final_acceptance.go
+++ b/internal/runtime/final_acceptance.go
@@ -94,6 +94,7 @@ func (s *Service) buildAcceptanceServiceInput(
 	runID := strings.TrimSpace(state.runID)
 	sessionID := strings.TrimSpace(state.session.ID)
 	turn := state.turn
+	maxTurnsReached := state.maxTurnsReached
 	maxTurns := resolveRuntimeMaxTurns(snapshot.Config.Runtime)
 	state.mu.Unlock()
 
@@ -109,6 +110,9 @@ func (s *Service) buildAcceptanceServiceInput(
 			completionReason = string(controlplane.CompletionBlockedReasonPendingTodo)
 		}
 	}
+	if !maxTurnsReached && maxTurns > 0 && turn+1 >= maxTurns {
+		maxTurnsReached = true
+	}
 	verifyInput := verify.FinalVerifyInput{
 		SessionID:          sessionID,
 		RunID:              runID,
@@ -121,7 +125,7 @@ func (s *Service) buildAcceptanceServiceInput(
 		RuntimeState: verify.RuntimeStateSnapshot{
 			Turn:                 turn,
 			MaxTurns:             maxTurns,
-			MaxTurnsReached:      false,
+			MaxTurnsReached:      maxTurnsReached,
 			FinalInterceptStreak: noProgressStreak,
 		},
 		VerificationConfig: snapshot.Config.Runtime.Verification.Clone(),
@@ -162,9 +166,27 @@ func toDeciderDecisionFromAcceptance(decision acceptance.AcceptanceDecision) dec
 		StopReason:          strings.TrimSpace(string(decision.StopReason)),
 		MissingFacts:        append([]decider.MissingFact(nil), decision.MissingFacts...),
 		RequiredNextActions: append([]decider.RequiredAction(nil), decision.RequiredNextActions...),
+		RequiredInput:       cloneRequiredInput(decision.RequiredInput),
+		IntentHint:          decision.IntentHint,
+		EffectiveTaskKind:   decision.EffectiveTaskKind,
 		UserVisibleSummary:  strings.TrimSpace(decision.UserVisibleSummary),
 		InternalSummary:     strings.TrimSpace(decision.InternalSummary),
 	}
+}
+
+func cloneRequiredInput(in *decider.RequiredInput) *decider.RequiredInput {
+	if in == nil {
+		return nil
+	}
+	cloned := *in
+	if len(in.Details) == 0 {
+		return &cloned
+	}
+	cloned.Details = make(map[string]any, len(in.Details))
+	for k, v := range in.Details {
+		cloned.Details[k] = v
+	}
+	return &cloned
 }
 
 // mapDeciderDecisionToAcceptance 把 FinalDecider 裁决映射到 acceptance 协议。
@@ -172,6 +194,9 @@ func toDeciderDecisionFromAcceptance(decision acceptance.AcceptanceDecision) dec
 func mapDeciderDecisionToAcceptance(decision decider.Decision) acceptance.AcceptanceDecision {
 	out := acceptance.AcceptanceDecision{
 		StopReason:         toControlplaneStopReason(decision.StopReason),
+		RequiredInput:      cloneRequiredInput(decision.RequiredInput),
+		IntentHint:         decision.IntentHint,
+		EffectiveTaskKind:  decision.EffectiveTaskKind,
 		UserVisibleSummary: strings.TrimSpace(decision.UserVisibleSummary),
 		InternalSummary:    strings.TrimSpace(decision.InternalSummary),
 		ContinueHint:       buildDeciderContinueHint(decision),

--- a/internal/runtime/final_acceptance.go
+++ b/internal/runtime/final_acceptance.go
@@ -31,10 +31,7 @@ func (s *Service) beforeAcceptFinal(
 		return acceptance.AcceptanceDecision{}, nil
 	}
 
-	maxNoProgress := snapshot.Config.Runtime.Verification.MaxNoProgress
-	if maxNoProgress <= 0 {
-		maxNoProgress = 3
-	}
+	maxNoProgress := resolveAcceptanceMaxNoProgress(snapshot.Config.Runtime.Verification)
 	noProgressStreak := state.finalInterceptStreak
 	if noProgressStreak < 0 {
 		noProgressStreak = 0
@@ -43,68 +40,62 @@ func (s *Service) beforeAcceptFinal(
 		noProgressStreak = state.noToolAfterFinalContinueStreak
 	}
 
-	deciderDecision := s.evaluateFinalDecision(
+	input := s.buildAcceptanceServiceInput(
 		state,
+		snapshot,
 		assistant,
 		completionPassed,
+		signals,
 		noProgressStreak,
 		maxNoProgress,
-		signals,
 	)
+	service := &acceptanceService{}
+	acceptanceDecision, err := service.Decide(ctx, input)
+	if err != nil {
+		return acceptance.AcceptanceDecision{}, err
+	}
+	deciderDecision := toDeciderDecisionFromAcceptance(acceptanceDecision)
 	state.mu.Lock()
 	state.lastDeciderDecision = deciderDecision
 	pendingFinalProgress := state.pendingFinalProgress
-	completionBlockedReason := strings.TrimSpace(string(state.completion.CompletionBlockedReason))
 	state.mu.Unlock()
 	s.emitRunScopedOptional(EventDecisionMade, state, deciderDecision)
 	s.emitRuntimeSnapshotUpdated(ctx, state, "decision_made")
-	acceptanceDecision := mapDeciderDecisionToAcceptance(deciderDecision)
 	if acceptanceDecision.Status == acceptance.AcceptanceContinue && pendingFinalProgress {
 		acceptanceDecision.HasProgress = true
-	}
-	if !completionPassed && completionBlockedReason != "" {
-		acceptanceDecision.CompletionBlockedReason = completionBlockedReason
 	}
 	return acceptanceDecision, nil
 }
 
-// evaluateFinalDecision 把当前 run facts + todo 快照输入 FinalDecider，生成唯一终态裁决。
-func (s *Service) evaluateFinalDecision(
+// buildAcceptanceServiceInput 从当前运行态抽取 AcceptanceService 所需输入。
+func (s *Service) buildAcceptanceServiceInput(
 	state *runState,
+	snapshot TurnBudgetSnapshot,
 	assistant providertypes.Message,
 	completionPassed bool,
+	signals beforeCompletionHookSignals,
 	noProgressStreak int,
 	maxNoProgress int,
-	signals beforeCompletionHookSignals,
-) decider.Decision {
-	if state == nil {
-		return decider.Decision{
-			Status:             decider.DecisionContinue,
-			StopReason:         string(controlplane.StopReasonTodoNotConverged),
-			UserVisibleSummary: "runtime state is unavailable",
-			InternalSummary:    "run state is nil",
-		}
-	}
+) acceptanceServiceInput {
 	state.mu.Lock()
 	taskKind := state.taskKind
 	userGoal := state.userGoal
 	completionReason := strings.TrimSpace(string(state.completion.CompletionBlockedReason))
 	verificationProfile := state.session.TaskState.VerificationProfile
-	todoSnapshot := buildTodoSnapshotFromItems(cloneTodosForPersistence(state.session.Todos))
+	sessionMessages := append([]providertypes.Message(nil), state.session.Messages...)
+	sessionTodos := cloneTodosForPersistence(state.session.Todos)
+	sessionTaskState := state.session.TaskState
+	todoSnapshot := buildTodoSnapshotFromItems(sessionTodos)
 	factsSnapshot := runtimefacts.RuntimeFacts{}
 	if state.factsCollector != nil {
 		factsSnapshot = state.factsCollector.Snapshot()
 	}
+	taskID := strings.TrimSpace(state.taskID)
+	runID := strings.TrimSpace(state.runID)
+	sessionID := strings.TrimSpace(state.session.ID)
+	turn := state.turn
+	maxTurns := resolveRuntimeMaxTurns(snapshot.Config.Runtime)
 	state.mu.Unlock()
-
-	if !verificationProfile.Valid() {
-		return decider.Decision{
-			Status:             decider.DecisionFailed,
-			StopReason:         string(controlplane.StopReasonVerificationFailed),
-			UserVisibleSummary: "verification profile 非法，任务终止。",
-			InternalSummary:    fmt.Sprintf("invalid verification profile: %q", verificationProfile),
-		}
-	}
 
 	if strings.TrimSpace(userGoal) == "" {
 		userGoal = renderPartsForVerification(assistant.Parts)
@@ -118,22 +109,62 @@ func (s *Service) evaluateFinalDecision(
 			completionReason = string(controlplane.CompletionBlockedReasonPendingTodo)
 		}
 	}
+	verifyInput := verify.FinalVerifyInput{
+		SessionID:          sessionID,
+		RunID:              runID,
+		TaskID:             taskID,
+		Workdir:            snapshot.Workdir,
+		Messages:           buildVerifyMessages(sessionMessages),
+		Todos:              buildVerifyTodos(sessionTodos),
+		LastAssistantFinal: renderPartsForVerification(assistant.Parts),
+		TaskState:          buildVerifyTaskState(sessionTaskState),
+		RuntimeState: verify.RuntimeStateSnapshot{
+			Turn:                 turn,
+			MaxTurns:             maxTurns,
+			MaxTurnsReached:      false,
+			FinalInterceptStreak: noProgressStreak,
+		},
+		VerificationConfig: snapshot.Config.Runtime.Verification.Clone(),
+	}
+	return acceptanceServiceInput{
+		RunID:                   runID,
+		SessionID:               sessionID,
+		TaskKind:                taskKind,
+		UserGoal:                userGoal,
+		CompletionPassed:        completionPassed,
+		CompletionBlockedReason: completionReason,
+		Facts:                   factsSnapshot,
+		Todos:                   toDeciderTodoSnapshot(todoSnapshot),
+		Progress:                toDeciderProgress(factsSnapshot),
+		LastAssistantText:       renderPartsForVerification(assistant.Parts),
+		HookAnnotations:         append([]string(nil), signals.Annotations...),
+		HookGuards:              append([]decider.HookGuardSignal(nil), signals.Guards...),
+		NoProgressStreak:        noProgressStreak,
+		MaxNoProgress:           maxNoProgress,
+		VerificationProfile:     verificationProfile,
+		VerificationInput:       verifyInput,
+	}
+}
 
-	return decider.Decide(decider.DecisionInput{
-		RunID:              strings.TrimSpace(state.runID),
-		SessionID:          strings.TrimSpace(state.session.ID),
-		TaskKind:           taskKind,
-		UserGoal:           userGoal,
-		Facts:              factsSnapshot,
-		Todos:              toDeciderTodoSnapshot(todoSnapshot),
-		Progress:           toDeciderProgress(factsSnapshot),
-		LastAssistantText:  renderPartsForVerification(assistant.Parts),
-		CompletionPassed:   completionPassed,
-		CompletionReason:   completionReason,
-		NoProgressExceeded: noProgressStreak >= maxNoProgress,
-		HookAnnotations:    append([]string(nil), signals.Annotations...),
-		HookGuards:         append([]decider.HookGuardSignal(nil), signals.Guards...),
-	})
+// toDeciderDecisionFromAcceptance 将统一 acceptance 决策投影为 runtime snapshot 兼容的 decider 视图。
+func toDeciderDecisionFromAcceptance(decision acceptance.AcceptanceDecision) decider.Decision {
+	status := decider.DecisionContinue
+	switch decision.Status {
+	case acceptance.AcceptanceAccepted:
+		status = decider.DecisionAccepted
+	case acceptance.AcceptanceFailed:
+		status = decider.DecisionFailed
+	case acceptance.AcceptanceIncomplete:
+		status = decider.DecisionIncomplete
+	}
+	return decider.Decision{
+		Status:              status,
+		StopReason:          strings.TrimSpace(string(decision.StopReason)),
+		MissingFacts:        append([]decider.MissingFact(nil), decision.MissingFacts...),
+		RequiredNextActions: append([]decider.RequiredAction(nil), decision.RequiredNextActions...),
+		UserVisibleSummary:  strings.TrimSpace(decision.UserVisibleSummary),
+		InternalSummary:     strings.TrimSpace(decision.InternalSummary),
+	}
 }
 
 // mapDeciderDecisionToAcceptance 把 FinalDecider 裁决映射到现有 acceptance 协议，保证主链兼容。

--- a/internal/runtime/final_acceptance.go
+++ b/internal/runtime/final_acceptance.go
@@ -25,6 +25,7 @@ func (s *Service) beforeAcceptFinal(
 	snapshot TurnBudgetSnapshot,
 	assistant providertypes.Message,
 	completionPassed bool,
+	signals beforeCompletionHookSignals,
 ) (acceptance.AcceptanceDecision, error) {
 	if state == nil {
 		return acceptance.AcceptanceDecision{}, nil
@@ -42,7 +43,14 @@ func (s *Service) beforeAcceptFinal(
 		noProgressStreak = state.noToolAfterFinalContinueStreak
 	}
 
-	deciderDecision := s.evaluateFinalDecision(state, assistant, completionPassed, noProgressStreak, maxNoProgress)
+	deciderDecision := s.evaluateFinalDecision(
+		state,
+		assistant,
+		completionPassed,
+		noProgressStreak,
+		maxNoProgress,
+		signals,
+	)
 	state.mu.Lock()
 	state.lastDeciderDecision = deciderDecision
 	pendingFinalProgress := state.pendingFinalProgress
@@ -67,6 +75,7 @@ func (s *Service) evaluateFinalDecision(
 	completionPassed bool,
 	noProgressStreak int,
 	maxNoProgress int,
+	signals beforeCompletionHookSignals,
 ) decider.Decision {
 	if state == nil {
 		return decider.Decision{
@@ -122,6 +131,8 @@ func (s *Service) evaluateFinalDecision(
 		CompletionPassed:   completionPassed,
 		CompletionReason:   completionReason,
 		NoProgressExceeded: noProgressStreak >= maxNoProgress,
+		HookAnnotations:    append([]string(nil), signals.Annotations...),
+		HookGuards:         append([]decider.HookGuardSignal(nil), signals.Guards...),
 	})
 }
 

--- a/internal/runtime/final_acceptance_additional_test.go
+++ b/internal/runtime/final_acceptance_additional_test.go
@@ -29,6 +29,28 @@ func TestFinalAcceptanceMappingAndLegacyPaths(t *testing.T) {
 		}
 	})
 
+	t.Run("projection keeps required input and task kinds", func(t *testing.T) {
+		t.Parallel()
+		required := &decider.RequiredInput{
+			Kind:    "missing_file_target_or_content",
+			Message: "need target path",
+			Details: map[string]any{"path": "test.txt"},
+		}
+		projected := toDeciderDecisionFromAcceptance(acceptance.AcceptanceDecision{
+			Status:            acceptance.AcceptanceContinue,
+			StopReason:        controlplane.StopReasonTodoNotConverged,
+			RequiredInput:     required,
+			IntentHint:        decider.TaskKindWorkspaceWrite,
+			EffectiveTaskKind: decider.TaskKindWorkspaceWrite,
+		})
+		if projected.RequiredInput == nil || projected.RequiredInput.Kind != "missing_file_target_or_content" {
+			t.Fatalf("required input lost in projection: %+v", projected)
+		}
+		if projected.IntentHint != decider.TaskKindWorkspaceWrite || projected.EffectiveTaskKind != decider.TaskKindWorkspaceWrite {
+			t.Fatalf("task kind hints lost in projection: %+v", projected)
+		}
+	})
+
 	t.Run("legacy path adds continue hint", func(t *testing.T) {
 		t.Parallel()
 		service := &Service{}
@@ -55,8 +77,8 @@ func TestFinalAcceptanceHelperBranches(t *testing.T) {
 	t.Parallel()
 
 	if got := buildAcceptanceContinueHint(acceptance.AcceptanceDecision{
-		Status:        acceptance.AcceptanceContinue,
-		ContinueHint:  "base",
+		Status:          acceptance.AcceptanceContinue,
+		ContinueHint:    "base",
 		VerifierResults: nil,
 	}); !strings.Contains(got, "base") {
 		t.Fatalf("continue hint fallback = %q", got)

--- a/internal/runtime/final_acceptance_test.go
+++ b/internal/runtime/final_acceptance_test.go
@@ -34,7 +34,7 @@ func TestBeforeAcceptFinalDecisionPaths(t *testing.T) {
 		decision, err := service.beforeAcceptFinal(context.Background(), &state, snapshot, providertypes.Message{
 			Role:  providertypes.RoleAssistant,
 			Parts: []providertypes.ContentPart{providertypes.NewTextPart("done")},
-		}, true)
+		}, true, beforeCompletionHookSignals{})
 		if err != nil {
 			t.Fatalf("beforeAcceptFinal() error = %v", err)
 		}
@@ -47,7 +47,7 @@ func TestBeforeAcceptFinalDecisionPaths(t *testing.T) {
 		t.Parallel()
 		state := newRunState("run-invalid-profile", agentsession.New("invalid-profile"))
 		state.session.TaskState.VerificationProfile = "bad"
-		decision, err := service.beforeAcceptFinal(context.Background(), &state, snapshot, providertypes.Message{}, true)
+		decision, err := service.beforeAcceptFinal(context.Background(), &state, snapshot, providertypes.Message{}, true, beforeCompletionHookSignals{})
 		if err != nil {
 			t.Fatalf("beforeAcceptFinal() error = %v", err)
 		}
@@ -65,7 +65,7 @@ func TestBeforeAcceptFinalDecisionPaths(t *testing.T) {
 		state.session.Todos = []agentsession.TodoItem{
 			{ID: "todo-1", Content: "do work", Status: agentsession.TodoStatusPending, Required: &required},
 		}
-		decision, err := service.beforeAcceptFinal(context.Background(), &state, snapshot, providertypes.Message{}, true)
+		decision, err := service.beforeAcceptFinal(context.Background(), &state, snapshot, providertypes.Message{}, true, beforeCompletionHookSignals{})
 		if err != nil {
 			t.Fatalf("beforeAcceptFinal() error = %v", err)
 		}
@@ -78,7 +78,7 @@ func TestBeforeAcceptFinalDecisionPaths(t *testing.T) {
 		t.Parallel()
 		state := newRunState("run-accepted", agentsession.New("accepted"))
 		state.session.TaskState.VerificationProfile = agentsession.VerificationProfileTaskOnly
-		decision, err := service.beforeAcceptFinal(context.Background(), &state, snapshot, providertypes.Message{}, true)
+		decision, err := service.beforeAcceptFinal(context.Background(), &state, snapshot, providertypes.Message{}, true, beforeCompletionHookSignals{})
 		if err != nil {
 			t.Fatalf("beforeAcceptFinal() error = %v", err)
 		}
@@ -96,7 +96,7 @@ func TestBeforeAcceptFinalDecisionPaths(t *testing.T) {
 		state.session.Todos = []agentsession.TodoItem{
 			{ID: "todo-1", Content: "do work", Status: agentsession.TodoStatusPending, Required: &required},
 		}
-		decision, err := service.beforeAcceptFinal(context.Background(), &state, snapshot, providertypes.Message{}, true)
+		decision, err := service.beforeAcceptFinal(context.Background(), &state, snapshot, providertypes.Message{}, true, beforeCompletionHookSignals{})
 		if err != nil {
 			t.Fatalf("beforeAcceptFinal() error = %v", err)
 		}

--- a/internal/runtime/hooks/executor.go
+++ b/internal/runtime/hooks/executor.go
@@ -110,6 +110,9 @@ func normalizeHookResultByCapability(point HookPoint, result HookResult) HookRes
 		return result
 	}
 	if result.Status == HookResultBlock && !capability.CanBlock {
+		result.Metadata.OriginalStatus = string(HookResultBlock)
+		result.Metadata.BlockDowngraded = true
+		result.Metadata.GuardSignal = true
 		result.Status = HookResultPass
 		if strings.TrimSpace(result.Message) == "" {
 			result.Message = "hook block downgraded: point does not allow blocking"

--- a/internal/runtime/hooks/result.go
+++ b/internal/runtime/hooks/result.go
@@ -30,9 +30,12 @@ type HookResult struct {
 
 // HookResultMetadata 描述 hook 执行结果的结构化附加信息。
 type HookResultMetadata struct {
-	Rewake        bool
-	RewakeReason  string
-	RewakeSummary string
+	Rewake          bool
+	RewakeReason    string
+	RewakeSummary   string
+	OriginalStatus  string
+	BlockDowngraded bool
+	GuardSignal     bool
 }
 
 // RunOutput 是一次点位执行的聚合结果。

--- a/internal/runtime/hooks_integration_test.go
+++ b/internal/runtime/hooks_integration_test.go
@@ -340,39 +340,26 @@ func TestBeforeCompletionDecisionOrchestratorRunsUserRepoBeforeInternalAndFeedsD
 
 	session := newRuntimeSession("session-before-completion-orchestrator")
 	state := newRunState("run-before-completion-orchestrator", session)
-	signals := service.runBeforeCompletionDecisionOrchestrator(
-		context.Background(),
-		&state,
-		t.TempDir(),
-		true,
-		false,
-		providertypes.RoleAssistant,
-	)
-	if got := strings.Join(callFlow, ","); got != "user,repo,internal" {
-		t.Fatalf("before_completion_decision hook order = %q, want %q", got, "user,repo,internal")
-	}
-	if len(signals.Annotations) < 2 {
-		t.Fatalf("signals annotations = %+v, want at least user/repo messages", signals.Annotations)
-	}
-	if len(signals.Guards) == 0 {
-		t.Fatal("expected guard signal from user hook failure")
-	}
-
 	snapshotCfg := TurnBudgetSnapshot{
 		Config:  config.StaticDefaults().Clone(),
 		Workdir: t.TempDir(),
 	}
 	state.session.TaskState.VerificationProfile = agentsession.VerificationProfileTaskOnly
-	decision, err := service.beforeAcceptFinal(
+	decision, err := service.runBeforeCompletionDecisionAcceptance(
 		context.Background(),
 		&state,
 		snapshotCfg,
 		providertypes.Message{Role: providertypes.RoleAssistant, Parts: []providertypes.ContentPart{providertypes.NewTextPart("done")}},
+		t.TempDir(),
 		true,
-		signals,
+		false,
+		providertypes.RoleAssistant,
 	)
 	if err != nil {
-		t.Fatalf("beforeAcceptFinal() error = %v", err)
+		t.Fatalf("runBeforeCompletionDecisionAcceptance() error = %v", err)
+	}
+	if got := strings.Join(callFlow, ","); got != "user,repo,internal" {
+		t.Fatalf("before_completion_decision hook order = %q, want %q", got, "user,repo,internal")
 	}
 	if !strings.Contains(decision.InternalSummary, "hook signals consumed") {
 		t.Fatalf("decision internal summary should include hook signal context, got %q", decision.InternalSummary)

--- a/internal/runtime/hooks_integration_test.go
+++ b/internal/runtime/hooks_integration_test.go
@@ -15,6 +15,7 @@ import (
 	approvalflow "neo-code/internal/runtime/approval"
 	"neo-code/internal/runtime/controlplane"
 	runtimehooks "neo-code/internal/runtime/hooks"
+	agentsession "neo-code/internal/session"
 	"neo-code/internal/subagent"
 	"neo-code/internal/tools"
 )
@@ -272,6 +273,109 @@ func TestRunBeforeCompletionDecisionHookBlockIsObservedOnly(t *testing.T) {
 	}
 	if capturedWorkdir == "" {
 		t.Fatalf("expected before_completion_decision hook metadata to include workdir")
+	}
+}
+
+func TestBeforeCompletionDecisionOrchestratorRunsUserRepoBeforeInternalAndFeedsDecision(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{events: make(chan RuntimeEvent, 16)}
+
+	var (
+		mu       sync.Mutex
+		callFlow []string
+	)
+	appendCall := func(value string) {
+		mu.Lock()
+		callFlow = append(callFlow, value)
+		mu.Unlock()
+	}
+
+	baseRegistry := runtimehooks.NewRegistry()
+	if err := baseRegistry.Register(runtimehooks.HookSpec{
+		ID:     "internal-before-completion",
+		Point:  runtimehooks.HookPointBeforeCompletionDecision,
+		Scope:  runtimehooks.HookScopeInternal,
+		Source: runtimehooks.HookSourceInternal,
+		Handler: func(_ context.Context, _ runtimehooks.HookContext) runtimehooks.HookResult {
+			appendCall("internal")
+			return runtimehooks.HookResult{Status: runtimehooks.HookResultPass}
+		},
+	}); err != nil {
+		t.Fatalf("register internal hook: %v", err)
+	}
+
+	userRegistry := runtimehooks.NewRegistry()
+	if err := userRegistry.Register(runtimehooks.HookSpec{
+		ID:     "user-before-completion",
+		Point:  runtimehooks.HookPointBeforeCompletionDecision,
+		Scope:  runtimehooks.HookScopeUser,
+		Source: runtimehooks.HookSourceUser,
+		Handler: func(_ context.Context, _ runtimehooks.HookContext) runtimehooks.HookResult {
+			appendCall("user")
+			return runtimehooks.HookResult{Status: runtimehooks.HookResultFailed, Message: "user guard signal"}
+		},
+	}); err != nil {
+		t.Fatalf("register user hook: %v", err)
+	}
+
+	repoRegistry := runtimehooks.NewRegistry()
+	if err := repoRegistry.Register(runtimehooks.HookSpec{
+		ID:     "repo-before-completion",
+		Point:  runtimehooks.HookPointBeforeCompletionDecision,
+		Scope:  runtimehooks.HookScopeRepo,
+		Source: runtimehooks.HookSourceRepo,
+		Handler: func(_ context.Context, _ runtimehooks.HookContext) runtimehooks.HookResult {
+			appendCall("repo")
+			return runtimehooks.HookResult{Status: runtimehooks.HookResultPass, Message: "repo annotation"}
+		},
+	}); err != nil {
+		t.Fatalf("register repo hook: %v", err)
+	}
+
+	baseExecutor := runtimehooks.NewExecutor(baseRegistry, newHookRuntimeEventEmitter(service), time.Second)
+	userExecutor := runtimehooks.NewExecutor(userRegistry, newHookRuntimeEventEmitter(service), time.Second)
+	repoExecutor := runtimehooks.NewExecutor(repoRegistry, newHookRuntimeEventEmitter(service), time.Second)
+	service.SetHookExecutor(composeRuntimeHookExecutors(baseExecutor, userExecutor, repoExecutor))
+
+	session := newRuntimeSession("session-before-completion-orchestrator")
+	state := newRunState("run-before-completion-orchestrator", session)
+	signals := service.runBeforeCompletionDecisionOrchestrator(
+		context.Background(),
+		&state,
+		t.TempDir(),
+		true,
+		false,
+		providertypes.RoleAssistant,
+	)
+	if got := strings.Join(callFlow, ","); got != "user,repo,internal" {
+		t.Fatalf("before_completion_decision hook order = %q, want %q", got, "user,repo,internal")
+	}
+	if len(signals.Annotations) < 2 {
+		t.Fatalf("signals annotations = %+v, want at least user/repo messages", signals.Annotations)
+	}
+	if len(signals.Guards) == 0 {
+		t.Fatal("expected guard signal from user hook failure")
+	}
+
+	snapshotCfg := TurnBudgetSnapshot{
+		Config:  config.StaticDefaults().Clone(),
+		Workdir: t.TempDir(),
+	}
+	state.session.TaskState.VerificationProfile = agentsession.VerificationProfileTaskOnly
+	decision, err := service.beforeAcceptFinal(
+		context.Background(),
+		&state,
+		snapshotCfg,
+		providertypes.Message{Role: providertypes.RoleAssistant, Parts: []providertypes.ContentPart{providertypes.NewTextPart("done")}},
+		true,
+		signals,
+	)
+	if err != nil {
+		t.Fatalf("beforeAcceptFinal() error = %v", err)
+	}
+	if !strings.Contains(decision.InternalSummary, "hook signals consumed") {
+		t.Fatalf("decision internal summary should include hook signal context, got %q", decision.InternalSummary)
 	}
 }
 

--- a/internal/runtime/run.go
+++ b/internal/runtime/run.go
@@ -344,34 +344,27 @@ func (s *Service) Run(ctx context.Context, input UserInput) (err error) {
 				if err := s.setBaseRunState(ctx, &state, controlplane.RunStateVerify); err != nil {
 					return s.handleRunError(err)
 				}
-				completionHookOutput := s.runHookPoint(
+				completionHookSignals := s.runBeforeCompletionDecisionOrchestrator(
 					ctx,
 					&state,
-					runtimehooks.HookPointBeforeCompletionDecision,
-					runtimehooks.HookContext{
-						Metadata: map[string]any{
-							"completion_passed": completed,
-							"has_tool_calls":    hasToolCalls,
-							"assistant_role":    strings.TrimSpace(turnOutput.assistant.Role),
-							"workdir":           strings.TrimSpace(snapshot.Workdir),
-						},
-					},
+					snapshot.Workdir,
+					completed,
+					hasToolCalls,
+					turnOutput.assistant.Role,
 				)
-				if completionHookOutput.Blocked {
-					s.emitRunScoped(ctx, EventHookBlocked, &state, HookBlockedPayload{
-						HookID:   strings.TrimSpace(completionHookOutput.BlockedBy),
-						Source:   string(findHookBlockSource(completionHookOutput)),
-						Point:    string(runtimehooks.HookPointBeforeCompletionDecision),
-						Reason:   findHookBlockMessage(completionHookOutput),
-						Enforced: false,
-					})
-				}
 
 				s.emitRunScopedOptional(EventVerificationStarted, &state, VerificationStartedPayload{
 					CompletionPassed:        completed,
 					CompletionBlockedReason: strings.TrimSpace(string(state.completion.CompletionBlockedReason)),
 				})
-				acceptanceDecision, err := s.beforeAcceptFinal(ctx, &state, snapshot, turnOutput.assistant, completed)
+				acceptanceDecision, err := s.beforeAcceptFinal(
+					ctx,
+					&state,
+					snapshot,
+					turnOutput.assistant,
+					completed,
+					completionHookSignals,
+				)
 				if err != nil {
 					return s.handleRunError(err)
 				}

--- a/internal/runtime/run.go
+++ b/internal/runtime/run.go
@@ -344,53 +344,20 @@ func (s *Service) Run(ctx context.Context, input UserInput) (err error) {
 				if err := s.setBaseRunState(ctx, &state, controlplane.RunStateVerify); err != nil {
 					return s.handleRunError(err)
 				}
-				completionHookSignals := s.runBeforeCompletionDecisionOrchestrator(
+				acceptanceDecision, err := s.runBeforeCompletionDecisionAcceptance(
 					ctx,
 					&state,
+					snapshot,
+					turnOutput.assistant,
 					snapshot.Workdir,
 					completed,
 					hasToolCalls,
 					turnOutput.assistant.Role,
 				)
-
-				s.emitRunScopedOptional(EventVerificationStarted, &state, VerificationStartedPayload{
-					CompletionPassed:        completed,
-					CompletionBlockedReason: strings.TrimSpace(string(state.completion.CompletionBlockedReason)),
-				})
-				acceptanceDecision, err := s.beforeAcceptFinal(
-					ctx,
-					&state,
-					snapshot,
-					turnOutput.assistant,
-					completed,
-					completionHookSignals,
-				)
 				if err != nil {
 					return s.handleRunError(err)
 				}
-				for _, result := range acceptanceDecision.VerifierResults {
-					s.emitRunScopedOptional(EventVerificationStageFinished, &state, VerificationStageFinishedPayload{
-						Name:       result.Name,
-						Status:     result.Status,
-						Summary:    result.Summary,
-						Reason:     result.Reason,
-						ErrorClass: result.ErrorClass,
-					})
-				}
-				s.emitRunScopedOptional(EventVerificationFinished, &state, VerificationFinishedPayload{
-					AcceptanceStatus: acceptanceDecision.Status,
-					StopReason:       acceptanceDecision.StopReason,
-					ErrorClass:       acceptanceDecision.ErrorClass,
-				})
-				s.emitRunScopedOptional(EventAcceptanceDecided, &state, AcceptanceDecidedPayload{
-					Status:                  acceptanceDecision.Status,
-					StopReason:              acceptanceDecision.StopReason,
-					ErrorClass:              acceptanceDecision.ErrorClass,
-					CompletionBlockedReason: strings.TrimSpace(acceptanceDecision.CompletionBlockedReason),
-					UserVisibleSummary:      acceptanceDecision.UserVisibleSummary,
-					InternalSummary:         acceptanceDecision.InternalSummary,
-					ContinueHint:            acceptanceDecision.ContinueHint,
-				})
+				s.emitAcceptanceDecisionEvents(&state, acceptanceDecision)
 				applyAcceptanceResultProgress(&state, acceptanceDecision)
 
 				switch acceptanceDecision.Status {


### PR DESCRIPTION
## 关联 Issue
- Closes #495

## 实现语义（与代码一致）
本 PR 将 final acceptance 收敛到 `before_completion_decision` 专用编排阶段：
先收集 user/repo hook signals，再由 runtime 内部 `AcceptanceService` 执行 completion gate + verification gate + decider 聚合，最终输出唯一 `AcceptanceDecision`。

## 变更摘要
1. `before_completion_decision` 编排收敛
- 顺序固定：user/repo signals -> ordinary internal observe -> AcceptanceService decision。
- 注释已明确：`AcceptanceDecision` 走强类型 runtime 内部路径，不通过通用 `HookResult` metadata 承载。

2. P7 主链单路径标识
- `beforeAcceptFinalLegacy` 标注为 Deprecated（rollback/对照用，主链不调用）。
- `mapDeciderDecisionToAcceptance` 标注为 Deprecated（仅 legacy 回滚对照/测试使用）。

3. completion + verification 双 gate
- `accepted` 仅在 `completion_passed && verification_passed` 时成立。
- completion/verification 任一未通过均不得 accepted。

4. error_class 兜底统一
- `AcceptanceService` 对关键 stop reason 做稳定 error_class 补齐，避免 TUI/Gateway 落入空/unknown 推断歧义。
- 覆盖 `verification_config_missing / execution_denied / execution_error / required_todo_failed / no_progress_after_final_intercept / verification_failed` 相关分支。

## 测试
新增/增强 `internal/runtime/acceptance_service_test.go`：
- hooks on/off parity（accepted/continue 场景终态一致）
- 双 gate 约束（两种单侧失败 + 双侧通过）
- chat answer（“你好”）不会被 verification 误拦
- no-progress 达阈值 -> `incomplete + no_progress_after_final_intercept`
- error_class 覆盖分支

并验证：
- `go test ./internal/runtime -run "Test(BeforeCompletionDecisionAcceptanceHooksOnOffParity|AcceptanceDecisionRequiresCompletionAndVerification|BeforeCompletionDecisionUserRepoCannotDirectlyTerminal|ChatAnswerAcceptancePassesWithoutHeavyVerification|NoProgressThresholdProducesIncomplete|VerificationFailureProducesStopReasonAndErrorClass|NormalizeAcceptanceErrorClassCoverage)" -count=1`
- `go test ./internal/runtime/decider ./internal/runtime/acceptance ./internal/runtime/verify ./internal/runtime/hooks -count=1`

## 非本 PR 范围
- provider 重构
- external hook kinds
- user/repo async
- TUI 大改
- FinalDecider 大拆分