### PR TITLE
feat(feishu): Phase 1 adapter bridge over Gateway protocol (#554)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,9 +247,10 @@ go run ./cmd/neocode --session <session_id>
 
 详细说明在文档内：
 
-- [Gateway 集成与协议（Guide）](https://neocode-docs.pages.dev/guide/gateway)
+- [Gateway 集成与协议（Reference）](https://neocode-docs.pages.dev/reference/gateway)
 - [MCP 工具接入（Guide）](https://neocode-docs.pages.dev/guide/mcp)
 - [Skills 使用（Guide）](https://neocode-docs.pages.dev/guide/skills)
+- [飞书远程接入配置（Guide）](https://neocode-docs.pages.dev/guide/feishu-remote-setup)
 - [工具与权限（Guide）](https://neocode-docs.pages.dev/guide/tools-permissions)
 - [Runtime / Provider 事件流（Repo Doc）](docs/runtime-provider-event-flow.md)
 
@@ -260,6 +261,7 @@ go run ./cmd/neocode --session <session_id>
 - 官方文档站：[https://neocode-docs.pages.dev/](https://neocode-docs.pages.dev/)
 - 快速引导（中文）：[www/guide/index.md](www/guide/index.md)
 - [配置指南](https://neocode-docs.pages.dev/guide/configuration)
+- [飞书远程接入配置](https://neocode-docs.pages.dev/guide/feishu-remote-setup)
 - [工具与权限](https://neocode-docs.pages.dev/guide/tools-permissions)
 - [Skills 使用](https://neocode-docs.pages.dev/guide/skills)
 - [MCP 工具接入](https://neocode-docs.pages.dev/guide/mcp)

--- a/docs/examples/feishu.yaml
+++ b/docs/examples/feishu.yaml
@@ -4,6 +4,7 @@ feishu:
   app_secret: "cli_secret_xxx"
   verify_token: "verify_token_xxx"
   signing_secret: "signing_secret_xxx"
+  insecure_skip_signature_verify: false
   callback_base_url: "https://example.com"
   adapter:
     listen: "127.0.0.1:18080"
@@ -17,4 +18,3 @@ feishu:
   gateway:
     listen: "127.0.0.1:8080"
     token_file: "~/.neocode/auth.json"
-

--- a/docs/examples/feishu.yaml
+++ b/docs/examples/feishu.yaml
@@ -1,0 +1,20 @@
+feishu:
+  enabled: true
+  app_id: "cli_xxx"
+  app_secret: "cli_secret_xxx"
+  verify_token: "verify_token_xxx"
+  signing_secret: "signing_secret_xxx"
+  callback_base_url: "https://example.com"
+  adapter:
+    listen: "127.0.0.1:18080"
+    event_path: "/feishu/events"
+    card_path: "/feishu/cards"
+  idempotency_ttl_sec: 600
+  request_timeout_sec: 8
+  reconnect_backoff_min_ms: 500
+  reconnect_backoff_max_ms: 10000
+  rebind_interval_sec: 15
+  gateway:
+    listen: "127.0.0.1:8080"
+    token_file: "~/.neocode/auth.json"
+

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -340,6 +340,7 @@ feishu:
   app_secret: "cli_secret_xxx"
   verify_token: "verify_token_xxx"
   signing_secret: "signing_secret_xxx"
+  insecure_skip_signature_verify: false
   callback_base_url: "https://example.com"
   adapter:
     listen: "127.0.0.1:18080"
@@ -365,6 +366,7 @@ neocode feishu-adapter
 
 - 本阶段不会新增 Gateway action，适配器只复用既有 `authenticate / bindStream / run / resolvePermission / gateway.event`。
 - `session_id` 与 `run_id` 由飞书 chat/message 标识稳定映射生成，用于去重与追踪。
+- 默认强制启用签名校验；仅在联调场景可显式设置 `insecure_skip_signature_verify=true` 跳过（不建议生产）。
 
 ## 常见错误
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -329,6 +329,43 @@ go run ./cmd/neocode --workdir /path/to/workspace
 - 不会回写到 `config.yaml`
 - 工具根目录与 session 隔离都会使用该工作区
 
+## Feishu Adapter 配置（Phase 1）
+
+如需启用飞书桥接器，可在 `config.yaml` 增加 `feishu` 段：
+
+```yaml
+feishu:
+  enabled: true
+  app_id: "cli_xxx"
+  app_secret: "cli_secret_xxx"
+  verify_token: "verify_token_xxx"
+  signing_secret: "signing_secret_xxx"
+  callback_base_url: "https://example.com"
+  adapter:
+    listen: "127.0.0.1:18080"
+    event_path: "/feishu/events"
+    card_path: "/feishu/cards"
+  idempotency_ttl_sec: 600
+  request_timeout_sec: 8
+  reconnect_backoff_min_ms: 500
+  reconnect_backoff_max_ms: 10000
+  rebind_interval_sec: 15
+  gateway:
+    listen: "127.0.0.1:8080"
+    token_file: "~/.neocode/auth.json"
+```
+
+启动命令：
+
+```bash
+neocode feishu-adapter
+```
+
+说明：
+
+- 本阶段不会新增 Gateway action，适配器只复用既有 `authenticate / bindStream / run / resolvePermission / gateway.event`。
+- `session_id` 与 `run_id` 由飞书 chat/message 标识稳定映射生成，用于去重与追踪。
+
 ## 常见错误
 
 ### 旧字段被拒绝

--- a/docs/guides/feishu-adapter.md
+++ b/docs/guides/feishu-adapter.md
@@ -37,6 +37,7 @@
 
 - 消息事件去重键：`event_id + message_id`（TTL 内只执行一次 run）。
 - 卡片回调去重键：`request_id + decision`（TTL 内只提交一次审批）。
+- 去重在 `run` 被网关受理后才标记成功；若受理失败会释放去重键，允许飞书重试恢复。
 
 ## 5. 审批闭环
 
@@ -56,6 +57,15 @@ Phase 1 仅支持最小动作：
 - `signing_secret`
 - `gateway token`
 - `Authorization` 头
+
+默认要求签名校验与回调 token 校验都开启：
+
+- `verify_token` 必填
+- `signing_secret` 必填
+
+仅在联调场景可显式设置 `insecure_skip_signature_verify=true` 跳过签名校验（不建议生产使用）。
+
+群聊消息默认仅在检测到 `@` 机器人时受理；私聊消息默认受理。
 
 用户可见错误仅返回摘要，不回传内部堆栈。
 
@@ -80,5 +90,4 @@ neocode feishu-adapter \
 
 ## 8. 配置示例
 
-参考 [docs/examples/feishu.yaml](/F:/Qiniu/neo-code/docs/examples/feishu.yaml)。
-
+参考 [../examples/feishu.yaml](../examples/feishu.yaml)。

--- a/docs/guides/feishu-adapter.md
+++ b/docs/guides/feishu-adapter.md
@@ -1,0 +1,84 @@
+# Feishu Adapter 接入指南（Phase 1）
+
+本文档描述 #554 Phase 1 的最小可用接入方式：通过 `neocode feishu-adapter` 把飞书消息桥接到现有 Gateway。
+
+## 1. 边界说明
+
+- 本阶段只实现云端控制面桥接（Adapter）。
+- 不新增任何 Gateway RPC action。
+- 仅复用：
+  - `gateway.authenticate`
+  - `gateway.bindStream`
+  - `gateway.run`
+  - `gateway.resolvePermission`
+  - `gateway.event`（通知）
+- 不依赖 `gateway.createSession`。
+- 真正“云端飞书 -> 用户本机执行”的主动长连通道属于 #555，不在本阶段内。
+
+## 2. 会话与运行 ID 规则
+
+- `session_id = "feishu:" + stableHash(chat_id)`
+- `run_id = "feishu:" + stableHash(message_id)`
+
+这两个 ID 都是确定性生成，便于幂等和追踪。
+
+## 3. 事件处理顺序
+
+飞书消息进入后，适配器固定执行：
+
+1. `authenticate`
+2. `bindStream(session_id, run_id)`
+3. `run(session_id, run_id, input_text)`
+4. 持续消费 `gateway.event`
+
+说明：必须先 `bindStream` 再 `run`，避免丢失 run 早期事件。
+
+## 4. 幂等与重放防护
+
+- 消息事件去重键：`event_id + message_id`（TTL 内只执行一次 run）。
+- 卡片回调去重键：`request_id + decision`（TTL 内只提交一次审批）。
+
+## 5. 审批闭环
+
+Phase 1 仅支持最小动作：
+
+- `allow_once`
+- `reject`
+
+当收到 `permission_requested` 事件时，适配器发送最小审批卡片；用户点击后回调 `gateway.resolvePermission`。
+
+## 6. 安全要求
+
+适配器日志不会打印以下敏感信息：
+
+- `app_secret`
+- `verify_token`
+- `signing_secret`
+- `gateway token`
+- `Authorization` 头
+
+用户可见错误仅返回摘要，不回传内部堆栈。
+
+## 7. 启动方式
+
+```bash
+neocode feishu-adapter
+```
+
+也可以通过命令行参数覆盖配置：
+
+```bash
+neocode feishu-adapter \
+  --listen 127.0.0.1:18080 \
+  --event-path /feishu/events \
+  --card-path /feishu/cards \
+  --app-id xxx \
+  --app-secret yyy \
+  --verify-token zzz \
+  --signing-secret sss
+```
+
+## 8. 配置示例
+
+参考 [docs/examples/feishu.yaml](/F:/Qiniu/neo-code/docs/examples/feishu.yaml)。
+

--- a/internal/cli/feishu_adapter_command.go
+++ b/internal/cli/feishu_adapter_command.go
@@ -1,0 +1,238 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"neo-code/internal/config"
+	"neo-code/internal/feishuadapter"
+	"neo-code/internal/gateway/transport"
+)
+
+var runFeishuAdapterCommand = defaultFeishuAdapterCommandRunner
+var newGatewayRPCClientForFeishu = feishuadapter.NewGatewayRPCClient
+var newFeishuMessenger = feishuadapter.NewFeishuMessenger
+var newFeishuAdapter = feishuadapter.New
+
+type feishuAdapterCommandOptions struct {
+	Listen               string
+	EventPath            string
+	CardPath             string
+	AppID                string
+	AppSecret            string
+	VerifyToken          string
+	SigningSecret        string
+	CallbackBaseURL      string
+	IdempotencyTTLSec    int
+	RequestTimeoutSec    int
+	ReconnectBackoffMinM int
+	ReconnectBackoffMaxM int
+	RebindIntervalSec    int
+	GatewayListen        string
+	GatewayTokenFile     string
+}
+
+// newFeishuAdapterCommand 创建飞书适配器子命令，用于桥接飞书事件与网关运行链路。
+func newFeishuAdapterCommand() *cobra.Command {
+	options := &feishuAdapterCommandOptions{}
+	cmd := &cobra.Command{
+		Use:          "feishu-adapter",
+		Short:        "Start Feishu adapter bridge for gateway",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		Annotations: map[string]string{
+			commandAnnotationSkipGlobalPreload:     "true",
+			commandAnnotationSkipSilentUpdateCheck: "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runFeishuAdapterCommand(cmd.Context(), *options)
+		},
+	}
+
+	cmd.Flags().StringVar(&options.Listen, "listen", "", "feishu adapter listen address (e.g. 127.0.0.1:18080)")
+	cmd.Flags().StringVar(&options.EventPath, "event-path", "", "feishu event callback path")
+	cmd.Flags().StringVar(&options.CardPath, "card-path", "", "feishu card callback path")
+	cmd.Flags().StringVar(&options.AppID, "app-id", "", "feishu app id")
+	cmd.Flags().StringVar(&options.AppSecret, "app-secret", "", "feishu app secret")
+	cmd.Flags().StringVar(&options.VerifyToken, "verify-token", "", "feishu verify token")
+	cmd.Flags().StringVar(&options.SigningSecret, "signing-secret", "", "feishu signing secret")
+	cmd.Flags().StringVar(&options.CallbackBaseURL, "callback-base-url", "", "feishu callback base url")
+	cmd.Flags().IntVar(&options.IdempotencyTTLSec, "idempotency-ttl-sec", 0, "idempotency ttl in seconds")
+	cmd.Flags().IntVar(&options.RequestTimeoutSec, "request-timeout-sec", 0, "gateway request timeout in seconds")
+	cmd.Flags().IntVar(&options.ReconnectBackoffMinM, "reconnect-backoff-min-ms", 0, "gateway reconnect min backoff in ms")
+	cmd.Flags().IntVar(&options.ReconnectBackoffMaxM, "reconnect-backoff-max-ms", 0, "gateway reconnect max backoff in ms")
+	cmd.Flags().IntVar(&options.RebindIntervalSec, "rebind-interval-sec", 0, "gateway active-session rebind interval in sec")
+	cmd.Flags().StringVar(&options.GatewayListen, "gateway-listen", "", "gateway listen address override")
+	cmd.Flags().StringVar(&options.GatewayTokenFile, "gateway-token-file", "", "gateway auth token file override")
+
+	return cmd
+}
+
+// defaultFeishuAdapterCommandRunner 读取配置并启动飞书适配器主循环。
+func defaultFeishuAdapterCommandRunner(ctx context.Context, options feishuAdapterCommandOptions) error {
+	loader := config.NewLoader("", config.StaticDefaults())
+	cfg, err := loader.Load(ctx)
+	if err != nil {
+		return err
+	}
+	merged := mergeFeishuOptions(cfg.Feishu, options, cfg.Gateway)
+	if err := merged.Validate(); err != nil {
+		return err
+	}
+	logger := log.New(os.Stderr, "neocode-feishu-adapter: ", log.LstdFlags)
+
+	gatewayClient, err := newGatewayRPCClientForFeishu(feishuadapter.GatewayClientConfig{
+		ListenAddress:  merged.GatewayListenAddress,
+		TokenFile:      merged.GatewayTokenFile,
+		RequestTimeout: time.Duration(merged.RequestTimeoutSec) * time.Second,
+	})
+	if err != nil {
+		return fmt.Errorf("init gateway client: %w", err)
+	}
+	messenger := newFeishuMessenger(merged.AppID, merged.AppSecret, nil)
+	adapter, err := newFeishuAdapter(merged.ToAdapterConfig(), gatewayClient, messenger, logger)
+	if err != nil {
+		_ = gatewayClient.Close()
+		return err
+	}
+	return adapter.Run(ctx)
+}
+
+type mergedFeishuOptions struct {
+	Enabled               bool
+	Listen                string
+	EventPath             string
+	CardPath              string
+	AppID                 string
+	AppSecret             string
+	VerifyToken           string
+	SigningSecret         string
+	CallbackBaseURL       string
+	IdempotencyTTLSec     int
+	RequestTimeoutSec     int
+	ReconnectBackoffMinMs int
+	ReconnectBackoffMaxMs int
+	RebindIntervalSec     int
+	GatewayListenAddress  string
+	GatewayTokenFile      string
+}
+
+// Validate 校验合并后的飞书参数，确保适配器启动前失败前置。
+func (o mergedFeishuOptions) Validate() error {
+	cfg := o.ToAdapterConfig()
+	return cfg.Validate()
+}
+
+// ToAdapterConfig 将 CLI/配置合并结果转换为适配器运行配置。
+func (o mergedFeishuOptions) ToAdapterConfig() feishuadapter.Config {
+	return feishuadapter.Config{
+		ListenAddress:       o.Listen,
+		EventPath:           o.EventPath,
+		CardPath:            o.CardPath,
+		AppID:               o.AppID,
+		AppSecret:           o.AppSecret,
+		VerifyToken:         o.VerifyToken,
+		SigningSecret:       o.SigningSecret,
+		CallbackBaseURL:     o.CallbackBaseURL,
+		RequestTimeout:      time.Duration(o.RequestTimeoutSec) * time.Second,
+		IdempotencyTTL:      time.Duration(o.IdempotencyTTLSec) * time.Second,
+		ReconnectBackoffMin: time.Duration(o.ReconnectBackoffMinMs) * time.Millisecond,
+		ReconnectBackoffMax: time.Duration(o.ReconnectBackoffMaxMs) * time.Millisecond,
+		RebindInterval:      time.Duration(o.RebindIntervalSec) * time.Second,
+	}
+}
+
+// mergeFeishuOptions 合并 config.yaml 与命令行参数，命令行优先。
+func mergeFeishuOptions(feishuCfg config.FeishuConfig, cliOptions feishuAdapterCommandOptions, gatewayCfg config.GatewayConfig) mergedFeishuOptions {
+	feishuCfg.ApplyDefaults(config.FeishuConfig{
+		Adapter: config.FeishuAdapterConfig{
+			Listen:   config.DefaultFeishuAdapterListen,
+			EventURI: config.DefaultFeishuAdapterEventPath,
+			CardURI:  config.DefaultFeishuAdapterCardPath,
+		},
+		RequestTimeoutSec:    config.DefaultFeishuGatewayRequestTimeoutSec,
+		IdempotencyTTLSec:    config.DefaultFeishuIdempotencyTTLSec,
+		ReconnectBackoffMinM: config.DefaultFeishuReconnectBackoffMinMs,
+		ReconnectBackoffMaxM: config.DefaultFeishuReconnectBackoffMaxMs,
+		RebindIntervalSec:    config.DefaultFeishuRebindIntervalSec,
+	})
+	merged := mergedFeishuOptions{
+		Enabled:               feishuCfg.Enabled,
+		Listen:                strings.TrimSpace(feishuCfg.Adapter.Listen),
+		EventPath:             strings.TrimSpace(feishuCfg.Adapter.EventURI),
+		CardPath:              strings.TrimSpace(feishuCfg.Adapter.CardURI),
+		AppID:                 strings.TrimSpace(feishuCfg.AppID),
+		AppSecret:             strings.TrimSpace(feishuCfg.AppSecret),
+		VerifyToken:           strings.TrimSpace(feishuCfg.VerifyToken),
+		SigningSecret:         strings.TrimSpace(feishuCfg.SigningSecret),
+		CallbackBaseURL:       strings.TrimSpace(feishuCfg.CallbackBaseURL),
+		IdempotencyTTLSec:     feishuCfg.IdempotencyTTLSec,
+		RequestTimeoutSec:     feishuCfg.RequestTimeoutSec,
+		ReconnectBackoffMinMs: feishuCfg.ReconnectBackoffMinM,
+		ReconnectBackoffMaxMs: feishuCfg.ReconnectBackoffMaxM,
+		RebindIntervalSec:     feishuCfg.RebindIntervalSec,
+		GatewayListenAddress:  strings.TrimSpace(feishuCfg.GatewayClient.ListenAddress),
+		GatewayTokenFile:      strings.TrimSpace(feishuCfg.GatewayClient.TokenFile),
+	}
+	if merged.GatewayListenAddress == "" {
+		if address, err := transport.DefaultListenAddress(); err == nil {
+			merged.GatewayListenAddress = address
+		}
+	}
+	if merged.GatewayTokenFile == "" {
+		merged.GatewayTokenFile = strings.TrimSpace(gatewayCfg.Security.TokenFile)
+	}
+
+	if value := strings.TrimSpace(cliOptions.Listen); value != "" {
+		merged.Listen = value
+	}
+	if value := strings.TrimSpace(cliOptions.EventPath); value != "" {
+		merged.EventPath = value
+	}
+	if value := strings.TrimSpace(cliOptions.CardPath); value != "" {
+		merged.CardPath = value
+	}
+	if value := strings.TrimSpace(cliOptions.AppID); value != "" {
+		merged.AppID = value
+	}
+	if value := strings.TrimSpace(cliOptions.AppSecret); value != "" {
+		merged.AppSecret = value
+	}
+	if value := strings.TrimSpace(cliOptions.VerifyToken); value != "" {
+		merged.VerifyToken = value
+	}
+	if value := strings.TrimSpace(cliOptions.SigningSecret); value != "" {
+		merged.SigningSecret = value
+	}
+	if value := strings.TrimSpace(cliOptions.CallbackBaseURL); value != "" {
+		merged.CallbackBaseURL = value
+	}
+	if cliOptions.IdempotencyTTLSec > 0 {
+		merged.IdempotencyTTLSec = cliOptions.IdempotencyTTLSec
+	}
+	if cliOptions.RequestTimeoutSec > 0 {
+		merged.RequestTimeoutSec = cliOptions.RequestTimeoutSec
+	}
+	if cliOptions.ReconnectBackoffMinM > 0 {
+		merged.ReconnectBackoffMinMs = cliOptions.ReconnectBackoffMinM
+	}
+	if cliOptions.ReconnectBackoffMaxM > 0 {
+		merged.ReconnectBackoffMaxMs = cliOptions.ReconnectBackoffMaxM
+	}
+	if cliOptions.RebindIntervalSec > 0 {
+		merged.RebindIntervalSec = cliOptions.RebindIntervalSec
+	}
+	if value := strings.TrimSpace(cliOptions.GatewayListen); value != "" {
+		merged.GatewayListenAddress = value
+	}
+	if value := strings.TrimSpace(cliOptions.GatewayTokenFile); value != "" {
+		merged.GatewayTokenFile = value
+	}
+	return merged
+}

--- a/internal/cli/feishu_adapter_command.go
+++ b/internal/cli/feishu_adapter_command.go
@@ -21,21 +21,22 @@ var newFeishuMessenger = feishuadapter.NewFeishuMessenger
 var newFeishuAdapter = feishuadapter.New
 
 type feishuAdapterCommandOptions struct {
-	Listen               string
-	EventPath            string
-	CardPath             string
-	AppID                string
-	AppSecret            string
-	VerifyToken          string
-	SigningSecret        string
-	CallbackBaseURL      string
-	IdempotencyTTLSec    int
-	RequestTimeoutSec    int
-	ReconnectBackoffMinM int
-	ReconnectBackoffMaxM int
-	RebindIntervalSec    int
-	GatewayListen        string
-	GatewayTokenFile     string
+	Listen                 string
+	EventPath              string
+	CardPath               string
+	AppID                  string
+	AppSecret              string
+	VerifyToken            string
+	SigningSecret          string
+	InsecureSkipSignVerify bool
+	CallbackBaseURL        string
+	IdempotencyTTLSec      int
+	RequestTimeoutSec      int
+	ReconnectBackoffMinM   int
+	ReconnectBackoffMaxM   int
+	RebindIntervalSec      int
+	GatewayListen          string
+	GatewayTokenFile       string
 }
 
 // newFeishuAdapterCommand 创建飞书适配器子命令，用于桥接飞书事件与网关运行链路。
@@ -62,6 +63,7 @@ func newFeishuAdapterCommand() *cobra.Command {
 	cmd.Flags().StringVar(&options.AppSecret, "app-secret", "", "feishu app secret")
 	cmd.Flags().StringVar(&options.VerifyToken, "verify-token", "", "feishu verify token")
 	cmd.Flags().StringVar(&options.SigningSecret, "signing-secret", "", "feishu signing secret")
+	cmd.Flags().BoolVar(&options.InsecureSkipSignVerify, "insecure-skip-signature-verify", false, "skip feishu callback signature verification (unsafe)")
 	cmd.Flags().StringVar(&options.CallbackBaseURL, "callback-base-url", "", "feishu callback base url")
 	cmd.Flags().IntVar(&options.IdempotencyTTLSec, "idempotency-ttl-sec", 0, "idempotency ttl in seconds")
 	cmd.Flags().IntVar(&options.RequestTimeoutSec, "request-timeout-sec", 0, "gateway request timeout in seconds")
@@ -105,22 +107,23 @@ func defaultFeishuAdapterCommandRunner(ctx context.Context, options feishuAdapte
 }
 
 type mergedFeishuOptions struct {
-	Enabled               bool
-	Listen                string
-	EventPath             string
-	CardPath              string
-	AppID                 string
-	AppSecret             string
-	VerifyToken           string
-	SigningSecret         string
-	CallbackBaseURL       string
-	IdempotencyTTLSec     int
-	RequestTimeoutSec     int
-	ReconnectBackoffMinMs int
-	ReconnectBackoffMaxMs int
-	RebindIntervalSec     int
-	GatewayListenAddress  string
-	GatewayTokenFile      string
+	Enabled                bool
+	Listen                 string
+	EventPath              string
+	CardPath               string
+	AppID                  string
+	AppSecret              string
+	VerifyToken            string
+	SigningSecret          string
+	InsecureSkipSignVerify bool
+	CallbackBaseURL        string
+	IdempotencyTTLSec      int
+	RequestTimeoutSec      int
+	ReconnectBackoffMinMs  int
+	ReconnectBackoffMaxMs  int
+	RebindIntervalSec      int
+	GatewayListenAddress   string
+	GatewayTokenFile       string
 }
 
 // Validate 校验合并后的飞书参数，确保适配器启动前失败前置。
@@ -132,19 +135,20 @@ func (o mergedFeishuOptions) Validate() error {
 // ToAdapterConfig 将 CLI/配置合并结果转换为适配器运行配置。
 func (o mergedFeishuOptions) ToAdapterConfig() feishuadapter.Config {
 	return feishuadapter.Config{
-		ListenAddress:       o.Listen,
-		EventPath:           o.EventPath,
-		CardPath:            o.CardPath,
-		AppID:               o.AppID,
-		AppSecret:           o.AppSecret,
-		VerifyToken:         o.VerifyToken,
-		SigningSecret:       o.SigningSecret,
-		CallbackBaseURL:     o.CallbackBaseURL,
-		RequestTimeout:      time.Duration(o.RequestTimeoutSec) * time.Second,
-		IdempotencyTTL:      time.Duration(o.IdempotencyTTLSec) * time.Second,
-		ReconnectBackoffMin: time.Duration(o.ReconnectBackoffMinMs) * time.Millisecond,
-		ReconnectBackoffMax: time.Duration(o.ReconnectBackoffMaxMs) * time.Millisecond,
-		RebindInterval:      time.Duration(o.RebindIntervalSec) * time.Second,
+		ListenAddress:          o.Listen,
+		EventPath:              o.EventPath,
+		CardPath:               o.CardPath,
+		AppID:                  o.AppID,
+		AppSecret:              o.AppSecret,
+		VerifyToken:            o.VerifyToken,
+		SigningSecret:          o.SigningSecret,
+		InsecureSkipSignVerify: o.InsecureSkipSignVerify,
+		CallbackBaseURL:        o.CallbackBaseURL,
+		RequestTimeout:         time.Duration(o.RequestTimeoutSec) * time.Second,
+		IdempotencyTTL:         time.Duration(o.IdempotencyTTLSec) * time.Second,
+		ReconnectBackoffMin:    time.Duration(o.ReconnectBackoffMinMs) * time.Millisecond,
+		ReconnectBackoffMax:    time.Duration(o.ReconnectBackoffMaxMs) * time.Millisecond,
+		RebindInterval:         time.Duration(o.RebindIntervalSec) * time.Second,
 	}
 }
 
@@ -163,22 +167,23 @@ func mergeFeishuOptions(feishuCfg config.FeishuConfig, cliOptions feishuAdapterC
 		RebindIntervalSec:    config.DefaultFeishuRebindIntervalSec,
 	})
 	merged := mergedFeishuOptions{
-		Enabled:               feishuCfg.Enabled,
-		Listen:                strings.TrimSpace(feishuCfg.Adapter.Listen),
-		EventPath:             strings.TrimSpace(feishuCfg.Adapter.EventURI),
-		CardPath:              strings.TrimSpace(feishuCfg.Adapter.CardURI),
-		AppID:                 strings.TrimSpace(feishuCfg.AppID),
-		AppSecret:             strings.TrimSpace(feishuCfg.AppSecret),
-		VerifyToken:           strings.TrimSpace(feishuCfg.VerifyToken),
-		SigningSecret:         strings.TrimSpace(feishuCfg.SigningSecret),
-		CallbackBaseURL:       strings.TrimSpace(feishuCfg.CallbackBaseURL),
-		IdempotencyTTLSec:     feishuCfg.IdempotencyTTLSec,
-		RequestTimeoutSec:     feishuCfg.RequestTimeoutSec,
-		ReconnectBackoffMinMs: feishuCfg.ReconnectBackoffMinM,
-		ReconnectBackoffMaxMs: feishuCfg.ReconnectBackoffMaxM,
-		RebindIntervalSec:     feishuCfg.RebindIntervalSec,
-		GatewayListenAddress:  strings.TrimSpace(feishuCfg.GatewayClient.ListenAddress),
-		GatewayTokenFile:      strings.TrimSpace(feishuCfg.GatewayClient.TokenFile),
+		Enabled:                feishuCfg.Enabled,
+		Listen:                 strings.TrimSpace(feishuCfg.Adapter.Listen),
+		EventPath:              strings.TrimSpace(feishuCfg.Adapter.EventURI),
+		CardPath:               strings.TrimSpace(feishuCfg.Adapter.CardURI),
+		AppID:                  strings.TrimSpace(feishuCfg.AppID),
+		AppSecret:              strings.TrimSpace(feishuCfg.AppSecret),
+		VerifyToken:            strings.TrimSpace(feishuCfg.VerifyToken),
+		SigningSecret:          strings.TrimSpace(feishuCfg.SigningSecret),
+		InsecureSkipSignVerify: feishuCfg.InsecureSkipSignVerify,
+		CallbackBaseURL:        strings.TrimSpace(feishuCfg.CallbackBaseURL),
+		IdempotencyTTLSec:      feishuCfg.IdempotencyTTLSec,
+		RequestTimeoutSec:      feishuCfg.RequestTimeoutSec,
+		ReconnectBackoffMinMs:  feishuCfg.ReconnectBackoffMinM,
+		ReconnectBackoffMaxMs:  feishuCfg.ReconnectBackoffMaxM,
+		RebindIntervalSec:      feishuCfg.RebindIntervalSec,
+		GatewayListenAddress:   strings.TrimSpace(feishuCfg.GatewayClient.ListenAddress),
+		GatewayTokenFile:       strings.TrimSpace(feishuCfg.GatewayClient.TokenFile),
 	}
 	if merged.GatewayListenAddress == "" {
 		if address, err := transport.DefaultListenAddress(); err == nil {
@@ -209,6 +214,9 @@ func mergeFeishuOptions(feishuCfg config.FeishuConfig, cliOptions feishuAdapterC
 	}
 	if value := strings.TrimSpace(cliOptions.SigningSecret); value != "" {
 		merged.SigningSecret = value
+	}
+	if cliOptions.InsecureSkipSignVerify {
+		merged.InsecureSkipSignVerify = true
 	}
 	if value := strings.TrimSpace(cliOptions.CallbackBaseURL); value != "" {
 		merged.CallbackBaseURL = value

--- a/internal/cli/feishu_adapter_command_test.go
+++ b/internal/cli/feishu_adapter_command_test.go
@@ -3,9 +3,14 @@ package cli
 import (
 	"context"
 	"errors"
+	"log"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"neo-code/internal/config"
+	"neo-code/internal/feishuadapter"
 )
 
 func TestNewFeishuAdapterCommandForwardsFlags(t *testing.T) {
@@ -64,6 +69,37 @@ func TestMergeFeishuOptionsAppliesDefaultsAndOverrides(t *testing.T) {
 	}
 }
 
+func TestMergeFeishuOptionsAppliesAllCLIOverrides(t *testing.T) {
+	merged := mergeFeishuOptions(config.FeishuConfig{
+		Enabled: false,
+	}, feishuAdapterCommandOptions{
+		EventPath:              "/event",
+		CardPath:               "/card",
+		VerifyToken:            "verify",
+		SigningSecret:          "sign",
+		InsecureSkipSignVerify: true,
+		IdempotencyTTLSec:      120,
+		ReconnectBackoffMinM:   30,
+		ReconnectBackoffMaxM:   60,
+		RebindIntervalSec:      7,
+		GatewayListen:          "unix:///tmp/gateway.sock",
+		GatewayTokenFile:       "/tmp/gateway.token",
+	}, config.GatewayConfig{})
+
+	if merged.EventPath != "/event" || merged.CardPath != "/card" {
+		t.Fatalf("paths not overridden: %#v", merged)
+	}
+	if merged.VerifyToken != "verify" || merged.SigningSecret != "sign" || !merged.InsecureSkipSignVerify {
+		t.Fatalf("security settings not overridden: %#v", merged)
+	}
+	if merged.IdempotencyTTLSec != 120 || merged.ReconnectBackoffMinMs != 30 || merged.ReconnectBackoffMaxMs != 60 || merged.RebindIntervalSec != 7 {
+		t.Fatalf("numeric overrides not applied: %#v", merged)
+	}
+	if merged.GatewayListenAddress != "unix:///tmp/gateway.sock" || merged.GatewayTokenFile != "/tmp/gateway.token" {
+		t.Fatalf("gateway overrides not applied: %#v", merged)
+	}
+}
+
 func TestNewRootCommandContainsFeishuAdapter(t *testing.T) {
 	root := NewRootCommand()
 	found := false
@@ -95,5 +131,182 @@ func TestNewFeishuAdapterCommandPropagatesRunnerError(t *testing.T) {
 	cmd := newFeishuAdapterCommand()
 	if err := cmd.ExecuteContext(context.Background()); !errors.Is(err, expected) {
 		t.Fatalf("error = %v, want %v", err, expected)
+	}
+}
+
+type stubFeishuGatewayClient struct {
+	closed bool
+}
+
+func (s *stubFeishuGatewayClient) Authenticate(context.Context) error { return nil }
+func (s *stubFeishuGatewayClient) BindStream(context.Context, string, string) error {
+	return nil
+}
+func (s *stubFeishuGatewayClient) Run(context.Context, string, string, string) error { return nil }
+func (s *stubFeishuGatewayClient) ResolvePermission(context.Context, string, string) error {
+	return nil
+}
+func (s *stubFeishuGatewayClient) Ping(context.Context) error { return nil }
+func (s *stubFeishuGatewayClient) Notifications() <-chan feishuadapter.GatewayNotification {
+	ch := make(chan feishuadapter.GatewayNotification)
+	close(ch)
+	return ch
+}
+func (s *stubFeishuGatewayClient) Close() error {
+	s.closed = true
+	return nil
+}
+
+type stubFeishuMessenger struct{}
+
+func (stubFeishuMessenger) SendText(context.Context, string, string) error { return nil }
+func (stubFeishuMessenger) SendPermissionCard(context.Context, string, feishuadapter.PermissionCardPayload) error {
+	return nil
+}
+
+func writeFeishuAdapterConfig(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	loader := config.NewLoader(filepath.Join(home, ".neocode"), config.StaticDefaults())
+	cfg := loader.DefaultConfig()
+	cfg.Feishu = config.FeishuConfig{
+		Enabled:       true,
+		AppID:         "app",
+		AppSecret:     "secret",
+		VerifyToken:   "verify",
+		SigningSecret: "sign",
+		Adapter: config.FeishuAdapterConfig{
+			Listen:   "127.0.0.1:18080",
+			EventURI: "/feishu/events",
+			CardURI:  "/feishu/cards",
+		},
+		RequestTimeoutSec:    1,
+		IdempotencyTTLSec:    60,
+		ReconnectBackoffMinM: 10,
+		ReconnectBackoffMaxM: 20,
+		RebindIntervalSec:    1,
+		GatewayClient: config.FeishuGatewayClientConfig{
+			ListenAddress: filepath.Join(home, "gateway.sock"),
+			TokenFile:     filepath.Join(home, "gateway.token"),
+		},
+	}
+	if err := loader.Save(context.Background(), &cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+}
+
+func TestDefaultFeishuAdapterCommandRunnerInitializesAdapter(t *testing.T) {
+	writeFeishuAdapterConfig(t)
+
+	originalGatewayFactory := newGatewayRPCClientForFeishu
+	originalMessengerFactory := newFeishuMessenger
+	t.Cleanup(func() {
+		newGatewayRPCClientForFeishu = originalGatewayFactory
+		newFeishuMessenger = originalMessengerFactory
+	})
+
+	var capturedGatewayConfig feishuadapter.GatewayClientConfig
+	newGatewayRPCClientForFeishu = func(cfg feishuadapter.GatewayClientConfig) (feishuadapter.GatewayClient, error) {
+		capturedGatewayConfig = cfg
+		return &stubFeishuGatewayClient{}, nil
+	}
+	newFeishuMessenger = func(appID string, appSecret string, httpClient feishuadapter.HTTPClient) feishuadapter.Messenger {
+		if appID != "app" || appSecret != "secret" {
+			t.Fatalf("unexpected messenger credentials: %q %q", appID, appSecret)
+		}
+		return stubFeishuMessenger{}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		cancel()
+	}()
+	err := defaultFeishuAdapterCommandRunner(ctx, feishuAdapterCommandOptions{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runner error = %v, want context canceled", err)
+	}
+	if capturedGatewayConfig.ListenAddress == "" || capturedGatewayConfig.TokenFile == "" {
+		t.Fatalf("gateway config not forwarded: %#v", capturedGatewayConfig)
+	}
+}
+
+func TestDefaultFeishuAdapterCommandRunnerClosesGatewayOnAdapterInitError(t *testing.T) {
+	writeFeishuAdapterConfig(t)
+
+	originalGatewayFactory := newGatewayRPCClientForFeishu
+	originalMessengerFactory := newFeishuMessenger
+	originalAdapterFactory := newFeishuAdapter
+	t.Cleanup(func() {
+		newGatewayRPCClientForFeishu = originalGatewayFactory
+		newFeishuMessenger = originalMessengerFactory
+		newFeishuAdapter = originalAdapterFactory
+	})
+
+	gateway := &stubFeishuGatewayClient{}
+	newGatewayRPCClientForFeishu = func(cfg feishuadapter.GatewayClientConfig) (feishuadapter.GatewayClient, error) {
+		return gateway, nil
+	}
+	newFeishuMessenger = func(string, string, feishuadapter.HTTPClient) feishuadapter.Messenger {
+		return stubFeishuMessenger{}
+	}
+	newFeishuAdapter = func(cfg feishuadapter.Config, gateway feishuadapter.GatewayClient, messenger feishuadapter.Messenger, logger *log.Logger) (*feishuadapter.Adapter, error) {
+		return nil, errors.New("adapter init failed")
+	}
+
+	err := defaultFeishuAdapterCommandRunner(context.Background(), feishuAdapterCommandOptions{})
+	if err == nil || err.Error() != "adapter init failed" {
+		t.Fatalf("runner error = %v, want adapter init failed", err)
+	}
+	if !gateway.closed {
+		t.Fatal("expected gateway client to close on adapter init failure")
+	}
+}
+
+func TestDefaultFeishuAdapterCommandRunnerPropagatesGatewayInitError(t *testing.T) {
+	writeFeishuAdapterConfig(t)
+
+	originalGatewayFactory := newGatewayRPCClientForFeishu
+	t.Cleanup(func() {
+		newGatewayRPCClientForFeishu = originalGatewayFactory
+	})
+	newGatewayRPCClientForFeishu = func(cfg feishuadapter.GatewayClientConfig) (feishuadapter.GatewayClient, error) {
+		return nil, errors.New("dial failed")
+	}
+
+	err := defaultFeishuAdapterCommandRunner(context.Background(), feishuAdapterCommandOptions{})
+	if err == nil || err.Error() != "init gateway client: dial failed" {
+		t.Fatalf("runner error = %v, want wrapped gateway init error", err)
+	}
+}
+
+func TestDefaultFeishuAdapterCommandRunnerPropagatesLoadAndValidateError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configDir := filepath.Join(home, ".neocode")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(":\n"), 0o644); err != nil {
+		t.Fatalf("write invalid config: %v", err)
+	}
+	if err := defaultFeishuAdapterCommandRunner(context.Background(), feishuAdapterCommandOptions{}); err == nil {
+		t.Fatal("expected config load error")
+	}
+
+	home = t.TempDir()
+	t.Setenv("HOME", home)
+	configDir = filepath.Join(home, ".neocode")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	invalidFeishu := "selected_provider: openai\ncurrent_model: gpt-4.1\nshell: bash\nfeishu:\n  enabled: true\n  app_id: app\n  app_secret: secret\n  signing_secret: sign\n  adapter:\n    listen: 127.0.0.1:18080\n    event_path: /feishu/events\n    card_path: /feishu/cards\n  request_timeout_sec: 1\n  idempotency_ttl_sec: 60\n  reconnect_backoff_min_ms: 10\n  reconnect_backoff_max_ms: 20\n  rebind_interval_sec: 1\n"
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(invalidFeishu), 0o644); err != nil {
+		t.Fatalf("write invalid feishu config: %v", err)
+	}
+	err := defaultFeishuAdapterCommandRunner(context.Background(), feishuAdapterCommandOptions{})
+	if err == nil {
+		t.Fatal("expected validation error from config")
 	}
 }

--- a/internal/cli/feishu_adapter_command_test.go
+++ b/internal/cli/feishu_adapter_command_test.go
@@ -25,6 +25,7 @@ func TestNewFeishuAdapterCommandForwardsFlags(t *testing.T) {
 		"--card-path", "/card",
 		"--app-id", "app",
 		"--app-secret", "secret",
+		"--insecure-skip-signature-verify",
 		"--gateway-listen", "tcp://gateway",
 	})
 	if err := cmd.ExecuteContext(context.Background()); err != nil {
@@ -35,6 +36,9 @@ func TestNewFeishuAdapterCommandForwardsFlags(t *testing.T) {
 	}
 	if captured.AppID != "app" || captured.AppSecret != "secret" || captured.GatewayListen != "tcp://gateway" {
 		t.Fatalf("unexpected credential/gateway options: %#v", captured)
+	}
+	if !captured.InsecureSkipSignVerify {
+		t.Fatalf("expected insecure skip flag to be forwarded, got %#v", captured)
 	}
 }
 

--- a/internal/cli/feishu_adapter_command_test.go
+++ b/internal/cli/feishu_adapter_command_test.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"neo-code/internal/config"
+)
+
+func TestNewFeishuAdapterCommandForwardsFlags(t *testing.T) {
+	originalRunner := runFeishuAdapterCommand
+	t.Cleanup(func() { runFeishuAdapterCommand = originalRunner })
+
+	var captured feishuAdapterCommandOptions
+	runFeishuAdapterCommand = func(ctx context.Context, options feishuAdapterCommandOptions) error {
+		captured = options
+		return nil
+	}
+
+	cmd := newFeishuAdapterCommand()
+	cmd.SetArgs([]string{
+		"--listen", "127.0.0.1:19090",
+		"--event-path", "/event",
+		"--card-path", "/card",
+		"--app-id", "app",
+		"--app-secret", "secret",
+		"--gateway-listen", "tcp://gateway",
+	})
+	if err := cmd.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute command: %v", err)
+	}
+	if captured.Listen != "127.0.0.1:19090" || captured.EventPath != "/event" || captured.CardPath != "/card" {
+		t.Fatalf("unexpected forwarded options: %#v", captured)
+	}
+	if captured.AppID != "app" || captured.AppSecret != "secret" || captured.GatewayListen != "tcp://gateway" {
+		t.Fatalf("unexpected credential/gateway options: %#v", captured)
+	}
+}
+
+func TestMergeFeishuOptionsAppliesDefaultsAndOverrides(t *testing.T) {
+	merged := mergeFeishuOptions(config.FeishuConfig{}, feishuAdapterCommandOptions{
+		Listen:            "127.0.0.1:20000",
+		AppID:             "app-x",
+		AppSecret:         "secret-x",
+		RequestTimeoutSec: 20,
+	}, config.GatewayConfig{})
+
+	if merged.Listen != "127.0.0.1:20000" {
+		t.Fatalf("listen = %q, want override", merged.Listen)
+	}
+	if merged.AppID != "app-x" || merged.AppSecret != "secret-x" {
+		t.Fatalf("app credentials not applied: %#v", merged)
+	}
+	if merged.RequestTimeoutSec != 20 {
+		t.Fatalf("request timeout = %d, want 20", merged.RequestTimeoutSec)
+	}
+	if merged.EventPath == "" || merged.CardPath == "" || merged.RebindIntervalSec <= 0 {
+		t.Fatalf("expected defaults applied, got %#v", merged)
+	}
+}
+
+func TestNewRootCommandContainsFeishuAdapter(t *testing.T) {
+	root := NewRootCommand()
+	found := false
+	for _, command := range root.Commands() {
+		if command.Name() == "feishu-adapter" {
+			found = true
+			if !shouldSkipGlobalPreload(command) {
+				t.Fatal("feishu-adapter should skip global preload")
+			}
+			if !shouldSkipSilentUpdateCheck(command) {
+				t.Fatal("feishu-adapter should skip silent update check")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected feishu-adapter command in root")
+	}
+}
+
+func TestNewFeishuAdapterCommandPropagatesRunnerError(t *testing.T) {
+	originalRunner := runFeishuAdapterCommand
+	t.Cleanup(func() { runFeishuAdapterCommand = originalRunner })
+
+	expected := errors.New("boom")
+	runFeishuAdapterCommand = func(ctx context.Context, options feishuAdapterCommandOptions) error {
+		return expected
+	}
+	cmd := newFeishuAdapterCommand()
+	if err := cmd.ExecuteContext(context.Background()); !errors.Is(err, expected) {
+		t.Fatalf("error = %v, want %v", err, expected)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -98,6 +98,7 @@ func NewRootCommand() *cobra.Command {
 	_ = settings.BindPFlag("wake-input-b64", cmd.PersistentFlags().Lookup("wake-input-b64"))
 	cmd.AddCommand(
 		newGatewayCommand(),
+		newFeishuAdapterCommand(),
 		newWebCommand(),
 		newDaemonCommand(),
 		newShellCommand(),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	Tools                   ToolsConfig      `yaml:"tools,omitempty"`
 	Memo                    MemoConfig       `yaml:"memo,omitempty"`
 	Gateway                 GatewayConfig    `yaml:"gateway,omitempty"`
+	Feishu                  FeishuConfig     `yaml:"feishu,omitempty"`
 }
 
 // StaticDefaults 返回 config 层负责的静态默认值骨架，不包含 provider 装配和选择状态修复。
@@ -45,6 +46,7 @@ func StaticDefaults() *Config {
 		},
 		Memo:    defaultMemoConfig(),
 		Gateway: defaultGatewayConfig(),
+		Feishu:  defaultFeishuConfig(),
 	}
 }
 
@@ -60,6 +62,7 @@ func (c *Config) Clone() Config {
 	clone.Tools = c.Tools.Clone()
 	clone.Memo = c.Memo.Clone()
 	clone.Gateway = c.Gateway.Clone()
+	clone.Feishu = c.Feishu.Clone()
 	return clone
 }
 
@@ -86,6 +89,7 @@ func (c *Config) applyStaticDefaults(defaults Config) {
 	c.Tools.ApplyDefaults(defaults.Tools)
 	c.Memo.ApplyDefaults(defaults.Memo)
 	c.Gateway.ApplyDefaults(defaults.Gateway)
+	c.Feishu.ApplyDefaults(defaults.Feishu)
 
 	c.Workdir = normalizeWorkdir(c.Workdir)
 }
@@ -150,6 +154,9 @@ func (c *Config) ValidateSnapshot() error {
 	}
 	if err := c.Gateway.Validate(); err != nil {
 		return fmt.Errorf("config: gateway: %w", err)
+	}
+	if err := c.Feishu.Validate(); err != nil {
+		return fmt.Errorf("config: feishu: %w", err)
 	}
 
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1753,6 +1753,18 @@ func TestValidateSnapshotPropagatesCompactError(t *testing.T) {
 	}
 }
 
+func TestValidateSnapshotPropagatesFeishuError(t *testing.T) {
+	t.Parallel()
+
+	cfg := testDefaultConfig().Clone()
+	cfg.Workdir = filepath.Clean(t.TempDir())
+	cfg.Feishu = FeishuConfig{Enabled: true}
+	err := cfg.ValidateSnapshot()
+	if err == nil || !strings.Contains(err.Error(), "config: feishu:") {
+		t.Fatalf("expected feishu validation error, got %v", err)
+	}
+}
+
 func TestManagerUpdateNilMutateFunc(t *testing.T) {
 	tempDir := t.TempDir()
 	manager := NewManager(NewLoader(tempDir, testDefaultConfig()))

--- a/internal/config/feishu.go
+++ b/internal/config/feishu.go
@@ -1,0 +1,134 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// DefaultFeishuAdapterListen 定义飞书适配器默认监听地址。
+	DefaultFeishuAdapterListen = "127.0.0.1:18080"
+	// DefaultFeishuAdapterEventPath 定义飞书事件回调默认路径。
+	DefaultFeishuAdapterEventPath = "/feishu/events"
+	// DefaultFeishuAdapterCardPath 定义飞书审批卡片回调默认路径。
+	DefaultFeishuAdapterCardPath = "/feishu/cards"
+	// DefaultFeishuIdempotencyTTLSec 定义飞书事件去重 TTL 默认秒数。
+	DefaultFeishuIdempotencyTTLSec = 600
+	// DefaultFeishuGatewayRequestTimeoutSec 定义飞书适配器访问网关默认超时秒数。
+	DefaultFeishuGatewayRequestTimeoutSec = 8
+	// DefaultFeishuReconnectBackoffMinMs 定义飞书网关重连最小退避时间毫秒。
+	DefaultFeishuReconnectBackoffMinMs = 500
+	// DefaultFeishuReconnectBackoffMaxMs 定义飞书网关重连最大退避时间毫秒。
+	DefaultFeishuReconnectBackoffMaxMs = 10000
+	// DefaultFeishuRebindIntervalSec 定义飞书适配器重绑会话默认间隔秒数。
+	DefaultFeishuRebindIntervalSec = 15
+)
+
+// FeishuConfig 表示飞书适配器配置。
+type FeishuConfig struct {
+	Enabled              bool                      `yaml:"enabled,omitempty"`
+	AppID                string                    `yaml:"app_id,omitempty"`
+	AppSecret            string                    `yaml:"app_secret,omitempty"`
+	VerifyToken          string                    `yaml:"verify_token,omitempty"`
+	SigningSecret        string                    `yaml:"signing_secret,omitempty"`
+	CallbackBaseURL      string                    `yaml:"callback_base_url,omitempty"`
+	Adapter              FeishuAdapterConfig       `yaml:"adapter,omitempty"`
+	GatewayClient        FeishuGatewayClientConfig `yaml:"gateway,omitempty"`
+	RequestTimeoutSec    int                       `yaml:"request_timeout_sec,omitempty"`
+	IdempotencyTTLSec    int                       `yaml:"idempotency_ttl_sec,omitempty"`
+	ReconnectBackoffMinM int                       `yaml:"reconnect_backoff_min_ms,omitempty"`
+	ReconnectBackoffMaxM int                       `yaml:"reconnect_backoff_max_ms,omitempty"`
+	RebindIntervalSec    int                       `yaml:"rebind_interval_sec,omitempty"`
+}
+
+// FeishuAdapterConfig 表示飞书适配器 HTTP 服务配置。
+type FeishuAdapterConfig struct {
+	Listen   string `yaml:"listen,omitempty"`
+	EventURI string `yaml:"event_path,omitempty"`
+	CardURI  string `yaml:"card_path,omitempty"`
+}
+
+// FeishuGatewayClientConfig 表示飞书适配器访问网关时的连接配置。
+type FeishuGatewayClientConfig struct {
+	ListenAddress string `yaml:"listen,omitempty"`
+	TokenFile     string `yaml:"token_file,omitempty"`
+}
+
+// defaultFeishuConfig 返回飞书配置默认值。
+func defaultFeishuConfig() FeishuConfig {
+	return FeishuConfig{}
+}
+
+// ApplyDefaults 为飞书配置补齐默认值。
+func (c *FeishuConfig) ApplyDefaults(defaults FeishuConfig) {
+	if c == nil {
+		return
+	}
+	if strings.TrimSpace(c.Adapter.Listen) == "" {
+		c.Adapter.Listen = defaults.Adapter.Listen
+	}
+	if strings.TrimSpace(c.Adapter.EventURI) == "" {
+		c.Adapter.EventURI = defaults.Adapter.EventURI
+	}
+	if strings.TrimSpace(c.Adapter.CardURI) == "" {
+		c.Adapter.CardURI = defaults.Adapter.CardURI
+	}
+	if c.RequestTimeoutSec <= 0 {
+		c.RequestTimeoutSec = defaults.RequestTimeoutSec
+	}
+	if c.IdempotencyTTLSec <= 0 {
+		c.IdempotencyTTLSec = defaults.IdempotencyTTLSec
+	}
+	if c.ReconnectBackoffMinM <= 0 {
+		c.ReconnectBackoffMinM = defaults.ReconnectBackoffMinM
+	}
+	if c.ReconnectBackoffMaxM <= 0 {
+		c.ReconnectBackoffMaxM = defaults.ReconnectBackoffMaxM
+	}
+	if c.RebindIntervalSec <= 0 {
+		c.RebindIntervalSec = defaults.RebindIntervalSec
+	}
+}
+
+// Clone 深拷贝飞书配置。
+func (c FeishuConfig) Clone() FeishuConfig {
+	return c
+}
+
+// Validate 校验飞书配置合法性。
+func (c FeishuConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if strings.TrimSpace(c.AppID) == "" {
+		return fmt.Errorf("app_id is required when feishu.enabled=true")
+	}
+	if strings.TrimSpace(c.AppSecret) == "" {
+		return fmt.Errorf("app_secret is required when feishu.enabled=true")
+	}
+	if strings.TrimSpace(c.Adapter.Listen) == "" {
+		return fmt.Errorf("adapter.listen is required when feishu.enabled=true")
+	}
+	if strings.TrimSpace(c.Adapter.EventURI) == "" {
+		return fmt.Errorf("adapter.event_path is required when feishu.enabled=true")
+	}
+	if strings.TrimSpace(c.Adapter.CardURI) == "" {
+		return fmt.Errorf("adapter.card_path is required when feishu.enabled=true")
+	}
+	if c.RequestTimeoutSec <= 0 {
+		return fmt.Errorf("request_timeout_sec must be greater than 0")
+	}
+	if c.IdempotencyTTLSec <= 0 {
+		return fmt.Errorf("idempotency_ttl_sec must be greater than 0")
+	}
+	if c.ReconnectBackoffMinM <= 0 || c.ReconnectBackoffMaxM <= 0 {
+		return fmt.Errorf("reconnect_backoff_min_ms/max_ms must be greater than 0")
+	}
+	if c.ReconnectBackoffMinM > c.ReconnectBackoffMaxM {
+		return fmt.Errorf("reconnect_backoff_min_ms must be less than or equal to reconnect_backoff_max_ms")
+	}
+	if c.RebindIntervalSec <= 0 {
+		return fmt.Errorf("rebind_interval_sec must be greater than 0")
+	}
+	return nil
+}

--- a/internal/config/feishu.go
+++ b/internal/config/feishu.go
@@ -56,7 +56,18 @@ type FeishuGatewayClientConfig struct {
 
 // defaultFeishuConfig 返回飞书配置默认值。
 func defaultFeishuConfig() FeishuConfig {
-	return FeishuConfig{}
+	return FeishuConfig{
+		Adapter: FeishuAdapterConfig{
+			Listen:   DefaultFeishuAdapterListen,
+			EventURI: DefaultFeishuAdapterEventPath,
+			CardURI:  DefaultFeishuAdapterCardPath,
+		},
+		RequestTimeoutSec:    DefaultFeishuGatewayRequestTimeoutSec,
+		IdempotencyTTLSec:    DefaultFeishuIdempotencyTTLSec,
+		ReconnectBackoffMinM: DefaultFeishuReconnectBackoffMinMs,
+		ReconnectBackoffMaxM: DefaultFeishuReconnectBackoffMaxMs,
+		RebindIntervalSec:    DefaultFeishuRebindIntervalSec,
+	}
 }
 
 // ApplyDefaults 为飞书配置补齐默认值。

--- a/internal/config/feishu.go
+++ b/internal/config/feishu.go
@@ -26,19 +26,20 @@ const (
 
 // FeishuConfig 表示飞书适配器配置。
 type FeishuConfig struct {
-	Enabled              bool                      `yaml:"enabled,omitempty"`
-	AppID                string                    `yaml:"app_id,omitempty"`
-	AppSecret            string                    `yaml:"app_secret,omitempty"`
-	VerifyToken          string                    `yaml:"verify_token,omitempty"`
-	SigningSecret        string                    `yaml:"signing_secret,omitempty"`
-	CallbackBaseURL      string                    `yaml:"callback_base_url,omitempty"`
-	Adapter              FeishuAdapterConfig       `yaml:"adapter,omitempty"`
-	GatewayClient        FeishuGatewayClientConfig `yaml:"gateway,omitempty"`
-	RequestTimeoutSec    int                       `yaml:"request_timeout_sec,omitempty"`
-	IdempotencyTTLSec    int                       `yaml:"idempotency_ttl_sec,omitempty"`
-	ReconnectBackoffMinM int                       `yaml:"reconnect_backoff_min_ms,omitempty"`
-	ReconnectBackoffMaxM int                       `yaml:"reconnect_backoff_max_ms,omitempty"`
-	RebindIntervalSec    int                       `yaml:"rebind_interval_sec,omitempty"`
+	Enabled                bool                      `yaml:"enabled,omitempty"`
+	AppID                  string                    `yaml:"app_id,omitempty"`
+	AppSecret              string                    `yaml:"app_secret,omitempty"`
+	VerifyToken            string                    `yaml:"verify_token,omitempty"`
+	SigningSecret          string                    `yaml:"signing_secret,omitempty"`
+	InsecureSkipSignVerify bool                      `yaml:"insecure_skip_signature_verify,omitempty"`
+	CallbackBaseURL        string                    `yaml:"callback_base_url,omitempty"`
+	Adapter                FeishuAdapterConfig       `yaml:"adapter,omitempty"`
+	GatewayClient          FeishuGatewayClientConfig `yaml:"gateway,omitempty"`
+	RequestTimeoutSec      int                       `yaml:"request_timeout_sec,omitempty"`
+	IdempotencyTTLSec      int                       `yaml:"idempotency_ttl_sec,omitempty"`
+	ReconnectBackoffMinM   int                       `yaml:"reconnect_backoff_min_ms,omitempty"`
+	ReconnectBackoffMaxM   int                       `yaml:"reconnect_backoff_max_ms,omitempty"`
+	RebindIntervalSec      int                       `yaml:"rebind_interval_sec,omitempty"`
 }
 
 // FeishuAdapterConfig 表示飞书适配器 HTTP 服务配置。
@@ -105,6 +106,12 @@ func (c FeishuConfig) Validate() error {
 	}
 	if strings.TrimSpace(c.AppSecret) == "" {
 		return fmt.Errorf("app_secret is required when feishu.enabled=true")
+	}
+	if strings.TrimSpace(c.VerifyToken) == "" {
+		return fmt.Errorf("verify_token is required when feishu.enabled=true")
+	}
+	if !c.InsecureSkipSignVerify && strings.TrimSpace(c.SigningSecret) == "" {
+		return fmt.Errorf("signing_secret is required when feishu.enabled=true unless insecure_skip_signature_verify=true")
 	}
 	if strings.TrimSpace(c.Adapter.Listen) == "" {
 		return fmt.Errorf("adapter.listen is required when feishu.enabled=true")

--- a/internal/config/feishu_test.go
+++ b/internal/config/feishu_test.go
@@ -82,6 +82,11 @@ func TestFeishuConfigApplyDefaults(t *testing.T) {
 	}
 }
 
+func TestFeishuConfigApplyDefaultsAllowsNilReceiver(t *testing.T) {
+	var cfg *FeishuConfig
+	cfg.ApplyDefaults(defaultFeishuConfig())
+}
+
 func TestDefaultFeishuConfigProvidesRuntimeDefaults(t *testing.T) {
 	defaults := defaultFeishuConfig()
 	if defaults.Adapter.Listen != DefaultFeishuAdapterListen {
@@ -107,5 +112,102 @@ func TestDefaultFeishuConfigProvidesRuntimeDefaults(t *testing.T) {
 	}
 	if defaults.RebindIntervalSec != DefaultFeishuRebindIntervalSec {
 		t.Fatalf("default rebind interval = %d, want %d", defaults.RebindIntervalSec, DefaultFeishuRebindIntervalSec)
+	}
+}
+
+func TestFeishuConfigClonePreservesValues(t *testing.T) {
+	original := FeishuConfig{
+		Enabled:       true,
+		AppID:         "app",
+		AppSecret:     "secret",
+		VerifyToken:   "verify",
+		SigningSecret: "sign",
+		Adapter: FeishuAdapterConfig{
+			Listen:   "127.0.0.1:18080",
+			EventURI: "/events",
+			CardURI:  "/cards",
+		},
+		RequestTimeoutSec:    8,
+		IdempotencyTTLSec:    600,
+		ReconnectBackoffMinM: 500,
+		ReconnectBackoffMaxM: 1000,
+		RebindIntervalSec:    15,
+	}
+	cloned := original.Clone()
+	if cloned != original {
+		t.Fatalf("clone = %#v, want %#v", cloned, original)
+	}
+}
+
+func TestFeishuConfigValidateRejectsInvalidNumericRanges(t *testing.T) {
+	base := FeishuConfig{
+		Enabled:       true,
+		AppID:         "app",
+		AppSecret:     "secret",
+		VerifyToken:   "verify",
+		SigningSecret: "sign",
+		Adapter: FeishuAdapterConfig{
+			Listen:   "127.0.0.1:18080",
+			EventURI: "/events",
+			CardURI:  "/cards",
+		},
+		RequestTimeoutSec:    8,
+		IdempotencyTTLSec:    600,
+		ReconnectBackoffMinM: 500,
+		ReconnectBackoffMaxM: 1000,
+		RebindIntervalSec:    15,
+	}
+	testCases := []struct {
+		name   string
+		mutate func(*FeishuConfig)
+	}{
+		{name: "request timeout", mutate: func(cfg *FeishuConfig) { cfg.RequestTimeoutSec = 0 }},
+		{name: "idempotency ttl", mutate: func(cfg *FeishuConfig) { cfg.IdempotencyTTLSec = 0 }},
+		{name: "reconnect min", mutate: func(cfg *FeishuConfig) { cfg.ReconnectBackoffMinM = 0 }},
+		{name: "reconnect order", mutate: func(cfg *FeishuConfig) { cfg.ReconnectBackoffMinM = 2000 }},
+		{name: "rebind interval", mutate: func(cfg *FeishuConfig) { cfg.RebindIntervalSec = 0 }},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := base.Clone()
+			testCase.mutate(&cfg)
+			if err := cfg.Validate(); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestFeishuConfigValidateRejectsMissingRequiredFieldsIndividually(t *testing.T) {
+	base := FeishuConfig{
+		Enabled:       true,
+		AppID:         "app",
+		AppSecret:     "secret",
+		VerifyToken:   "verify",
+		SigningSecret: "sign",
+		Adapter: FeishuAdapterConfig{
+			Listen:   "127.0.0.1:18080",
+			EventURI: "/events",
+			CardURI:  "/cards",
+		},
+		RequestTimeoutSec:    8,
+		IdempotencyTTLSec:    600,
+		ReconnectBackoffMinM: 500,
+		ReconnectBackoffMaxM: 1000,
+		RebindIntervalSec:    15,
+	}
+	testCases := []func(*FeishuConfig){
+		func(cfg *FeishuConfig) { cfg.AppSecret = "" },
+		func(cfg *FeishuConfig) { cfg.SigningSecret = "" },
+		func(cfg *FeishuConfig) { cfg.Adapter.Listen = "" },
+		func(cfg *FeishuConfig) { cfg.Adapter.EventURI = "" },
+		func(cfg *FeishuConfig) { cfg.Adapter.CardURI = "" },
+	}
+	for index, mutate := range testCases {
+		cfg := base.Clone()
+		mutate(&cfg)
+		if err := cfg.Validate(); err == nil {
+			t.Fatalf("case %d: expected validation error", index)
+		}
 	}
 }

--- a/internal/config/feishu_test.go
+++ b/internal/config/feishu_test.go
@@ -1,0 +1,39 @@
+package config
+
+import "testing"
+
+func TestFeishuConfigValidateDisabledAllowsEmpty(t *testing.T) {
+	var cfg FeishuConfig
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate disabled feishu config: %v", err)
+	}
+}
+
+func TestFeishuConfigValidateEnabledRequiresFields(t *testing.T) {
+	cfg := FeishuConfig{Enabled: true}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected validation error for incomplete enabled config")
+	}
+}
+
+func TestFeishuConfigApplyDefaults(t *testing.T) {
+	var cfg FeishuConfig
+	cfg.ApplyDefaults(FeishuConfig{
+		Adapter: FeishuAdapterConfig{
+			Listen:   DefaultFeishuAdapterListen,
+			EventURI: DefaultFeishuAdapterEventPath,
+			CardURI:  DefaultFeishuAdapterCardPath,
+		},
+		RequestTimeoutSec:    DefaultFeishuGatewayRequestTimeoutSec,
+		IdempotencyTTLSec:    DefaultFeishuIdempotencyTTLSec,
+		ReconnectBackoffMinM: DefaultFeishuReconnectBackoffMinMs,
+		ReconnectBackoffMaxM: DefaultFeishuReconnectBackoffMaxMs,
+		RebindIntervalSec:    DefaultFeishuRebindIntervalSec,
+	})
+	if cfg.Adapter.Listen == "" || cfg.Adapter.EventURI == "" || cfg.Adapter.CardURI == "" {
+		t.Fatalf("adapter defaults not applied: %#v", cfg.Adapter)
+	}
+	if cfg.RequestTimeoutSec <= 0 || cfg.IdempotencyTTLSec <= 0 || cfg.RebindIntervalSec <= 0 {
+		t.Fatalf("scalar defaults not applied: %#v", cfg)
+	}
+}

--- a/internal/config/feishu_test.go
+++ b/internal/config/feishu_test.go
@@ -81,3 +81,31 @@ func TestFeishuConfigApplyDefaults(t *testing.T) {
 		t.Fatalf("scalar defaults not applied: %#v", cfg)
 	}
 }
+
+func TestDefaultFeishuConfigProvidesRuntimeDefaults(t *testing.T) {
+	defaults := defaultFeishuConfig()
+	if defaults.Adapter.Listen != DefaultFeishuAdapterListen {
+		t.Fatalf("default adapter listen = %q, want %q", defaults.Adapter.Listen, DefaultFeishuAdapterListen)
+	}
+	if defaults.Adapter.EventURI != DefaultFeishuAdapterEventPath {
+		t.Fatalf("default adapter event path = %q, want %q", defaults.Adapter.EventURI, DefaultFeishuAdapterEventPath)
+	}
+	if defaults.Adapter.CardURI != DefaultFeishuAdapterCardPath {
+		t.Fatalf("default adapter card path = %q, want %q", defaults.Adapter.CardURI, DefaultFeishuAdapterCardPath)
+	}
+	if defaults.RequestTimeoutSec != DefaultFeishuGatewayRequestTimeoutSec {
+		t.Fatalf("default request timeout = %d, want %d", defaults.RequestTimeoutSec, DefaultFeishuGatewayRequestTimeoutSec)
+	}
+	if defaults.IdempotencyTTLSec != DefaultFeishuIdempotencyTTLSec {
+		t.Fatalf("default idempotency ttl = %d, want %d", defaults.IdempotencyTTLSec, DefaultFeishuIdempotencyTTLSec)
+	}
+	if defaults.ReconnectBackoffMinM != DefaultFeishuReconnectBackoffMinMs {
+		t.Fatalf("default reconnect min = %d, want %d", defaults.ReconnectBackoffMinM, DefaultFeishuReconnectBackoffMinMs)
+	}
+	if defaults.ReconnectBackoffMaxM != DefaultFeishuReconnectBackoffMaxMs {
+		t.Fatalf("default reconnect max = %d, want %d", defaults.ReconnectBackoffMaxM, DefaultFeishuReconnectBackoffMaxMs)
+	}
+	if defaults.RebindIntervalSec != DefaultFeishuRebindIntervalSec {
+		t.Fatalf("default rebind interval = %d, want %d", defaults.RebindIntervalSec, DefaultFeishuRebindIntervalSec)
+	}
+}

--- a/internal/config/feishu_test.go
+++ b/internal/config/feishu_test.go
@@ -16,6 +16,50 @@ func TestFeishuConfigValidateEnabledRequiresFields(t *testing.T) {
 	}
 }
 
+func TestFeishuConfigValidateRequiresVerifyAndSigningSecretByDefault(t *testing.T) {
+	cfg := FeishuConfig{
+		Enabled:   true,
+		AppID:     "app",
+		AppSecret: "secret",
+		Adapter: FeishuAdapterConfig{
+			Listen:   "127.0.0.1:18080",
+			EventURI: "/feishu/events",
+			CardURI:  "/feishu/cards",
+		},
+		RequestTimeoutSec:    8,
+		IdempotencyTTLSec:    600,
+		ReconnectBackoffMinM: 500,
+		ReconnectBackoffMaxM: 10000,
+		RebindIntervalSec:    15,
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected validation error when verify/signing secret are missing")
+	}
+}
+
+func TestFeishuConfigValidateAllowsInsecureSkipSignatureVerify(t *testing.T) {
+	cfg := FeishuConfig{
+		Enabled:                true,
+		AppID:                  "app",
+		AppSecret:              "secret",
+		VerifyToken:            "verify",
+		InsecureSkipSignVerify: true,
+		Adapter: FeishuAdapterConfig{
+			Listen:   "127.0.0.1:18080",
+			EventURI: "/feishu/events",
+			CardURI:  "/feishu/cards",
+		},
+		RequestTimeoutSec:    8,
+		IdempotencyTTLSec:    600,
+		ReconnectBackoffMinM: 500,
+		ReconnectBackoffMaxM: 10000,
+		RebindIntervalSec:    15,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected config to pass with insecure skip, got %v", err)
+	}
+}
+
 func TestFeishuConfigApplyDefaults(t *testing.T) {
 	var cfg FeishuConfig
 	cfg.ApplyDefaults(FeishuConfig{

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -32,6 +32,7 @@ type persistedConfig struct {
 	Tools                   ToolsConfig            `yaml:"tools,omitempty"`
 	Memo                    persistedMemoConfig    `yaml:"memo,omitempty"`
 	Gateway                 GatewayConfig          `yaml:"gateway,omitempty"`
+	Feishu                  FeishuConfig           `yaml:"feishu,omitempty"`
 }
 
 type persistedContextConfig struct {
@@ -236,6 +237,7 @@ func parseCurrentConfig(data []byte, contextDefaults ContextConfig, memoDefaults
 		Tools:                   file.Tools,
 		Memo:                    fromPersistedMemoConfig(file.Memo, memoDefaults),
 		Gateway:                 file.Gateway,
+		Feishu:                  file.Feishu,
 	}
 
 	return cfg, nil
@@ -253,6 +255,7 @@ func marshalPersistedConfig(snapshot Config) ([]byte, error) {
 		Tools:                   snapshot.Tools,
 		Memo:                    newPersistedMemoConfig(snapshot.Memo),
 		Gateway:                 snapshot.Gateway,
+		Feishu:                  snapshot.Feishu,
 	}
 
 	data, err := yaml.Marshal(&file)

--- a/internal/feishuadapter/adapter.go
+++ b/internal/feishuadapter/adapter.go
@@ -186,6 +186,17 @@ func (a *Adapter) handleCardCallback(writer http.ResponseWriter, request *http.R
 	if !ok {
 		return
 	}
+	var envelope inboundEnvelope
+	if err := json.Unmarshal(body, &envelope); err == nil {
+		if strings.EqualFold(strings.TrimSpace(envelope.Type), "url_verification") {
+			if !a.verifyCallbackToken(envelope.Token, envelope.Header.Token) {
+				http.Error(writer, "invalid verify token", http.StatusUnauthorized)
+				return
+			}
+			writeJSON(writer, http.StatusOK, map[string]string{"challenge": envelope.Challenge})
+			return
+		}
+	}
 	var callback inboundCardCallback
 	if err := json.Unmarshal(body, &callback); err != nil {
 		http.Error(writer, "invalid card callback body", http.StatusBadRequest)
@@ -198,7 +209,8 @@ func (a *Adapter) handleCardCallback(writer http.ResponseWriter, request *http.R
 	requestID := strings.TrimSpace(callback.Action.Value["request_id"])
 	decision := strings.TrimSpace(strings.ToLower(callback.Action.Value["decision"]))
 	if requestID == "" || (decision != "allow_once" && decision != "reject") {
-		http.Error(writer, "invalid card action", http.StatusBadRequest)
+		// 飞书后台在“回调地址验证”阶段可能下发不带 action 的探测请求，此处返回 200 以便完成校验。
+		writeJSON(writer, http.StatusOK, map[string]any{"toast": map[string]string{"type": "info", "content": "callback ready"}})
 		return
 	}
 	dedupeKey := "card:" + requestID + ":" + decision
@@ -285,7 +297,7 @@ func (a *Adapter) consumeGatewayEvents(ctx context.Context) {
 
 // handleGatewayEvent 将 gateway.event 映射成飞书文本或审批卡片。
 func (a *Adapter) handleGatewayEvent(ctx context.Context, raw json.RawMessage) {
-	eventType, sessionID, runID, envelope, err := parseGatewayRuntimeEvent(raw)
+	eventType, sessionID, _, envelope, err := parseGatewayRuntimeEvent(raw)
 	if err != nil {
 		a.safeLog("decode gateway event failed: %v", err)
 		return
@@ -296,7 +308,6 @@ func (a *Adapter) handleGatewayEvent(ctx context.Context, raw json.RawMessage) {
 	}
 	switch strings.ToLower(strings.TrimSpace(eventType)) {
 	case "run_progress":
-		text := "运行中"
 		if envelope != nil {
 			if runtimeType := readString(envelope, "runtime_event_type"); runtimeType != "" {
 				if strings.EqualFold(runtimeType, "permission_requested") {
@@ -309,21 +320,22 @@ func (a *Adapter) handleGatewayEvent(ctx context.Context, raw json.RawMessage) {
 						return
 					}
 				}
-				if !a.shouldEmitProgress(sessionID, runID, runtimeType) {
-					return
-				}
-				text = fmt.Sprintf("运行进度：%s", runtimeType)
-			} else if !a.shouldEmitProgress(sessionID, runID, "progress") {
-				return
 			}
-		} else if !a.shouldEmitProgress(sessionID, runID, "progress") {
-			return
 		}
-		_ = a.messenger.SendText(ctx, chatID, text)
+		// 除审批请求外，内部 runtime_event_type 不直接透出到飞书用户视图，避免暴露控制面细节。
+		return
 	case "run_done":
-		_ = a.messenger.SendText(ctx, chatID, fmt.Sprintf("任务完成（run_id=%s）", runID))
+		doneText := extractUserVisibleDoneText(envelope)
+		if doneText == "" {
+			doneText = "任务完成。"
+		}
+		_ = a.messenger.SendText(ctx, chatID, doneText)
 	case "run_error":
-		_ = a.messenger.SendText(ctx, chatID, fmt.Sprintf("任务失败（run_id=%s）", runID))
+		errText := extractUserVisibleErrorText(envelope)
+		if errText == "" {
+			errText = "任务失败，请稍后重试。"
+		}
+		_ = a.messenger.SendText(ctx, chatID, errText)
 	}
 }
 
@@ -484,6 +496,65 @@ func extractPermissionRequest(envelope map[string]any) (string, string) {
 		reason = "工具执行请求审批，请确认是否放行。"
 	}
 	return requestID, reason
+}
+
+// extractUserVisibleDoneText 从 run_done 事件中提取可展示给飞书用户的最终文本。
+func extractUserVisibleDoneText(envelope map[string]any) string {
+	if envelope == nil {
+		return ""
+	}
+	payload, _ := envelope["payload"].(map[string]any)
+	if payload == nil {
+		return ""
+	}
+	if text := strings.TrimSpace(readString(payload, "content")); text != "" {
+		return text
+	}
+	if text := strings.TrimSpace(readString(payload, "text")); text != "" {
+		return text
+	}
+	parts, _ := payload["parts"].([]any)
+	if len(parts) == 0 {
+		return ""
+	}
+	lines := make([]string, 0, len(parts))
+	for _, raw := range parts {
+		part, _ := raw.(map[string]any)
+		if part == nil {
+			continue
+		}
+		partType := strings.TrimSpace(strings.ToLower(readString(part, "type")))
+		if partType != "" && partType != "text" {
+			continue
+		}
+		text := strings.TrimSpace(readString(part, "text"))
+		if text == "" {
+			text = strings.TrimSpace(readString(part, "content"))
+		}
+		if text != "" {
+			lines = append(lines, text)
+		}
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}
+
+// extractUserVisibleErrorText 从 run_error 事件中提取对用户友好的失败摘要。
+func extractUserVisibleErrorText(envelope map[string]any) string {
+	if envelope == nil {
+		return ""
+	}
+	payload, _ := envelope["payload"].(map[string]any)
+	if payload == nil {
+		return ""
+	}
+	message := strings.TrimSpace(readString(payload, "message"))
+	if message == "" {
+		message = strings.TrimSpace(readString(payload, "error"))
+	}
+	if message == "" {
+		return ""
+	}
+	return "任务失败：" + message
 }
 
 // nextBackoff 计算指数退避下一步等待时间。

--- a/internal/feishuadapter/adapter.go
+++ b/internal/feishuadapter/adapter.go
@@ -16,6 +16,7 @@ import (
 )
 
 const defaultSignatureMaxSkew = 5 * time.Minute
+const defaultProgressNotifyInterval = 5 * time.Second
 
 type sessionBinding struct {
 	ChatID string
@@ -34,6 +35,7 @@ type Adapter struct {
 
 	mu             sync.RWMutex
 	activeSessions map[string]sessionBinding
+	lastProgressAt map[string]time.Time
 }
 
 // New 创建飞书适配器实例。
@@ -58,6 +60,7 @@ func New(cfg Config, gateway GatewayClient, messenger Messenger, logger *log.Log
 		idem:           newIdempotencyStore(cfg.IdempotencyTTL),
 		nowFn:          func() time.Time { return time.Now().UTC() },
 		activeSessions: make(map[string]sessionBinding),
+		lastProgressAt: make(map[string]time.Time),
 	}, nil
 }
 
@@ -141,11 +144,23 @@ func (a *Adapter) handleFeishuEvent(writer http.ResponseWriter, request *http.Re
 		return
 	}
 
+	if !shouldHandleChatMessage(event) {
+		writeJSON(writer, http.StatusOK, map[string]string{"message": "ignored_not_mentioned"})
+		return
+	}
 	dedupeKey := "msg:" + strings.TrimSpace(envelope.Header.EventID) + ":" + strings.TrimSpace(event.Message.MessageID)
-	if a.idem.Seen(dedupeKey, a.nowFn()) {
+	if !a.idem.TryStart(dedupeKey, a.nowFn()) {
 		writeJSON(writer, http.StatusOK, map[string]string{"message": "duplicated"})
 		return
 	}
+	succeeded := false
+	defer func() {
+		if succeeded {
+			a.idem.MarkDone(dedupeKey, a.nowFn())
+			return
+		}
+		a.idem.MarkFailed(dedupeKey)
+	}()
 
 	text, err := decodeMessageText(event.Message.Content)
 	if err != nil {
@@ -161,6 +176,7 @@ func (a *Adapter) handleFeishuEvent(writer http.ResponseWriter, request *http.Re
 		writeJSON(writer, http.StatusOK, map[string]string{"message": "accepted_with_error"})
 		return
 	}
+	succeeded = true
 	writeJSON(writer, http.StatusOK, map[string]string{"message": "accepted"})
 }
 
@@ -186,10 +202,18 @@ func (a *Adapter) handleCardCallback(writer http.ResponseWriter, request *http.R
 		return
 	}
 	dedupeKey := "card:" + requestID + ":" + decision
-	if a.idem.Seen(dedupeKey, a.nowFn()) {
+	if !a.idem.TryStart(dedupeKey, a.nowFn()) {
 		writeJSON(writer, http.StatusOK, map[string]any{"toast": map[string]string{"type": "info", "content": "已处理"}})
 		return
 	}
+	succeeded := false
+	defer func() {
+		if succeeded {
+			a.idem.MarkDone(dedupeKey, a.nowFn())
+			return
+		}
+		a.idem.MarkFailed(dedupeKey)
+	}()
 	ctx, cancel := context.WithTimeout(request.Context(), a.cfg.RequestTimeout)
 	defer cancel()
 	if err := a.gateway.ResolvePermission(ctx, requestID, decision); err != nil {
@@ -197,6 +221,7 @@ func (a *Adapter) handleCardCallback(writer http.ResponseWriter, request *http.R
 		writeJSON(writer, http.StatusOK, map[string]any{"toast": map[string]string{"type": "error", "content": "审批提交失败"}})
 		return
 	}
+	succeeded = true
 	writeJSON(writer, http.StatusOK, map[string]any{"toast": map[string]string{"type": "success", "content": "审批已提交"}})
 }
 
@@ -274,7 +299,6 @@ func (a *Adapter) handleGatewayEvent(ctx context.Context, raw json.RawMessage) {
 		text := "运行中"
 		if envelope != nil {
 			if runtimeType := readString(envelope, "runtime_event_type"); runtimeType != "" {
-				text = fmt.Sprintf("运行进度：%s", runtimeType)
 				if strings.EqualFold(runtimeType, "permission_requested") {
 					requestID, reason := extractPermissionRequest(envelope)
 					if requestID != "" {
@@ -285,7 +309,15 @@ func (a *Adapter) handleGatewayEvent(ctx context.Context, raw json.RawMessage) {
 						return
 					}
 				}
+				if !a.shouldEmitProgress(sessionID, runID, runtimeType) {
+					return
+				}
+				text = fmt.Sprintf("运行进度：%s", runtimeType)
+			} else if !a.shouldEmitProgress(sessionID, runID, "progress") {
+				return
 			}
+		} else if !a.shouldEmitProgress(sessionID, runID, "progress") {
+			return
 		}
 		_ = a.messenger.SendText(ctx, chatID, text)
 	case "run_done":
@@ -371,7 +403,14 @@ func (a *Adapter) readAndVerifyRequest(writer http.ResponseWriter, request *http
 		http.Error(writer, "read request failed", http.StatusBadRequest)
 		return nil, false
 	}
-	if !verifyFeishuSignature(a.cfg.SigningSecret, defaultSignatureMaxSkew, request.Header, body, a.nowFn()) {
+	if !verifyFeishuSignature(
+		a.cfg.SigningSecret,
+		defaultSignatureMaxSkew,
+		request.Header,
+		body,
+		a.nowFn(),
+		a.cfg.InsecureSkipSignVerify,
+	) {
 		http.Error(writer, "invalid signature", http.StatusUnauthorized)
 		return nil, false
 	}
@@ -381,9 +420,6 @@ func (a *Adapter) readAndVerifyRequest(writer http.ResponseWriter, request *http
 // verifyCallbackToken 校验飞书回调 token，支持 body/header 双位置兼容。
 func (a *Adapter) verifyCallbackToken(rawToken string, headerToken string) bool {
 	expected := strings.TrimSpace(a.cfg.VerifyToken)
-	if expected == "" {
-		return true
-	}
 	candidates := []string{strings.TrimSpace(rawToken), strings.TrimSpace(headerToken)}
 	for _, candidate := range candidates {
 		if candidate == expected {
@@ -391,6 +427,36 @@ func (a *Adapter) verifyCallbackToken(rawToken string, headerToken string) bool 
 		}
 	}
 	return false
+}
+
+// shouldEmitProgress 控制普通运行进度消息推送频率，避免飞书侧刷屏。
+func (a *Adapter) shouldEmitProgress(sessionID string, runID string, runtimeEventType string) bool {
+	key := sessionID + "|" + runID + "|" + strings.TrimSpace(strings.ToLower(runtimeEventType))
+	now := a.nowFn()
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	last, ok := a.lastProgressAt[key]
+	if ok && now.Sub(last) < defaultProgressNotifyInterval {
+		return false
+	}
+	a.lastProgressAt[key] = now
+	return true
+}
+
+// shouldHandleChatMessage 约束群聊场景仅在 @ 机器人时触发 run；私聊保持默认受理。
+func shouldHandleChatMessage(event inboundMessageEvent) bool {
+	chatType := strings.TrimSpace(strings.ToLower(event.Message.ChatType))
+	if chatType == "" {
+		chatType = strings.TrimSpace(strings.ToLower(event.ChatType))
+	}
+	if chatType != "group" {
+		return true
+	}
+	if len(event.Message.Mentions) > 0 {
+		return true
+	}
+	normalized := strings.ToLower(strings.TrimSpace(event.Message.Content))
+	return strings.Contains(normalized, "<at ")
 }
 
 // decodeMessageText 从飞书消息 content JSON 中提取文本内容。

--- a/internal/feishuadapter/adapter.go
+++ b/internal/feishuadapter/adapter.go
@@ -1,0 +1,458 @@
+package feishuadapter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"neo-code/internal/gateway/protocol"
+)
+
+const defaultSignatureMaxSkew = 5 * time.Minute
+
+type sessionBinding struct {
+	ChatID string
+	RunID  string
+}
+
+// Adapter 负责桥接飞书回调与 Gateway JSON-RPC 长连接。
+type Adapter struct {
+	cfg       Config
+	gateway   GatewayClient
+	messenger Messenger
+	logger    *log.Logger
+	idem      *idempotencyStore
+
+	nowFn func() time.Time
+
+	mu             sync.RWMutex
+	activeSessions map[string]sessionBinding
+}
+
+// New 创建飞书适配器实例。
+func New(cfg Config, gateway GatewayClient, messenger Messenger, logger *log.Logger) (*Adapter, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	if gateway == nil {
+		return nil, fmt.Errorf("gateway client is required")
+	}
+	if messenger == nil {
+		return nil, fmt.Errorf("messenger is required")
+	}
+	if logger == nil {
+		logger = log.New(io.Discard, "", 0)
+	}
+	return &Adapter{
+		cfg:            cfg,
+		gateway:        gateway,
+		messenger:      messenger,
+		logger:         logger,
+		idem:           newIdempotencyStore(cfg.IdempotencyTTL),
+		nowFn:          func() time.Time { return time.Now().UTC() },
+		activeSessions: make(map[string]sessionBinding),
+	}, nil
+}
+
+// Run 启动飞书适配器 HTTP 服务与网关事件消费循环。
+func (a *Adapter) Run(ctx context.Context) error {
+	if err := a.gateway.Authenticate(ctx); err != nil {
+		return fmt.Errorf("authenticate gateway: %w", err)
+	}
+
+	go a.consumeGatewayEvents(ctx)
+	go a.reconnectAndRebindLoop(ctx)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(a.cfg.EventPath, a.handleFeishuEvent)
+	mux.HandleFunc(a.cfg.CardPath, a.handleCardCallback)
+	server := &http.Server{
+		Addr:              a.cfg.ListenAddress,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      15 * time.Second,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- server.ListenAndServe()
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+		_ = a.gateway.Close()
+		return ctx.Err()
+	case err := <-done:
+		_ = a.gateway.Close()
+		if err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
+	}
+}
+
+// handleFeishuEvent 处理飞书事件回调，完成 challenge、签名校验与消息转发。
+func (a *Adapter) handleFeishuEvent(writer http.ResponseWriter, request *http.Request) {
+	body, ok := a.readAndVerifyRequest(writer, request)
+	if !ok {
+		return
+	}
+	var envelope inboundEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		http.Error(writer, "invalid json body", http.StatusBadRequest)
+		return
+	}
+
+	if strings.EqualFold(strings.TrimSpace(envelope.Type), "url_verification") {
+		if !a.verifyCallbackToken(envelope.Token, envelope.Header.Token) {
+			http.Error(writer, "invalid verify token", http.StatusUnauthorized)
+			return
+		}
+		writeJSON(writer, http.StatusOK, map[string]string{"challenge": envelope.Challenge})
+		return
+	}
+	if strings.TrimSpace(envelope.Header.EventType) != "im.message.receive_v1" {
+		writeJSON(writer, http.StatusOK, map[string]string{"message": "ignored"})
+		return
+	}
+	if !a.verifyCallbackToken(envelope.Token, envelope.Header.Token) {
+		http.Error(writer, "invalid verify token", http.StatusUnauthorized)
+		return
+	}
+
+	var event inboundMessageEvent
+	if err := json.Unmarshal(envelope.Event, &event); err != nil {
+		http.Error(writer, "invalid event body", http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(event.Message.MessageID) == "" || strings.TrimSpace(event.Message.ChatID) == "" {
+		http.Error(writer, "missing message_id or chat_id", http.StatusBadRequest)
+		return
+	}
+
+	dedupeKey := "msg:" + strings.TrimSpace(envelope.Header.EventID) + ":" + strings.TrimSpace(event.Message.MessageID)
+	if a.idem.Seen(dedupeKey, a.nowFn()) {
+		writeJSON(writer, http.StatusOK, map[string]string{"message": "duplicated"})
+		return
+	}
+
+	text, err := decodeMessageText(event.Message.Content)
+	if err != nil {
+		http.Error(writer, "invalid message content", http.StatusBadRequest)
+		return
+	}
+	sessionID := BuildSessionID(event.Message.ChatID)
+	runID := BuildRunID(event.Message.MessageID)
+
+	if err := a.bindThenRun(request.Context(), sessionID, runID, event.Message.ChatID, text); err != nil {
+		a.safeLog("handle message failed: %v", err)
+		_ = a.messenger.SendText(context.Background(), event.Message.ChatID, "任务受理失败，请稍后重试。")
+		writeJSON(writer, http.StatusOK, map[string]string{"message": "accepted_with_error"})
+		return
+	}
+	writeJSON(writer, http.StatusOK, map[string]string{"message": "accepted"})
+}
+
+// handleCardCallback 处理飞书审批卡片回调并映射到 gateway.resolvePermission。
+func (a *Adapter) handleCardCallback(writer http.ResponseWriter, request *http.Request) {
+	body, ok := a.readAndVerifyRequest(writer, request)
+	if !ok {
+		return
+	}
+	var callback inboundCardCallback
+	if err := json.Unmarshal(body, &callback); err != nil {
+		http.Error(writer, "invalid card callback body", http.StatusBadRequest)
+		return
+	}
+	if !a.verifyCallbackToken(callback.Token, callback.Header.Token) {
+		http.Error(writer, "invalid verify token", http.StatusUnauthorized)
+		return
+	}
+	requestID := strings.TrimSpace(callback.Action.Value["request_id"])
+	decision := strings.TrimSpace(strings.ToLower(callback.Action.Value["decision"]))
+	if requestID == "" || (decision != "allow_once" && decision != "reject") {
+		http.Error(writer, "invalid card action", http.StatusBadRequest)
+		return
+	}
+	dedupeKey := "card:" + requestID + ":" + decision
+	if a.idem.Seen(dedupeKey, a.nowFn()) {
+		writeJSON(writer, http.StatusOK, map[string]any{"toast": map[string]string{"type": "info", "content": "已处理"}})
+		return
+	}
+	ctx, cancel := context.WithTimeout(request.Context(), a.cfg.RequestTimeout)
+	defer cancel()
+	if err := a.gateway.ResolvePermission(ctx, requestID, decision); err != nil {
+		a.safeLog("resolve permission failed: %v", err)
+		writeJSON(writer, http.StatusOK, map[string]any{"toast": map[string]string{"type": "error", "content": "审批提交失败"}})
+		return
+	}
+	writeJSON(writer, http.StatusOK, map[string]any{"toast": map[string]string{"type": "success", "content": "审批已提交"}})
+}
+
+// bindThenRun 按 authenticate -> bindStream -> run 的顺序提交一次请求并记录会话绑定。
+func (a *Adapter) bindThenRun(ctx context.Context, sessionID string, runID string, chatID string, text string) error {
+	callCtx, cancel := context.WithTimeout(ctx, a.cfg.RequestTimeout)
+	defer cancel()
+	if err := a.gateway.Authenticate(callCtx); err != nil {
+		return err
+	}
+	if err := a.gateway.BindStream(callCtx, sessionID, runID); err != nil {
+		return err
+	}
+	a.trackSession(sessionID, runID, chatID)
+	if err := a.gateway.Run(callCtx, sessionID, runID, text); err != nil {
+		return err
+	}
+	_ = a.messenger.SendText(context.Background(), chatID, "任务已受理，正在执行。")
+	return nil
+}
+
+// trackSession 记录 session 到飞书 chat 的映射，用于事件回推。
+func (a *Adapter) trackSession(sessionID string, runID string, chatID string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.activeSessions[sessionID] = sessionBinding{
+		ChatID: chatID,
+		RunID:  runID,
+	}
+}
+
+// lookupChatID 根据 session_id 查找需要回推的飞书 chat_id。
+func (a *Adapter) lookupChatID(sessionID string) string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	binding, ok := a.activeSessions[sessionID]
+	if !ok {
+		return ""
+	}
+	return binding.ChatID
+}
+
+// consumeGatewayEvents 持续消费网关通知流并转发到飞书侧展示。
+func (a *Adapter) consumeGatewayEvents(ctx context.Context) {
+	notifications := a.gateway.Notifications()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case notification, ok := <-notifications:
+			if !ok {
+				return
+			}
+			if strings.TrimSpace(notification.Method) != protocol.MethodGatewayEvent {
+				continue
+			}
+			a.handleGatewayEvent(ctx, notification.Params)
+		}
+	}
+}
+
+// handleGatewayEvent 将 gateway.event 映射成飞书文本或审批卡片。
+func (a *Adapter) handleGatewayEvent(ctx context.Context, raw json.RawMessage) {
+	eventType, sessionID, runID, envelope, err := parseGatewayRuntimeEvent(raw)
+	if err != nil {
+		a.safeLog("decode gateway event failed: %v", err)
+		return
+	}
+	chatID := a.lookupChatID(sessionID)
+	if chatID == "" {
+		return
+	}
+	switch strings.ToLower(strings.TrimSpace(eventType)) {
+	case "run_progress":
+		text := "运行中"
+		if envelope != nil {
+			if runtimeType := readString(envelope, "runtime_event_type"); runtimeType != "" {
+				text = fmt.Sprintf("运行进度：%s", runtimeType)
+				if strings.EqualFold(runtimeType, "permission_requested") {
+					requestID, reason := extractPermissionRequest(envelope)
+					if requestID != "" {
+						_ = a.messenger.SendPermissionCard(ctx, chatID, PermissionCardPayload{
+							RequestID: requestID,
+							Message:   reason,
+						})
+						return
+					}
+				}
+			}
+		}
+		_ = a.messenger.SendText(ctx, chatID, text)
+	case "run_done":
+		_ = a.messenger.SendText(ctx, chatID, fmt.Sprintf("任务完成（run_id=%s）", runID))
+	case "run_error":
+		_ = a.messenger.SendText(ctx, chatID, fmt.Sprintf("任务失败（run_id=%s）", runID))
+	}
+}
+
+// reconnectAndRebindLoop 定期保活网关连接，并在重连后重绑活跃会话。
+func (a *Adapter) reconnectAndRebindLoop(ctx context.Context) {
+	delay := a.cfg.ReconnectBackoffMin
+	ticker := time.NewTicker(a.cfg.RebindInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			callCtx, cancel := context.WithTimeout(ctx, a.cfg.RequestTimeout)
+			err := a.gateway.Ping(callCtx)
+			cancel()
+			if err == nil {
+				delay = a.cfg.ReconnectBackoffMin
+				a.rebindActiveSessions(ctx)
+				continue
+			}
+			a.safeLog("gateway ping failed, will reconnect: %v", err)
+			if !a.retryAuthenticateAndRebind(ctx, delay) {
+				return
+			}
+			delay = nextBackoff(delay, a.cfg.ReconnectBackoffMax)
+		}
+	}
+}
+
+// retryAuthenticateAndRebind 在连接异常后执行一次认证重试与会话重绑。
+func (a *Adapter) retryAuthenticateAndRebind(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delayWithJitter(delay))
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+	}
+	callCtx, cancel := context.WithTimeout(ctx, a.cfg.RequestTimeout)
+	defer cancel()
+	if err := a.gateway.Authenticate(callCtx); err != nil {
+		a.safeLog("gateway re-authenticate failed: %v", err)
+		return true
+	}
+	a.rebindActiveSessions(callCtx)
+	return true
+}
+
+// rebindActiveSessions 对当前活跃会话重新执行 bindStream，恢复事件订阅关系。
+func (a *Adapter) rebindActiveSessions(ctx context.Context) {
+	a.mu.RLock()
+	snapshot := make(map[string]sessionBinding, len(a.activeSessions))
+	for sessionID, binding := range a.activeSessions {
+		snapshot[sessionID] = binding
+	}
+	a.mu.RUnlock()
+
+	for sessionID, binding := range snapshot {
+		callCtx, cancel := context.WithTimeout(ctx, a.cfg.RequestTimeout)
+		err := a.gateway.BindStream(callCtx, sessionID, binding.RunID)
+		cancel()
+		if err != nil {
+			a.safeLog("rebind session failed session_id=%s err=%v", sessionID, err)
+		}
+	}
+}
+
+// readAndVerifyRequest 读取回调请求体并完成签名校验。
+func (a *Adapter) readAndVerifyRequest(writer http.ResponseWriter, request *http.Request) ([]byte, bool) {
+	if request.Method != http.MethodPost {
+		http.Error(writer, "method not allowed", http.StatusMethodNotAllowed)
+		return nil, false
+	}
+	body, err := io.ReadAll(io.LimitReader(request.Body, 1<<20))
+	if err != nil {
+		http.Error(writer, "read request failed", http.StatusBadRequest)
+		return nil, false
+	}
+	if !verifyFeishuSignature(a.cfg.SigningSecret, defaultSignatureMaxSkew, request.Header, body, a.nowFn()) {
+		http.Error(writer, "invalid signature", http.StatusUnauthorized)
+		return nil, false
+	}
+	return body, true
+}
+
+// verifyCallbackToken 校验飞书回调 token，支持 body/header 双位置兼容。
+func (a *Adapter) verifyCallbackToken(rawToken string, headerToken string) bool {
+	expected := strings.TrimSpace(a.cfg.VerifyToken)
+	if expected == "" {
+		return true
+	}
+	candidates := []string{strings.TrimSpace(rawToken), strings.TrimSpace(headerToken)}
+	for _, candidate := range candidates {
+		if candidate == expected {
+			return true
+		}
+	}
+	return false
+}
+
+// decodeMessageText 从飞书消息 content JSON 中提取文本内容。
+func decodeMessageText(rawContent string) (string, error) {
+	trimmed := strings.TrimSpace(rawContent)
+	if trimmed == "" {
+		return "", nil
+	}
+	var payload inboundMessageContent
+	if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(payload.Text), nil
+}
+
+// extractPermissionRequest 从 permission_requested 事件中抽取审批请求关键信息。
+func extractPermissionRequest(envelope map[string]any) (string, string) {
+	payload, _ := envelope["payload"].(map[string]any)
+	if payload == nil {
+		return "", "需要审批"
+	}
+	requestID := readString(payload, "request_id")
+	reason := readString(payload, "reason")
+	if reason == "" {
+		reason = "工具执行请求审批，请确认是否放行。"
+	}
+	return requestID, reason
+}
+
+// nextBackoff 计算指数退避下一步等待时间。
+func nextBackoff(current time.Duration, max time.Duration) time.Duration {
+	next := current * 2
+	if next > max {
+		return max
+	}
+	return next
+}
+
+// delayWithJitter 为退避时间添加轻量随机抖动，减少重连风暴。
+func delayWithJitter(delay time.Duration) time.Duration {
+	if delay <= 0 {
+		return 200 * time.Millisecond
+	}
+	span := int64(delay / 4)
+	if span <= 0 {
+		return delay
+	}
+	jitter := rand.Int63n(span)
+	return delay - time.Duration(span/2) + time.Duration(jitter)
+}
+
+// writeJSON 向回调响应写入 JSON 内容。
+func writeJSON(writer http.ResponseWriter, status int, payload any) {
+	writer.Header().Set("Content-Type", "application/json")
+	writer.WriteHeader(status)
+	_ = json.NewEncoder(writer).Encode(payload)
+}
+
+// safeLog 输出适配器日志，并避免 nil logger 导致 panic。
+func (a *Adapter) safeLog(format string, args ...any) {
+	if a.logger == nil {
+		return
+	}
+	a.logger.Printf(format, args...)
+}

--- a/internal/feishuadapter/adapter.go
+++ b/internal/feishuadapter/adapter.go
@@ -252,6 +252,8 @@ func (a *Adapter) bindThenRun(ctx context.Context, sessionID string, runID strin
 	}
 	a.trackSession(sessionID, runID, chatID)
 	if err := a.gateway.Run(callCtx, sessionID, runID, text); err != nil {
+		// run 受理失败时及时回收活跃绑定，避免重连阶段反复重绑无效 run。
+		a.untrackRun(sessionID, runID)
 		return err
 	}
 	_ = a.messenger.SendText(context.Background(), chatID, "任务已受理，正在执行。")

--- a/internal/feishuadapter/adapter.go
+++ b/internal/feishuadapter/adapter.go
@@ -376,7 +376,6 @@ func (a *Adapter) reconnectAndRebindLoop(ctx context.Context) {
 			cancel()
 			if err == nil {
 				delay = a.cfg.ReconnectBackoffMin
-				a.rebindActiveSessions(ctx)
 				continue
 			}
 			a.safeLog("gateway ping failed, will reconnect: %v", err)

--- a/internal/feishuadapter/adapter_test.go
+++ b/internal/feishuadapter/adapter_test.go
@@ -24,7 +24,11 @@ type fakeGatewayClient struct {
 	notifications chan GatewayNotification
 	runCount      int
 	resolveCount  int
+	authCount     int
 	pingErr       error
+	authErr       error
+	bindErr       error
+	resolveErr    error
 	runErr        error
 	runErrOnce    bool
 }
@@ -35,11 +39,16 @@ func newFakeGatewayClient() *fakeGatewayClient {
 
 func (f *fakeGatewayClient) Authenticate(context.Context) error {
 	f.record("authenticate")
-	return nil
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.authCount++
+	return f.authErr
 }
 func (f *fakeGatewayClient) BindStream(_ context.Context, sessionID string, runID string) error {
 	f.record("bind:" + sessionID + ":" + runID)
-	return nil
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.bindErr
 }
 func (f *fakeGatewayClient) Run(_ context.Context, sessionID string, runID string, inputText string) error {
 	f.record("run:" + sessionID + ":" + runID + ":" + inputText)
@@ -56,9 +65,9 @@ func (f *fakeGatewayClient) Run(_ context.Context, sessionID string, runID strin
 func (f *fakeGatewayClient) ResolvePermission(_ context.Context, requestID string, decision string) error {
 	f.record("resolve:" + requestID + ":" + decision)
 	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.resolveCount++
-	f.mu.Unlock()
-	return nil
+	return f.resolveErr
 }
 func (f *fakeGatewayClient) Ping(context.Context) error {
 	f.record("ping")
@@ -131,6 +140,62 @@ func TestBuildIDsStable(t *testing.T) {
 	}
 }
 
+func TestNewRejectsMissingDependencies(t *testing.T) {
+	cfg := Config{
+		ListenAddress:       "127.0.0.1:18080",
+		EventPath:           "/feishu/events",
+		CardPath:            "/feishu/cards",
+		AppID:               "app",
+		AppSecret:           "secret",
+		VerifyToken:         "verify",
+		SigningSecret:       "sign-secret",
+		RequestTimeout:      time.Second,
+		IdempotencyTTL:      time.Minute,
+		ReconnectBackoffMin: 100 * time.Millisecond,
+		ReconnectBackoffMax: time.Second,
+		RebindInterval:      time.Second,
+	}
+	if _, err := New(cfg, nil, &fakeMessenger{}, nil); err == nil {
+		t.Fatal("expected missing gateway error")
+	}
+	if _, err := New(cfg, newFakeGatewayClient(), nil, nil); err == nil {
+		t.Fatal("expected missing messenger error")
+	}
+}
+
+func TestRunReturnsAuthenticateFailure(t *testing.T) {
+	adapter := newTestAdapter(t)
+	gateway := adapterTestGateway(adapter)
+	gateway.mu.Lock()
+	gateway.authErr = assertErr("auth failed")
+	gateway.mu.Unlock()
+
+	err := adapter.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "authenticate gateway") {
+		t.Fatalf("run error = %v, want authenticate failure", err)
+	}
+}
+
+func TestRunStopsOnContextCancel(t *testing.T) {
+	adapter := newTestAdapter(t)
+	adapter.cfg.ListenAddress = "127.0.0.1:0"
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- adapter.Run(ctx)
+	}()
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Fatalf("run error = %v, want context canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for adapter shutdown")
+	}
+}
+
 func TestHandleFeishuEventChallenge(t *testing.T) {
 	adapter := newTestAdapter(t)
 	body := `{"type":"url_verification","challenge":"abc","token":"verify"}`
@@ -155,6 +220,32 @@ func TestHandleFeishuEventRejectsInvalidSignature(t *testing.T) {
 	adapter.handleFeishuEvent(recorder, request)
 	if recorder.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want 401", recorder.Code)
+	}
+}
+
+func TestHandleFeishuEventCoversValidationFailures(t *testing.T) {
+	adapter := newTestAdapter(t)
+	testCases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{name: "invalid json", body: `{`, want: http.StatusBadRequest},
+		{name: "ignored event", body: `{"header":{"event_type":"other","token":"verify"}}`, want: http.StatusOK},
+		{name: "invalid token", body: `{"header":{"event_type":"im.message.receive_v1","token":"bad"},"event":{}}`, want: http.StatusUnauthorized},
+		{name: "invalid event body", body: `{"header":{"event_type":"im.message.receive_v1","token":"verify"},"event":"oops"}`, want: http.StatusBadRequest},
+		{name: "missing ids", body: `{"header":{"event_type":"im.message.receive_v1","token":"verify"},"event":{"message":{"message_id":"","chat_id":""}}}`, want: http.StatusBadRequest},
+		{name: "invalid content", body: "{\"header\":{\"event_id\":\"evt-invalid-content\",\"event_type\":\"im.message.receive_v1\",\"token\":\"verify\"},\"event\":{\"message\":{\"message_id\":\"msg-invalid-content\",\"chat_id\":\"chat-invalid-content\",\"content\":\"{\"}}}", want: http.StatusBadRequest},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			request := signedRequest(t, adapter.cfg.SigningSecret, testCase.body)
+			recorder := httptest.NewRecorder()
+			adapter.handleFeishuEvent(recorder, request)
+			if recorder.Code != testCase.want {
+				t.Fatalf("status = %d, want %d body=%s", recorder.Code, testCase.want, recorder.Body.String())
+			}
+		})
 	}
 }
 
@@ -461,6 +552,25 @@ func TestCardCallbackDedupeResolveOnce(t *testing.T) {
 	}
 }
 
+func TestCardCallbackResolveFailureKeepsHTTP200(t *testing.T) {
+	adapter := newTestAdapter(t)
+	gateway := adapterTestGateway(adapter)
+	gateway.mu.Lock()
+	gateway.resolveErr = assertErr("deny")
+	gateway.mu.Unlock()
+
+	body := `{"action":{"value":{"request_id":"perm-3","decision":"reject"}},"token":"verify"}`
+	request := signedRequest(t, adapter.cfg.SigningSecret, body)
+	recorder := httptest.NewRecorder()
+	adapter.handleCardCallback(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	if !strings.Contains(recorder.Body.String(), "审批提交失败") {
+		t.Fatalf("response = %s, want failure toast", recorder.Body.String())
+	}
+}
+
 func TestCardCallbackUrlVerificationAccepted(t *testing.T) {
 	adapter := newTestAdapter(t)
 	body := `{"type":"url_verification","challenge":"card-challenge","token":"verify","header":{"token":"verify"}}`
@@ -472,6 +582,28 @@ func TestCardCallbackUrlVerificationAccepted(t *testing.T) {
 	}
 	if !strings.Contains(recorder.Body.String(), `"challenge":"card-challenge"`) {
 		t.Fatalf("response = %s, want challenge", recorder.Body.String())
+	}
+}
+
+func TestHandleCardCallbackValidationFailures(t *testing.T) {
+	adapter := newTestAdapter(t)
+	testCases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{name: "invalid token", body: `{"token":"bad","header":{"token":"bad"}}`, want: http.StatusUnauthorized},
+		{name: "invalid json", body: `{`, want: http.StatusBadRequest},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			request := signedRequest(t, adapter.cfg.SigningSecret, testCase.body)
+			recorder := httptest.NewRecorder()
+			adapter.handleCardCallback(recorder, request)
+			if recorder.Code != testCase.want {
+				t.Fatalf("status = %d, want %d", recorder.Code, testCase.want)
+			}
+		})
 	}
 }
 
@@ -552,6 +684,109 @@ func TestReconnectHealthyPathDoesNotRebind(t *testing.T) {
 	if strings.Contains(calls, "bind:session-steady:run-steady") {
 		t.Fatalf("did not expect steady-state rebind call in %v", calls)
 	}
+}
+
+func TestRetryAuthenticateAndRebindHandlesAuthFailure(t *testing.T) {
+	adapter := newTestAdapter(t)
+	gateway := adapterTestGateway(adapter)
+	gateway.mu.Lock()
+	gateway.authErr = assertErr("re-auth failed")
+	gateway.mu.Unlock()
+	adapter.trackSession("session-auth-fail", "run-auth-fail", "chat-auth-fail")
+
+	if ok := adapter.retryAuthenticateAndRebind(context.Background(), time.Millisecond); !ok {
+		t.Fatal("expected retry loop to continue after auth failure")
+	}
+	calls := strings.Join(gateway.snapshotCalls(), "|")
+	if strings.Contains(calls, "bind:session-auth-fail:run-auth-fail") {
+		t.Fatalf("did not expect rebind after auth failure: %v", calls)
+	}
+}
+
+func TestRetryAuthenticateAndRebindStopsWhenContextCanceled(t *testing.T) {
+	adapter := newTestAdapter(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if ok := adapter.retryAuthenticateAndRebind(ctx, time.Hour); ok {
+		t.Fatal("expected retry to stop when context is canceled")
+	}
+}
+
+func TestReadAndVerifyRequestRejectsNonPost(t *testing.T) {
+	adapter := newTestAdapter(t)
+	request := httptest.NewRequest(http.MethodGet, "/feishu/events", nil)
+	recorder := httptest.NewRecorder()
+	if body, ok := adapter.readAndVerifyRequest(recorder, request); ok || body != nil {
+		t.Fatalf("expected non-post request rejection, body=%q ok=%v", string(body), ok)
+	}
+	if recorder.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", recorder.Code)
+	}
+}
+
+func TestReadAndVerifyRequestRejectsUnreadableBody(t *testing.T) {
+	adapter := newTestAdapter(t)
+	request := httptest.NewRequest(http.MethodPost, "/feishu/events", errReader{})
+	request.Header.Set(headerLarkTimestamp, strconvTimestamp(time.Now().UTC()))
+	request.Header.Set(headerLarkNonce, "nonce")
+	request.Header.Set(headerLarkSignature, "sig")
+	recorder := httptest.NewRecorder()
+	if _, ok := adapter.readAndVerifyRequest(recorder, request); ok {
+		t.Fatal("expected unreadable body to fail")
+	}
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", recorder.Code)
+	}
+}
+
+func TestShouldEmitProgressThrottlesRapidDuplicates(t *testing.T) {
+	adapter := newTestAdapter(t)
+	now := time.Now().UTC()
+	adapter.nowFn = func() time.Time { return now }
+	if !adapter.shouldEmitProgress("session", "run", "agent_chunk") {
+		t.Fatal("expected first progress event to emit")
+	}
+	if adapter.shouldEmitProgress("session", "run", "agent_chunk") {
+		t.Fatal("expected duplicate progress event to be throttled")
+	}
+	adapter.nowFn = func() time.Time { return now.Add(defaultProgressNotifyInterval + time.Millisecond) }
+	if !adapter.shouldEmitProgress("session", "run", "agent_chunk") {
+		t.Fatal("expected event after interval to emit")
+	}
+}
+
+func TestHelperFunctionsCoverFallbackBranches(t *testing.T) {
+	if text, err := decodeMessageText(""); err != nil || text != "" {
+		t.Fatalf("decode empty text = %q, %v", text, err)
+	}
+	if _, err := decodeMessageText("{"); err == nil {
+		t.Fatal("expected invalid message content error")
+	}
+	requestID, reason := extractPermissionRequest(nil)
+	if requestID != "" || reason == "" {
+		t.Fatalf("unexpected permission extraction: request=%q reason=%q", requestID, reason)
+	}
+	if text := extractUserVisibleDoneText(map[string]any{
+		"payload": map[string]any{"content": "done"},
+	}); text != "done" {
+		t.Fatalf("done text = %q, want direct content", text)
+	}
+	if text := extractUserVisibleErrorText(map[string]any{
+		"payload": map[string]any{"error": "boom"},
+	}); text != "任务失败：boom" {
+		t.Fatalf("error text = %q, want fallback error", text)
+	}
+	if text := extractUserVisibleErrorText(nil); text != "" {
+		t.Fatalf("error text = %q, want empty", text)
+	}
+	if delay := nextBackoff(time.Second, 1500*time.Millisecond); delay != 1500*time.Millisecond {
+		t.Fatalf("next backoff = %s, want capped max", delay)
+	}
+	if delay := delayWithJitter(0); delay != 200*time.Millisecond {
+		t.Fatalf("jitter delay = %s, want default fallback", delay)
+	}
+	safeLogAdapter := &Adapter{}
+	safeLogAdapter.safeLog("ignored")
 }
 
 func newTestAdapter(t *testing.T) *Adapter {
@@ -650,3 +885,9 @@ func pushGatewayEvent(t *testing.T, gw *fakeGatewayClient, sessionID string, run
 type assertErr string
 
 func (e assertErr) Error() string { return string(e) }
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) {
+	return 0, assertErr("read failed")
+}

--- a/internal/feishuadapter/adapter_test.go
+++ b/internal/feishuadapter/adapter_test.go
@@ -296,7 +296,37 @@ func TestGatewayEventsMappedToMessagesAndPermissionCard(t *testing.T) {
 	}
 }
 
-func TestRunProgressIsRateLimited(t *testing.T) {
+func TestRunDonePrefersAssistantTextForUserFacingReply(t *testing.T) {
+	adapter := newTestAdapter(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go adapter.consumeGatewayEvents(ctx)
+
+	sessionID := BuildSessionID("chat-done-text")
+	runID := BuildRunID("msg-done-text")
+	adapter.trackSession(sessionID, runID, "chat-done-text")
+
+	pushGatewayEvent(t, adapterTestGateway(adapter), sessionID, runID, "run_done", map[string]any{
+		"runtime_event_type": "agent_done",
+		"payload": map[string]any{
+			"parts": []map[string]any{
+				{"type": "text", "text": "这是最终回复"},
+			},
+		},
+	})
+	time.Sleep(30 * time.Millisecond)
+
+	msgs := adapterTestMessenger(adapter).snapshot()
+	if len(msgs) == 0 {
+		t.Fatalf("expected at least one message")
+	}
+	last := msgs[len(msgs)-1]
+	if last.kind != "text" || !strings.Contains(last.text, "这是最终回复") {
+		t.Fatalf("expected assistant final text, got %#v", last)
+	}
+}
+
+func TestRunProgressInternalEventsAreNotUserFacing(t *testing.T) {
 	adapter := newTestAdapter(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -320,8 +350,8 @@ func TestRunProgressIsRateLimited(t *testing.T) {
 			textCount++
 		}
 	}
-	if textCount != 1 {
-		t.Fatalf("progress message count = %d, want 1", textCount)
+	if textCount != 0 {
+		t.Fatalf("progress message count = %d, want 0", textCount)
 	}
 }
 
@@ -338,6 +368,34 @@ func TestCardCallbackDedupeResolveOnce(t *testing.T) {
 	}
 	if adapterTestGateway(adapter).resolveCount != 1 {
 		t.Fatalf("resolve count = %d, want 1", adapterTestGateway(adapter).resolveCount)
+	}
+}
+
+func TestCardCallbackUrlVerificationAccepted(t *testing.T) {
+	adapter := newTestAdapter(t)
+	body := `{"type":"url_verification","challenge":"card-challenge","token":"verify","header":{"token":"verify"}}`
+	request := signedRequest(t, adapter.cfg.SigningSecret, body)
+	recorder := httptest.NewRecorder()
+	adapter.handleCardCallback(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	if !strings.Contains(recorder.Body.String(), `"challenge":"card-challenge"`) {
+		t.Fatalf("response = %s, want challenge", recorder.Body.String())
+	}
+}
+
+func TestCardCallbackProbeWithoutActionReturnsOK(t *testing.T) {
+	adapter := newTestAdapter(t)
+	body := `{"token":"verify","header":{"token":"verify"}}`
+	request := signedRequest(t, adapter.cfg.SigningSecret, body)
+	recorder := httptest.NewRecorder()
+	adapter.handleCardCallback(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	if adapterTestGateway(adapter).resolveCount != 0 {
+		t.Fatalf("resolve count = %d, want 0", adapterTestGateway(adapter).resolveCount)
 	}
 }
 

--- a/internal/feishuadapter/adapter_test.go
+++ b/internal/feishuadapter/adapter_test.go
@@ -25,6 +25,8 @@ type fakeGatewayClient struct {
 	runCount      int
 	resolveCount  int
 	pingErr       error
+	runErr        error
+	runErrOnce    bool
 }
 
 func newFakeGatewayClient() *fakeGatewayClient {
@@ -43,8 +45,13 @@ func (f *fakeGatewayClient) Run(_ context.Context, sessionID string, runID strin
 	f.record("run:" + sessionID + ":" + runID + ":" + inputText)
 	f.mu.Lock()
 	f.runCount++
+	runErr := f.runErr
+	if f.runErrOnce {
+		f.runErr = nil
+		f.runErrOnce = false
+	}
 	f.mu.Unlock()
-	return nil
+	return runErr
 }
 func (f *fakeGatewayClient) ResolvePermission(_ context.Context, requestID string, decision string) error {
 	f.record("resolve:" + requestID + ":" + decision)
@@ -167,6 +174,75 @@ func TestMessageEventDedupeOnlyRunsOnce(t *testing.T) {
 	}
 }
 
+func TestMessageEventRetryAfterRunFailure(t *testing.T) {
+	adapter := newTestAdapter(t)
+	gateway := adapterTestGateway(adapter)
+	gateway.mu.Lock()
+	gateway.runErr = assertErr("transient")
+	gateway.runErrOnce = true
+	gateway.mu.Unlock()
+
+	body := messageEventBody("evt-retry", "msg-retry", "chat-retry", "hello")
+	for i := 0; i < 2; i++ {
+		request := signedRequest(t, adapter.cfg.SigningSecret, body)
+		recorder := httptest.NewRecorder()
+		adapter.handleFeishuEvent(recorder, request)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", recorder.Code)
+		}
+	}
+	if adapterTestGateway(adapter).runCount != 2 {
+		t.Fatalf("run count = %d, want 2", adapterTestGateway(adapter).runCount)
+	}
+}
+
+func TestGroupMessageWithoutMentionIgnored(t *testing.T) {
+	adapter := newTestAdapter(t)
+	body := messageEventBodyWithChatType("evt-group", "msg-group", "chat-group", "hello group", "group")
+	request := signedRequest(t, adapter.cfg.SigningSecret, body)
+	recorder := httptest.NewRecorder()
+	adapter.handleFeishuEvent(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	if adapterTestGateway(adapter).runCount != 0 {
+		t.Fatalf("run count = %d, want 0", adapterTestGateway(adapter).runCount)
+	}
+}
+
+func TestGroupMessageWithMentionAccepted(t *testing.T) {
+	adapter := newTestAdapter(t)
+	content, _ := json.Marshal(map[string]string{"text": "<at user_id=\"ou_xxx\">neo</at> hi"})
+	payload := map[string]any{
+		"header": map[string]any{
+			"event_id":   "evt-group-mention",
+			"event_type": "im.message.receive_v1",
+			"token":      "verify",
+		},
+		"event": map[string]any{
+			"message": map[string]any{
+				"message_id": "msg-group-mention",
+				"chat_id":    "chat-group-mention",
+				"chat_type":  "group",
+				"content":    string(content),
+				"mentions": []map[string]any{
+					{"name": "neo", "key": "@_user_1"},
+				},
+			},
+		},
+	}
+	raw, _ := json.Marshal(payload)
+	request := signedRequest(t, adapter.cfg.SigningSecret, string(raw))
+	recorder := httptest.NewRecorder()
+	adapter.handleFeishuEvent(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	if adapterTestGateway(adapter).runCount != 1 {
+		t.Fatalf("run count = %d, want 1", adapterTestGateway(adapter).runCount)
+	}
+}
+
 func TestCallOrderAuthenticateBindRun(t *testing.T) {
 	adapter := newTestAdapter(t)
 	body := messageEventBody("evt-2", "msg-2", "chat-2", "run it")
@@ -217,6 +293,35 @@ func TestGatewayEventsMappedToMessagesAndPermissionCard(t *testing.T) {
 	}
 	if !foundCard {
 		t.Fatalf("expected permission card message, got %#v", msgs)
+	}
+}
+
+func TestRunProgressIsRateLimited(t *testing.T) {
+	adapter := newTestAdapter(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go adapter.consumeGatewayEvents(ctx)
+
+	sessionID := BuildSessionID("chat-throttle")
+	runID := BuildRunID("msg-throttle")
+	adapter.trackSession(sessionID, runID, "chat-throttle")
+
+	pushGatewayEvent(t, adapterTestGateway(adapter), sessionID, runID, "run_progress", map[string]any{
+		"runtime_event_type": "agent_chunk",
+	})
+	pushGatewayEvent(t, adapterTestGateway(adapter), sessionID, runID, "run_progress", map[string]any{
+		"runtime_event_type": "agent_chunk",
+	})
+	time.Sleep(30 * time.Millisecond)
+
+	textCount := 0
+	for _, message := range adapterTestMessenger(adapter).snapshot() {
+		if message.kind == "text" && strings.Contains(message.text, "运行进度") {
+			textCount++
+		}
+	}
+	if textCount != 1 {
+		t.Fatalf("progress message count = %d, want 1", textCount)
 	}
 }
 
@@ -291,6 +396,10 @@ func adapterTestMessenger(adapter *Adapter) *fakeMessenger {
 }
 
 func messageEventBody(eventID string, messageID string, chatID string, text string) string {
+	return messageEventBodyWithChatType(eventID, messageID, chatID, text, "")
+}
+
+func messageEventBodyWithChatType(eventID string, messageID string, chatID string, text string, chatType string) string {
 	content, _ := json.Marshal(map[string]string{"text": text})
 	payload := map[string]any{
 		"header": map[string]any{
@@ -302,6 +411,7 @@ func messageEventBody(eventID string, messageID string, chatID string, text stri
 			"message": map[string]any{
 				"message_id": messageID,
 				"chat_id":    chatID,
+				"chat_type":  chatType,
 				"content":    string(content),
 			},
 		},

--- a/internal/feishuadapter/adapter_test.go
+++ b/internal/feishuadapter/adapter_test.go
@@ -1,0 +1,351 @@
+package feishuadapter
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"neo-code/internal/gateway/protocol"
+)
+
+type fakeGatewayClient struct {
+	mu            sync.Mutex
+	calls         []string
+	notifications chan GatewayNotification
+	runCount      int
+	resolveCount  int
+	pingErr       error
+}
+
+func newFakeGatewayClient() *fakeGatewayClient {
+	return &fakeGatewayClient{notifications: make(chan GatewayNotification, 16)}
+}
+
+func (f *fakeGatewayClient) Authenticate(context.Context) error {
+	f.record("authenticate")
+	return nil
+}
+func (f *fakeGatewayClient) BindStream(_ context.Context, sessionID string, runID string) error {
+	f.record("bind:" + sessionID + ":" + runID)
+	return nil
+}
+func (f *fakeGatewayClient) Run(_ context.Context, sessionID string, runID string, inputText string) error {
+	f.record("run:" + sessionID + ":" + runID + ":" + inputText)
+	f.mu.Lock()
+	f.runCount++
+	f.mu.Unlock()
+	return nil
+}
+func (f *fakeGatewayClient) ResolvePermission(_ context.Context, requestID string, decision string) error {
+	f.record("resolve:" + requestID + ":" + decision)
+	f.mu.Lock()
+	f.resolveCount++
+	f.mu.Unlock()
+	return nil
+}
+func (f *fakeGatewayClient) Ping(context.Context) error {
+	f.record("ping")
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.pingErr
+}
+func (f *fakeGatewayClient) Notifications() <-chan GatewayNotification { return f.notifications }
+func (f *fakeGatewayClient) Close() error {
+	close(f.notifications)
+	return nil
+}
+func (f *fakeGatewayClient) record(call string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, call)
+}
+func (f *fakeGatewayClient) snapshotCalls() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+type sentMessage struct {
+	chatID string
+	kind   string
+	text   string
+	card   PermissionCardPayload
+}
+
+type fakeMessenger struct {
+	mu       sync.Mutex
+	messages []sentMessage
+}
+
+func (m *fakeMessenger) SendText(_ context.Context, chatID string, text string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.messages = append(m.messages, sentMessage{chatID: chatID, kind: "text", text: text})
+	return nil
+}
+
+func (m *fakeMessenger) SendPermissionCard(_ context.Context, chatID string, payload PermissionCardPayload) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.messages = append(m.messages, sentMessage{chatID: chatID, kind: "card", card: payload})
+	return nil
+}
+
+func (m *fakeMessenger) snapshot() []sentMessage {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]sentMessage, len(m.messages))
+	copy(out, m.messages)
+	return out
+}
+
+func TestBuildIDsStable(t *testing.T) {
+	sessionA := BuildSessionID("chat-1")
+	sessionB := BuildSessionID("chat-1")
+	if sessionA == "" || sessionA != sessionB {
+		t.Fatalf("expected stable session id, got %q and %q", sessionA, sessionB)
+	}
+	runA := BuildRunID("msg-1")
+	runB := BuildRunID("msg-1")
+	if runA == "" || runA != runB {
+		t.Fatalf("expected stable run id, got %q and %q", runA, runB)
+	}
+}
+
+func TestHandleFeishuEventChallenge(t *testing.T) {
+	adapter := newTestAdapter(t)
+	body := `{"type":"url_verification","challenge":"abc","token":"verify"}`
+	request := signedRequest(t, adapter.cfg.SigningSecret, body)
+	recorder := httptest.NewRecorder()
+	adapter.handleFeishuEvent(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	if !strings.Contains(recorder.Body.String(), `"challenge":"abc"`) {
+		t.Fatalf("response = %s, want challenge", recorder.Body.String())
+	}
+}
+
+func TestHandleFeishuEventRejectsInvalidSignature(t *testing.T) {
+	adapter := newTestAdapter(t)
+	request := httptest.NewRequest(http.MethodPost, "/feishu/events", strings.NewReader(`{"type":"url_verification","challenge":"abc"}`))
+	request.Header.Set(headerLarkTimestamp, strconvTimestamp(time.Now().UTC()))
+	request.Header.Set(headerLarkNonce, "nonce")
+	request.Header.Set(headerLarkSignature, "invalid")
+	recorder := httptest.NewRecorder()
+	adapter.handleFeishuEvent(recorder, request)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", recorder.Code)
+	}
+}
+
+func TestMessageEventDedupeOnlyRunsOnce(t *testing.T) {
+	adapter := newTestAdapter(t)
+	body := messageEventBody("evt-1", "msg-1", "chat-1", "hello")
+	for i := 0; i < 2; i++ {
+		request := signedRequest(t, adapter.cfg.SigningSecret, body)
+		recorder := httptest.NewRecorder()
+		adapter.handleFeishuEvent(recorder, request)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", recorder.Code)
+		}
+	}
+	if adapterTestGateway(adapter).runCount != 1 {
+		t.Fatalf("run count = %d, want 1", adapterTestGateway(adapter).runCount)
+	}
+}
+
+func TestCallOrderAuthenticateBindRun(t *testing.T) {
+	adapter := newTestAdapter(t)
+	body := messageEventBody("evt-2", "msg-2", "chat-2", "run it")
+	request := signedRequest(t, adapter.cfg.SigningSecret, body)
+	recorder := httptest.NewRecorder()
+	adapter.handleFeishuEvent(recorder, request)
+
+	calls := adapterTestGateway(adapter).snapshotCalls()
+	joined := strings.Join(calls, "|")
+	authIndex := strings.Index(joined, "authenticate")
+	bindIndex := strings.Index(joined, "bind:")
+	runIndex := strings.Index(joined, "run:")
+	if !(authIndex >= 0 && bindIndex > authIndex && runIndex > bindIndex) {
+		t.Fatalf("unexpected call order: %v", calls)
+	}
+}
+
+func TestGatewayEventsMappedToMessagesAndPermissionCard(t *testing.T) {
+	adapter := newTestAdapter(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go adapter.consumeGatewayEvents(ctx)
+
+	adapter.trackSession(BuildSessionID("chat-x"), BuildRunID("msg-x"), "chat-x")
+	pushGatewayEvent(t, adapterTestGateway(adapter), BuildSessionID("chat-x"), BuildRunID("msg-x"), "run_done", map[string]any{
+		"runtime_event_type": "agent_done",
+	})
+	pushGatewayEvent(t, adapterTestGateway(adapter), BuildSessionID("chat-x"), BuildRunID("msg-x"), "run_error", map[string]any{
+		"runtime_event_type": "error",
+	})
+	pushGatewayEvent(t, adapterTestGateway(adapter), BuildSessionID("chat-x"), BuildRunID("msg-x"), "run_progress", map[string]any{
+		"runtime_event_type": "permission_requested",
+		"payload": map[string]any{
+			"request_id": "perm-1",
+			"reason":     "need approval",
+		},
+	})
+	time.Sleep(30 * time.Millisecond)
+	msgs := adapterTestMessenger(adapter).snapshot()
+	if len(msgs) < 3 {
+		t.Fatalf("messages = %#v, want >=3", msgs)
+	}
+	foundCard := false
+	for _, message := range msgs {
+		if message.kind == "card" && message.card.RequestID == "perm-1" {
+			foundCard = true
+		}
+	}
+	if !foundCard {
+		t.Fatalf("expected permission card message, got %#v", msgs)
+	}
+}
+
+func TestCardCallbackDedupeResolveOnce(t *testing.T) {
+	adapter := newTestAdapter(t)
+	body := `{"action":{"value":{"request_id":"perm-2","decision":"allow_once"}},"token":"verify"}`
+	for i := 0; i < 2; i++ {
+		request := signedRequest(t, adapter.cfg.SigningSecret, body)
+		recorder := httptest.NewRecorder()
+		adapter.handleCardCallback(recorder, request)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", recorder.Code)
+		}
+	}
+	if adapterTestGateway(adapter).resolveCount != 1 {
+		t.Fatalf("resolve count = %d, want 1", adapterTestGateway(adapter).resolveCount)
+	}
+}
+
+func TestReconnectRebindActiveSessions(t *testing.T) {
+	adapter := newTestAdapter(t)
+	gw := adapterTestGateway(adapter)
+	gw.pingErr = assertErr("dial failed")
+	adapter.trackSession("session-a", "run-a", "chat-a")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go adapter.reconnectAndRebindLoop(ctx)
+	time.Sleep(30 * time.Millisecond)
+	gw.mu.Lock()
+	gw.pingErr = nil
+	gw.mu.Unlock()
+	time.Sleep(80 * time.Millisecond)
+	cancel()
+	time.Sleep(20 * time.Millisecond)
+
+	calls := strings.Join(gw.snapshotCalls(), "|")
+	if !strings.Contains(calls, "bind:session-a:run-a") {
+		t.Fatalf("expected rebind call in %v", calls)
+	}
+}
+
+func newTestAdapter(t *testing.T) *Adapter {
+	t.Helper()
+	gateway := newFakeGatewayClient()
+	messenger := &fakeMessenger{}
+	adapter, err := New(Config{
+		ListenAddress:       "127.0.0.1:18080",
+		EventPath:           "/feishu/events",
+		CardPath:            "/feishu/cards",
+		AppID:               "app",
+		AppSecret:           "secret",
+		VerifyToken:         "verify",
+		SigningSecret:       "sign-secret",
+		RequestTimeout:      200 * time.Millisecond,
+		IdempotencyTTL:      2 * time.Minute,
+		ReconnectBackoffMin: 10 * time.Millisecond,
+		ReconnectBackoffMax: 20 * time.Millisecond,
+		RebindInterval:      20 * time.Millisecond,
+	}, gateway, messenger, nil)
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+	return adapter
+}
+
+func adapterTestGateway(adapter *Adapter) *fakeGatewayClient {
+	return adapter.gateway.(*fakeGatewayClient)
+}
+
+func adapterTestMessenger(adapter *Adapter) *fakeMessenger {
+	return adapter.messenger.(*fakeMessenger)
+}
+
+func messageEventBody(eventID string, messageID string, chatID string, text string) string {
+	content, _ := json.Marshal(map[string]string{"text": text})
+	payload := map[string]any{
+		"header": map[string]any{
+			"event_id":   eventID,
+			"event_type": "im.message.receive_v1",
+			"token":      "verify",
+		},
+		"event": map[string]any{
+			"message": map[string]any{
+				"message_id": messageID,
+				"chat_id":    chatID,
+				"content":    string(content),
+			},
+		},
+	}
+	data, _ := json.Marshal(payload)
+	return string(data)
+}
+
+func signedRequest(t *testing.T, secret string, body string) *http.Request {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, "/callback", bytes.NewBufferString(body))
+	timestamp := strconvTimestamp(time.Now().UTC())
+	nonce := "nonce"
+	raw := timestamp + nonce + body
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(raw))
+	signature := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	request.Header.Set(headerLarkTimestamp, timestamp)
+	request.Header.Set(headerLarkNonce, nonce)
+	request.Header.Set(headerLarkSignature, signature)
+	return request
+}
+
+func strconvTimestamp(now time.Time) string {
+	return fmt.Sprintf("%d", now.Unix())
+}
+
+func pushGatewayEvent(t *testing.T, gw *fakeGatewayClient, sessionID string, runID string, eventType string, envelope map[string]any) {
+	t.Helper()
+	frame := map[string]any{
+		"session_id": sessionID,
+		"run_id":     runID,
+		"payload": map[string]any{
+			"event_type": eventType,
+			"payload":    envelope,
+		},
+	}
+	data, err := json.Marshal(frame)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	gw.notifications <- GatewayNotification{Method: protocol.MethodGatewayEvent, Params: data}
+}
+
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }

--- a/internal/feishuadapter/adapter_test.go
+++ b/internal/feishuadapter/adapter_test.go
@@ -196,6 +196,25 @@ func TestMessageEventRetryAfterRunFailure(t *testing.T) {
 	}
 }
 
+func TestRunFailureCleansTrackedRunBinding(t *testing.T) {
+	adapter := newTestAdapter(t)
+	gateway := adapterTestGateway(adapter)
+	gateway.mu.Lock()
+	gateway.runErr = assertErr("reject")
+	gateway.mu.Unlock()
+
+	err := adapter.bindThenRun(context.Background(), "session-fail", "run-fail", "chat-fail", "hello")
+	if err == nil {
+		t.Fatal("expected bindThenRun error")
+	}
+	adapter.mu.RLock()
+	_, exists := adapter.activeRuns[runBindingKey("session-fail", "run-fail")]
+	adapter.mu.RUnlock()
+	if exists {
+		t.Fatal("expected failed run binding to be cleaned")
+	}
+}
+
 func TestGroupMessageWithoutMentionIgnored(t *testing.T) {
 	adapter := newTestAdapter(t)
 	body := messageEventBodyWithChatType("evt-group", "msg-group", "chat-group", "hello group", "group")

--- a/internal/feishuadapter/adapter_test.go
+++ b/internal/feishuadapter/adapter_test.go
@@ -537,6 +537,23 @@ func TestReconnectRebindTracksMultipleRunsPerSession(t *testing.T) {
 	}
 }
 
+func TestReconnectHealthyPathDoesNotRebind(t *testing.T) {
+	adapter := newTestAdapter(t)
+	gw := adapterTestGateway(adapter)
+	adapter.trackSession("session-steady", "run-steady", "chat-steady")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go adapter.reconnectAndRebindLoop(ctx)
+	time.Sleep(80 * time.Millisecond)
+	cancel()
+	time.Sleep(20 * time.Millisecond)
+
+	calls := strings.Join(gw.snapshotCalls(), "|")
+	if strings.Contains(calls, "bind:session-steady:run-steady") {
+		t.Fatalf("did not expect steady-state rebind call in %v", calls)
+	}
+}
+
 func newTestAdapter(t *testing.T) *Adapter {
 	t.Helper()
 	gateway := newFakeGatewayClient()

--- a/internal/feishuadapter/gateway_client.go
+++ b/internal/feishuadapter/gateway_client.go
@@ -1,0 +1,136 @@
+package feishuadapter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	gatewayclient "neo-code/internal/gateway/client"
+	"neo-code/internal/gateway/protocol"
+)
+
+// GatewayClientConfig 表示构造网关 RPC 客户端时使用的参数。
+type GatewayClientConfig struct {
+	ListenAddress  string
+	TokenFile      string
+	RequestTimeout time.Duration
+}
+
+type gatewayRPCClient struct {
+	client *gatewayclient.GatewayRPCClient
+}
+
+// NewGatewayRPCClient 基于现有网关 JSON-RPC 客户端构造 Feishu 适配层网关客户端。
+func NewGatewayRPCClient(cfg GatewayClientConfig) (GatewayClient, error) {
+	client, err := gatewayclient.NewGatewayRPCClient(gatewayclient.GatewayRPCClientOptions{
+		ListenAddress:  cfg.ListenAddress,
+		TokenFile:      cfg.TokenFile,
+		RequestTimeout: cfg.RequestTimeout,
+		RetryCount:     gatewayclient.DefaultGatewayRPCRetryCount,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &gatewayRPCClient{client: client}, nil
+}
+
+// Authenticate 建立网关认证状态。
+func (c *gatewayRPCClient) Authenticate(ctx context.Context) error {
+	return c.client.Authenticate(ctx)
+}
+
+// BindStream 绑定网关事件流订阅。
+func (c *gatewayRPCClient) BindStream(ctx context.Context, sessionID string, runID string) error {
+	var result map[string]any
+	return c.client.Call(ctx, protocol.MethodGatewayBindStream, protocol.BindStreamParams{
+		SessionID: sessionID,
+		RunID:     runID,
+		Channel:   "all",
+	}, &result)
+}
+
+// Run 提交一次网关运行请求。
+func (c *gatewayRPCClient) Run(ctx context.Context, sessionID string, runID string, inputText string) error {
+	var result map[string]any
+	return c.client.Call(ctx, protocol.MethodGatewayRun, protocol.RunParams{
+		SessionID: sessionID,
+		RunID:     runID,
+		InputText: inputText,
+	}, &result)
+}
+
+// ResolvePermission 提交一次审批决策。
+func (c *gatewayRPCClient) ResolvePermission(ctx context.Context, requestID string, decision string) error {
+	var result map[string]any
+	return c.client.Call(ctx, protocol.MethodGatewayResolvePermission, protocol.ResolvePermissionParams{
+		RequestID: requestID,
+		Decision:  decision,
+	}, &result)
+}
+
+// Ping 调用网关保活接口，触发自动重连与链路健康检查。
+func (c *gatewayRPCClient) Ping(ctx context.Context) error {
+	var result map[string]any
+	return c.client.Call(ctx, protocol.MethodGatewayPing, map[string]any{}, &result)
+}
+
+// Notifications 返回网关原始通知流。
+func (c *gatewayRPCClient) Notifications() <-chan GatewayNotification {
+	source := c.client.Notifications()
+	out := make(chan GatewayNotification, 64)
+	go func() {
+		defer close(out)
+		for notification := range source {
+			out <- GatewayNotification{
+				Method: notification.Method,
+				Params: cloneRawMessage(notification.Params),
+			}
+		}
+	}()
+	return out
+}
+
+// Close 关闭网关客户端连接。
+func (c *gatewayRPCClient) Close() error {
+	return c.client.Close()
+}
+
+func cloneRawMessage(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	cloned := make([]byte, len(raw))
+	copy(cloned, raw)
+	return cloned
+}
+
+// parseGatewayRuntimeEvent 从 gateway.event 通知中解析事件类型与运行字段。
+func parseGatewayRuntimeEvent(raw json.RawMessage) (string, string, string, map[string]any, error) {
+	var frame map[string]any
+	if err := json.Unmarshal(raw, &frame); err != nil {
+		return "", "", "", nil, fmt.Errorf("decode gateway event frame: %w", err)
+	}
+	sessionID := readString(frame, "session_id")
+	runID := readString(frame, "run_id")
+	payload, _ := frame["payload"].(map[string]any)
+	if payload == nil {
+		return "", sessionID, runID, nil, nil
+	}
+	eventType := readString(payload, "event_type")
+	envelope, _ := payload["payload"].(map[string]any)
+	return eventType, sessionID, runID, envelope, nil
+}
+
+// readString 从松散 map 中读取字符串字段并做空值兜底。
+func readString(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	raw, ok := m[key]
+	if !ok {
+		return ""
+	}
+	value, _ := raw.(string)
+	return value
+}

--- a/internal/feishuadapter/gateway_client_test.go
+++ b/internal/feishuadapter/gateway_client_test.go
@@ -1,0 +1,230 @@
+package feishuadapter
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	gatewayclient "neo-code/internal/gateway/client"
+	"neo-code/internal/gateway/protocol"
+)
+
+type rpcTestServer struct {
+	t        *testing.T
+	conn     net.Conn
+	mu       sync.Mutex
+	methods  []string
+	requests []protocol.JSONRPCRequest
+	encoder  *json.Encoder
+	done     chan struct{}
+}
+
+func newRPCTestClient(t *testing.T) (*gatewayRPCClient, *rpcTestServer) {
+	t.Helper()
+	clientConn, serverConn := net.Pipe()
+	tokenFile := filepath.Join(t.TempDir(), "gateway.token")
+	tokenBody := `{"version":1,"token":"token","created_at":"2026-05-05T00:00:00Z","updated_at":"2026-05-05T00:00:00Z"}`
+	if err := os.WriteFile(tokenFile, []byte(tokenBody), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+	raw, err := gatewayclient.NewGatewayRPCClient(gatewayclient.GatewayRPCClientOptions{
+		ListenAddress:     "ignored",
+		TokenFile:         tokenFile,
+		RequestTimeout:    500 * time.Millisecond,
+		HeartbeatInterval: time.Hour,
+		HeartbeatTimeout:  500 * time.Millisecond,
+		RetryCount:        0,
+		DisableAutoSpawn:  true,
+		ResolveListenAddress: func(override string) (string, error) {
+			return override, nil
+		},
+		Dial: func(address string) (net.Conn, error) {
+			return clientConn, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("new raw gateway client: %v", err)
+	}
+	server := &rpcTestServer{
+		t:       t,
+		conn:    serverConn,
+		encoder: json.NewEncoder(serverConn),
+		done:    make(chan struct{}),
+	}
+	go server.serve()
+	t.Cleanup(func() {
+		_ = raw.Close()
+		_ = serverConn.Close()
+		select {
+		case <-server.done:
+		case <-time.After(time.Second):
+			t.Fatal("rpc test server did not stop")
+		}
+	})
+	return &gatewayRPCClient{client: raw}, server
+}
+
+func (s *rpcTestServer) serve() {
+	defer close(s.done)
+	decoder := json.NewDecoder(s.conn)
+	for {
+		var request protocol.JSONRPCRequest
+		if err := decoder.Decode(&request); err != nil {
+			return
+		}
+		s.mu.Lock()
+		s.methods = append(s.methods, request.Method)
+		s.requests = append(s.requests, request)
+		s.mu.Unlock()
+		response := protocol.JSONRPCResponse{
+			JSONRPC: protocol.JSONRPCVersion,
+			ID:      request.ID,
+			Result:  json.RawMessage(`{}`),
+		}
+		if err := s.encoder.Encode(response); err != nil {
+			return
+		}
+	}
+}
+
+func (s *rpcTestServer) snapshot() ([]string, []protocol.JSONRPCRequest) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	methods := append([]string(nil), s.methods...)
+	requests := append([]protocol.JSONRPCRequest(nil), s.requests...)
+	return methods, requests
+}
+
+func (s *rpcTestServer) sendNotification(t *testing.T, method string, params any) {
+	t.Helper()
+	if err := s.encoder.Encode(protocol.JSONRPCNotification{
+		JSONRPC: protocol.JSONRPCVersion,
+		Method:  method,
+		Params:  params,
+	}); err != nil {
+		t.Fatalf("send notification: %v", err)
+	}
+}
+
+func TestGatewayRPCClientDelegatesRPCMethods(t *testing.T) {
+	client, server := newRPCTestClient(t)
+	ctx := context.Background()
+
+	if err := client.Authenticate(ctx); err != nil {
+		t.Fatalf("authenticate: %v", err)
+	}
+	if err := client.BindStream(ctx, "session-1", "run-1"); err != nil {
+		t.Fatalf("bind stream: %v", err)
+	}
+	if err := client.Run(ctx, "session-1", "run-1", "hello"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if err := client.ResolvePermission(ctx, "perm-1", "allow_once"); err != nil {
+		t.Fatalf("resolve permission: %v", err)
+	}
+	if err := client.Ping(ctx); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+
+	server.sendNotification(t, protocol.MethodGatewayEvent, map[string]any{
+		"session_id": "session-1",
+	})
+	select {
+	case notification := <-client.Notifications():
+		if notification.Method != protocol.MethodGatewayEvent {
+			t.Fatalf("notification method = %q, want %q", notification.Method, protocol.MethodGatewayEvent)
+		}
+		if string(notification.Params) == "" {
+			t.Fatal("expected notification params")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for notification")
+	}
+
+	methods, requests := server.snapshot()
+	wantMethods := []string{
+		protocol.MethodGatewayAuthenticate,
+		protocol.MethodGatewayBindStream,
+		protocol.MethodGatewayRun,
+		protocol.MethodGatewayResolvePermission,
+		protocol.MethodGatewayPing,
+	}
+	if len(methods) < len(wantMethods) {
+		t.Fatalf("methods = %v, want prefix %v", methods, wantMethods)
+	}
+	for index, want := range wantMethods {
+		if methods[index] != want {
+			t.Fatalf("method[%d] = %q, want %q", index, methods[index], want)
+		}
+	}
+
+	var bindParams protocol.BindStreamParams
+	if err := json.Unmarshal(requests[1].Params, &bindParams); err != nil {
+		t.Fatalf("decode bind params: %v", err)
+	}
+	if bindParams.Channel != "all" || bindParams.SessionID != "session-1" || bindParams.RunID != "run-1" {
+		t.Fatalf("unexpected bind params: %#v", bindParams)
+	}
+
+	var runParams protocol.RunParams
+	if err := json.Unmarshal(requests[2].Params, &runParams); err != nil {
+		t.Fatalf("decode run params: %v", err)
+	}
+	if runParams.InputText != "hello" {
+		t.Fatalf("run params = %#v, want input text", runParams)
+	}
+}
+
+func TestGatewayRPCClientCloseStopsNotificationBridge(t *testing.T) {
+	client, _ := newRPCTestClient(t)
+	if err := client.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	select {
+	case _, ok := <-client.Notifications():
+		if ok {
+			t.Fatal("expected notifications channel to close")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for notifications to close")
+	}
+}
+
+func TestNewGatewayRPCClientConstructsWrapper(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "gateway.sock")
+	client, err := NewGatewayRPCClient(GatewayClientConfig{
+		ListenAddress:  socketPath,
+		TokenFile:      filepath.Join(t.TempDir(), "gateway.token"),
+		RequestTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("new gateway rpc client: %v", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("close wrapper: %v", err)
+	}
+}
+
+func TestParseGatewayRuntimeEventHandlesEdgeCases(t *testing.T) {
+	eventType, sessionID, runID, envelope, err := parseGatewayRuntimeEvent(json.RawMessage(`{"session_id":"s","run_id":"r","payload":{}}`))
+	if err != nil {
+		t.Fatalf("parse event: %v", err)
+	}
+	if eventType != "" || sessionID != "s" || runID != "r" || envelope != nil {
+		t.Fatalf("unexpected parsed event: type=%q session=%q run=%q payload=%#v", eventType, sessionID, runID, envelope)
+	}
+	if _, _, _, _, err := parseGatewayRuntimeEvent(json.RawMessage(`{`)); err == nil {
+		t.Fatal("expected invalid json error")
+	}
+	if cloned := cloneRawMessage(nil); cloned != nil {
+		t.Fatalf("clone nil = %#v, want nil", cloned)
+	}
+	if value := readString(map[string]any{"answer": 42}, "answer"); value != "" {
+		t.Fatalf("readString = %q, want empty for non-string", value)
+	}
+}

--- a/internal/feishuadapter/idempotency.go
+++ b/internal/feishuadapter/idempotency.go
@@ -9,7 +9,19 @@ import (
 type idempotencyStore struct {
 	ttl   time.Duration
 	mu    sync.Mutex
-	items map[string]time.Time
+	items map[string]idempotencyItem
+}
+
+type idempotencyState string
+
+const (
+	idempotencyStatePending idempotencyState = "pending"
+	idempotencyStateDone    idempotencyState = "done"
+)
+
+type idempotencyItem struct {
+	ExpireAt time.Time
+	State    idempotencyState
 }
 
 // newIdempotencyStore 创建带 TTL 的内存去重存储。
@@ -19,15 +31,15 @@ func newIdempotencyStore(ttl time.Duration) *idempotencyStore {
 	}
 	return &idempotencyStore{
 		ttl:   ttl,
-		items: make(map[string]time.Time),
+		items: make(map[string]idempotencyItem),
 	}
 }
 
-// Seen 会在首次看到 key 时返回 false，TTL 窗口内重复看到返回 true。
-func (s *idempotencyStore) Seen(key string, now time.Time) bool {
+// TryStart 尝试开始处理一个去重键，若键仍在有效窗口内则返回 false。
+func (s *idempotencyStore) TryStart(key string, now time.Time) bool {
 	trimmed := strings.TrimSpace(key)
 	if trimmed == "" {
-		return false
+		return true
 	}
 	if now.IsZero() {
 		now = time.Now().UTC()
@@ -35,12 +47,44 @@ func (s *idempotencyStore) Seen(key string, now time.Time) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.cleanupLocked(now)
-	expireAt, exists := s.items[trimmed]
-	if exists && expireAt.After(now) {
-		return true
+	item, exists := s.items[trimmed]
+	if exists && item.ExpireAt.After(now) {
+		return false
 	}
-	s.items[trimmed] = now.Add(s.ttl)
-	return false
+	s.items[trimmed] = idempotencyItem{
+		ExpireAt: now.Add(s.ttl),
+		State:    idempotencyStatePending,
+	}
+	return true
+}
+
+// MarkDone 在请求成功受理后标记去重键为完成态。
+func (s *idempotencyStore) MarkDone(key string, now time.Time) {
+	trimmed := strings.TrimSpace(key)
+	if trimmed == "" {
+		return
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cleanupLocked(now)
+	s.items[trimmed] = idempotencyItem{
+		ExpireAt: now.Add(s.ttl),
+		State:    idempotencyStateDone,
+	}
+}
+
+// MarkFailed 在请求失败后释放去重键，允许后续重试。
+func (s *idempotencyStore) MarkFailed(key string) {
+	trimmed := strings.TrimSpace(key)
+	if trimmed == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.items, trimmed)
 }
 
 // cleanupLocked 清理已经过期的去重键。
@@ -48,8 +92,8 @@ func (s *idempotencyStore) cleanupLocked(now time.Time) {
 	if len(s.items) == 0 {
 		return
 	}
-	for key, expireAt := range s.items {
-		if expireAt.After(now) {
+	for key, item := range s.items {
+		if item.ExpireAt.After(now) {
 			continue
 		}
 		delete(s.items, key)

--- a/internal/feishuadapter/idempotency.go
+++ b/internal/feishuadapter/idempotency.go
@@ -1,0 +1,57 @@
+package feishuadapter
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+type idempotencyStore struct {
+	ttl   time.Duration
+	mu    sync.Mutex
+	items map[string]time.Time
+}
+
+// newIdempotencyStore 创建带 TTL 的内存去重存储。
+func newIdempotencyStore(ttl time.Duration) *idempotencyStore {
+	if ttl <= 0 {
+		ttl = 10 * time.Minute
+	}
+	return &idempotencyStore{
+		ttl:   ttl,
+		items: make(map[string]time.Time),
+	}
+}
+
+// Seen 会在首次看到 key 时返回 false，TTL 窗口内重复看到返回 true。
+func (s *idempotencyStore) Seen(key string, now time.Time) bool {
+	trimmed := strings.TrimSpace(key)
+	if trimmed == "" {
+		return false
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cleanupLocked(now)
+	expireAt, exists := s.items[trimmed]
+	if exists && expireAt.After(now) {
+		return true
+	}
+	s.items[trimmed] = now.Add(s.ttl)
+	return false
+}
+
+// cleanupLocked 清理已经过期的去重键。
+func (s *idempotencyStore) cleanupLocked(now time.Time) {
+	if len(s.items) == 0 {
+		return
+	}
+	for key, expireAt := range s.items {
+		if expireAt.After(now) {
+			continue
+		}
+		delete(s.items, key)
+	}
+}

--- a/internal/feishuadapter/idempotency_test.go
+++ b/internal/feishuadapter/idempotency_test.go
@@ -31,3 +31,21 @@ func TestIdempotencyMarkFailedAllowsRetry(t *testing.T) {
 		t.Fatal("expected retry after MarkFailed to pass")
 	}
 }
+
+func TestIdempotencyDefaultsAndCleanupBranches(t *testing.T) {
+	store := newIdempotencyStore(0)
+	if store.ttl != 10*time.Minute {
+		t.Fatalf("ttl = %s, want default 10m", store.ttl)
+	}
+	if !store.TryStart("", time.Time{}) {
+		t.Fatal("expected empty key to bypass dedupe")
+	}
+	store.MarkDone("", time.Time{})
+	store.MarkFailed("")
+
+	now := time.Now().UTC()
+	store.items["expired"] = idempotencyItem{ExpireAt: now.Add(-time.Second), State: idempotencyStateDone}
+	if !store.TryStart("expired", now) {
+		t.Fatal("expected expired key to be cleaned and accepted")
+	}
+}

--- a/internal/feishuadapter/idempotency_test.go
+++ b/internal/feishuadapter/idempotency_test.go
@@ -1,0 +1,33 @@
+package feishuadapter
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIdempotencyTryStartAndMarkDone(t *testing.T) {
+	store := newIdempotencyStore(2 * time.Minute)
+	now := time.Now().UTC()
+	if !store.TryStart("k1", now) {
+		t.Fatal("expected first TryStart to pass")
+	}
+	if store.TryStart("k1", now.Add(1*time.Second)) {
+		t.Fatal("expected repeated TryStart within ttl to be blocked")
+	}
+	store.MarkDone("k1", now.Add(2*time.Second))
+	if store.TryStart("k1", now.Add(3*time.Second)) {
+		t.Fatal("expected done key to remain blocked within ttl")
+	}
+}
+
+func TestIdempotencyMarkFailedAllowsRetry(t *testing.T) {
+	store := newIdempotencyStore(2 * time.Minute)
+	now := time.Now().UTC()
+	if !store.TryStart("k2", now) {
+		t.Fatal("expected first TryStart to pass")
+	}
+	store.MarkFailed("k2")
+	if !store.TryStart("k2", now.Add(1*time.Second)) {
+		t.Fatal("expected retry after MarkFailed to pass")
+	}
+}

--- a/internal/feishuadapter/ids.go
+++ b/internal/feishuadapter/ids.go
@@ -1,0 +1,27 @@
+package feishuadapter
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// BuildSessionID 基于飞书 chat_id 生成稳定会话标识。
+func BuildSessionID(chatID string) string {
+	return "feishu:" + stableHash(chatID)
+}
+
+// BuildRunID 基于飞书 message_id 生成稳定运行标识。
+func BuildRunID(messageID string) string {
+	return "feishu:" + stableHash(messageID)
+}
+
+// stableHash 对外部输入做稳定散列，避免直接暴露原始平台标识。
+func stableHash(raw string) string {
+	normalized := strings.TrimSpace(raw)
+	if normalized == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(normalized))
+	return hex.EncodeToString(sum[:8])
+}

--- a/internal/feishuadapter/ids.go
+++ b/internal/feishuadapter/ids.go
@@ -8,12 +8,12 @@ import (
 
 // BuildSessionID 基于飞书 chat_id 生成稳定会话标识。
 func BuildSessionID(chatID string) string {
-	return "feishu:" + stableHash(chatID)
+	return "feishu_" + stableHash(chatID)
 }
 
 // BuildRunID 基于飞书 message_id 生成稳定运行标识。
 func BuildRunID(messageID string) string {
-	return "feishu:" + stableHash(messageID)
+	return "feishu_" + stableHash(messageID)
 }
 
 // stableHash 对外部输入做稳定散列，避免直接暴露原始平台标识。

--- a/internal/feishuadapter/messenger.go
+++ b/internal/feishuadapter/messenger.go
@@ -1,0 +1,184 @@
+package feishuadapter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	feishuAPIBase = "https://open.feishu.cn"
+)
+
+// HTTPClient 定义发送飞书 API 请求所需的最小接口。
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type feishuMessenger struct {
+	appID      string
+	appSecret  string
+	baseURL    string
+	httpClient HTTPClient
+
+	mu          sync.Mutex
+	cachedToken string
+	expireAt    time.Time
+}
+
+// NewFeishuMessenger 创建默认飞书消息发送器。
+func NewFeishuMessenger(appID string, appSecret string, httpClient HTTPClient) Messenger {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &feishuMessenger{
+		appID:      strings.TrimSpace(appID),
+		appSecret:  strings.TrimSpace(appSecret),
+		baseURL:    feishuAPIBase,
+		httpClient: httpClient,
+	}
+}
+
+// SendText 向指定 chat_id 发送文本消息。
+func (m *feishuMessenger) SendText(ctx context.Context, chatID string, text string) error {
+	content, err := json.Marshal(map[string]string{"text": text})
+	if err != nil {
+		return err
+	}
+	return m.sendMessage(ctx, chatID, "text", string(content))
+}
+
+// SendPermissionCard 向指定 chat_id 发送最小审批卡片。
+func (m *feishuMessenger) SendPermissionCard(ctx context.Context, chatID string, payload PermissionCardPayload) error {
+	card := map[string]any{
+		"config": map[string]any{"wide_screen_mode": true},
+		"elements": []map[string]any{
+			{
+				"tag":  "div",
+				"text": map[string]any{"tag": "lark_md", "content": payload.Message},
+			},
+			{
+				"tag": "action",
+				"actions": []map[string]any{
+					{
+						"tag":  "button",
+						"text": map[string]any{"tag": "plain_text", "content": "允许一次"},
+						"type": "primary",
+						"value": map[string]string{
+							"decision":   "allow_once",
+							"request_id": payload.RequestID,
+						},
+					},
+					{
+						"tag":  "button",
+						"text": map[string]any{"tag": "plain_text", "content": "拒绝"},
+						"type": "default",
+						"value": map[string]string{
+							"decision":   "reject",
+							"request_id": payload.RequestID,
+						},
+					},
+				},
+			},
+		},
+	}
+	content, err := json.Marshal(card)
+	if err != nil {
+		return err
+	}
+	return m.sendMessage(ctx, chatID, "interactive", string(content))
+}
+
+// sendMessage 统一封装飞书消息发送请求，复用鉴权与错误处理。
+func (m *feishuMessenger) sendMessage(ctx context.Context, chatID string, msgType string, content string) error {
+	token, err := m.tenantAccessToken(ctx)
+	if err != nil {
+		return err
+	}
+	body := map[string]string{
+		"receive_id": chatID,
+		"msg_type":   msgType,
+		"content":    content,
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	url := strings.TrimRight(m.baseURL, "/") + "/open-apis/im/v1/messages?receive_id_type=chat_id"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("send feishu message failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	return nil
+}
+
+// tenantAccessToken 获取并缓存 tenant access token，避免每次发送都重复换取。
+func (m *feishuMessenger) tenantAccessToken(ctx context.Context) (string, error) {
+	m.mu.Lock()
+	if m.cachedToken != "" && time.Now().UTC().Before(m.expireAt) {
+		token := m.cachedToken
+		m.mu.Unlock()
+		return token, nil
+	}
+	m.mu.Unlock()
+
+	body := map[string]string{
+		"app_id":     m.appID,
+		"app_secret": m.appSecret,
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return "", err
+	}
+	url := strings.TrimRight(m.baseURL, "/") + "/open-apis/auth/v3/tenant_access_token/internal"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	var payload struct {
+		Code              int    `json:"code"`
+		Message           string `json:"msg"`
+		TenantAccessToken string `json:"tenant_access_token"`
+		Expire            int    `json:"expire"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&payload); err != nil {
+		return "", err
+	}
+	if resp.StatusCode/100 != 2 || payload.Code != 0 || strings.TrimSpace(payload.TenantAccessToken) == "" {
+		return "", fmt.Errorf("fetch feishu tenant token failed: status=%d code=%d message=%s", resp.StatusCode, payload.Code, payload.Message)
+	}
+	expire := time.Duration(payload.Expire) * time.Second
+	if expire <= 0 {
+		expire = time.Hour
+	}
+	refreshAt := time.Now().UTC().Add(expire - 30*time.Second)
+	m.mu.Lock()
+	m.cachedToken = strings.TrimSpace(payload.TenantAccessToken)
+	m.expireAt = refreshAt
+	token := m.cachedToken
+	m.mu.Unlock()
+	return token, nil
+}

--- a/internal/feishuadapter/messenger.go
+++ b/internal/feishuadapter/messenger.go
@@ -122,9 +122,22 @@ func (m *feishuMessenger) sendMessage(ctx context.Context, chatID string, msgTyp
 		return err
 	}
 	defer resp.Body.Close()
+	var payload struct {
+		Code    int    `json:"code"`
+		Message string `json:"msg"`
+	}
+	decodeErr := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&payload)
 	if resp.StatusCode/100 != 2 {
-		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("send feishu message failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(raw)))
+		if decodeErr == nil {
+			return fmt.Errorf("send feishu message failed: status=%d code=%d message=%s", resp.StatusCode, payload.Code, payload.Message)
+		}
+		return fmt.Errorf("send feishu message failed: status=%d body=invalid_json", resp.StatusCode)
+	}
+	if decodeErr != nil {
+		return fmt.Errorf("send feishu message failed: invalid response body: %w", decodeErr)
+	}
+	if payload.Code != 0 {
+		return fmt.Errorf("send feishu message failed: status=%d code=%d message=%s", resp.StatusCode, payload.Code, payload.Message)
 	}
 	return nil
 }

--- a/internal/feishuadapter/messenger_test.go
+++ b/internal/feishuadapter/messenger_test.go
@@ -1,7 +1,9 @@
 package feishuadapter
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -18,13 +20,25 @@ type queuedHTTPResponse struct {
 type queuedHTTPClient struct {
 	mu        sync.Mutex
 	responses []queuedHTTPResponse
+	requests  []*http.Request
+	bodies    [][]byte
 }
 
-func (c *queuedHTTPClient) Do(*http.Request) (*http.Response, error) {
+func (c *queuedHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if len(c.responses) == 0 {
 		return nil, assertErr("unexpected http call")
+	}
+	if req != nil {
+		cloned := req.Clone(req.Context())
+		if req.Body != nil {
+			body, _ := io.ReadAll(req.Body)
+			cloned.Body = io.NopCloser(bytes.NewReader(body))
+			req.Body = io.NopCloser(bytes.NewReader(body))
+			c.bodies = append(c.bodies, body)
+		}
+		c.requests = append(c.requests, cloned)
 	}
 	current := c.responses[0]
 	c.responses = c.responses[1:]
@@ -77,5 +91,117 @@ func TestSendMessageSuccessWhenHTTPAndBusinessCodePass(t *testing.T) {
 	messenger := NewFeishuMessenger("app", "secret", client)
 	if err := messenger.SendText(context.Background(), "chat-id", "hello"); err != nil {
 		t.Fatalf("send message: %v", err)
+	}
+}
+
+func TestSendPermissionCardUsesInteractiveMessage(t *testing.T) {
+	client := &queuedHTTPClient{
+		responses: []queuedHTTPResponse{
+			{
+				status: 200,
+				body:   `{"code":0,"msg":"ok","tenant_access_token":"token","expire":7200}`,
+			},
+			{
+				status: 200,
+				body:   `{"code":0,"msg":"ok","data":{"message_id":"mid"}}`,
+			},
+		},
+	}
+	messenger := NewFeishuMessenger("app", "secret", client)
+	if err := messenger.SendPermissionCard(context.Background(), "chat-id", PermissionCardPayload{
+		RequestID: "perm-1",
+		Message:   "需要审批",
+	}); err != nil {
+		t.Fatalf("send permission card: %v", err)
+	}
+	if len(client.requests) != 2 {
+		t.Fatalf("request count = %d, want 2", len(client.requests))
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(client.bodies[1], &payload); err != nil {
+		t.Fatalf("decode send body: %v", err)
+	}
+	if payload["msg_type"] != "interactive" {
+		t.Fatalf("msg_type = %v, want interactive", payload["msg_type"])
+	}
+	content, _ := payload["content"].(string)
+	if !strings.Contains(content, "allow_once") || !strings.Contains(content, "perm-1") {
+		t.Fatalf("content = %q, want permission buttons", content)
+	}
+}
+
+func TestSendMessageReturnsInvalidJSONOnHTTPFailure(t *testing.T) {
+	client := &queuedHTTPClient{
+		responses: []queuedHTTPResponse{
+			{
+				status: 200,
+				body:   `{"code":0,"msg":"ok","tenant_access_token":"token","expire":7200}`,
+			},
+			{
+				status: 500,
+				body:   `{`,
+			},
+		},
+	}
+	messenger := NewFeishuMessenger("app", "secret", client)
+	err := messenger.SendText(context.Background(), "chat-id", "hello")
+	if err == nil || !strings.Contains(err.Error(), "body=invalid_json") {
+		t.Fatalf("error = %v, want invalid_json failure", err)
+	}
+}
+
+func TestTenantAccessTokenUsesCache(t *testing.T) {
+	client := &queuedHTTPClient{
+		responses: []queuedHTTPResponse{
+			{
+				status: 200,
+				body:   `{"code":0,"msg":"ok","tenant_access_token":"token","expire":7200}`,
+			},
+			{
+				status: 200,
+				body:   `{"code":0,"msg":"ok","data":{"message_id":"mid-1"}}`,
+			},
+			{
+				status: 200,
+				body:   `{"code":0,"msg":"ok","data":{"message_id":"mid-2"}}`,
+			},
+		},
+	}
+	messenger := NewFeishuMessenger("app", "secret", client)
+	if err := messenger.SendText(context.Background(), "chat-id", "hello"); err != nil {
+		t.Fatalf("first send: %v", err)
+	}
+	if err := messenger.SendText(context.Background(), "chat-id", "hello again"); err != nil {
+		t.Fatalf("second send: %v", err)
+	}
+	if len(client.requests) != 3 {
+		t.Fatalf("request count = %d, want 3", len(client.requests))
+	}
+	if !strings.Contains(client.requests[1].Header.Get("Authorization"), "Bearer token") {
+		t.Fatalf("authorization header missing cached token: %#v", client.requests[1].Header)
+	}
+	if !strings.Contains(client.requests[2].Header.Get("Authorization"), "Bearer token") {
+		t.Fatalf("authorization header missing cached token on second send: %#v", client.requests[2].Header)
+	}
+}
+
+func TestMessengerCoversConstructorAndTokenFailures(t *testing.T) {
+	defaultMessenger := NewFeishuMessenger(" app ", " secret ", nil)
+	if defaultMessenger == nil {
+		t.Fatal("expected default messenger")
+	}
+
+	client := &queuedHTTPClient{
+		responses: []queuedHTTPResponse{
+			{
+				status: 500,
+				body:   `{"code":999,"msg":"bad app"}`,
+			},
+		},
+	}
+	messenger := NewFeishuMessenger("app", "secret", client)
+	err := messenger.SendText(context.Background(), "chat-id", "hello")
+	if err == nil || !strings.Contains(err.Error(), "fetch feishu tenant token failed") {
+		t.Fatalf("error = %v, want token fetch failure", err)
 	}
 }

--- a/internal/feishuadapter/messenger_test.go
+++ b/internal/feishuadapter/messenger_test.go
@@ -1,0 +1,81 @@
+package feishuadapter
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type queuedHTTPResponse struct {
+	status int
+	body   string
+	err    error
+}
+
+type queuedHTTPClient struct {
+	mu        sync.Mutex
+	responses []queuedHTTPResponse
+}
+
+func (c *queuedHTTPClient) Do(*http.Request) (*http.Response, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.responses) == 0 {
+		return nil, assertErr("unexpected http call")
+	}
+	current := c.responses[0]
+	c.responses = c.responses[1:]
+	if current.err != nil {
+		return nil, current.err
+	}
+	return &http.Response{
+		StatusCode: current.status,
+		Body:       io.NopCloser(strings.NewReader(current.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestSendMessageRequiresFeishuBusinessCodeZero(t *testing.T) {
+	client := &queuedHTTPClient{
+		responses: []queuedHTTPResponse{
+			{
+				status: 200,
+				body:   `{"code":0,"msg":"ok","tenant_access_token":"token","expire":7200}`,
+			},
+			{
+				status: 200,
+				body:   `{"code":999,"msg":"forbidden"}`,
+			},
+		},
+	}
+	messenger := NewFeishuMessenger("app", "secret", client)
+	err := messenger.SendText(context.Background(), "chat-id", "hello")
+	if err == nil {
+		t.Fatal("expected send message business error")
+	}
+	if !strings.Contains(err.Error(), "code=999") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSendMessageSuccessWhenHTTPAndBusinessCodePass(t *testing.T) {
+	client := &queuedHTTPClient{
+		responses: []queuedHTTPResponse{
+			{
+				status: 200,
+				body:   `{"code":0,"msg":"ok","tenant_access_token":"token","expire":7200}`,
+			},
+			{
+				status: 200,
+				body:   `{"code":0,"msg":"ok","data":{"message_id":"mid"}}`,
+			},
+		},
+	}
+	messenger := NewFeishuMessenger("app", "secret", client)
+	if err := messenger.SendText(context.Background(), "chat-id", "hello"); err != nil {
+		t.Fatalf("send message: %v", err)
+	}
+}

--- a/internal/feishuadapter/signature.go
+++ b/internal/feishuadapter/signature.go
@@ -1,0 +1,79 @@
+package feishuadapter
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	headerLarkTimestamp = "X-Lark-Request-Timestamp"
+	headerLarkNonce     = "X-Lark-Request-Nonce"
+	headerLarkSignature = "X-Lark-Signature"
+)
+
+// verifyFeishuSignature 校验飞书回调签名与时间窗口，防止伪造请求与重放。
+func verifyFeishuSignature(secret string, maxSkew time.Duration, header http.Header, body []byte, now time.Time) bool {
+	if strings.TrimSpace(secret) == "" {
+		return true
+	}
+	timestamp := strings.TrimSpace(header.Get(headerLarkTimestamp))
+	nonce := strings.TrimSpace(header.Get(headerLarkNonce))
+	signature := strings.TrimSpace(header.Get(headerLarkSignature))
+	if timestamp == "" || signature == "" {
+		return false
+	}
+	if maxSkew > 0 {
+		if !withinSkew(timestamp, maxSkew, now) {
+			return false
+		}
+	}
+	payload := timestamp + nonce + string(body)
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(payload))
+	sum := mac.Sum(nil)
+	base64Sign := base64.StdEncoding.EncodeToString(sum)
+	hexSign := hex.EncodeToString(sum)
+	normalizedSig := normalizeSignature(signature)
+	return hmac.Equal([]byte(normalizeSignature(base64Sign)), []byte(normalizedSig)) ||
+		hmac.Equal([]byte(normalizeSignature(hexSign)), []byte(normalizedSig))
+}
+
+// withinSkew 判断请求时间戳是否在允许偏差窗口内。
+func withinSkew(timestamp string, maxSkew time.Duration, now time.Time) bool {
+	parsed, err := parseUnixSeconds(timestamp)
+	if err != nil {
+		return false
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	diff := now.Sub(parsed)
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff <= maxSkew
+}
+
+// parseUnixSeconds 解析 Unix 秒级时间戳。
+func parseUnixSeconds(raw string) (time.Time, error) {
+	value := strings.TrimSpace(raw)
+	seconds, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(seconds, 0).UTC(), nil
+}
+
+// normalizeSignature 统一签名格式，兼容常见前缀。
+func normalizeSignature(signature string) string {
+	trimmed := strings.TrimSpace(strings.ToLower(signature))
+	trimmed = strings.TrimPrefix(trimmed, "v0=")
+	trimmed = strings.TrimPrefix(trimmed, "sha256=")
+	return trimmed
+}

--- a/internal/feishuadapter/signature.go
+++ b/internal/feishuadapter/signature.go
@@ -18,9 +18,19 @@ const (
 )
 
 // verifyFeishuSignature 校验飞书回调签名与时间窗口，防止伪造请求与重放。
-func verifyFeishuSignature(secret string, maxSkew time.Duration, header http.Header, body []byte, now time.Time) bool {
-	if strings.TrimSpace(secret) == "" {
+func verifyFeishuSignature(
+	secret string,
+	maxSkew time.Duration,
+	header http.Header,
+	body []byte,
+	now time.Time,
+	insecureSkip bool,
+) bool {
+	if insecureSkip {
 		return true
+	}
+	if strings.TrimSpace(secret) == "" {
+		return false
 	}
 	timestamp := strings.TrimSpace(header.Get(headerLarkTimestamp))
 	nonce := strings.TrimSpace(header.Get(headerLarkNonce))

--- a/internal/feishuadapter/signature.go
+++ b/internal/feishuadapter/signature.go
@@ -49,9 +49,10 @@ func verifyFeishuSignature(
 	sum := mac.Sum(nil)
 	base64Sign := base64.StdEncoding.EncodeToString(sum)
 	hexSign := hex.EncodeToString(sum)
-	normalizedSig := normalizeSignature(signature)
-	return hmac.Equal([]byte(normalizeSignature(base64Sign)), []byte(normalizedSig)) ||
-		hmac.Equal([]byte(normalizeSignature(hexSign)), []byte(normalizedSig))
+	normalizedBase64Sig := normalizeBase64Signature(signature)
+	normalizedHexSig := normalizeHexSignature(signature)
+	return hmac.Equal([]byte(base64Sign), []byte(normalizedBase64Sig)) ||
+		hmac.Equal([]byte(normalizeHexSignature(hexSign)), []byte(normalizedHexSig))
 }
 
 // withinSkew 判断请求时间戳是否在允许偏差窗口内。
@@ -80,9 +81,17 @@ func parseUnixSeconds(raw string) (time.Time, error) {
 	return time.Unix(seconds, 0).UTC(), nil
 }
 
-// normalizeSignature 统一签名格式，兼容常见前缀。
-func normalizeSignature(signature string) string {
+// normalizeHexSignature 统一 hex 签名格式，兼容常见前缀并做大小写归一。
+func normalizeHexSignature(signature string) string {
 	trimmed := strings.TrimSpace(strings.ToLower(signature))
+	trimmed = strings.TrimPrefix(trimmed, "v0=")
+	trimmed = strings.TrimPrefix(trimmed, "sha256=")
+	return trimmed
+}
+
+// normalizeBase64Signature 统一 base64 签名格式，仅裁剪空白与前缀，不改变大小写。
+func normalizeBase64Signature(signature string) string {
+	trimmed := strings.TrimSpace(signature)
 	trimmed = strings.TrimPrefix(trimmed, "v0=")
 	trimmed = strings.TrimPrefix(trimmed, "sha256=")
 	return trimmed

--- a/internal/feishuadapter/signature_test.go
+++ b/internal/feishuadapter/signature_test.go
@@ -69,6 +69,27 @@ func TestVerifyFeishuSignatureAcceptsExactBase64(t *testing.T) {
 	}
 }
 
+func TestVerifyFeishuSignatureCoversFallbackBranches(t *testing.T) {
+	header := make(http.Header)
+	if !verifyFeishuSignature("", time.Minute, header, nil, time.Time{}, true) {
+		t.Fatal("expected insecure skip to bypass verification")
+	}
+	if verifyFeishuSignature("", time.Minute, header, nil, time.Time{}, false) {
+		t.Fatal("expected empty secret to fail")
+	}
+	header.Set(headerLarkTimestamp, "invalid")
+	header.Set(headerLarkSignature, "sig")
+	if verifyFeishuSignature("secret", time.Minute, header, nil, time.Time{}, false) {
+		t.Fatal("expected invalid timestamp to fail skew check")
+	}
+	if withinSkew(formatUnix(time.Now().UTC().Unix()+600), time.Minute, time.Time{}) {
+		t.Fatal("expected skew check to fail for distant future timestamp")
+	}
+	if _, err := parseUnixSeconds("nope"); err == nil {
+		t.Fatal("expected invalid unix seconds parse error")
+	}
+}
+
 func signPayload(secret string, payload string) []byte {
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write([]byte(payload))

--- a/internal/feishuadapter/signature_test.go
+++ b/internal/feishuadapter/signature_test.go
@@ -1,0 +1,96 @@
+package feishuadapter
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestVerifyFeishuSignatureAcceptsHexCaseInsensitive(t *testing.T) {
+	secret := "secret"
+	body := []byte(`{"hello":"world"}`)
+	ts := time.Now().UTC().Unix()
+	nonce := "nonce"
+	payload := formatPayload(ts, nonce, body)
+	sum := signPayload(secret, payload)
+	upperHex := "SHA256=" + stringsToUpper(hex.EncodeToString(sum))
+
+	header := make(http.Header)
+	header.Set(headerLarkTimestamp, formatUnix(ts))
+	header.Set(headerLarkNonce, nonce)
+	header.Set(headerLarkSignature, upperHex)
+
+	if !verifyFeishuSignature(secret, 5*time.Minute, header, body, time.Unix(ts, 0).UTC(), false) {
+		t.Fatal("expected uppercase hex signature to be accepted")
+	}
+}
+
+func TestVerifyFeishuSignatureRejectsBase64CaseModified(t *testing.T) {
+	secret := "secret"
+	body := []byte(`{"hello":"world"}`)
+	ts := time.Now().UTC().Unix()
+	nonce := "nonce"
+	payload := formatPayload(ts, nonce, body)
+	sum := signPayload(secret, payload)
+	base64Sig := base64.StdEncoding.EncodeToString(sum)
+	tampered := stringsToUpper(base64Sig)
+
+	header := make(http.Header)
+	header.Set(headerLarkTimestamp, formatUnix(ts))
+	header.Set(headerLarkNonce, nonce)
+	header.Set(headerLarkSignature, tampered)
+
+	if verifyFeishuSignature(secret, 5*time.Minute, header, body, time.Unix(ts, 0).UTC(), false) {
+		t.Fatal("expected case-modified base64 signature to be rejected")
+	}
+}
+
+func TestVerifyFeishuSignatureAcceptsExactBase64(t *testing.T) {
+	secret := "secret"
+	body := []byte(`{"hello":"world"}`)
+	ts := time.Now().UTC().Unix()
+	nonce := "nonce"
+	payload := formatPayload(ts, nonce, body)
+	sum := signPayload(secret, payload)
+	base64Sig := base64.StdEncoding.EncodeToString(sum)
+
+	header := make(http.Header)
+	header.Set(headerLarkTimestamp, formatUnix(ts))
+	header.Set(headerLarkNonce, nonce)
+	header.Set(headerLarkSignature, base64Sig)
+
+	if !verifyFeishuSignature(secret, 5*time.Minute, header, body, time.Unix(ts, 0).UTC(), false) {
+		t.Fatal("expected exact base64 signature to be accepted")
+	}
+}
+
+func signPayload(secret string, payload string) []byte {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(payload))
+	return mac.Sum(nil)
+}
+
+func formatPayload(ts int64, nonce string, body []byte) string {
+	return formatUnix(ts) + nonce + string(body)
+}
+
+func formatUnix(ts int64) string {
+	return strconv.FormatInt(ts, 10)
+}
+
+func stringsToUpper(value string) string {
+	out := make([]byte, len(value))
+	for index := range value {
+		current := value[index]
+		if current >= 'a' && current <= 'z' {
+			current -= 32
+		}
+		out[index] = current
+	}
+	return string(out)
+}

--- a/internal/feishuadapter/types.go
+++ b/internal/feishuadapter/types.go
@@ -1,0 +1,149 @@
+package feishuadapter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Config 描述 Feishu Adapter 的运行配置。
+type Config struct {
+	ListenAddress       string
+	EventPath           string
+	CardPath            string
+	AppID               string
+	AppSecret           string
+	VerifyToken         string
+	SigningSecret       string
+	CallbackBaseURL     string
+	RequestTimeout      time.Duration
+	IdempotencyTTL      time.Duration
+	ReconnectBackoffMin time.Duration
+	ReconnectBackoffMax time.Duration
+	RebindInterval      time.Duration
+}
+
+// Validate 校验 Feishu Adapter 配置最小可用性。
+func (c Config) Validate() error {
+	if strings.TrimSpace(c.ListenAddress) == "" {
+		return fmt.Errorf("listen address is required")
+	}
+	if strings.TrimSpace(c.EventPath) == "" {
+		return fmt.Errorf("event path is required")
+	}
+	if strings.TrimSpace(c.CardPath) == "" {
+		return fmt.Errorf("card path is required")
+	}
+	if strings.TrimSpace(c.AppID) == "" {
+		return fmt.Errorf("app id is required")
+	}
+	if strings.TrimSpace(c.AppSecret) == "" {
+		return fmt.Errorf("app secret is required")
+	}
+	if c.RequestTimeout <= 0 {
+		return fmt.Errorf("request timeout must be greater than zero")
+	}
+	if c.IdempotencyTTL <= 0 {
+		return fmt.Errorf("idempotency ttl must be greater than zero")
+	}
+	if c.ReconnectBackoffMin <= 0 || c.ReconnectBackoffMax <= 0 {
+		return fmt.Errorf("reconnect backoff must be greater than zero")
+	}
+	if c.ReconnectBackoffMin > c.ReconnectBackoffMax {
+		return fmt.Errorf("reconnect backoff min cannot exceed max")
+	}
+	if c.RebindInterval <= 0 {
+		return fmt.Errorf("rebind interval must be greater than zero")
+	}
+	return nil
+}
+
+// GatewayNotification 表示网关推送的原始通知。
+type GatewayNotification struct {
+	Method string
+	Params json.RawMessage
+}
+
+// GatewayClient 定义 Feishu Adapter 所需的网关最小调用能力。
+type GatewayClient interface {
+	Authenticate(ctx context.Context) error
+	BindStream(ctx context.Context, sessionID string, runID string) error
+	Run(ctx context.Context, sessionID string, runID string, inputText string) error
+	ResolvePermission(ctx context.Context, requestID string, decision string) error
+	Ping(ctx context.Context) error
+	Notifications() <-chan GatewayNotification
+	Close() error
+}
+
+// Messenger 定义飞书消息发送器接口，便于测试替换。
+type Messenger interface {
+	SendText(ctx context.Context, chatID string, text string) error
+	SendPermissionCard(ctx context.Context, chatID string, payload PermissionCardPayload) error
+}
+
+// PermissionCardPayload 表示最小审批卡片的关键字段。
+type PermissionCardPayload struct {
+	RequestID string
+	Message   string
+}
+
+// inboundEnvelope 表示飞书回调统一信封。
+type inboundEnvelope struct {
+	Type      string          `json:"type,omitempty"`
+	Token     string          `json:"token,omitempty"`
+	Challenge string          `json:"challenge,omitempty"`
+	Header    inboundHeader   `json:"header,omitempty"`
+	Event     json.RawMessage `json:"event,omitempty"`
+}
+
+// inboundHeader 表示飞书 schema 2.0 回调头字段。
+type inboundHeader struct {
+	EventID   string `json:"event_id,omitempty"`
+	EventType string `json:"event_type,omitempty"`
+	Token     string `json:"token,omitempty"`
+}
+
+// inboundMessageEvent 表示消息回调事件最小结构。
+type inboundMessageEvent struct {
+	Message inboundMessage `json:"message,omitempty"`
+}
+
+// inboundMessage 表示消息体结构。
+type inboundMessage struct {
+	MessageID string `json:"message_id,omitempty"`
+	ChatID    string `json:"chat_id,omitempty"`
+	Content   string `json:"content,omitempty"`
+}
+
+// inboundMessageContent 表示消息 JSON 内容中的文本字段。
+type inboundMessageContent struct {
+	Text string `json:"text,omitempty"`
+}
+
+// inboundCardCallback 表示卡片回调最小结构。
+type inboundCardCallback struct {
+	OpenMessageID string            `json:"open_message_id,omitempty"`
+	Token         string            `json:"token,omitempty"`
+	Action        inboundCardAction `json:"action,omitempty"`
+	Header        inboundCardHeader `json:"header,omitempty"`
+	Event         *inboundCardEvent `json:"event,omitempty"`
+}
+
+type inboundCardHeader struct {
+	EventID string `json:"event_id,omitempty"`
+	Token   string `json:"token,omitempty"`
+}
+
+type inboundCardEvent struct {
+	Operator inboundCardOperator `json:"operator,omitempty"`
+}
+
+type inboundCardOperator struct {
+	OpenID string `json:"open_id,omitempty"`
+}
+
+type inboundCardAction struct {
+	Value map[string]string `json:"value,omitempty"`
+}

--- a/internal/feishuadapter/types.go
+++ b/internal/feishuadapter/types.go
@@ -10,19 +10,20 @@ import (
 
 // Config 描述 Feishu Adapter 的运行配置。
 type Config struct {
-	ListenAddress       string
-	EventPath           string
-	CardPath            string
-	AppID               string
-	AppSecret           string
-	VerifyToken         string
-	SigningSecret       string
-	CallbackBaseURL     string
-	RequestTimeout      time.Duration
-	IdempotencyTTL      time.Duration
-	ReconnectBackoffMin time.Duration
-	ReconnectBackoffMax time.Duration
-	RebindInterval      time.Duration
+	ListenAddress          string
+	EventPath              string
+	CardPath               string
+	AppID                  string
+	AppSecret              string
+	VerifyToken            string
+	SigningSecret          string
+	InsecureSkipSignVerify bool
+	CallbackBaseURL        string
+	RequestTimeout         time.Duration
+	IdempotencyTTL         time.Duration
+	ReconnectBackoffMin    time.Duration
+	ReconnectBackoffMax    time.Duration
+	RebindInterval         time.Duration
 }
 
 // Validate 校验 Feishu Adapter 配置最小可用性。
@@ -41,6 +42,12 @@ func (c Config) Validate() error {
 	}
 	if strings.TrimSpace(c.AppSecret) == "" {
 		return fmt.Errorf("app secret is required")
+	}
+	if strings.TrimSpace(c.VerifyToken) == "" {
+		return fmt.Errorf("verify token is required")
+	}
+	if !c.InsecureSkipSignVerify && strings.TrimSpace(c.SigningSecret) == "" {
+		return fmt.Errorf("signing secret is required unless insecure skip signature verify is enabled")
 	}
 	if c.RequestTimeout <= 0 {
 		return fmt.Errorf("request timeout must be greater than zero")
@@ -107,14 +114,23 @@ type inboundHeader struct {
 
 // inboundMessageEvent 表示消息回调事件最小结构。
 type inboundMessageEvent struct {
-	Message inboundMessage `json:"message,omitempty"`
+	ChatType string         `json:"chat_type,omitempty"`
+	Message  inboundMessage `json:"message,omitempty"`
 }
 
 // inboundMessage 表示消息体结构。
 type inboundMessage struct {
-	MessageID string `json:"message_id,omitempty"`
-	ChatID    string `json:"chat_id,omitempty"`
-	Content   string `json:"content,omitempty"`
+	MessageID string           `json:"message_id,omitempty"`
+	ChatID    string           `json:"chat_id,omitempty"`
+	ChatType  string           `json:"chat_type,omitempty"`
+	Content   string           `json:"content,omitempty"`
+	Mentions  []inboundMention `json:"mentions,omitempty"`
+}
+
+// inboundMention 表示群聊消息中的 @ 信息。
+type inboundMention struct {
+	Name string `json:"name,omitempty"`
+	Key  string `json:"key,omitempty"`
 }
 
 // inboundMessageContent 表示消息 JSON 内容中的文本字段。

--- a/internal/feishuadapter/types_test.go
+++ b/internal/feishuadapter/types_test.go
@@ -1,0 +1,76 @@
+package feishuadapter
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestConfigValidateAcceptsValidConfiguration(t *testing.T) {
+	cfg := Config{
+		ListenAddress:       "127.0.0.1:18080",
+		EventPath:           "/feishu/events",
+		CardPath:            "/feishu/cards",
+		AppID:               "app",
+		AppSecret:           "secret",
+		VerifyToken:         "verify",
+		SigningSecret:       "sign",
+		RequestTimeout:      time.Second,
+		IdempotencyTTL:      time.Minute,
+		ReconnectBackoffMin: 100 * time.Millisecond,
+		ReconnectBackoffMax: time.Second,
+		RebindInterval:      time.Second,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate valid config: %v", err)
+	}
+}
+
+func TestConfigValidateRejectsInvalidInputs(t *testing.T) {
+	testCases := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{name: "missing listen", cfg: Config{}, want: "listen address is required"},
+		{name: "missing event path", cfg: Config{ListenAddress: "127.0.0.1:1"}, want: "event path is required"},
+		{name: "missing card path", cfg: Config{ListenAddress: "127.0.0.1:1", EventPath: "/events"}, want: "card path is required"},
+		{name: "missing app id", cfg: Config{ListenAddress: "127.0.0.1:1", EventPath: "/events", CardPath: "/cards"}, want: "app id is required"},
+		{name: "missing app secret", cfg: Config{ListenAddress: "127.0.0.1:1", EventPath: "/events", CardPath: "/cards", AppID: "app"}, want: "app secret is required"},
+		{name: "missing verify token", cfg: Config{ListenAddress: "127.0.0.1:1", EventPath: "/events", CardPath: "/cards", AppID: "app", AppSecret: "secret"}, want: "verify token is required"},
+		{name: "missing signing secret", cfg: Config{ListenAddress: "127.0.0.1:1", EventPath: "/events", CardPath: "/cards", AppID: "app", AppSecret: "secret", VerifyToken: "verify"}, want: "signing secret is required"},
+		{name: "request timeout", cfg: Config{ListenAddress: "127.0.0.1:1", EventPath: "/events", CardPath: "/cards", AppID: "app", AppSecret: "secret", VerifyToken: "verify", SigningSecret: "sign"}, want: "request timeout must be greater than zero"},
+		{name: "idempotency ttl", cfg: Config{ListenAddress: "127.0.0.1:1", EventPath: "/events", CardPath: "/cards", AppID: "app", AppSecret: "secret", VerifyToken: "verify", SigningSecret: "sign", RequestTimeout: time.Second}, want: "idempotency ttl must be greater than zero"},
+		{name: "backoff", cfg: Config{ListenAddress: "127.0.0.1:1", EventPath: "/events", CardPath: "/cards", AppID: "app", AppSecret: "secret", VerifyToken: "verify", SigningSecret: "sign", RequestTimeout: time.Second, IdempotencyTTL: time.Minute}, want: "reconnect backoff must be greater than zero"},
+		{name: "backoff order", cfg: Config{ListenAddress: "127.0.0.1:1", EventPath: "/events", CardPath: "/cards", AppID: "app", AppSecret: "secret", VerifyToken: "verify", SigningSecret: "sign", RequestTimeout: time.Second, IdempotencyTTL: time.Minute, ReconnectBackoffMin: time.Second, ReconnectBackoffMax: 100 * time.Millisecond}, want: "reconnect backoff min cannot exceed max"},
+		{name: "rebind", cfg: Config{ListenAddress: "127.0.0.1:1", EventPath: "/events", CardPath: "/cards", AppID: "app", AppSecret: "secret", VerifyToken: "verify", SigningSecret: "sign", RequestTimeout: time.Second, IdempotencyTTL: time.Minute, ReconnectBackoffMin: 100 * time.Millisecond, ReconnectBackoffMax: time.Second}, want: "rebind interval must be greater than zero"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := testCase.cfg.Validate()
+			if err == nil || !strings.Contains(err.Error(), testCase.want) {
+				t.Fatalf("error = %v, want substring %q", err, testCase.want)
+			}
+		})
+	}
+}
+
+func TestConfigValidateAllowsSkippingSignatureVerification(t *testing.T) {
+	cfg := Config{
+		ListenAddress:          "127.0.0.1:18080",
+		EventPath:              "/feishu/events",
+		CardPath:               "/feishu/cards",
+		AppID:                  "app",
+		AppSecret:              "secret",
+		VerifyToken:            "verify",
+		InsecureSkipSignVerify: true,
+		RequestTimeout:         time.Second,
+		IdempotencyTTL:         time.Minute,
+		ReconnectBackoffMin:    100 * time.Millisecond,
+		ReconnectBackoffMax:    time.Second,
+		RebindInterval:         time.Second,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate insecure config: %v", err)
+	}
+}

--- a/www/.vitepress/config.mts
+++ b/www/.vitepress/config.mts
@@ -105,6 +105,7 @@ export default defineConfig({
               items: [
                 { text: "MCP 工具接入", link: "/guide/mcp" },
                 { text: "Skills 使用", link: "/guide/skills" },
+                { text: "飞书远程接入配置", link: "/guide/feishu-remote-setup" },
               ],
             },
             {

--- a/www/guide/feishu-remote-setup.md
+++ b/www/guide/feishu-remote-setup.md
@@ -1,0 +1,184 @@
+---
+title: 飞书远程接入配置指南
+description: 用 Feishu + NeoCode Gateway + Feishu Adapter 完成远程消息驱动本地执行的完整配置与排障。
+---
+
+# 飞书远程接入配置指南
+
+本文是 NeoCode 的飞书接入实操文档，目标是让你可以在飞书（含手机端）发消息，驱动 NeoCode 执行任务并回传结果。
+
+当前实现（#554 Phase 1）采用 **飞书 Webhook 回调 + NeoCode Feishu Adapter 长连接 Gateway** 的模式。
+
+## 1. 先理解这条链路
+
+```mermaid
+flowchart LR
+  A["飞书消息（私聊 / 群聊@机器人）"] --> B["飞书开放平台回调（公网 HTTPS）"]
+  B --> C["neocode feishu-adapter"]
+  C --> D["Gateway JSON-RPC 长连接"]
+  D --> E["Runtime / Tools 执行"]
+  E --> D
+  D --> C
+  C --> F["回发飞书文本/审批卡片"]
+```
+
+关键点：
+
+- 飞书到 Adapter 这段必须是公网可访问的 HTTPS 回调地址。
+- Adapter 到 Gateway 是本地/内网长连接，不需要暴露 Runtime 私有接口。
+- 当前不是“飞书官方 SDK 长连接接收事件”模式；那是后续阶段（#555）目标。
+
+## 2. 你需要准备的四个字段
+
+在飞书开放平台应用里，你至少要拿到并回填这 4 个值：
+
+1. `App ID` -> `feishu.app_id`
+2. `App Secret` -> `feishu.app_secret`
+3. `Verification Token` -> `feishu.verify_token`
+4. `Signing Secret` -> `feishu.signing_secret`
+
+说明：
+
+- 代码默认要求签名校验开启：`signing_secret` 必填。
+- 仅本地联调可设置 `feishu.insecure_skip_signature_verify: true` 临时跳过签名校验，不建议生产使用。
+- 若飞书后台开启了“加密推送（Encrypt Key）”，请确认你的服务端支持解密。当前建议先用未加密模式完成联调。
+
+## 3. 配置文件示例（完整可用）
+
+把下面配置写入 `~/.neocode/config.yaml`（Windows 一般是 `C:\Users\<你>\.neocode\config.yaml`）：
+
+```yaml
+gateway:
+  listen: "\\\\.\\pipe\\neocode-gateway-feishu"
+  http_listen: "127.0.0.1:18181"
+
+feishu:
+  enabled: true
+  app_id: "cli_xxx"
+  app_secret: "xxx"
+  verify_token: "xxx"
+  signing_secret: "xxx"
+  insecure_skip_signature_verify: false
+
+  # 对外可访问的 HTTPS 前缀（ngrok/cloudflared 分配的地址）
+  callback_base_url: "https://xxxx.ngrok-free.app"
+
+  adapter:
+    listen: "127.0.0.1:19080"
+    event_path: "/feishu/events"
+    card_path: "/feishu/cards"
+
+  idempotency_ttl_sec: 600
+  request_timeout_sec: 8
+  reconnect_backoff_min_ms: 500
+  reconnect_backoff_max_ms: 10000
+  rebind_interval_sec: 15
+
+  gateway:
+    # adapter 连接 gateway 的地址（可用命名管道或 TCP）
+    listen: "\\\\.\\pipe\\neocode-gateway-feishu"
+    # 可选：网关 token 文件路径
+    token_file: ""
+```
+
+如果你用纯 TCP（不用命名管道），把 `gateway.listen` 和 `feishu.gateway.listen` 改成 `127.0.0.1:<port>`。
+
+## 4. 本地启动顺序
+
+建议两个终端：
+
+1) 启动 Gateway
+
+```powershell
+go run ./cmd/neocode-gateway --listen "\\.\pipe\neocode-gateway-feishu" --http-listen 127.0.0.1:18181
+```
+
+2) 启动 Feishu Adapter
+
+```powershell
+go run ./cmd/neocode feishu-adapter --gateway-listen "\\.\pipe\neocode-gateway-feishu" --listen 127.0.0.1:19080
+```
+
+看到 adapter 无报错并保持阻塞运行是正常状态。
+
+## 5. 公网回调地址（ngrok 示例）
+
+把本地 `19080` 暴露到公网：
+
+```powershell
+ngrok http 19080
+```
+
+假设拿到公网前缀：
+
+```text
+https://xxxx.ngrok-free.app
+```
+
+那么飞书回调地址应为：
+
+- 事件回调：`https://xxxx.ngrok-free.app/feishu/events`
+- 卡片回调：`https://xxxx.ngrok-free.app/feishu/cards`
+
+## 6. 飞书后台怎么填
+
+在飞书开放平台应用里：
+
+1. 订阅方式选择“将回调发送至开发者服务器”。
+2. 事件配置里添加机器人消息事件（如 `im.message.receive_v1`）。
+3. 回调配置里填写：
+   - 请求地址：`https://xxxx.ngrok-free.app/feishu/events`
+   - 卡片回调请求地址：`https://xxxx.ngrok-free.app/feishu/cards`
+4. 加密策略页确认 `Verification Token` 与你配置一致；`Signing Secret` 与本地配置一致。
+
+如果页面提示“返回数据不是合法 JSON”，优先检查：
+
+- URL 是否填错（events 和 cards 路径不要混）；
+- adapter 是否正在监听对应端口；
+- `verify_token` / `signing_secret` 是否一致；
+- ngrok 是否转发到正确本地端口。
+
+## 7. 实际收发行为说明
+
+- 私聊：默认受理消息。
+- 群聊：默认需要 `@机器人` 才触发执行。
+- 成功触发后会先返回“任务已受理，正在执行”，随后回传最终结果。
+- 审批事件会发卡片（允许一次 / 拒绝）。
+
+## 8. 常见报错与处理
+
+### 8.1 `signing_secret is required ...`
+
+你开启了 `feishu.enabled: true` 但未配置签名密钥。  
+处理：
+
+- 推荐：补上 `feishu.signing_secret`。
+- 仅联调：`feishu.insecure_skip_signature_verify: true`。
+
+### 8.2 `workspace hash is empty and no default configured`
+
+Gateway 运行时没有默认工作区。  
+处理：
+
+- 用带 `workdir` 的会话启动 NeoCode，或在配置里补默认工作区相关项。
+
+### 8.3 `session id ... contains unsupported characters`
+
+旧配置/旧分支仍在使用不兼容的 session_id 格式。  
+处理：更新到当前实现并重启 gateway + adapter。
+
+### 8.4 飞书里只看到“受理中”，看不到有效结果
+
+先看 Gateway 日志是否出现 `run async failed`。常见是工作区、权限、Provider 配置问题，不是飞书回调问题。
+
+## 9. 安全建议
+
+- 不要把 `app_secret`、`signing_secret`、`verify_token` 提交到仓库。
+- 生产环境不要开启 `insecure_skip_signature_verify`。
+- 回调地址建议走专用域名与 HTTPS，配合最小权限网络策略。
+
+## 10. 进一步阅读
+
+- [配置指南](./configuration)
+- [排障与常见问题](./troubleshooting)
+- [Gateway 集成参考](/reference/gateway)

--- a/www/guide/feishu-remote-setup.md
+++ b/www/guide/feishu-remote-setup.md
@@ -48,10 +48,6 @@ flowchart LR
 把下面配置写入 `~/.neocode/config.yaml`（Windows 一般是 `C:\Users\<你>\.neocode\config.yaml`）：
 
 ```yaml
-gateway:
-  listen: "\\\\.\\pipe\\neocode-gateway-feishu"
-  http_listen: "127.0.0.1:18181"
-
 feishu:
   enabled: true
   app_id: "cli_xxx"
@@ -79,6 +75,9 @@ feishu:
 ```
 
 如果你用纯 TCP（不用命名管道），把 `gateway.listen` 和 `feishu.gateway.listen` 改成 `127.0.0.1:<port>`。
+
+> 注意：`config.yaml` 顶层 `gateway` 段不支持 `listen/http_listen` 这类监听地址字段。  
+> Gateway 的监听地址请通过 `neocode-gateway` 启动参数传入（见下一节命令）。
 
 ## 4. 本地启动顺序
 

--- a/www/guide/index.md
+++ b/www/guide/index.md
@@ -38,6 +38,7 @@ NeoCode 是一个在终端里运行的本地 AI 编码助手。它不是云端 S
 
 - [Skills 使用](./skills) — 用 `SKILL.md` 固化当前任务的工作方式
 - [MCP 工具接入](./mcp) — 把外部工具接入 NeoCode
+- [飞书远程接入配置指南](./feishu-remote-setup) — 飞书消息到本地执行的回调与长连接配置
 
 ## 遇到问题
 


### PR DESCRIPTION
## 背景与目标
Close #554 
本 PR 落地 Feishu 接入 Phase 1（Issue #554）：在不改动 Runtime 私有边界、不新增 Gateway action 的前提下，提供一个可独立运行的 **Feishu Adapter**，把飞书消息桥接到 NeoCode Gateway。

核心目标：
- 飞书消息可触发 NeoCode 任务执行并回传结果。
- 采用 Gateway 现有协议能力（authenticate / bindStream / run / resolvePermission / gateway.event）。
- 支持最小审批闭环、幂等与重连，保证本地开发和内网联调可用。

---

## 用户价值

### 1) 远程操控本地执行
用户可在飞书（含手机端）发送消息，由 Adapter 路由到本机/可连通环境中的 NeoCode Gateway 执行，实现“移动端发起、开发机执行”的协同路径。

### 2) 不破坏现有架构边界
保持 `TUI/Gateway/Runtime/Tools` 分层，外部集成只经由 Gateway 协议，不直接侵入 Runtime。

### 3) 可观察、可恢复
通过 `gateway.event` 订阅拿到运行进度/完成/失败/审批事件，配套幂等和重连机制，降低 webhook 重放与连接抖动带来的不确定性。

---

## 用户故事

- 作为研发，我希望在飞书里对机器人说“帮我检查某文件”，系统能在本地执行并把结果回传到同一会话。
- 作为管理员，我希望审批请求能在飞书卡片里一键“允许一次/拒绝”，并严格映射到 Gateway permission 决议。
- 作为平台开发者，我希望即使 Gateway 断线重连，Adapter 也能自动 rebind 活跃 session，避免 run 期间事件丢失。

---

## 设计与实现

### 1) 新增命令入口
- `neocode feishu-adapter`
- 独立进程启动 Feishu 回调 HTTP 服务 + Gateway 长连接客户端。

### 2) Gateway 调用顺序（严格）
对每条消息执行：
1. `gateway.authenticate`
2. `gateway.bindStream(session_id, run_id)`
3. `gateway.run(session_id, run_id, input_text)`
4. 持续消费 `gateway.event`

> 先 bind 再 run，避免丢 started/progress 早期事件。

### 3) 确定性 ID 与幂等
- `session_id = feishu_<stableHash(chat_id)>`
- `run_id = feishu_<stableHash(message_id)>`
- 消息去重：`event_id + message_id`
- 卡片去重：`request_id + decision`
- 去重标记时机修正：仅在 run 受理后标记成功；失败则释放，允许飞书重试恢复。

### 4) 回调安全
- Challenge 校验 + Verify Token 校验 + 签名校验。
- 默认安全策略：`signing_secret` 必填（除非显式 `insecure_skip_signature_verify=true`）。
- 日志脱敏，避免泄露 app secret / token / auth 头。

### 5) 事件映射与用户视图优化
- `permission_requested` -> 飞书审批卡片。
- `run_done` -> 提取用户可读最终文本回传。
- `run_error` -> 友好错误摘要。
- 普通内部 `runtime_event_type` 不再直接透出给飞书终端用户，避免暴露控制面细节与刷屏。

### 6) 群聊触发语义
- 私聊默认受理。
- 群聊仅在 `@机器人` 时受理，避免误触发。

### 7) 文档补齐
新增完整指南：
- `www/guide/feishu-remote-setup.md`
- 覆盖字段映射、config 示例、ngrok 回填、启动顺序、回调地址、常见错误定位。
并已接入：
- `www/.vitepress/config.mts`
- `www/guide/index.md`
- `README.md` 文档入口

---

## 配置示例（摘要）

```yaml
feishu:
  enabled: true
  app_id: "cli_xxx"
  app_secret: "xxx"
  verify_token: "xxx"
  signing_secret: "xxx"
  insecure_skip_signature_verify: false
  callback_base_url: "https://xxxx.ngrok-free.app"
  adapter:
    listen: "127.0.0.1:19080"
    event_path: "/feishu/events"
    card_path: "/feishu/cards"
  gateway:
    listen: "\\\\.\\pipe\\neocode-gateway-feishu"
```

---

## 测试与验证

### 自动化测试
- `go test ./internal/feishuadapter/...`

### 覆盖的关键场景
- challenge 处理
- verify token / 签名失败拒绝
- 群聊无 @ 忽略 / 有 @ 受理
- 消息幂等与卡片幂等
- 调用顺序：authenticate -> bindStream -> run
- run_done 文本提取与 run_error 摘要回传
- 重连后 rebind 活跃 session

---

## 与 #555 的边界

本 PR 只实现 #554（Webhook 控制面桥接）。

不包含：
- Local Runner 主动长连通道
- 云端到本机穿透链路产品化
- 多设备路由/选择

#555 负责“云端控制面 -> 本机执行面”的完整闭环补完。

---

## 兼容性与风险

- 未新增 Gateway action，复用现有协议，兼容成本低。
- 对飞书用户可见输出做了降噪，减少内部事件泄露。
- 默认安全策略更严格；如本地联调需跳过签名，必须显式开关。
