### PR TITLE
feat(runtime-hooks): #494 P6-lite builtin hooks 用户可配置体验闭环（builtin-only）

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,13 +180,14 @@ go run ./cmd/neocode --session <session_id>
 
 ---
 
-## Gateway / MCP / Skills
+## Gateway / MCP / Skills / Hooks
 
 详细说明在文档内：
 
 - [Gateway 集成与协议（Guide）](https://neocode-docs.pages.dev/guide/gateway)
 - [MCP 工具接入（Guide）](https://neocode-docs.pages.dev/guide/mcp)
 - [Skills 使用（Guide）](https://neocode-docs.pages.dev/guide/skills)
+- [Hooks 使用（Guide）](https://neocode-docs.pages.dev/guide/hooks)
 - [工具与权限（Guide）](https://neocode-docs.pages.dev/guide/tools-permissions)
 - [Runtime / Provider 事件流（Repo Doc）](docs/runtime-provider-event-flow.md)
 
@@ -197,9 +198,6 @@ go run ./cmd/neocode --session <session_id>
 - 官方文档站：[https://neocode-docs.pages.dev/](https://neocode-docs.pages.dev/)
 - 快速引导（中文）：[www/guide/index.md](www/guide/index.md)
 - [配置指南](https://neocode-docs.pages.dev/guide/configuration)
-- [工具与权限](https://neocode-docs.pages.dev/guide/tools-permissions)
-- [Skills 使用](https://neocode-docs.pages.dev/guide/skills)
-- [MCP 工具接入](https://neocode-docs.pages.dev/guide/mcp)
 - [升级与版本检查](https://neocode-docs.pages.dev/guide/update)
 - [排障与常见问题](https://neocode-docs.pages.dev/guide/troubleshooting)
 

--- a/docs/examples/hooks.yaml
+++ b/docs/examples/hooks.yaml
@@ -1,0 +1,33 @@
+hooks:
+  items:
+    - id: project-context
+      enabled: true
+      point: user_prompt_submit
+      scope: repo
+      kind: builtin
+      mode: sync
+      handler: add_context_note
+      params:
+        note: "本项目要求优先小改，不允许无说明的大范围重构。"
+
+    - id: warn-bash
+      enabled: true
+      point: before_tool_call
+      scope: repo
+      kind: builtin
+      mode: sync
+      handler: warn_on_tool_call
+      params:
+        tool_names: ["bash"]
+        message: "执行 bash 前请确认命令不会破坏工作区。"
+
+    - id: require-readme-before-final
+      enabled: true
+      point: before_completion_decision
+      scope: repo
+      kind: builtin
+      mode: sync
+      handler: require_file_exists
+      params:
+        path: "README.md"
+        message: "请先补齐 README.md。"

--- a/docs/examples/user-hooks-config.yaml
+++ b/docs/examples/user-hooks-config.yaml
@@ -1,0 +1,30 @@
+selected_provider: openai
+current_model: gpt-5.4
+
+runtime:
+  hooks:
+    enabled: true
+    user_hooks_enabled: true
+    default_timeout_sec: 2
+    default_failure_policy: warn_only
+    items:
+      - id: user-context-note
+        enabled: true
+        point: user_prompt_submit
+        scope: user
+        kind: builtin
+        mode: sync
+        handler: add_context_note
+        params:
+          note: "优先最小改动，避免无说明的大范围重构。"
+
+      - id: user-warn-bash
+        enabled: true
+        point: before_tool_call
+        scope: user
+        kind: builtin
+        mode: sync
+        handler: warn_on_tool_call
+        params:
+          tool_names: ["bash"]
+          message: "执行 bash 前请确认命令不会破坏工作区。"

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -191,6 +191,12 @@ trust store 示例：
 docs/examples/hooks.yaml
 ```
 
+全局 user hooks 示例见：
+
+```text
+docs/examples/user-hooks-config.yaml
+```
+
 ## Budget 解析规则
 
 NeoCode 已不再使用旧的 `auto_compact` 阈值语义，当前统一使用 `context.budget`：

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -179,10 +179,17 @@ trust store 示例：
 
 - `runtime.hooks.enabled=false` 会关闭全部 hooks（internal/user/repo）。
 - repo hooks 仅支持 builtin 子集（上述 points + 3 个 handlers）。
+- P6-lite 阶段会显式拒绝 external kinds（`command/http/prompt/agent`），报错并且不会注册执行。
 - 执行顺序固定：`internal -> user -> repo`。
 - 跨来源同 ID 允许并存；同来源内重复 ID 会报错。
 - trust store 缺失/空文件/损坏 JSON/结构错误时，按 untrusted 处理并发出 `repo_hooks_trust_store_invalid` 事件，不阻断启动。
 - `before_permission_decision` / `pre_compact` / `subagent_start` 不允许 user/repo 挂载，配置会 fail-fast。
+
+完整仓库级示例见：
+
+```text
+docs/examples/hooks.yaml
+```
 
 ## Budget 解析规则
 

--- a/docs/runtime-hooks-design.md
+++ b/docs/runtime-hooks-design.md
@@ -24,11 +24,13 @@ P2 仅支持：
 - `scope=user`
 - `kind=builtin`
 - `mode=sync`
-- 挂载点：`before_tool_call`、`after_tool_result`、`before_completion_decision`
+- 挂载点：与 `HookPointCapability` 中 `UserAllowed=true` 的点位一致，当前包括：
+  `before_tool_call`、`after_tool_result`、`before_completion_decision`、`after_tool_failure`、
+  `session_start`、`session_end`、`user_prompt_submit`、`post_compact`、`subagent_stop`
 - handler：`require_file_exists`、`warn_on_tool_call`、`add_context_note`
 - external kinds（`command/http/prompt/agent`）在 P6-lite 阶段显式拒绝，不会半生效
 
-当前（P3）明确定义：
+当前（P3）明确不支持：
 
 - user hook 修改 tool 输入或 tool result
 - user hook 直接写入 provider-facing prompt
@@ -43,7 +45,7 @@ repo hooks 文件路径固定为：
 <workspace>/.neocode/hooks.yaml
 ```
 
-仅支持与 P2 相同的 builtin 子集（`kind=builtin`、`mode=sync`、3 个 points、3 个 handlers）。
+仅支持与 P2 相同的 builtin 子集（`kind=builtin`、`mode=sync`、`UserAllowed=true` points、3 个 handlers）。
 external kinds（`command/http/prompt/agent`）在 P6-lite 阶段显式拒绝，不会加载执行。
 
 执行顺序固定为：

--- a/docs/runtime-hooks-design.md
+++ b/docs/runtime-hooks-design.md
@@ -11,10 +11,10 @@
 - P2：全局 user builtin hooks（`runtime.hooks`）
 - P3：repo hooks（`<workspace>/.neocode/hooks.yaml`）+ workspace trust gate（`~/.neocode/trusted-workspaces.json`）
 - P4：生命周期点位扩展（permission/session/compact/subagent）+ 点位能力矩阵
+- P5：internal hooks 支持 `async/async_rewake` + run 内存通知队列（ephemeral 注入）
 
 当前未实现能力：
 
-- async / async_rewake（P5）
 - command/http/prompt/agent hooks（P6）
 
 ## P2 user hooks 边界
@@ -26,6 +26,7 @@ P2 仅支持：
 - `mode=sync`
 - 挂载点：`before_tool_call`、`after_tool_result`、`before_completion_decision`
 - handler：`require_file_exists`、`warn_on_tool_call`、`add_context_note`
+- external kinds（`command/http/prompt/agent`）在 P6-lite 阶段显式拒绝，不会半生效
 
 当前（P3）明确定义：
 
@@ -43,6 +44,7 @@ repo hooks 文件路径固定为：
 ```
 
 仅支持与 P2 相同的 builtin 子集（`kind=builtin`、`mode=sync`、3 个 points、3 个 handlers）。
+external kinds（`command/http/prompt/agent`）在 P6-lite 阶段显式拒绝，不会加载执行。
 
 执行顺序固定为：
 
@@ -142,6 +144,12 @@ runtime 会透传 hooks 生命周期事件：
 `hook_finished/hook_failed` 包含 `message` 字段，用于承载 warning/note 文本。  
 hook 事件额外携带 `source` 字段；展示层建议使用 `<source>:<id>`。  
 user/repo hook 的 `message` 会进入 runtime 的 annotation buffer（运行态内存缓冲），用于后续观测与诊断。
+
+## 示例配置
+
+- 全局 user builtin hooks：`~/.neocode/config.yaml` -> `runtime.hooks.items`
+- 仓库级 repo builtin hooks：`<workspace>/.neocode/hooks.yaml`
+- 示例文件：`docs/examples/hooks.yaml`
 
 ## 失败策略
 

--- a/internal/config/runtime_hooks.go
+++ b/internal/config/runtime_hooks.go
@@ -26,6 +26,13 @@ const (
 	runtimeHookModeSync    = "sync"
 )
 
+var runtimeHookExternalKinds = map[string]struct{}{
+	"command": {},
+	"http":    {},
+	"prompt":  {},
+	"agent":   {},
+}
+
 const (
 	runtimeHookPointBeforeToolCall           = "before_tool_call"
 	runtimeHookPointAfterToolResult          = "after_tool_result"
@@ -254,6 +261,12 @@ func (c RuntimeHookItemConfig) Validate(defaultFailurePolicy string) error {
 		return fmt.Errorf("scope %q is not supported", c.Scope)
 	}
 	if normalizedKind := strings.ToLower(strings.TrimSpace(c.Kind)); normalizedKind != runtimeHookKindBuiltIn {
+		if _, external := runtimeHookExternalKinds[normalizedKind]; external {
+			return fmt.Errorf(
+				"external hook kind %q is not supported in P6-lite; only builtin hooks are enabled",
+				c.Kind,
+			)
+		}
 		return fmt.Errorf("kind %q is not supported", c.Kind)
 	}
 	if normalizedMode := strings.ToLower(strings.TrimSpace(c.Mode)); normalizedMode != runtimeHookModeSync {

--- a/internal/config/runtime_hooks_test.go
+++ b/internal/config/runtime_hooks_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestRuntimeHooksConfigApplyDefaultsAndValidate(t *testing.T) {
 	t.Parallel()
@@ -90,6 +93,43 @@ func TestRuntimeHooksConfigValidateUnsupportedFields(t *testing.T) {
 		if err := cfg.Validate(); err == nil {
 			t.Fatalf("expected validate error for item=%+v", item)
 		}
+	}
+}
+
+func TestRuntimeHooksConfigValidateRejectsExternalKindsWithP6LiteMessage(t *testing.T) {
+	t.Parallel()
+
+	base := RuntimeHooksConfig{
+		Enabled:              boolPtr(true),
+		UserHooksEnabled:     boolPtr(true),
+		DefaultTimeoutSec:    2,
+		DefaultFailurePolicy: runtimeHookFailurePolicyWarnOnly,
+	}
+	externalKinds := []string{"command", "http", "prompt", "agent"}
+	for _, kind := range externalKinds {
+		kind := kind
+		t.Run(kind, func(t *testing.T) {
+			cfg := base.Clone()
+			cfg.Items = []RuntimeHookItemConfig{
+				{
+					ID:      "external-kind",
+					Point:   runtimeHookPointBeforeToolCall,
+					Scope:   runtimeHookScopeUser,
+					Kind:    kind,
+					Mode:    runtimeHookModeSync,
+					Handler: runtimeHookHandlerWarnOnToolCall,
+					Params:  map[string]any{"tool_name": "bash"},
+				},
+			}
+			cfg.ApplyDefaults(defaultRuntimeHooksConfig())
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("expected external kind %q to be rejected", kind)
+			}
+			if !strings.Contains(err.Error(), "not supported in P6-lite") {
+				t.Fatalf("error=%q, want contains not supported in P6-lite", err.Error())
+			}
+		})
 	}
 }
 

--- a/internal/runtime/repo_hooks.go
+++ b/internal/runtime/repo_hooks.go
@@ -29,6 +29,13 @@ const (
 	repoHookFailurePolicyFailClose = "fail_closed"
 )
 
+var repoHookExternalKinds = map[string]struct{}{
+	"command": {},
+	"http":    {},
+	"prompt":  {},
+	"agent":   {},
+}
+
 // repoHooksConfigFile 描述仓库 hooks 配置文件结构。
 type repoHooksConfigFile struct {
 	Hooks repoHooksSection `yaml:"hooks"`
@@ -335,7 +342,13 @@ func validateRepoHookItem(item config.RuntimeHookItemConfig) error {
 	if strings.ToLower(strings.TrimSpace(item.Scope)) != repoHookScopeValue {
 		return fmt.Errorf("scope %q is not supported", item.Scope)
 	}
-	if strings.ToLower(strings.TrimSpace(item.Kind)) != repoHookKindBuiltIn {
+	if normalizedKind := strings.ToLower(strings.TrimSpace(item.Kind)); normalizedKind != repoHookKindBuiltIn {
+		if _, external := repoHookExternalKinds[normalizedKind]; external {
+			return fmt.Errorf(
+				"external hook kind %q is not supported in P6-lite; only builtin hooks are enabled",
+				item.Kind,
+			)
+		}
 		return fmt.Errorf("kind %q is not supported", item.Kind)
 	}
 	if strings.ToLower(strings.TrimSpace(item.Mode)) != repoHookModeSync {

--- a/internal/runtime/repo_hooks_test.go
+++ b/internal/runtime/repo_hooks_test.go
@@ -261,6 +261,72 @@ hooks:
 	}
 }
 
+func TestRepoHookExecutionEventCarriesRepoSource(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	workspace := t.TempDir()
+	hooksPath := filepath.Join(workspace, ".neocode", "hooks.yaml")
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o755); err != nil {
+		t.Fatalf("mkdir hooks dir: %v", err)
+	}
+	content := `
+hooks:
+  items:
+    - id: repo-note
+      point: before_tool_call
+      scope: repo
+      kind: builtin
+      mode: sync
+      handler: add_context_note
+      params:
+        note: repo-note
+`
+	if err := os.WriteFile(hooksPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write hooks: %v", err)
+	}
+	storePath := resolveTrustedWorkspacesPath()
+	if err := os.MkdirAll(filepath.Dir(storePath), 0o755); err != nil {
+		t.Fatalf("mkdir trust store dir: %v", err)
+	}
+	rawStore, err := json.Marshal(trustedWorkspaceStore{
+		Version:    repoHooksTrustStoreVersion,
+		Workspaces: []string{workspace},
+	})
+	if err != nil {
+		t.Fatalf("marshal trust store: %v", err)
+	}
+	if err := os.WriteFile(storePath, rawStore, 0o644); err != nil {
+		t.Fatalf("write trust store: %v", err)
+	}
+
+	service := &Service{events: make(chan RuntimeEvent, 64)}
+	exec, err := buildRepoHookExecutorForWorkspace(service, workspace, config.StaticDefaults().Runtime.Hooks)
+	if err != nil {
+		t.Fatalf("buildRepoHookExecutorForWorkspace() error = %v", err)
+	}
+	if exec == nil {
+		t.Fatal("expected repo executor for trusted workspace")
+	}
+	_ = exec.Run(
+		context.Background(),
+		runtimehooks.HookPointBeforeToolCall,
+		runtimehooks.HookContext{Metadata: map[string]any{"tool_name": "bash", "workdir": workspace}},
+	)
+
+	events := collectRuntimeEvents(service.Events())
+	finishedIndex := eventIndex(events, EventHookFinished)
+	if finishedIndex < 0 {
+		t.Fatal("expected hook_finished event from repo hook execution")
+	}
+	payload, ok := events[finishedIndex].Payload.(HookEventPayload)
+	if !ok {
+		t.Fatalf("payload type = %T, want HookEventPayload", events[finishedIndex].Payload)
+	}
+	if payload.Source != string(runtimehooks.HookSourceRepo) {
+		t.Fatalf("payload.Source = %q, want %q", payload.Source, runtimehooks.HookSourceRepo)
+	}
+}
+
 func TestBuildRepoHookExecutorMissingTrustStoreEmitsInvalidEvent(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
@@ -300,6 +366,57 @@ hooks:
 	}
 	if !containsRuntimeEventType(events, EventRepoHooksSkippedUntrusted) {
 		t.Fatalf("expected %s event", EventRepoHooksSkippedUntrusted)
+	}
+}
+
+func TestBuildRepoHookExecutorRejectsExternalKindAndDoesNotRegister(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	workspace := t.TempDir()
+	hooksPath := filepath.Join(workspace, ".neocode", "hooks.yaml")
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o755); err != nil {
+		t.Fatalf("mkdir hooks dir: %v", err)
+	}
+	content := `
+hooks:
+  items:
+    - id: repo-external-command
+      point: before_tool_call
+      scope: repo
+      kind: command
+      mode: sync
+      handler: warn_on_tool_call
+      params:
+        tool_name: bash
+`
+	if err := os.WriteFile(hooksPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write hooks: %v", err)
+	}
+	storePath := resolveTrustedWorkspacesPath()
+	if err := os.MkdirAll(filepath.Dir(storePath), 0o755); err != nil {
+		t.Fatalf("mkdir trust store dir: %v", err)
+	}
+	rawStore, err := json.Marshal(trustedWorkspaceStore{
+		Version:    repoHooksTrustStoreVersion,
+		Workspaces: []string{workspace},
+	})
+	if err != nil {
+		t.Fatalf("marshal trust store: %v", err)
+	}
+	if err := os.WriteFile(storePath, rawStore, 0o644); err != nil {
+		t.Fatalf("write trust store: %v", err)
+	}
+
+	service := &Service{events: make(chan RuntimeEvent, 16)}
+	exec, err := buildRepoHookExecutorForWorkspace(service, workspace, config.StaticDefaults().Runtime.Hooks)
+	if err == nil {
+		t.Fatal("expected external kind in repo hook config to be rejected")
+	}
+	if !strings.Contains(err.Error(), "not supported in P6-lite") {
+		t.Fatalf("error=%q, want contains not supported in P6-lite", err.Error())
+	}
+	if exec != nil {
+		t.Fatalf("unexpected repo executor after rejection: %T", exec)
 	}
 }
 
@@ -443,6 +560,37 @@ func TestValidateRepoHookItemBranches(t *testing.T) {
 			tc.edit(&item)
 			if err := validateRepoHookItem(item); err == nil {
 				t.Fatalf("validateRepoHookItem(%s) expected error", tc.name)
+			}
+		})
+	}
+}
+
+func TestValidateRepoHookItemRejectsExternalKindsWithP6LiteMessage(t *testing.T) {
+	t.Parallel()
+
+	base := config.RuntimeHookItemConfig{
+		ID:            "repo-hook",
+		Point:         "before_tool_call",
+		Scope:         "repo",
+		Kind:          "builtin",
+		Mode:          "sync",
+		Handler:       "add_context_note",
+		TimeoutSec:    2,
+		FailurePolicy: "warn_only",
+		Params:        map[string]any{"note": "x"},
+	}
+	externalKinds := []string{"command", "http", "prompt", "agent"}
+	for _, kind := range externalKinds {
+		kind := kind
+		t.Run(kind, func(t *testing.T) {
+			item := base.Clone()
+			item.Kind = kind
+			err := validateRepoHookItem(item)
+			if err == nil {
+				t.Fatalf("expected external kind %q to be rejected", kind)
+			}
+			if !strings.Contains(err.Error(), "not supported in P6-lite") {
+				t.Fatalf("error=%q, want contains not supported in P6-lite", err.Error())
 			}
 		})
 	}

--- a/internal/runtime/user_hooks.go
+++ b/internal/runtime/user_hooks.go
@@ -173,6 +173,9 @@ func buildConfiguredHookSpec(
 	scope runtimehooks.HookScope,
 	source runtimehooks.HookSource,
 ) (runtimehooks.HookSpec, error) {
+	if err := validateConfiguredHookItemForP6Lite(item, scope); err != nil {
+		return runtimehooks.HookSpec{}, err
+	}
 	handler, err := buildUserBuiltinHookHandler(strings.TrimSpace(item.Handler), item.Params, defaultWorkdir)
 	if err != nil {
 		return runtimehooks.HookSpec{}, err
@@ -189,6 +192,41 @@ func buildConfiguredHookSpec(
 		FailurePolicy: mapRuntimeHookFailurePolicy(item.FailurePolicy),
 		Handler:       handler,
 	}, nil
+}
+
+// validateConfiguredHookItemForP6Lite 在 runtime 装配阶段执行兜底校验，防止绕过配置层校验后出现半生效。
+func validateConfiguredHookItemForP6Lite(item config.RuntimeHookItemConfig, scope runtimehooks.HookScope) error {
+	expectedScope := strings.TrimSpace(string(scope))
+	actualScope := strings.ToLower(strings.TrimSpace(item.Scope))
+	if actualScope != expectedScope {
+		return fmt.Errorf("scope %q is not supported", item.Scope)
+	}
+
+	kind := strings.ToLower(strings.TrimSpace(item.Kind))
+	if kind != "builtin" {
+		if isExternalHookKind(kind) {
+			return fmt.Errorf(
+				"external hook kind %q is not supported in P6-lite; only builtin hooks are enabled",
+				item.Kind,
+			)
+		}
+		return fmt.Errorf("kind %q is not supported", item.Kind)
+	}
+
+	mode := strings.ToLower(strings.TrimSpace(item.Mode))
+	if mode != "sync" {
+		return fmt.Errorf("mode %q is not supported", item.Mode)
+	}
+	return nil
+}
+
+func isExternalHookKind(kind string) bool {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "command", "http", "prompt", "agent":
+		return true
+	default:
+		return false
+	}
 }
 
 func mapRuntimeHookFailurePolicy(policy string) runtimehooks.FailurePolicy {

--- a/internal/runtime/user_hooks_test.go
+++ b/internal/runtime/user_hooks_test.go
@@ -558,6 +558,31 @@ func TestConfigureRuntimeHooksFromConfigNoEnabledUserItemsKeepsRepoCapableExecut
 	}
 }
 
+func TestConfigureRuntimeHooksWithoutItemsKeepsBehaviorUnchanged(t *testing.T) {
+	t.Parallel()
+
+	cfg := *config.StaticDefaults()
+	cfg.Workdir = t.TempDir()
+	cfg.Runtime.Hooks.Items = nil
+	cfg.Runtime.Hooks.ApplyDefaults(config.StaticDefaults().Runtime.Hooks)
+
+	service := &Service{events: make(chan RuntimeEvent, 8)}
+	if err := configureRuntimeHooksFromConfig(service, cfg); err != nil {
+		t.Fatalf("configureRuntimeHooksFromConfig() error = %v", err)
+	}
+	if service.hookExecutor == nil {
+		t.Fatal("expected runtime hooks chain to remain available for repo discovery")
+	}
+	out := service.hookExecutor.Run(
+		context.Background(),
+		runtimehooks.HookPointBeforeToolCall,
+		runtimehooks.HookContext{Metadata: map[string]any{"tool_name": "bash", "workdir": cfg.Workdir}},
+	)
+	if out.Blocked || len(out.Results) != 0 {
+		t.Fatalf("unexpected hook output without user/repo config: %+v", out)
+	}
+}
+
 func TestBuildUserBuiltinHookHandlerEdgeCases(t *testing.T) {
 	t.Parallel()
 
@@ -621,6 +646,38 @@ func TestBuildUserBuiltinHookHandlerEdgeCases(t *testing.T) {
 	}
 	_ = defaultWorkdirHandler(context.Background(), runtimehooks.HookContext{Metadata: map[string]any{"workdir": ""}})
 
+}
+
+func TestConfigureRuntimeHooksRejectsExternalKindAndDoesNotRegister(t *testing.T) {
+	t.Parallel()
+
+	cfg := *config.StaticDefaults()
+	cfg.Workdir = t.TempDir()
+	cfg.Runtime.Hooks.Items = []config.RuntimeHookItemConfig{
+		{
+			ID:      "external-command",
+			Enabled: runtimeBoolPtr(true),
+			Point:   "before_tool_call",
+			Scope:   "user",
+			Kind:    "command",
+			Mode:    "sync",
+			Handler: "warn_on_tool_call",
+			Params:  map[string]any{"tool_name": "bash"},
+		},
+	}
+	cfg.Runtime.Hooks.ApplyDefaults(config.StaticDefaults().Runtime.Hooks)
+
+	service := &Service{events: make(chan RuntimeEvent, 8)}
+	err := configureRuntimeHooksFromConfig(service, cfg)
+	if err == nil {
+		t.Fatal("expected external kind to be rejected")
+	}
+	if !strings.Contains(err.Error(), "not supported in P6-lite") {
+		t.Fatalf("error=%q, want contains not supported in P6-lite", err.Error())
+	}
+	if service.hookExecutor != nil {
+		t.Fatalf("unexpected hook executor after external kind rejection: %T", service.hookExecutor)
+	}
 }
 
 func TestConfigureRuntimeHooksInjectsAsyncResultSinkIntoBaseExecutor(t *testing.T) {

--- a/internal/runtime/user_hooks_test.go
+++ b/internal/runtime/user_hooks_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"neo-code/internal/config"
+	providertypes "neo-code/internal/provider/types"
 	runtimehooks "neo-code/internal/runtime/hooks"
 )
 
@@ -677,6 +678,81 @@ func TestConfigureRuntimeHooksRejectsExternalKindAndDoesNotRegister(t *testing.T
 	}
 	if service.hookExecutor != nil {
 		t.Fatalf("unexpected hook executor after external kind rejection: %T", service.hookExecutor)
+	}
+}
+
+func TestUserBuiltinHookConfiguredEndToEndOnUserPromptSubmit(t *testing.T) {
+	t.Parallel()
+
+	manager := newRuntimeConfigManager(t)
+	if err := manager.Update(context.Background(), func(cfg *config.Config) error {
+		cfg.Runtime.Hooks.Items = []config.RuntimeHookItemConfig{
+			{
+				ID:      "user-context-note",
+				Enabled: runtimeBoolPtr(true),
+				Point:   "user_prompt_submit",
+				Scope:   "user",
+				Kind:    "builtin",
+				Mode:    "sync",
+				Handler: "add_context_note",
+				Params:  map[string]any{"note": "user note from config"},
+			},
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("update runtime hook config: %v", err)
+	}
+
+	store := newMemoryStore()
+	scripted := &scriptedProvider{
+		streams: [][]providertypes.StreamEvent{
+			{
+				providertypes.NewTextDeltaStreamEvent("ok"),
+				providertypes.NewMessageDoneStreamEvent("", nil),
+			},
+		},
+	}
+	service := NewWithFactory(
+		manager,
+		&stubToolManager{},
+		store,
+		&scriptedProviderFactory{provider: scripted},
+		&stubContextBuilder{},
+	)
+	if err := configureRuntimeHooksFromConfig(service, manager.Get()); err != nil {
+		t.Fatalf("configureRuntimeHooksFromConfig() error = %v", err)
+	}
+	if err := service.Run(context.Background(), UserInput{
+		RunID: "run-user-hook-user-prompt-submit",
+		Parts: []providertypes.ContentPart{providertypes.NewTextPart("hello")},
+	}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	events := collectRuntimeEvents(service.Events())
+	found := false
+	for _, evt := range events {
+		if evt.Type != EventHookFinished {
+			continue
+		}
+		payload, ok := evt.Payload.(HookEventPayload)
+		if !ok {
+			continue
+		}
+		if payload.Point != string(runtimehooks.HookPointUserPromptSubmit) {
+			continue
+		}
+		if payload.Source != string(runtimehooks.HookSourceUser) {
+			t.Fatalf("payload.Source = %q, want %q", payload.Source, runtimehooks.HookSourceUser)
+		}
+		if payload.Message != "user note from config" {
+			t.Fatalf("payload.Message = %q, want %q", payload.Message, "user note from config")
+		}
+		found = true
+		break
+	}
+	if !found {
+		t.Fatal("expected user_prompt_submit hook_finished event from user config hook")
 	}
 }
 

--- a/www/.vitepress/config.mts
+++ b/www/.vitepress/config.mts
@@ -105,6 +105,7 @@ export default defineConfig({
               items: [
                 { text: "MCP 工具接入", link: "/guide/mcp" },
                 { text: "Skills 使用", link: "/guide/skills" },
+                { text: "Hooks 使用", link: "/guide/hooks" },
               ],
             },
             {

--- a/www/guide/hooks.md
+++ b/www/guide/hooks.md
@@ -5,46 +5,42 @@ description: 通过安全 builtin hooks 在 runtime 生命周期点配置用户/
 
 # Hooks 使用指南
 
-Hook 是 NeoCode runtime 生命周期里的受控扩展点。你可以在固定 HookPoint 上配置规则，让运行过程附加注释、告警或守卫信号。
+Hooks 是给 NeoCode 加“运行规则”的方式。
 
-Hook 不是让配置文件执行任意脚本，而是在 NeoCode 已定义的生命周期点位上，执行受控的 builtin handler。
+它不是任意脚本执行器。你只能在固定点位配置内置能力（builtin handler）。
 
-当前阶段是 P6-lite：
+如果你是第一次接触，可以把它理解成三件事：
 
-- 仅开放 builtin hooks。
-- `command` / `http` / `prompt` / `agent` 等 external kinds 暂不开放。
-- user/repo 配置主路径为 `sync`，`async` / `async_rewake` 主要用于 internal hooks。
+1. 在任务开始时给模型补一条规则（例如“优先最小改动”）  
+2. 在调用某些工具时给提醒（例如调用 `bash` 前提醒）  
+3. 在任务完成前做简单检查（例如 `README.md` 必须存在）
 
-## Hook 来源与顺序
+## 什么时候用 Hooks
 
-Hook 有三类来源：
+| 需求 | 建议 |
+|---|---|
+| 每次都想提醒模型遵守同一条习惯 | 用 `add_context_note` |
+| 调用某些工具时想打提示 | 用 `warn_on_tool_call` |
+| 完成前需要一个文件存在 | 用 `require_file_exists` |
+| 想执行自定义脚本或 HTTP 回调 | 当前不支持（见下文） |
 
-- `internal`：NeoCode 内部系统 hook，用于安全、验收、事件与 runtime 控制。
-- `user`：用户全局 hook，配置在 `~/.neocode/config.yaml`，影响该用户所有工作区。
-- `repo`：项目级 hook，配置在 `<workspace>/.neocode/hooks.yaml`，用于表达项目规则。
+## 配置放在哪里
 
-执行顺序固定为：
-
-```text
-internal -> user -> repo
-```
-
-边界说明：
-
-- user/repo 不会高于 internal。
-- repo hook 默认不执行，只有 workspace 被 trust 后才执行。
-- user/repo 都受 HookPoint capability matrix 限制。
-- 在 `before_completion_decision` 阶段，user/repo 只提供 annotation / guard signal，不直接决定 `accepted/failed/incomplete`；最终裁决由 runtime 内部 acceptance 决策链路完成。
-
-## 配置路径
-
-全局 user hooks：
+全局（对你所有项目生效）：
 
 ```text
 ~/.neocode/config.yaml
 ```
 
-配置位置：
+项目级（只对当前工作区生效）：
+
+```text
+<workspace>/.neocode/hooks.yaml
+```
+
+## 先抄可用模板
+
+### A. 全局规则（推荐先用）
 
 ```yaml
 runtime:
@@ -52,109 +48,74 @@ runtime:
     enabled: true
     user_hooks_enabled: true
     items:
-      ...
+      - id: user-context-note
+        enabled: true
+        point: user_prompt_submit
+        scope: user
+        kind: builtin
+        mode: sync
+        handler: add_context_note
+        params:
+          note: "优先最小改动，避免无说明的大范围重构。"
+
+      - id: user-warn-bash
+        enabled: true
+        point: before_tool_call
+        scope: user
+        kind: builtin
+        mode: sync
+        handler: warn_on_tool_call
+        params:
+          tool_names: ["bash"]
+          message: "执行 bash 前请确认命令不会破坏工作区。"
 ```
 
-项目 repo hooks：
+### B. 项目完成前检查
 
-```text
-<workspace>/.neocode/hooks.yaml
-```
-
-文件结构：
+在 `<workspace>/.neocode/hooks.yaml`：
 
 ```yaml
 hooks:
   items:
-    ...
+    - id: require-readme-before-final
+      enabled: true
+      point: before_completion_decision
+      scope: repo
+      kind: builtin
+      mode: sync
+      handler: require_file_exists
+      params:
+        path: "README.md"
+        message: "请先补齐 README.md。"
 ```
 
-## 支持的 Builtin Handlers
+## 支持哪些内置能力
 
-当前 P6-lite 仅支持这 3 个 handler：
+当前只支持 3 个 builtin handler：
 
-- `add_context_note`
-- `warn_on_tool_call`
-- `require_file_exists`
+| handler | 作用 | 常见点位 |
+|---|---|---|
+| `add_context_note` | 给本轮任务补充一条规则说明 | `user_prompt_submit` |
+| `warn_on_tool_call` | 调用指定工具时给提醒 | `before_tool_call` |
+| `require_file_exists` | 完成前检查文件是否存在 | `before_completion_decision` |
 
-### `add_context_note`
+字段说明（最常用）：
 
-用途：给当前 run 注入规则说明（例如“优先最小改动”）。
+- `params.note` / `params.message`：`add_context_note` 文案
+- `params.tool_name` 或 `params.tool_names`：`warn_on_tool_call` 目标工具
+- `params.path`：`require_file_exists` 要检查的文件
 
-常见挂点：`user_prompt_submit`
+## repo hooks 为什么有时不生效
 
-```yaml
-- id: user-context-note
-  enabled: true
-  point: user_prompt_submit
-  scope: user
-  kind: builtin
-  mode: sync
-  handler: add_context_note
-  params:
-    note: "优先最小改动，避免无说明的大范围重构。"
-```
+repo hooks 需要 workspace 先被信任（trusted）。
 
-补充：`params.message` 也可作为同义输入。
-
-### `warn_on_tool_call`
-
-用途：当模型调用指定工具时写入 warning/annotation（不改变主链行为）。
-
-常见挂点：`before_tool_call`
-
-```yaml
-- id: user-warn-bash
-  enabled: true
-  point: before_tool_call
-  scope: user
-  kind: builtin
-  mode: sync
-  handler: warn_on_tool_call
-  params:
-    tool_names: ["bash"]
-    message: "执行 bash 前请确认命令不会破坏工作区。"
-```
-
-补充：`params.tool_name`（单个）和 `params.tool_names`（多个）都支持。
-
-### `require_file_exists`
-
-用途：在完成前检查某个文件必须存在（如 `README.md`）。
-
-常见挂点：`before_completion_decision`
-
-```yaml
-- id: require-readme-before-final
-  enabled: true
-  point: before_completion_decision
-  scope: repo
-  kind: builtin
-  mode: sync
-  handler: require_file_exists
-  params:
-    path: "README.md"
-    message: "请先补齐 README.md。"
-```
-
-说明：`require_file_exists` 在 final 阶段提供 guard/annotation 信号，不直接输出最终 accepted/failed 结论。
-
-## Trusted Workspace（repo hooks 安全门）
-
-repo hooks 的安全模型是“先发现，后判定”：
-
-- 默认只发现 `<workspace>/.neocode/hooks.yaml`，不直接执行。
-- 仅当 workspace 在 trust store 中被标记为 trusted 时执行。
-- trust store 路径是：
+trust 文件路径：
 
 ```text
 ~/.neocode/trusted-workspaces.json
 ```
 
-- trust 文件缺失、空文件、损坏 JSON、结构不合法时，都按 untrusted 处理。
-- 当前 trust 由本地 trust store 文件驱动，没有独立 trust 管理命令。
-
-最小示例（路径必须是绝对路径）：
+最小示例（绝对路径）：
 
 ```json
 {
@@ -165,67 +126,19 @@ repo hooks 的安全模型是“先发现，后判定”：
 }
 ```
 
-## Capability Matrix 与安全边界
+如果文件缺失、格式错误或路径不在列表里，repo hooks 会被跳过。这是安全设计，不是 bug。
 
-不是所有 HookPoint 都允许 user/repo 挂载。当前 `UserAllowed=false` 的点位：
+## 怎么确认生效了
 
-- `before_permission_decision`
-- `pre_compact`
-- `subagent_start`
+1. 执行一次会触发 Hook 的任务  
+2. 在日志视图看事件（`Ctrl+L`）
 
-可用于 user/repo 的常见点位包括：
-
-- `user_prompt_submit`
-- `before_tool_call`
-- `after_tool_result`
-- `after_tool_failure`
-- `before_completion_decision`
-- `session_start` / `session_end`
-- `post_compact`
-- `subagent_stop`
-
-其他边界：
-
-- external kinds 暂不开放。
-- user/repo hook 上下文会做白名单裁剪，不暴露 API key、capability token、service 指针等敏感对象。
-- user/repo `mode` 当前仅支持 `sync`。
-
-## 当前不支持的 Hook Kind
-
-P6-lite 不支持：
-
-- `command`
-- `http`
-- `prompt`
-- `agent`
-
-配置这些 kind 时会被拒绝，例如：
-
-```text
-external hook kind "command" is not supported in P6-lite; only builtin hooks are enabled
-```
-
-暂缓原因：external hooks 涉及命令执行、网络请求、凭据泄露、prompt 注入和 agent 循环等风险，仍需后续 sandbox、allowlist、budget 与审计设计。
-
-## 如何确认 Hook 已生效
-
-可通过 runtime 事件日志确认：
+常见事件：
 
 - `hook_started`
 - `hook_finished`
 - `hook_failed`
-- `hook_blocked`
-- `repo_hooks_discovered`
-- `repo_hooks_loaded`
 - `repo_hooks_skipped_untrusted`
-- `repo_hooks_trust_store_invalid`
-
-关键字段包括：
-
-- `source`（`user` / `repo` / `internal`）
-- `point`
-- `hook_id`
-- `message`
 
 示例：
 
@@ -233,18 +146,16 @@ external hook kind "command" is not supported in P6-lite; only builtin hooks are
 hook_finished source=user point=user_prompt_submit hook_id=user-context-note message="优先最小改动..."
 ```
 
-在 TUI 中可通过日志视图查看（`Ctrl+L` 打开日志视图）。
+## 你需要知道的限制
 
-## Demo A：全局用户规则
+- 目前只支持 `kind: builtin`。
+- `command` / `http` / `prompt` / `agent` 暂不支持。
+- `mode` 对用户配置仅支持 `sync`。
+- 配置字段是 `params`，不是 `with`。
+- Hooks 主要用于“补充规则、提醒、检查”，不是最终裁决器。
 
-1. 在 `~/.neocode/config.yaml` 的 `runtime.hooks.items` 配置 `add_context_note`。
-2. 让 Agent 执行一次常规改动任务。
-3. 在日志中确认 `user_prompt_submit` 的 hook 事件。
-4. 当前 run 会收到“优先最小改动”注释。
+如果配置了不支持的 kind，会看到类似报错：
 
-## Demo B：项目完成前检查
-
-1. 在 `<workspace>/.neocode/hooks.yaml` 配置 `require_file_exists`（挂到 `before_completion_decision`）。
-2. workspace 未 trust 时，repo hook 会被跳过，并出现 `repo_hooks_skipped_untrusted`。
-3. 将 workspace 绝对路径写入 `~/.neocode/trusted-workspaces.json` 后再次运行。
-4. 在 final 阶段可看到对应 hook 事件与 guard 信号，再由 runtime acceptance 链路统一裁决。
+```text
+external hook kind "command" is not supported in P6-lite; only builtin hooks are enabled
+```

--- a/www/guide/hooks.md
+++ b/www/guide/hooks.md
@@ -1,0 +1,250 @@
+---
+title: Hooks 使用指南
+description: 通过安全 builtin hooks 在 runtime 生命周期点配置用户/项目规则。
+---
+
+# Hooks 使用指南
+
+Hook 是 NeoCode runtime 生命周期里的受控扩展点。你可以在固定 HookPoint 上配置规则，让运行过程附加注释、告警或守卫信号。
+
+Hook 不是让配置文件执行任意脚本，而是在 NeoCode 已定义的生命周期点位上，执行受控的 builtin handler。
+
+当前阶段是 P6-lite：
+
+- 仅开放 builtin hooks。
+- `command` / `http` / `prompt` / `agent` 等 external kinds 暂不开放。
+- user/repo 配置主路径为 `sync`，`async` / `async_rewake` 主要用于 internal hooks。
+
+## Hook 来源与顺序
+
+Hook 有三类来源：
+
+- `internal`：NeoCode 内部系统 hook，用于安全、验收、事件与 runtime 控制。
+- `user`：用户全局 hook，配置在 `~/.neocode/config.yaml`，影响该用户所有工作区。
+- `repo`：项目级 hook，配置在 `<workspace>/.neocode/hooks.yaml`，用于表达项目规则。
+
+执行顺序固定为：
+
+```text
+internal -> user -> repo
+```
+
+边界说明：
+
+- user/repo 不会高于 internal。
+- repo hook 默认不执行，只有 workspace 被 trust 后才执行。
+- user/repo 都受 HookPoint capability matrix 限制。
+- 在 `before_completion_decision` 阶段，user/repo 只提供 annotation / guard signal，不直接决定 `accepted/failed/incomplete`；最终裁决由 runtime 内部 acceptance 决策链路完成。
+
+## 配置路径
+
+全局 user hooks：
+
+```text
+~/.neocode/config.yaml
+```
+
+配置位置：
+
+```yaml
+runtime:
+  hooks:
+    enabled: true
+    user_hooks_enabled: true
+    items:
+      ...
+```
+
+项目 repo hooks：
+
+```text
+<workspace>/.neocode/hooks.yaml
+```
+
+文件结构：
+
+```yaml
+hooks:
+  items:
+    ...
+```
+
+## 支持的 Builtin Handlers
+
+当前 P6-lite 仅支持这 3 个 handler：
+
+- `add_context_note`
+- `warn_on_tool_call`
+- `require_file_exists`
+
+### `add_context_note`
+
+用途：给当前 run 注入规则说明（例如“优先最小改动”）。
+
+常见挂点：`user_prompt_submit`
+
+```yaml
+- id: user-context-note
+  enabled: true
+  point: user_prompt_submit
+  scope: user
+  kind: builtin
+  mode: sync
+  handler: add_context_note
+  params:
+    note: "优先最小改动，避免无说明的大范围重构。"
+```
+
+补充：`params.message` 也可作为同义输入。
+
+### `warn_on_tool_call`
+
+用途：当模型调用指定工具时写入 warning/annotation（不改变主链行为）。
+
+常见挂点：`before_tool_call`
+
+```yaml
+- id: user-warn-bash
+  enabled: true
+  point: before_tool_call
+  scope: user
+  kind: builtin
+  mode: sync
+  handler: warn_on_tool_call
+  params:
+    tool_names: ["bash"]
+    message: "执行 bash 前请确认命令不会破坏工作区。"
+```
+
+补充：`params.tool_name`（单个）和 `params.tool_names`（多个）都支持。
+
+### `require_file_exists`
+
+用途：在完成前检查某个文件必须存在（如 `README.md`）。
+
+常见挂点：`before_completion_decision`
+
+```yaml
+- id: require-readme-before-final
+  enabled: true
+  point: before_completion_decision
+  scope: repo
+  kind: builtin
+  mode: sync
+  handler: require_file_exists
+  params:
+    path: "README.md"
+    message: "请先补齐 README.md。"
+```
+
+说明：`require_file_exists` 在 final 阶段提供 guard/annotation 信号，不直接输出最终 accepted/failed 结论。
+
+## Trusted Workspace（repo hooks 安全门）
+
+repo hooks 的安全模型是“先发现，后判定”：
+
+- 默认只发现 `<workspace>/.neocode/hooks.yaml`，不直接执行。
+- 仅当 workspace 在 trust store 中被标记为 trusted 时执行。
+- trust store 路径是：
+
+```text
+~/.neocode/trusted-workspaces.json
+```
+
+- trust 文件缺失、空文件、损坏 JSON、结构不合法时，都按 untrusted 处理。
+- 当前 trust 由本地 trust store 文件驱动，没有独立 trust 管理命令。
+
+最小示例（路径必须是绝对路径）：
+
+```json
+{
+  "version": 1,
+  "workspaces": [
+    "/absolute/path/to/workspace"
+  ]
+}
+```
+
+## Capability Matrix 与安全边界
+
+不是所有 HookPoint 都允许 user/repo 挂载。当前 `UserAllowed=false` 的点位：
+
+- `before_permission_decision`
+- `pre_compact`
+- `subagent_start`
+
+可用于 user/repo 的常见点位包括：
+
+- `user_prompt_submit`
+- `before_tool_call`
+- `after_tool_result`
+- `after_tool_failure`
+- `before_completion_decision`
+- `session_start` / `session_end`
+- `post_compact`
+- `subagent_stop`
+
+其他边界：
+
+- external kinds 暂不开放。
+- user/repo hook 上下文会做白名单裁剪，不暴露 API key、capability token、service 指针等敏感对象。
+- user/repo `mode` 当前仅支持 `sync`。
+
+## 当前不支持的 Hook Kind
+
+P6-lite 不支持：
+
+- `command`
+- `http`
+- `prompt`
+- `agent`
+
+配置这些 kind 时会被拒绝，例如：
+
+```text
+external hook kind "command" is not supported in P6-lite; only builtin hooks are enabled
+```
+
+暂缓原因：external hooks 涉及命令执行、网络请求、凭据泄露、prompt 注入和 agent 循环等风险，仍需后续 sandbox、allowlist、budget 与审计设计。
+
+## 如何确认 Hook 已生效
+
+可通过 runtime 事件日志确认：
+
+- `hook_started`
+- `hook_finished`
+- `hook_failed`
+- `hook_blocked`
+- `repo_hooks_discovered`
+- `repo_hooks_loaded`
+- `repo_hooks_skipped_untrusted`
+- `repo_hooks_trust_store_invalid`
+
+关键字段包括：
+
+- `source`（`user` / `repo` / `internal`）
+- `point`
+- `hook_id`
+- `message`
+
+示例：
+
+```text
+hook_finished source=user point=user_prompt_submit hook_id=user-context-note message="优先最小改动..."
+```
+
+在 TUI 中可通过日志视图查看（`Ctrl+L` 打开日志视图）。
+
+## Demo A：全局用户规则
+
+1. 在 `~/.neocode/config.yaml` 的 `runtime.hooks.items` 配置 `add_context_note`。
+2. 让 Agent 执行一次常规改动任务。
+3. 在日志中确认 `user_prompt_submit` 的 hook 事件。
+4. 当前 run 会收到“优先最小改动”注释。
+
+## Demo B：项目完成前检查
+
+1. 在 `<workspace>/.neocode/hooks.yaml` 配置 `require_file_exists`（挂到 `before_completion_decision`）。
+2. workspace 未 trust 时，repo hook 会被跳过，并出现 `repo_hooks_skipped_untrusted`。
+3. 将 workspace 绝对路径写入 `~/.neocode/trusted-workspaces.json` 后再次运行。
+4. 在 final 阶段可看到对应 hook 事件与 guard 信号，再由 runtime acceptance 链路统一裁决。

--- a/www/guide/index.md
+++ b/www/guide/index.md
@@ -38,6 +38,7 @@ NeoCode 是一个在终端里运行的本地 AI 编码助手。它不是云端 S
 
 - [Skills 使用](./skills) — 用 `SKILL.md` 固化当前任务的工作方式
 - [MCP 工具接入](./mcp) — 把外部工具接入 NeoCode
+- [Hooks 使用](./hooks) — 在 runtime 生命周期点配置安全 builtin 规则
 
 ## 遇到问题
 


### PR DESCRIPTION
## 背景
当前 runtime hooks 已具备 P0~P5 主干能力，但从“用户可配置体验”角度仍有两个现实问题：

1. **外部 hook kind（command/http/prompt/agent）的拒绝语义不够显式**
   - 在部分路径下虽然不会真正执行，但报错语义不够统一，不利于用户理解“P6-lite 只支持 builtin”。
2. **缺少“可直接复现”的用户级示例与端到端证明**
   - repo hooks 示例已有，但全局 user hooks 的配置与触发链路缺少一份可复制模板与测试证据。

本 PR 聚焦 #494 的 **P6-lite 最低闭环**：builtin-only、安全可解释、可配置、可测试、可观测。

---

## 价值（Why this matters）

### 1) 降低误配与误解成本
当用户尝试写 `kind: command/http/prompt/agent` 时，系统现在会给出明确、统一、可操作的错误：

> `external hook kind "<kind>" is not supported in P6-lite; only builtin hooks are enabled`

这比泛化的 “not supported” 更能解释当前阶段边界，减少反复试错。

### 2) 提升“用户自定义规则”可用性
补齐了全局 user hooks 示例和端到端触发测试，用户可直接按文档配置并验证：
- 配完即生效
- 生效后可在事件中看到 `source=user`
- 不需要阅读 runtime 内部代码才能确认系统行为

### 3) 保持安全边界不退化
在不开放 external hooks 的前提下，继续确保：
- repo hooks 仍由 trusted workspace gate 控制
- user/repo hooks 仍受 capability matrix 的 `UserAllowed` 限制
- 无 hooks 配置时主链行为不回归

---

## 用户故事（User Stories）

### Story A：平台使用者（全局规则）
> 作为使用者，我希望在 `~/.neocode/config.yaml` 中定义“调用 bash 前给 warning”这类规则，且系统能稳定触发并可观测。

本 PR 提供：
- 全局 user hooks 示例（`runtime.hooks.items`）
- 端到端测试证明 `user_prompt_submit` 触发后事件中 `source=user` 且 message 生效

### Story B：仓库维护者（项目规则）
> 作为仓库维护者，我希望通过 `<workspace>/.neocode/hooks.yaml` 约束项目行为，但未 trust 的仓库不能自动执行这些规则。

本 PR保持并增强：
- repo hooks 发现/加载/跳过事件链路
- trust gate 仍是执行前置条件

### Story C：安全审阅者（阶段边界）
> 作为安全审阅者，我希望外部执行类 hook 在 P6-lite 阶段被强拒绝，而不是“看起来可配置但行为不确定”。

本 PR实现：
- user/repo 侧均显式拒绝 external kinds
- 拒绝后不注册进 registry，不进入执行链

---

## 变更范围

### 代码变更
- `internal/config/runtime_hooks.go`
  - user hooks 配置校验新增 external kind 显式拒绝语义。
- `internal/runtime/repo_hooks.go`
  - repo hooks 校验新增 external kind 显式拒绝语义。
- `internal/runtime/user_hooks.go`
  - 增加 runtime 装配层兜底校验，避免绕过配置层验证导致 external kind 半生效。

### 测试补强
- `internal/config/runtime_hooks_test.go`
  - 覆盖 user external kinds（command/http/prompt/agent）拒绝与报错文案。
- `internal/runtime/repo_hooks_test.go`
  - 覆盖 repo external kinds 拒绝。
  - 新增 repo hook 执行事件 `source=repo` 断言。
- `internal/runtime/user_hooks_test.go`
  - 新增无 hooks 配置行为不变测试。
  - 新增 user external kind 拒绝且不注册测试。
  - 新增 **端到端 user hook 触发测试**：`user_prompt_submit + add_context_note`，断言 `source=user` 和 message。

### 文档与示例
- 新增 `docs/examples/hooks.yaml`（repo hooks 示例）
- 新增 `docs/examples/user-hooks-config.yaml`（全局 user hooks 示例）
- 更新 `docs/guides/configuration.md`
- 更新 `docs/runtime-hooks-design.md`

---

## 使用案例

### 案例 1：全局 user hook（P6-lite 推荐）
在 `~/.neocode/config.yaml` 中配置：
- `add_context_note` 挂 `user_prompt_submit`
- `warn_on_tool_call` 挂 `before_tool_call`

参考示例：`docs/examples/user-hooks-config.yaml`

### 案例 2：仓库 repo hook（需 trust）
在仓库中配置 `<workspace>/.neocode/hooks.yaml`，并在 `~/.neocode/trusted-workspaces.json` 中加入工作区。

参考示例：`docs/examples/hooks.yaml`

### 案例 3：误配 external kind
若配置 `kind: command`（或 http/prompt/agent），会被明确拒绝，不会注册、不执行。

---

## 兼容性与非目标

### 兼容性
- 不改变现有 internal -> user -> repo 执行链。
- 不改变 P7 的 `before_completion_decision` 特殊编排语义。
- 无 hooks 配置时行为保持不变。

### 非目标（明确不做）
- 不实现 command/http/prompt/agent external hooks。
- 不引入 external sandbox。
- 不改 Verification precheck / AcceptanceService（属于 P7 follow-up）。
- 不做 TUI 大改或 Gateway 外置队列改造。

---

## 测试

已执行并通过：

```bash
go test ./internal/config -run RuntimeHooks -count=1
go test ./internal/runtime -run "(RepoHook|RuntimeHooks|UserBuiltinHookConfiguredEndToEndOnUserPromptSubmit|BeforeCompletionDecision|Hook)" -count=1
go test ./internal/runtime/... -count=1
```

重点验证：
- user/repo external kind 全部拒绝
- rejected hook 不注册不执行
- repo source 事件可观测
- user 配置触发链路可观测（`source=user`）
- 无 hooks 配置不回归

---

## 风险与回滚

### 风险
- 主要是校验策略变严格：此前写错 kind 可能得到泛化报错，现在会得到阶段化拒绝文案（预期行为变化）。

### 回滚
- 本 PR 变更集中于 hooks 校验与测试/文档。
- 如需回滚，可按提交粒度回退，不影响 runtime 主推理链路和 provider 协议层。

---

## 关联
close #494
