### PR TITLE
feat(tui):改进 TAB 模式切换并稳定斜杠/粘贴输入行为

### DIFF
--- a/internal/tui/core/app/app.go
+++ b/internal/tui/core/app/app.go
@@ -17,6 +17,7 @@ import (
 	configstate "neo-code/internal/config/state"
 	"neo-code/internal/memo"
 	providertypes "neo-code/internal/provider/types"
+	agentsession "neo-code/internal/session"
 	tuibootstrap "neo-code/internal/tui/bootstrap"
 	tuiservices "neo-code/internal/tui/services"
 	tuistate "neo-code/internal/tui/state"
@@ -356,9 +357,10 @@ func newApp(container tuibootstrap.Container) (App, error) {
 
 	app := App{
 		state: tuistate.UIState{
-			StatusText:      statusReady,
-			CurrentProvider: cfg.SelectedProvider,
-			CurrentModel:    cfg.CurrentModel,
+			StatusText:       statusReady,
+			CurrentProvider:  cfg.SelectedProvider,
+			CurrentModel:     cfg.CurrentModel,
+			CurrentAgentMode: string(agentsession.AgentModeBuild),
 			// CurrentWorkdir 初始化为启动配置中的工作目录，避免启动阶段丢失目录上下文。
 			CurrentWorkdir:     cfg.Workdir,
 			ActiveSessionTitle: draftSessionTitle,
@@ -401,6 +403,7 @@ func newApp(container tuibootstrap.Container) (App, error) {
 		styles: uiStyles,
 	}
 
+	app.setCurrentAgentMode(app.state.CurrentAgentMode)
 	app.syncActiveSessionTitle()
 	app.syncConfigState(configManager.Get())
 	if err := app.refreshProviderPicker(); err != nil {

--- a/internal/tui/core/app/app.go
+++ b/internal/tui/core/app/app.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/charmbracelet/bubbles/filepicker"
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/progress"
@@ -88,7 +87,6 @@ type appComponents struct {
 	modelPicker      list.Model
 	sessionPicker    list.Model
 	helpPicker       list.Model
-	fileBrowser      filepicker.Model
 	progress         progress.Model
 	transcript       viewport.Model
 	activity         viewport.Model
@@ -353,15 +351,6 @@ func newApp(container tuibootstrap.Container) (App, error) {
 
 	commandMenu := newCommandMenuModel(uiStyles)
 
-	fileBrowser := filepicker.New()
-	fileBrowser.SetHeight(10)
-	fileBrowser.AutoHeight = false
-	fileBrowser.ShowPermissions = false
-	fileBrowser.ShowSize = false
-	fileBrowser.FileAllowed = true
-	fileBrowser.DirAllowed = true
-	fileBrowser.CurrentDirectory = cfg.Workdir
-
 	progressBar := progress.New(progress.WithDefaultGradient(), progress.WithoutPercentage())
 	progressBar.Width = 22
 
@@ -390,7 +379,6 @@ func newApp(container tuibootstrap.Container) (App, error) {
 			modelPicker:      newSelectionPickerItems(nil),
 			sessionPicker:    newSelectionPickerItems(nil),
 			helpPicker:       newHelpPickerItems(nil),
-			fileBrowser:      fileBrowser,
 			progress:         progressBar,
 			transcript:       viewport.New(0, 0),
 			activity:         viewport.New(0, 0),

--- a/internal/tui/core/app/command_menu.go
+++ b/internal/tui/core/app/command_menu.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"fmt"
 	"io"
-	"path/filepath"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -29,7 +28,6 @@ type commandMenuItem struct {
 	useReplaceRange bool
 	replaceStart    int
 	replaceEnd      int
-	openFileBrowser bool
 }
 
 func (c commandMenuItem) Title() string {
@@ -306,13 +304,13 @@ func (a *App) resizeCommandMenu() {
 }
 
 func (a App) buildCommandMenuItems(input string, _ int) ([]commandMenuItem, tuistate.CommandMenuMeta) {
-	trimmed := strings.TrimSpace(input)
+	leadingTrimmed := strings.TrimLeft(input, " \t\r\n")
 
 	// 1. 优先检查 Slash 命令
-	if strings.HasPrefix(trimmed, slashPrefix) {
-		suggestions := a.matchingSlashCommands(trimmed)
+	if strings.HasPrefix(leadingTrimmed, slashPrefix) {
+		suggestions := a.matchingSlashCommands(leadingTrimmed)
 		if len(suggestions) > 0 {
-			start, end, _, _ := tokenRange(input, tokenSelectorFirst)
+			start, end := slashInputReplaceRange(input)
 			items := make([]commandMenuItem, 0, len(suggestions))
 			for _, suggestion := range suggestions {
 				items = append(items, commandMenuItem{
@@ -336,6 +334,19 @@ func (a App) buildCommandMenuItems(input string, _ int) ([]commandMenuItem, tuis
 	}
 
 	return nil, tuistate.CommandMenuMeta{}
+}
+
+func slashInputReplaceRange(input string) (start int, end int) {
+	start = 0
+	for start < len(input) {
+		switch input[start] {
+		case ' ', '\t', '\r', '\n':
+			start++
+		default:
+			return start, len(input)
+		}
+	}
+	return 0, len(input)
 }
 
 func (a App) fileMenuSuggestions(input string) []commandMenuItem {
@@ -376,10 +387,6 @@ func (a *App) applySelectedCommandSuggestion() bool {
 	if !ok {
 		return false
 	}
-	if item.openFileBrowser {
-		a.openFileBrowser()
-		return true
-	}
 
 	current := a.input.Value()
 	next := current
@@ -417,20 +424,4 @@ func (a *App) updateCommandMenuSelection(msg tea.KeyMsg) (tea.Cmd, bool) {
 	default:
 		return nil, false // 非导航键，让它们继续传递
 	}
-}
-
-func (a *App) openFileBrowser() {
-	workdir := strings.TrimSpace(a.state.CurrentWorkdir)
-	if workdir == "" {
-		return
-	}
-
-	absolute, err := filepath.Abs(workdir)
-	if err == nil {
-		a.fileBrowser.CurrentDirectory = absolute
-	}
-	a.state.ActivePicker = pickerFile
-	a.state.StatusText = statusBrowseFile
-	a.input.Blur()
-	a.applyComponentLayout(true)
 }

--- a/internal/tui/core/app/command_menu_test.go
+++ b/internal/tui/core/app/command_menu_test.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"bytes"
 	"io"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -24,7 +23,6 @@ func TestCommandMenuItem(t *testing.T) {
 		useReplaceRange: false,
 		replaceStart:    0,
 		replaceEnd:      0,
-		openFileBrowser: false,
 	}
 
 	if item.Title() != "Test Command" {
@@ -119,9 +117,6 @@ func TestFileMenuSuggestionsEmptyQueryReturnsFileReferences(t *testing.T) {
 	if len(items) == 0 {
 		t.Fatalf("expected file suggestions")
 	}
-	if items[0].openFileBrowser {
-		t.Fatalf("expected browse file entry to be removed")
-	}
 	if !strings.HasPrefix(items[0].replacement, "@") {
 		t.Fatalf("expected replacement to start with @, got %q", items[0].replacement)
 	}
@@ -158,6 +153,24 @@ func TestApplySelectedCommandSuggestionReplacesInput(t *testing.T) {
 	}
 }
 
+func TestApplySelectedCommandSuggestionReplacesFullSlashInput(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.input.SetValue("/provider a")
+	app.state.InputText = "/provider a"
+	app.transcript.Width = 80
+	app.refreshCommandMenu()
+
+	if !app.commandMenuHasSuggestions() {
+		t.Fatalf("expected suggestions")
+	}
+	if !app.applySelectedCommandSuggestion() {
+		t.Fatalf("expected suggestion to apply")
+	}
+	if got := strings.TrimSpace(app.input.Value()); got != slashUsageProviderAdd {
+		t.Fatalf("expected input to become %q, got %q", slashUsageProviderAdd, got)
+	}
+}
+
 func TestApplySelectedCommandSuggestionAppliesFileReference(t *testing.T) {
 	app, _ := newTestApp(t)
 	app.fileCandidates = []string{"README.md"}
@@ -191,22 +204,6 @@ func TestUpdateCommandMenuSelectionHandlesNavigationKeys(t *testing.T) {
 	_, handled = app.updateCommandMenuSelection(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
 	if handled {
 		t.Fatalf("expected non-navigation key to be ignored")
-	}
-}
-
-func TestOpenFileBrowserUsesAbsoluteWorkdir(t *testing.T) {
-	app, _ := newTestApp(t)
-	root := t.TempDir()
-	app.state.CurrentWorkdir = root
-
-	app.openFileBrowser()
-
-	expected, _ := filepath.Abs(root)
-	if app.fileBrowser.CurrentDirectory != expected {
-		t.Fatalf("expected absolute directory, got %q", app.fileBrowser.CurrentDirectory)
-	}
-	if app.state.ActivePicker != pickerFile {
-		t.Fatalf("expected file picker to be active")
 	}
 }
 

--- a/internal/tui/core/app/input_features.go
+++ b/internal/tui/core/app/input_features.go
@@ -38,9 +38,6 @@ func (a *App) refreshFileCandidates() error {
 		return err
 	}
 	a.fileCandidates = candidates
-	if absolute := tuiservices.ResolveWorkspaceDirectory(a.state.CurrentWorkdir); absolute != "" {
-		a.fileBrowser.CurrentDirectory = absolute
-	}
 	a.refreshCommandMenu()
 	return nil
 }

--- a/internal/tui/core/app/keymap.go
+++ b/internal/tui/core/app/keymap.go
@@ -7,10 +7,7 @@ type keyMap struct {
 	Newline          key.Binding
 	CancelAgent      key.Binding
 	NewSession       key.Binding
-	OpenWorkspace    key.Binding
 	ToggleFullAccess key.Binding
-	NextPanel        key.Binding
-	PrevPanel        key.Binding
 	FocusInput       key.Binding
 	ToggleHelp       key.Binding
 	Quit             key.Binding
@@ -42,21 +39,9 @@ func newKeyMap() keyMap {
 			key.WithKeys("ctrl+n"),
 			key.WithHelp("Ctrl+N", "New chat"),
 		),
-		OpenWorkspace: key.NewBinding(
-			key.WithKeys("ctrl+o"),
-			key.WithHelp("Ctrl+O", "Workspace"),
-		),
 		ToggleFullAccess: key.NewBinding(
 			key.WithKeys("ctrl+f"),
 			key.WithHelp("Ctrl+F", "Full access"),
-		),
-		NextPanel: key.NewBinding(
-			key.WithKeys("tab"),
-			key.WithHelp("Tab", "Next panel"),
-		),
-		PrevPanel: key.NewBinding(
-			key.WithKeys("shift+tab"),
-			key.WithHelp("Shift+Tab", "Prev panel"),
 		),
 		FocusInput: key.NewBinding(
 			key.WithKeys("esc"),
@@ -112,8 +97,7 @@ func (k keyMap) ShortHelp() []key.Binding {
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Send, k.Newline, k.CancelAgent, k.NewSession},
-		{k.OpenWorkspace, k.ToggleFullAccess},
-		{k.FocusInput, k.NextPanel, k.PrevPanel},
+		{k.ToggleFullAccess, k.FocusInput},
 		{k.ToggleHelp, k.Quit, k.PasteImage, k.ScrollUp},
 		{k.PageUp, k.PageDown, k.Top, k.Bottom},
 		{k.LogViewer},

--- a/internal/tui/core/app/keymap_test.go
+++ b/internal/tui/core/app/keymap_test.go
@@ -31,19 +31,6 @@ func TestFullHelpIncludesLogViewer(t *testing.T) {
 	}
 }
 
-func TestFullHelpIncludesOpenWorkspace(t *testing.T) {
-	keys := newKeyMap()
-	help := keys.FullHelp()
-	for _, row := range help {
-		for _, binding := range row {
-			if binding.Help().Key == keys.OpenWorkspace.Help().Key {
-				return
-			}
-		}
-	}
-	t.Fatalf("expected full help to include open workspace binding")
-}
-
 func TestFullHelpIncludesToggleFullAccess(t *testing.T) {
 	keys := newKeyMap()
 	help := keys.FullHelp()

--- a/internal/tui/core/app/mode.go
+++ b/internal/tui/core/app/mode.go
@@ -1,0 +1,66 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	agentsession "neo-code/internal/session"
+)
+
+const planAccent = "#f59e0b"
+
+func normalizeAgentModeValue(mode string) agentsession.AgentMode {
+	return agentsession.NormalizeAgentMode(agentsession.AgentMode(strings.TrimSpace(mode)))
+}
+
+func (a *App) currentAgentMode() agentsession.AgentMode {
+	return normalizeAgentModeValue(a.state.CurrentAgentMode)
+}
+
+func (a *App) setCurrentAgentMode(mode string) {
+	normalized := normalizeAgentModeValue(mode)
+	a.state.CurrentAgentMode = string(normalized)
+	a.state.RunContext.Mode = string(normalized)
+	a.applyModeTheme(normalized)
+}
+
+func (a *App) toggleAgentMode() agentsession.AgentMode {
+	next := agentsession.AgentModeBuild
+	if a.currentAgentMode() == agentsession.AgentModeBuild {
+		next = agentsession.AgentModePlan
+	}
+	a.setCurrentAgentMode(string(next))
+	return next
+}
+
+func formatAgentModeLabel(mode string) string {
+	return strings.ToUpper(string(normalizeAgentModeValue(mode)))
+}
+
+func modeAccent(mode agentsession.AgentMode) string {
+	if mode == agentsession.AgentModePlan {
+		return planAccent
+	}
+	return purpleAccent
+}
+
+func (a *App) applyModeTheme(mode agentsession.AgentMode) {
+	accent := lipgloss.Color(modeAccent(mode))
+
+	a.styles.panelFocused = a.styles.panelFocused.BorderForeground(accent)
+	a.styles.sessionMetaFocus = a.styles.sessionMetaFocus.Foreground(accent)
+	a.styles.commandMenuTitle = a.styles.commandMenuTitle.Foreground(accent)
+	a.styles.commandUsageMatch = a.styles.commandUsageMatch.Foreground(accent)
+	a.styles.inputPrefix = a.styles.inputPrefix.Foreground(accent).Bold(true)
+	a.styles.inputBoxFocused = a.styles.inputBoxFocused.BorderForeground(accent)
+	a.styles.startupPrompt = a.styles.startupPrompt.Foreground(accent).Bold(true)
+
+	a.input.Cursor.Style = a.input.Cursor.Style.Foreground(accent)
+	a.input.FocusedStyle.Prompt = a.input.FocusedStyle.Prompt.Foreground(accent).Bold(true)
+	a.input.BlurredStyle.Prompt = a.input.BlurredStyle.Prompt.Foreground(accent).Bold(true)
+
+	a.spinner.Style = a.spinner.Style.Foreground(accent)
+	a.help.Styles.ShortKey = a.help.Styles.ShortKey.Foreground(accent).Bold(true)
+	a.help.Styles.FullKey = a.help.Styles.FullKey.Foreground(accent).Bold(true)
+}

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -430,6 +430,11 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				tabMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'	'}, Paste: typed.Paste}
 				return a.updateInputPanel(tabMsg, tabMsg, cmds)
 			}
+			if a.shouldToggleAgentModeOnTab(typed) {
+				mode := a.toggleAgentMode()
+				a.state.StatusText = fmt.Sprintf("Mode switched to %s", strings.ToUpper(string(mode)))
+				return a, batchUpdateCmds()
+			}
 		}
 		if key.Matches(typed, a.keys.FocusInput) {
 			a.clearTextSelection()
@@ -1992,6 +1997,7 @@ func (a *App) beginAgentRun(input string, images []tuiservices.UserImageInput) t
 		SessionID: a.state.ActiveSessionID,
 		RunID:     runID,
 		Workdir:   requestedWorkdir,
+		Mode:      string(a.currentAgentMode()),
 		Text:      normalizedInput,
 		Images:    clonedImages,
 	})
@@ -2560,6 +2566,7 @@ func (a *App) applySessionSnapshot(session agentsession.Session, warnOnMissingWo
 	a.clearActivities()
 	a.syncTodos(session.Todos)
 	a.state.ActiveSessionTitle = session.Title
+	a.setCurrentAgentMode(string(session.AgentMode))
 	a.syncSessionWorkdir(session.Workdir, warnOnMissingWorkdir)
 	a.loadLogEntriesForSession(session.ID)
 	a.refreshRuntimeSourceSnapshot()
@@ -2573,6 +2580,7 @@ func (a *App) resetSessionRuntimeState() {
 	a.lastUserMessageRunID = ""
 	a.state.ToolStates = nil
 	a.state.RunContext = tuistate.ContextWindowState{}
+	a.setCurrentAgentMode(string(agentsession.AgentModeBuild))
 	a.state.TokenUsage = tuistate.TokenUsageState{}
 	a.pendingPermission = nil
 	a.queuedIntervention = nil
@@ -2690,7 +2698,9 @@ func (a *App) refreshRuntimeSourceSnapshot() {
 					a.state.RunContext.Provider = mapped.Provider
 					a.state.RunContext.Model = mapped.Model
 					a.state.RunContext.Workdir = mapped.Workdir
-					a.state.RunContext.Mode = mapped.Mode
+					if strings.TrimSpace(mapped.Mode) != "" {
+						a.setCurrentAgentMode(mapped.Mode)
+					}
 					a.state.RunContext.SessionID = mapped.SessionID
 				}
 			}
@@ -2716,8 +2726,11 @@ func (a *App) refreshRuntimeSourceSnapshot() {
 			runSnapshot, parsed := tuiservices.ParseRunSnapshot(raw)
 			if parsed {
 				contextVM, toolVM, usageVM := tuiservices.MapRunSnapshot(runSnapshot)
-				if strings.TrimSpace(contextVM.Provider) != "" {
+				if strings.TrimSpace(contextVM.Provider) != "" || strings.TrimSpace(contextVM.Mode) != "" {
 					a.state.RunContext = contextVM
+					if strings.TrimSpace(contextVM.Mode) != "" {
+						a.setCurrentAgentMode(contextVM.Mode)
+					}
 				}
 				if len(toolVM) > 0 {
 					a.state.ToolStates = append([]tuistate.ToolState(nil), toolVM...)
@@ -3863,6 +3876,9 @@ func runtimeEventRunContextHandler(a *App, event tuiservices.RuntimeEvent) bool 
 	}
 	if strings.TrimSpace(mapped.Workdir) != "" {
 		a.setCurrentWorkdir(mapped.Workdir)
+	}
+	if strings.TrimSpace(mapped.Mode) != "" {
+		a.setCurrentAgentMode(mapped.Mode)
 	}
 	return false
 }
@@ -5329,6 +5345,7 @@ func (a *App) startDraftSession() {
 	a.lastUserMessageRunID = ""
 	a.state.ToolStates = nil
 	a.state.RunContext = tuistate.ContextWindowState{}
+	a.setCurrentAgentMode(string(agentsession.AgentModeBuild))
 	a.state.TokenUsage = tuistate.TokenUsageState{}
 	a.pendingPermission = nil
 	a.queuedIntervention = nil
@@ -5454,6 +5471,16 @@ func (a *App) setActiveSessionID(sessionID string) {
 	if current == "" && len(previousEntries) > 0 {
 		a.persistLogEntriesForActiveSession()
 	}
+}
+
+func (a App) shouldToggleAgentModeOnTab(typed tea.KeyMsg) bool {
+	if a.focus != panelInput || a.state.ActivePicker != pickerNone || typed.Type != tea.KeyTab {
+		return false
+	}
+	if a.input.Value() != "" {
+		return false
+	}
+	return !typed.Paste && !a.pasteMode
 }
 
 func (a *App) loadLogEntriesForSession(sessionID string) {

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -1720,15 +1720,12 @@ func (a App) shouldCapturePasteTxnChunk(typed tea.KeyMsg) bool {
 	if typed.Paste {
 		return false
 	}
-	chunk := string(typed.Runes)
 	if a.pasteTxnActive {
-		// Do not lock the input while a paste transaction is open:
-		// only keep capturing obviously paste-like chunks.
-		if len(typed.Runes) > 1 {
-			return true
-		}
-		return strings.ContainsRune(chunk, '\n') || strings.ContainsRune(chunk, '\r') || strings.ContainsRune(chunk, '\t')
+		// Once a paste transaction starts, keep absorbing rune chunks until debounce flush.
+		// This avoids fragmenting one long paste into repeated summary tokens.
+		return true
 	}
+	chunk := string(typed.Runes)
 	if len(typed.Runes) > 1 {
 		return true
 	}
@@ -1750,7 +1747,7 @@ func (a App) shouldCaptureSingleRunePasteChunk(typed tea.KeyMsg) bool {
 		return false
 	}
 	clip = normalizeClipboardText(clip)
-	if strings.TrimSpace(clip) == "" {
+	if !shouldSummarizePastedText(clip) {
 		return false
 	}
 	chunk := normalizeClipboardText(string(typed.Runes))

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -71,7 +71,6 @@ type sessionLogPersistenceRuntime interface {
 	SaveSessionLogEntries(ctx context.Context, sessionID string, entries []tuiservices.SessionLogEntry) error
 }
 
-var panelOrder = []panel{panelTranscript, panelInput}
 var supportsUserEnvPersistence = config.SupportsUserEnvPersistence
 var persistProviderUserEnvVar = config.PersistUserEnvVar
 var deleteProviderUserEnvVar = config.DeleteUserEnvVar
@@ -423,7 +422,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return a, batchUpdateCmds()
 			}
 		}
-		if a.focus == panelInput && key.Matches(typed, a.keys.NextPanel) {
+		if a.focus == panelInput && typed.Type == tea.KeyTab {
 			if a.applySelectedCommandSuggestion() {
 				return a, batchUpdateCmds()
 			}
@@ -431,14 +430,6 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				tabMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'	'}, Paste: typed.Paste}
 				return a.updateInputPanel(tabMsg, tabMsg, cmds)
 			}
-		}
-		if key.Matches(typed, a.keys.NextPanel) {
-			a.focusNext()
-			return a, batchUpdateCmds()
-		}
-		if key.Matches(typed, a.keys.PrevPanel) {
-			a.focusPrev()
-			return a, batchUpdateCmds()
 		}
 		if key.Matches(typed, a.keys.FocusInput) {
 			a.clearTextSelection()
@@ -451,11 +442,6 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.startupScreenLocked = true
 			return a, batchUpdateCmds()
 		}
-		if key.Matches(typed, a.keys.OpenWorkspace) {
-			a.openFileBrowser()
-			return a, batchUpdateCmds()
-		}
-
 		if key.Matches(typed, a.keys.LogViewer) {
 			a.logViewerVisible = true
 			a.logViewerOffset = 0
@@ -2066,30 +2052,6 @@ func (a App) updatePicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		a.sessionPicker, cmd = updateListPickerModel(a.sessionPicker, msg)
 	case pickerHelp:
 		a.helpPicker, cmd = updateListPickerModel(a.helpPicker, msg)
-	case pickerFile:
-		a.fileBrowser, cmd = a.fileBrowser.Update(msg)
-		if didSelect, path := a.fileBrowser.DidSelectFile(msg); didSelect {
-			a.closePicker()
-			if tuiinfra.IsSupportedImageFormat(path) {
-				if err := a.addImageAttachment(path); err != nil {
-					a.state.ExecutionError = err.Error()
-					a.state.StatusText = err.Error()
-					a.appendActivity("multimodal", "Failed to add image", err.Error(), true)
-					return a, cmd
-				}
-				return a, cmd
-			}
-			if err := a.applyFileReference(path); err != nil {
-				a.state.ExecutionError = err.Error()
-				a.state.StatusText = err.Error()
-				a.appendActivity("workspace", "Failed to apply file reference", err.Error(), true)
-				return a, cmd
-			}
-			return a, cmd
-		}
-		if disabled, path := a.fileBrowser.DidSelectDisabledFile(msg); disabled {
-			a.state.StatusText = fmt.Sprintf("[System] %s is not selectable.", filepath.Base(path))
-		}
 	case pickerProviderAdd:
 		return a.handleProviderAddFormInput(msg)
 	case pickerModelScope:
@@ -4982,39 +4944,6 @@ func (a App) shouldHandleTabAsInput(typed tea.KeyMsg) bool {
 	return strings.TrimSpace(a.input.Value()) != ""
 }
 
-func (a *App) focusNext() {
-	order := panelOrder
-	current := 0
-	for i, item := range order {
-		if item == a.focus {
-			current = i
-			break
-		}
-	}
-
-	a.focus = order[(current+1)%len(order)]
-	a.applyFocus()
-}
-
-func (a *App) focusPrev() {
-	order := panelOrder
-	current := 0
-	for i, item := range order {
-		if item == a.focus {
-			current = i
-			break
-		}
-	}
-
-	if current == 0 {
-		a.focus = order[len(order)-1]
-	} else {
-		a.focus = order[current-1]
-	}
-
-	a.applyFocus()
-}
-
 func (a *App) applyFocus() {
 	a.state.Focus = a.focus
 	if a.focus == panelInput && a.state.ActivePicker == pickerNone {
@@ -5072,7 +5001,6 @@ func (a *App) applyComponentLayout(rebuildTranscript bool) {
 		pickerLayout.listWidth,
 		tuiutils.Clamp(helpPickerDesiredHeight, pickerListMinHeight, pickerLayout.listHeight),
 	)
-	a.fileBrowser.SetHeight(max(pickerListMinHeight, pickerLayout.listHeight))
 	if rebuildTranscript || prevTranscriptWidth != a.transcript.Width {
 		a.rebuildTranscript()
 	} else if a.transcript.AtBottom() {
@@ -5930,7 +5858,7 @@ func (a *App) handleProviderAddFormInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			a.state.ActivePicker = pickerNone
 			a.state.StatusText = statusReady
 			return a, nil
-		case key.Matches(typed, a.keys.PrevPanel):
+		case typed.Type == tea.KeyShiftTab:
 			a.providerAddForm.Stage = providerAddFormStageFields
 			a.providerAddForm.Error = ""
 			a.providerAddForm.ErrorIsHard = false
@@ -5957,9 +5885,9 @@ func (a *App) handleProviderAddFormInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	switch {
-	case key.Matches(typed, a.keys.PrevPanel):
+	case typed.Type == tea.KeyShiftTab:
 		a.providerAddForm.Step = (a.providerAddForm.Step + fieldCount - 1) % fieldCount
-	case key.Matches(typed, a.keys.NextPanel):
+	case typed.Type == tea.KeyTab:
 		a.providerAddForm.Step = (a.providerAddForm.Step + 1) % fieldCount
 	case key.Matches(typed, a.keys.Send):
 		return a, a.submitProviderAddForm()

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -426,10 +426,6 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if a.applySelectedCommandSuggestion() {
 				return a, batchUpdateCmds()
 			}
-			if a.shouldHandleTabAsInput(typed) {
-				tabMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'	'}, Paste: typed.Paste}
-				return a.updateInputPanel(tabMsg, tabMsg, cmds)
-			}
 			if a.shouldToggleAgentModeOnTab(typed) {
 				mode := a.toggleAgentMode()
 				a.state.StatusText = fmt.Sprintf("Mode switched to %s", strings.ToUpper(string(mode)))
@@ -4950,16 +4946,6 @@ func (a *App) scrollInputPage(direction int) {
 	a.state.InputText = a.input.Value()
 }
 
-func (a App) shouldHandleTabAsInput(typed tea.KeyMsg) bool {
-	if a.focus != panelInput || a.state.ActivePicker != pickerNone || typed.Type != tea.KeyTab {
-		return false
-	}
-	if typed.Paste || a.pasteMode {
-		return true
-	}
-	return strings.TrimSpace(a.input.Value()) != ""
-}
-
 func (a *App) applyFocus() {
 	a.state.Focus = a.focus
 	if a.focus == panelInput && a.state.ActivePicker == pickerNone {
@@ -5475,9 +5461,6 @@ func (a *App) setActiveSessionID(sessionID string) {
 
 func (a App) shouldToggleAgentModeOnTab(typed tea.KeyMsg) bool {
 	if a.focus != panelInput || a.state.ActivePicker != pickerNone || typed.Type != tea.KeyTab {
-		return false
-	}
-	if a.input.Value() != "" {
 		return false
 	}
 	return !typed.Paste && !a.pasteMode

--- a/internal/tui/core/app/update_test.go
+++ b/internal/tui/core/app/update_test.go
@@ -1566,6 +1566,63 @@ func TestUpdateSingleRuneInputDoesNotPrimeFromClipboard(t *testing.T) {
 	}
 }
 
+func TestUpdateSingleRuneInputDoesNotCaptureClipboardPrefix(t *testing.T) {
+	app, _ := newTestApp(t)
+	clipboardText := "你好，你是谁？"
+
+	originalReadText := readClipboardText
+	defer func() { readClipboardText = originalReadText }()
+	readClipboardText = func() (string, error) { return clipboardText, nil }
+
+	model, cmd := app.Update(tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune("你"),
+		Paste: false,
+	})
+	if cmd != nil {
+		_ = cmd()
+	}
+	app = model.(App)
+
+	if app.input.Value() != "你" {
+		t.Fatalf("expected single-rune input to stay as regular typing, got %q", app.input.Value())
+	}
+}
+
+func TestUpdateSingleRuneChunksForMultilinePasteStaySingleToken(t *testing.T) {
+	app, _ := newTestApp(t)
+	clipboardText := "可以，已经解决并落地了\n改文件：\nupdate.go"
+
+	originalReadText := readClipboardText
+	defer func() { readClipboardText = originalReadText }()
+	readClipboardText = func() (string, error) { return clipboardText, nil }
+
+	for _, chunk := range []string{"可", "以", "，"} {
+		model, cmd := app.Update(tea.KeyMsg{
+			Type:  tea.KeyRunes,
+			Runes: []rune(chunk),
+			Paste: false,
+		})
+		if cmd != nil {
+			_ = cmd()
+		}
+		app = model.(App)
+	}
+
+	model, cmd := app.Update(pasteTxnFlushMsg{Version: app.pasteTxnVersion})
+	if cmd != nil {
+		_ = cmd()
+	}
+	app = model.(App)
+
+	if got := app.input.Value(); got != "[paste 3 LINE]" {
+		t.Fatalf("expected one summarized token after chunked multiline paste, got %q", got)
+	}
+	if len(app.pendingTextPastes) != 1 {
+		t.Fatalf("expected one pending text paste entry, got %d", len(app.pendingTextPastes))
+	}
+}
+
 func TestUpdateEnterDoesNotSendWhilePasteEchoPending(t *testing.T) {
 	app, runtime := newTestApp(t)
 	now := time.Now()

--- a/internal/tui/core/app/update_test.go
+++ b/internal/tui/core/app/update_test.go
@@ -2129,6 +2129,24 @@ func TestUpdatePastedTextLoadReadyAppendsSeparatorBeforeDeferredSend(t *testing.
 	}
 }
 
+func TestBeginAgentRunPropagatesCurrentMode(t *testing.T) {
+	app, runtime := newTestApp(t)
+	app.setCurrentAgentMode(string(agentsession.AgentModePlan))
+
+	cmd := app.beginAgentRun("hello", nil)
+	if cmd == nil {
+		t.Fatalf("expected beginAgentRun to return submit command")
+	}
+	_ = cmd()
+
+	if len(runtime.prepareInputs) != 1 {
+		t.Fatalf("expected one prepare input, got %d", len(runtime.prepareInputs))
+	}
+	if runtime.prepareInputs[0].Mode != string(agentsession.AgentModePlan) {
+		t.Fatalf("prepare input mode = %q, want %q", runtime.prepareInputs[0].Mode, agentsession.AgentModePlan)
+	}
+}
+
 func TestPasteSessionHelpers(t *testing.T) {
 	app, _ := newTestApp(t)
 	now := time.Now()
@@ -3014,6 +3032,45 @@ func TestShouldHandleTabAsInput(t *testing.T) {
 	app.input.SetValue("")
 	if app.shouldHandleTabAsInput(tea.KeyMsg{Type: tea.KeyTab}) {
 		t.Fatalf("expected tab to be ignored for empty input")
+	}
+}
+
+func TestTabSwitchesAgentModeWhenInputEmpty(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.focus = panelInput
+	app.state.ActivePicker = pickerNone
+	app.input.SetValue("")
+	app.state.InputText = ""
+	app.setCurrentAgentMode(string(agentsession.AgentModeBuild))
+
+	model, _ := app.Update(tea.KeyMsg{Type: tea.KeyTab})
+	app = model.(App)
+	if app.currentAgentMode() != agentsession.AgentModePlan {
+		t.Fatalf("expected mode to switch to plan, got %q", app.currentAgentMode())
+	}
+	if !strings.Contains(strings.ToLower(app.state.StatusText), "plan") {
+		t.Fatalf("expected status to mention plan mode, got %q", app.state.StatusText)
+	}
+
+	model, _ = app.Update(tea.KeyMsg{Type: tea.KeyTab})
+	app = model.(App)
+	if app.currentAgentMode() != agentsession.AgentModeBuild {
+		t.Fatalf("expected mode to switch back to build, got %q", app.currentAgentMode())
+	}
+}
+
+func TestTabWithNonEmptyInputDoesNotSwitchAgentMode(t *testing.T) {
+	app, _ := newTestApp(t)
+	app.focus = panelInput
+	app.state.ActivePicker = pickerNone
+	app.input.SetValue("x")
+	app.state.InputText = "x"
+	app.setCurrentAgentMode(string(agentsession.AgentModeBuild))
+
+	model, _ := app.Update(tea.KeyMsg{Type: tea.KeyTab})
+	app = model.(App)
+	if app.currentAgentMode() != agentsession.AgentModeBuild {
+		t.Fatalf("expected mode to stay build, got %q", app.currentAgentMode())
 	}
 }
 

--- a/internal/tui/core/app/update_test.go
+++ b/internal/tui/core/app/update_test.go
@@ -497,20 +497,6 @@ func TestStartupRegularInputDismissesStartup(t *testing.T) {
 	}
 }
 
-func TestStartupCtrlONavigatesToWorkspaceBrowser(t *testing.T) {
-	app, _ := newTestApp(t)
-	app.startupScreenLocked = true
-
-	model, _ := app.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
-	next := model.(App)
-	if !next.startupScreenLocked {
-		t.Fatalf("expected opening workspace picker not to unlock startup")
-	}
-	if next.state.ActivePicker != pickerFile {
-		t.Fatalf("expected file picker active, got %v", next.state.ActivePicker)
-	}
-}
-
 func TestStartupCtrlNStartsDraftSession(t *testing.T) {
 	app, _ := newTestApp(t)
 	app.startupScreenLocked = true
@@ -3087,16 +3073,6 @@ func TestManualSlashCompletionDoesNotMoveInput(t *testing.T) {
 	if app.commandMenuHasSuggestions() {
 		t.Fatalf("expected command menu to clear for complete slash command")
 	}
-}
-
-func TestFocusNextPrev(t *testing.T) {
-	app, _ := newTestApp(t)
-	app.focus = panelTranscript
-	app.focusNext()
-	if app.focus == panelTranscript {
-		t.Fatalf("expected focus to move")
-	}
-	app.focusPrev()
 }
 
 func TestHandleViewportKeys(t *testing.T) {

--- a/internal/tui/core/app/update_test.go
+++ b/internal/tui/core/app/update_test.go
@@ -3021,20 +3021,6 @@ func TestAppendAssistantAndInlineMessage(t *testing.T) {
 	}
 }
 
-func TestShouldHandleTabAsInput(t *testing.T) {
-	app, _ := newTestApp(t)
-	app.focus = panelInput
-	app.state.ActivePicker = pickerNone
-	app.input.SetValue("/he")
-	if !app.shouldHandleTabAsInput(tea.KeyMsg{Type: tea.KeyTab}) {
-		t.Fatalf("expected tab to be handled as input")
-	}
-	app.input.SetValue("")
-	if app.shouldHandleTabAsInput(tea.KeyMsg{Type: tea.KeyTab}) {
-		t.Fatalf("expected tab to be ignored for empty input")
-	}
-}
-
 func TestTabSwitchesAgentModeWhenInputEmpty(t *testing.T) {
 	app, _ := newTestApp(t)
 	app.focus = panelInput
@@ -3059,7 +3045,7 @@ func TestTabSwitchesAgentModeWhenInputEmpty(t *testing.T) {
 	}
 }
 
-func TestTabWithNonEmptyInputDoesNotSwitchAgentMode(t *testing.T) {
+func TestTabWithNonEmptyInputSwitchesAgentMode(t *testing.T) {
 	app, _ := newTestApp(t)
 	app.focus = panelInput
 	app.state.ActivePicker = pickerNone
@@ -3069,8 +3055,8 @@ func TestTabWithNonEmptyInputDoesNotSwitchAgentMode(t *testing.T) {
 
 	model, _ := app.Update(tea.KeyMsg{Type: tea.KeyTab})
 	app = model.(App)
-	if app.currentAgentMode() != agentsession.AgentModeBuild {
-		t.Fatalf("expected mode to stay build, got %q", app.currentAgentMode())
+	if app.currentAgentMode() != agentsession.AgentModePlan {
+		t.Fatalf("expected mode to switch to plan, got %q", app.currentAgentMode())
 	}
 }
 
@@ -3080,6 +3066,7 @@ func TestSlashTabCompletionDoesNotMoveInput(t *testing.T) {
 	app.height = 28
 	app.focus = panelInput
 	app.state.ActivePicker = pickerNone
+	app.setCurrentAgentMode(string(agentsession.AgentModeBuild))
 	app.input.SetValue("/he")
 	app.state.InputText = "/he"
 	app.applyComponentLayout(true)
@@ -3100,6 +3087,9 @@ func TestSlashTabCompletionDoesNotMoveInput(t *testing.T) {
 	}
 	if app.commandMenuHasSuggestions() {
 		t.Fatalf("expected command menu to clear for complete slash command")
+	}
+	if app.currentAgentMode() != agentsession.AgentModeBuild {
+		t.Fatalf("expected slash completion to keep mode unchanged, got %q", app.currentAgentMode())
 	}
 }
 

--- a/internal/tui/core/app/view.go
+++ b/internal/tui/core/app/view.go
@@ -343,11 +343,6 @@ func (a App) renderPicker(width int, height int) string {
 		subtitle = sessionPickerSubtitle
 		body = a.sessionPicker.View()
 	}
-	if a.state.ActivePicker == pickerFile {
-		title = filePickerTitle
-		subtitle = filePickerSubtitle
-		body = a.fileBrowser.View()
-	}
 	if a.state.ActivePicker == pickerHelp {
 		title = helpPickerTitle
 		subtitle = helpPickerSubtitle

--- a/internal/tui/core/app/view.go
+++ b/internal/tui/core/app/view.go
@@ -110,10 +110,16 @@ func (a App) renderHeader(width int) string {
 	status = tuiutils.Fallback(status, statusReady)
 
 	model := tuiutils.Fallback(strings.TrimSpace(a.state.CurrentModel), "unknown-model")
+	mode := formatAgentModeLabel(a.state.CurrentAgentMode)
 	workdir := tuiutils.Fallback(strings.TrimSpace(a.state.CurrentWorkdir), "-")
-	leftText := fmt.Sprintf("NeoCode / %s / %s", model, status)
+	leftText := fmt.Sprintf("NeoCode / %s / %s / %s", model, mode, status)
 	rightText := "cwd: " + workdir
 	headerText := composeHeaderLine(leftText, rightText, width)
+	modeStyled := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(modeAccent(a.currentAgentMode()))).
+		Bold(true).
+		Render(mode)
+	headerText = strings.Replace(headerText, mode, modeStyled, 1)
 	return a.styles.headerBar.Width(width).Height(headerBarHeight).Render(headerText)
 }
 

--- a/internal/tui/core/app/view_test.go
+++ b/internal/tui/core/app/view_test.go
@@ -130,7 +130,7 @@ func TestRenderPickerSessionMode(t *testing.T) {
 	}
 }
 
-func TestRenderPickerProviderAndFileMode(t *testing.T) {
+func TestRenderPickerProviderAndProviderAddMode(t *testing.T) {
 	app, _ := newTestApp(t)
 
 	app.state.ActivePicker = pickerProvider
@@ -138,12 +138,6 @@ func TestRenderPickerProviderAndFileMode(t *testing.T) {
 	providerView := app.renderPicker(48, 14)
 	if !strings.Contains(providerView, providerPickerTitle) {
 		t.Fatalf("expected provider picker title")
-	}
-
-	app.state.ActivePicker = pickerFile
-	fileView := app.renderPicker(48, 14)
-	if !strings.Contains(fileView, filePickerTitle) {
-		t.Fatalf("expected file picker title")
 	}
 
 	app.startProviderAddForm()

--- a/internal/tui/core/commands/parser.go
+++ b/internal/tui/core/commands/parser.go
@@ -24,7 +24,7 @@ func MatchSlashCommands(input string, slashPrefix string, commands []SlashComman
 		return nil
 	}
 
-	query := strings.ToLower(strings.TrimSpace(input))
+	query := strings.ToLower(strings.TrimLeft(input, " \t\r\n"))
 	if IsCompleteSlashCommand(query, commands) {
 		return nil
 	}
@@ -75,8 +75,12 @@ func MatchSlashCommands(input string, slashPrefix string, commands []SlashComman
 
 // IsCompleteSlashCommand 判断输入是否已完整匹配某个命令。
 func IsCompleteSlashCommand(input string, commands []SlashCommand) bool {
+	normalizedInput := strings.ToLower(strings.TrimLeft(input, " \t\r\n"))
+	if strings.TrimRight(normalizedInput, " \t\r\n") != normalizedInput {
+		return false
+	}
 	for _, command := range commands {
-		if strings.EqualFold(strings.TrimSpace(command.Usage), strings.TrimSpace(input)) {
+		if strings.EqualFold(strings.TrimSpace(command.Usage), normalizedInput) {
 			return true
 		}
 	}

--- a/internal/tui/core/commands/parser_test.go
+++ b/internal/tui/core/commands/parser_test.go
@@ -6,12 +6,13 @@ func TestMatchSlashCommands(t *testing.T) {
 	commands := []SlashCommand{
 		{Usage: "/help", Description: "show help"},
 		{Usage: "/provider", Description: "pick provider"},
+		{Usage: "/provider add", Description: "add provider"},
 		{Usage: "/model", Description: "pick model"},
 	}
 
 	got := MatchSlashCommands("/pro", "/", commands)
-	if len(got) != 1 {
-		t.Fatalf("expected one suggestion for /pro, got %d", len(got))
+	if len(got) == 0 {
+		t.Fatalf("expected suggestions for /pro, got %d", len(got))
 	}
 	if got[0].Command.Usage != "/provider" || !got[0].Match {
 		t.Fatalf("unexpected suggestion: %+v", got[0])
@@ -28,6 +29,14 @@ func TestMatchSlashCommands(t *testing.T) {
 	if fuzzy[0].Command.Usage != "/model" {
 		t.Fatalf("expected /model for fuzzy query /mdl, got %+v", fuzzy[0])
 	}
+
+	multiWord := MatchSlashCommands("/provider ", "/", commands)
+	if len(multiWord) == 0 {
+		t.Fatalf("expected multi-word slash suggestions after trailing space")
+	}
+	if multiWord[0].Command.Usage != "/provider add" {
+		t.Fatalf("expected /provider add suggestion, got %+v", multiWord[0])
+	}
 }
 
 func TestIsCompleteSlashCommand(t *testing.T) {
@@ -37,6 +46,9 @@ func TestIsCompleteSlashCommand(t *testing.T) {
 	}
 	if IsCompleteSlashCommand("/hel", commands) {
 		t.Fatalf("expected /hel to be incomplete")
+	}
+	if IsCompleteSlashCommand("/provider ", commands) {
+		t.Fatalf("expected trailing-space input to remain incomplete")
 	}
 }
 

--- a/internal/tui/services/remote_runtime_adapter.go
+++ b/internal/tui/services/remote_runtime_adapter.go
@@ -189,6 +189,7 @@ func (r *RemoteRuntimeAdapter) PrepareUserInput(ctx context.Context, input Prepa
 		RunID:     runID,
 		Parts:     parts,
 		Workdir:   strings.TrimSpace(input.Workdir),
+		Mode:      strings.TrimSpace(input.Mode),
 	}, nil
 }
 
@@ -198,6 +199,7 @@ func (r *RemoteRuntimeAdapter) Run(ctx context.Context, input UserInput) error {
 		SessionID: strings.TrimSpace(input.SessionID),
 		RunID:     strings.TrimSpace(input.RunID),
 		Workdir:   strings.TrimSpace(input.Workdir),
+		Mode:      strings.TrimSpace(input.Mode),
 		Text:      renderInputTextFromParts(input.Parts),
 		Images:    renderInputImagesFromParts(input.Parts),
 	}
@@ -639,6 +641,7 @@ func buildGatewayRunParams(sessionID string, runID string, input PrepareInput) p
 		InputText:  strings.TrimSpace(input.Text),
 		InputParts: parts,
 		Workdir:    strings.TrimSpace(input.Workdir),
+		Mode:       strings.TrimSpace(input.Mode),
 	}
 }
 

--- a/internal/tui/services/remote_runtime_adapter_additional_test.go
+++ b/internal/tui/services/remote_runtime_adapter_additional_test.go
@@ -639,8 +639,8 @@ func TestRemoteRuntimeAdapterRenderInputHelpers(t *testing.T) {
 		t.Fatalf("renderInputImagesFromParts() = %#v", images)
 	}
 
-	params := buildGatewayRunParams(" s ", " r ", PrepareInput{Text: " hi ", Workdir: " /w ", Images: []UserImageInput{{Path: " /img.png ", MimeType: " image/png "}, {Path: " "}}})
-	if params.SessionID != "s" || params.RunID != "r" || params.Workdir != "/w" || params.InputText != "hi" || len(params.InputParts) != 1 {
+	params := buildGatewayRunParams(" s ", " r ", PrepareInput{Text: " hi ", Workdir: " /w ", Mode: " plan ", Images: []UserImageInput{{Path: " /img.png ", MimeType: " image/png "}, {Path: " "}}})
+	if params.SessionID != "s" || params.RunID != "r" || params.Workdir != "/w" || params.Mode != "plan" || params.InputText != "hi" || len(params.InputParts) != 1 {
 		t.Fatalf("buildGatewayRunParams() = %#v", params)
 	}
 }

--- a/internal/tui/services/remote_runtime_adapter_test.go
+++ b/internal/tui/services/remote_runtime_adapter_test.go
@@ -60,6 +60,7 @@ func TestRemoteRuntimeAdapterSubmitAuthenticatesBindsPreloadsAndRuns(t *testing.
 		SessionID: "session-1",
 		RunID:     "run-1",
 		Workdir:   "/repo",
+		Mode:      "plan",
 		Text:      " hello ",
 		Images: []UserImageInput{
 			{Path: " /tmp/a.png ", MimeType: " image/png "},
@@ -96,6 +97,9 @@ func TestRemoteRuntimeAdapterSubmitAuthenticatesBindsPreloadsAndRuns(t *testing.
 	}
 	if params.SessionID != "session-1" || params.RunID != "run-1" || params.Workdir != "/repo" {
 		t.Fatalf("unexpected run params ids/workdir: %#v", params)
+	}
+	if params.Mode != "plan" {
+		t.Fatalf("run mode = %q, want %q", params.Mode, "plan")
 	}
 	if params.InputText != "hello" {
 		t.Fatalf("run input_text = %q, want %q", params.InputText, "hello")

--- a/internal/tui/services/runtime_contract.go
+++ b/internal/tui/services/runtime_contract.go
@@ -49,6 +49,7 @@ type UserInput struct {
 	RunID     string
 	Parts     []providertypes.ContentPart
 	Workdir   string
+	Mode      string
 	TaskID    string
 	AgentID   string
 }
@@ -64,6 +65,7 @@ type PrepareInput struct {
 	SessionID string
 	RunID     string
 	Workdir   string
+	Mode      string
 	Text      string
 	Images    []UserImageInput
 }

--- a/internal/tui/state/ui_state.go
+++ b/internal/tui/state/ui_state.go
@@ -45,6 +45,7 @@ type UIState struct {
 	StatusText         string
 	CurrentProvider    string
 	CurrentModel       string
+	CurrentAgentMode   string
 	CurrentWorkdir     string
 	ShowHelp           bool
 	ActivePicker       PickerMode


### PR DESCRIPTION
## 背景
这组改动主要聚焦 TUI 输入交互的一致性和可预期性，覆盖三类问题：
1. slash 多词补全异常，以及已废弃快捷能力的清理。
2. `TAB` 切换 `plan/build` 模式能力落地，并修复输入态下无法切换的问题。
3. 粘贴启发式导致的误判与长文本粘贴重复 token 问题修复。

## 改动概览

### 1) slash 补全与废弃能力清理
- 修复了带空格的 slash 指令在 `TAB` 补全时的替换范围问题（避免多词命令补全后残留异常字符）。
- 删除冗余/废弃交互：
  - `Ctrl+O` 文件浏览入口移除。
  - 面板焦点切换相关能力移除（后续由 `TAB` 承接模式切换）。

对应 commit: `2e387dac`

### 2) 新增 TAB 切换 plan/build（含后端透传）
- 新增 `TAB` 在 TUI 中切换 `plan/build` 的能力。
- 增加模式状态管理（UI state + run context）。
- 在提交运行时将 mode 透传到 gateway/runtime。
- header 中显示当前 mode，并与主题强调色联动。

对应 commit: `0d224144`

### 3) 修复“输入时无法切换 plan/build”
- 调整 `TAB` 事件优先级：保留“补全优先”，移除“输入态 Tab 插入制表符”的抢占。
- 现在在正常输入状态下也可以切换 `plan/build`（有补全候选时仍优先补全）。

对应 commit: `1ea96dfd`

### 4) 粘贴行为修复（误判与长文本重复 token）
- 修复单字输入与剪贴板前缀重叠时的误判问题（避免普通输入被当作粘贴流）。
- 修复长文本粘贴在分片场景下重复注入 `[paste N LINE]` token 的问题：
  - 进入 paste transaction 后持续吸收分片，统一 flush，避免同一段内容被拆分多次摘要。
- 补充对应回归测试用例。

对应 commit: `1151ea6e`

## 影响与兼容性
- `TAB` 在输入框中的语义已调整为“补全优先，其次模式切换”，不再用于插入制表符。
- 粘贴启发式更保守，优先保证“普通输入不误判”，同时维持长文本粘贴摘要能力。

## 测试
已执行：
- `go test ./internal/tui/...`

关键用例覆盖：
- slash 多词补全稳定性。
- 输入态 `TAB` 模式切换。
- 长文本粘贴摘要去重。
- 单字普通输入不被剪贴板前缀误判。

