### PR TITLE
feat(Phase4)：提升终端诊断与 IDM 模式可用性

### DIFF
--- a/internal/ptyproxy/diagnosis_coordinator.go
+++ b/internal/ptyproxy/diagnosis_coordinator.go
@@ -1,0 +1,365 @@
+//go:build !windows
+
+package ptyproxy
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"neo-code/internal/gateway"
+	gatewayclient "neo-code/internal/gateway/client"
+	"neo-code/internal/gateway/protocol"
+	"neo-code/internal/tools"
+)
+
+const (
+	diagnosisCacheTTL           = 5 * time.Minute
+	diagnosisCacheMaxEntries    = 64
+	diagnosisAutoDedupeTTL      = 10 * time.Second
+	diagnosisQuickMaxConfidence = 0.55
+)
+
+type preparedDiagnosisRequest struct {
+	Payload           []byte
+	Fingerprint       string
+	SanitizedErrorLog string
+	SanitizedCommand  string
+}
+
+type diagnosisOutcome struct {
+	Result tools.ToolResult
+	Err    error
+}
+
+type diagnosisFlight struct {
+	done    chan struct{}
+	outcome diagnosisOutcome
+}
+
+type diagnosisCacheEntry struct {
+	outcome   diagnosisOutcome
+	expiresAt time.Time
+}
+
+// diagnosisCoordinator 负责诊断请求去重、短期缓存与自动诊断去抖。
+type diagnosisCoordinator struct {
+	mu         sync.Mutex
+	inFlight   map[string]*diagnosisFlight
+	cache      map[string]diagnosisCacheEntry
+	cacheOrder []string
+	recentAuto map[string]time.Time
+	now        func() time.Time
+}
+
+// newDiagnosisCoordinator 创建一次 shell 会话内复用的诊断调度器。
+func newDiagnosisCoordinator() *diagnosisCoordinator {
+	return &diagnosisCoordinator{
+		inFlight:   make(map[string]*diagnosisFlight),
+		cache:      make(map[string]diagnosisCacheEntry),
+		recentAuto: make(map[string]time.Time),
+		now:        time.Now,
+	}
+}
+
+// prepareDiagnoseRequest 统一构建脱敏后的 diagnose payload 与 fingerprint。
+func prepareDiagnoseRequest(
+	buffer *UTF8RingBuffer,
+	options ManualShellOptions,
+	socketPath string,
+	trigger diagnoseTrigger,
+) (preparedDiagnosisRequest, error) {
+	if buffer == nil {
+		buffer = NewUTF8RingBuffer(DefaultRingBufferCapacity)
+	}
+	logSnapshot := buffer.SnapshotString()
+	if strings.TrimSpace(trigger.OutputText) != "" {
+		logSnapshot = trigger.OutputText
+	}
+	sanitizedErrorLog := SanitizeDiagnosisText(logSnapshot, defaultDiagnosisPayloadMaxBytes)
+	if strings.TrimSpace(sanitizedErrorLog) == "" {
+		sanitizedErrorLog = "no terminal output captured"
+	}
+	sanitizedCommand := SanitizeDiagnosisText(trigger.CommandText, 1024)
+
+	requestArgs := diagnoseToolArgs{
+		ErrorLog: sanitizedErrorLog,
+		OSEnv: map[string]string{
+			"os":     runtime.GOOS,
+			"shell":  resolveShellPath(options.Shell),
+			"cwd":    options.Workdir,
+			"socket": socketPath,
+		},
+		CommandText: sanitizedCommand,
+		ExitCode:    trigger.ExitCode,
+	}
+	requestPayload, err := json.Marshal(requestArgs)
+	if err != nil {
+		return preparedDiagnosisRequest{}, err
+	}
+	return preparedDiagnosisRequest{
+		Payload:           requestPayload,
+		Fingerprint:       fingerprintDiagnosisRequest(sanitizedCommand, trigger.ExitCode, sanitizedErrorLog),
+		SanitizedErrorLog: sanitizedErrorLog,
+		SanitizedCommand:  sanitizedCommand,
+	}, nil
+}
+
+// fingerprintDiagnosisRequest 为脱敏后的诊断输入生成稳定指纹。
+func fingerprintDiagnosisRequest(command string, exitCode int, errorLog string) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		strings.TrimSpace(command),
+		fmt.Sprint(exitCode),
+		strings.TrimSpace(errorLog),
+	}, "\x00")))
+	return hex.EncodeToString(sum[:])
+}
+
+// executePreparedDiagnoseToolWithTimeout 执行已构建好的 diagnose payload。
+func executePreparedDiagnoseToolWithTimeout(
+	rpcClient *gatewayclient.GatewayRPCClient,
+	options ManualShellOptions,
+	prepared preparedDiagnosisRequest,
+	timeout time.Duration,
+) (tools.ToolResult, error) {
+	if rpcClient == nil {
+		return tools.ToolResult{}, errors.New("诊断服务未就绪，请确认 gateway 已连接后重试")
+	}
+
+	callContext, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var frame gateway.MessageFrame
+	if err := rpcClient.CallWithOptions(
+		callContext,
+		protocol.MethodGatewayExecuteSystemTool,
+		protocol.ExecuteSystemToolParams{
+			Workdir:   options.Workdir,
+			ToolName:  tools.ToolNameDiagnose,
+			Arguments: prepared.Payload,
+		},
+		&frame,
+		gatewayclient.GatewayRPCCallOptions{
+			Timeout: timeout,
+			Retries: 1,
+		},
+	); err != nil {
+		if options.Stderr != nil {
+			writeProxyf(options.Stderr, "neocode diag: executeSystemTool rpc failed: %v\n", err)
+		}
+		return tools.ToolResult{}, errors.New("诊断调用失败，请检查 gateway 连接后重试，或使用 `neocode diag -i` 继续排查")
+	}
+
+	if frame.Type == gateway.FrameTypeError && frame.Error != nil {
+		if options.Stderr != nil {
+			writeProxyf(
+				options.Stderr,
+				"neocode diag: gateway returned frame error code=%s message=%s\n",
+				strings.TrimSpace(frame.Error.Code),
+				strings.TrimSpace(frame.Error.Message),
+			)
+		}
+		return tools.ToolResult{}, errors.New("诊断服务暂不可用，请稍后重试，或使用 `neocode diag -i` 继续排查")
+	}
+	if frame.Type != gateway.FrameTypeAck {
+		if options.Stderr != nil {
+			writeProxyf(options.Stderr, "neocode diag: unexpected gateway frame type: %s\n", frame.Type)
+		}
+		return tools.ToolResult{}, errors.New("诊断服务返回异常响应，请稍后重试")
+	}
+
+	toolResult, err := decodeToolResult(frame.Payload)
+	if err != nil {
+		if options.Stderr != nil {
+			writeProxyf(options.Stderr, "neocode diag: decode diagnose payload failed: %v\n", err)
+		}
+		return tools.ToolResult{}, errors.New("诊断结果解析失败，请重试或更新 NeoCode")
+	}
+	return toolResult, nil
+}
+
+// shouldDropAuto 判断自动诊断是否命中短窗口去抖。
+func (c *diagnosisCoordinator) shouldDropAuto(fingerprint string) bool {
+	if c == nil || strings.TrimSpace(fingerprint) == "" {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := c.currentTime()
+	for key, seenAt := range c.recentAuto {
+		if now.Sub(seenAt) > diagnosisAutoDedupeTTL {
+			delete(c.recentAuto, key)
+		}
+	}
+	if seenAt, ok := c.recentAuto[fingerprint]; ok && now.Sub(seenAt) <= diagnosisAutoDedupeTTL {
+		return true
+	}
+	c.recentAuto[fingerprint] = now
+	return false
+}
+
+// cached 返回仍在有效期内的缓存诊断结果。
+func (c *diagnosisCoordinator) cached(fingerprint string) (diagnosisOutcome, bool) {
+	if c == nil || strings.TrimSpace(fingerprint) == "" || !IsDiagCacheEnabledFromEnv() {
+		return diagnosisOutcome{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.cache[fingerprint]
+	if !ok {
+		return diagnosisOutcome{}, false
+	}
+	if c.currentTime().After(entry.expiresAt) {
+		delete(c.cache, fingerprint)
+		return diagnosisOutcome{}, false
+	}
+	return entry.outcome, true
+}
+
+// run 执行或复用一次诊断请求，成功结果会进入短期缓存。
+func (c *diagnosisCoordinator) run(
+	ctx context.Context,
+	fingerprint string,
+	execute func() (tools.ToolResult, error),
+) diagnosisOutcome {
+	if c == nil || strings.TrimSpace(fingerprint) == "" || !IsDiagCacheEnabledFromEnv() {
+		result, err := execute()
+		return diagnosisOutcome{Result: result, Err: err}
+	}
+	if cached, ok := c.cached(fingerprint); ok {
+		return cached
+	}
+
+	c.mu.Lock()
+	if flight, ok := c.inFlight[fingerprint]; ok {
+		c.mu.Unlock()
+		return waitDiagnosisFlight(ctx, flight)
+	}
+	flight := &diagnosisFlight{done: make(chan struct{})}
+	c.inFlight[fingerprint] = flight
+	c.mu.Unlock()
+
+	result, err := execute()
+	outcome := diagnosisOutcome{Result: result, Err: err}
+
+	c.mu.Lock()
+	flight.outcome = outcome
+	delete(c.inFlight, fingerprint)
+	if err == nil {
+		c.storeCacheLocked(fingerprint, outcome)
+	}
+	close(flight.done)
+	c.mu.Unlock()
+	return outcome
+}
+
+// waitDiagnosisFlight 等待已存在的同指纹诊断完成。
+func waitDiagnosisFlight(ctx context.Context, flight *diagnosisFlight) diagnosisOutcome {
+	if flight == nil {
+		return diagnosisOutcome{Err: errors.New("diagnosis flight is nil")}
+	}
+	select {
+	case <-ctx.Done():
+		return diagnosisOutcome{Err: ctx.Err()}
+	case <-flight.done:
+		return flight.outcome
+	}
+}
+
+// storeCacheLocked 在持锁状态下写入缓存并维护容量上限。
+func (c *diagnosisCoordinator) storeCacheLocked(fingerprint string, outcome diagnosisOutcome) {
+	if c == nil || strings.TrimSpace(fingerprint) == "" {
+		return
+	}
+	if _, exists := c.cache[fingerprint]; !exists {
+		c.cacheOrder = append(c.cacheOrder, fingerprint)
+	}
+	c.cache[fingerprint] = diagnosisCacheEntry{
+		outcome:   outcome,
+		expiresAt: c.currentTime().Add(diagnosisCacheTTL),
+	}
+	for len(c.cacheOrder) > diagnosisCacheMaxEntries {
+		oldest := c.cacheOrder[0]
+		c.cacheOrder = c.cacheOrder[1:]
+		delete(c.cache, oldest)
+	}
+}
+
+// currentTime 返回可在测试中替换的当前时间。
+func (c *diagnosisCoordinator) currentTime() time.Time {
+	if c != nil && c.now != nil {
+		return c.now()
+	}
+	return time.Now()
+}
+
+// renderDiagnosisInitialFeedback 输出诊断快速首响或低干扰预判。
+func renderDiagnosisInitialFeedback(output io.Writer, prepared preparedDiagnosisRequest, isAuto bool) {
+	if output == nil || !IsDiagFastResponseEnabledFromEnv() {
+		return
+	}
+	hint, ok := buildDiagnosisQuickHint(prepared)
+	if isAuto && !ok {
+		return
+	}
+	if isAuto {
+		writeProxyLine(output, "\n\033[36m[NeoCode Diagnosis]\033[0m 快速预判（低置信度，完整诊断稍后返回）")
+	} else {
+		writeProxyLine(output, "\n\033[36m[NeoCode Diagnosis]\033[0m 正在诊断，完整结果稍后返回。")
+		if !ok {
+			return
+		}
+		writeProxyLine(output, "快速预判（低置信度）:")
+	}
+	if !ok {
+		return
+	}
+	writeProxyf(output, "置信度: %.2f\n", hint.Confidence)
+	writeProxyf(output, "可能根因: %s\n", strings.TrimSpace(hint.RootCause))
+	if len(hint.InvestigationCommands) > 0 {
+		writeProxyLine(output, "建议先查:")
+		for _, command := range hint.InvestigationCommands {
+			writeProxyf(output, "- %s\n", strings.TrimSpace(command))
+		}
+	}
+}
+
+// buildDiagnosisQuickHint 根据常见终端错误模式生成低置信度快速预判。
+func buildDiagnosisQuickHint(prepared preparedDiagnosisRequest) (diagnoseToolResult, bool) {
+	text := strings.ToLower(strings.TrimSpace(prepared.SanitizedErrorLog + "\n" + prepared.SanitizedCommand))
+	switch {
+	case strings.Contains(text, "command not found") || strings.Contains(text, "not recognized as"):
+		return quickHint("命令不存在或未加入 PATH。", []string{"which <command>", "echo $PATH"}), true
+	case strings.Contains(text, "permission denied"):
+		return quickHint("当前用户缺少执行或访问目标路径的权限。", []string{"ls -la", "id"}), true
+	case strings.Contains(text, "no such file or directory") || strings.Contains(text, "cannot find the path"):
+		return quickHint("路径或工作目录可能不正确，目标文件不存在。", []string{"pwd", "ls -la"}), true
+	case strings.Contains(text, "address already in use") || strings.Contains(text, "port already in use"):
+		return quickHint("端口已被其他进程占用。", []string{"lsof -i :<port>", "netstat -an | grep <port>"}), true
+	case strings.Contains(text, "module not found") || strings.Contains(text, "cannot find module") ||
+		strings.Contains(text, "cannot find package") || strings.Contains(text, "undefined reference"):
+		return quickHint("依赖缺失或链接配置不完整。", []string{"go env GOPATH", "go mod tidy"}), true
+	case strings.Contains(text, "context deadline exceeded") || strings.Contains(text, "connection refused"):
+		return quickHint("外部服务或网络连接暂不可用。", []string{"ping 127.0.0.1", "curl -v <url>"}), true
+	default:
+		return diagnoseToolResult{}, false
+	}
+}
+
+// quickHint 统一限制快速预判的置信度上限。
+func quickHint(rootCause string, investigation []string) diagnoseToolResult {
+	return diagnoseToolResult{
+		Confidence:            diagnosisQuickMaxConfidence,
+		RootCause:             rootCause,
+		FixCommands:           []string{},
+		InvestigationCommands: investigation,
+	}
+}

--- a/internal/ptyproxy/diagnosis_coordinator_test.go
+++ b/internal/ptyproxy/diagnosis_coordinator_test.go
@@ -1,0 +1,227 @@
+//go:build !windows
+
+package ptyproxy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"neo-code/internal/tools"
+)
+
+func TestDiagnosisCoordinatorFingerprintAndAutoDedupe(t *testing.T) {
+	first := fingerprintDiagnosisRequest(" go test ./... ", 1, "fatal error")
+	if len(first) != 64 {
+		t.Fatalf("fingerprint length = %d, want 64", len(first))
+	}
+	if got := fingerprintDiagnosisRequest("go test ./...", 1, "fatal error"); got != first {
+		t.Fatalf("fingerprint should trim stable inputs, got %q want %q", got, first)
+	}
+	if got := fingerprintDiagnosisRequest("go test ./...", 2, "fatal error"); got == first {
+		t.Fatal("fingerprint should change when exit code changes")
+	}
+
+	now := time.Unix(100, 0)
+	coordinator := newDiagnosisCoordinator()
+	coordinator.now = func() time.Time { return now }
+	if coordinator.shouldDropAuto(first) {
+		t.Fatal("first auto diagnosis should not be dropped")
+	}
+	if !coordinator.shouldDropAuto(first) {
+		t.Fatal("same auto diagnosis should be dropped within dedupe window")
+	}
+	now = now.Add(diagnosisAutoDedupeTTL + time.Millisecond)
+	if coordinator.shouldDropAuto(first) {
+		t.Fatal("auto diagnosis should be allowed after dedupe window")
+	}
+}
+
+func TestDiagnosisCoordinatorRunJoinsInflightAndCaches(t *testing.T) {
+	t.Setenv(DiagCacheDisableEnv, "")
+
+	coordinator := newDiagnosisCoordinator()
+	var executeCalls int32
+	release := make(chan struct{})
+	started := make(chan struct{})
+	var startedOnce sync.Once
+
+	firstDone := make(chan diagnosisOutcome, 1)
+	go func() {
+		firstDone <- coordinator.run(context.Background(), "fp-join", func() (tools.ToolResult, error) {
+			atomic.AddInt32(&executeCalls, 1)
+			startedOnce.Do(func() { close(started) })
+			<-release
+			return tools.ToolResult{Content: "joined-result"}, nil
+		})
+	}()
+	<-started
+
+	secondDone := make(chan diagnosisOutcome, 1)
+	go func() {
+		secondDone <- coordinator.run(context.Background(), "fp-join", func() (tools.ToolResult, error) {
+			atomic.AddInt32(&executeCalls, 1)
+			return tools.ToolResult{Content: "unexpected-second-execute"}, nil
+		})
+	}()
+
+	select {
+	case outcome := <-secondDone:
+		t.Fatalf("joined diagnosis returned before in-flight work completed: %#v", outcome)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(release)
+
+	first := <-firstDone
+	second := <-secondDone
+	if first.Err != nil || second.Err != nil {
+		t.Fatalf("joined outcomes should be successful: first=%v second=%v", first.Err, second.Err)
+	}
+	if first.Result.Content != "joined-result" || second.Result.Content != "joined-result" {
+		t.Fatalf("joined contents = %q/%q, want joined-result", first.Result.Content, second.Result.Content)
+	}
+	if got := atomic.LoadInt32(&executeCalls); got != 1 {
+		t.Fatalf("execute calls = %d, want 1", got)
+	}
+
+	cached := coordinator.run(context.Background(), "fp-join", func() (tools.ToolResult, error) {
+		atomic.AddInt32(&executeCalls, 1)
+		return tools.ToolResult{}, errors.New("should not execute cached request")
+	})
+	if cached.Err != nil || cached.Result.Content != "joined-result" {
+		t.Fatalf("cached outcome = %#v, want joined-result", cached)
+	}
+	if got := atomic.LoadInt32(&executeCalls); got != 1 {
+		t.Fatalf("execute calls after cache hit = %d, want 1", got)
+	}
+}
+
+func TestDiagnosisCoordinatorCacheTTLCapacityAndErrorPolicy(t *testing.T) {
+	t.Setenv(DiagCacheDisableEnv, "")
+
+	now := time.Unix(200, 0)
+	coordinator := newDiagnosisCoordinator()
+	coordinator.now = func() time.Time { return now }
+
+	coordinator.mu.Lock()
+	coordinator.storeCacheLocked("ttl", diagnosisOutcome{Result: tools.ToolResult{Content: "fresh"}})
+	coordinator.mu.Unlock()
+	if cached, ok := coordinator.cached("ttl"); !ok || cached.Result.Content != "fresh" {
+		t.Fatalf("cached ttl entry = %#v ok=%v, want fresh", cached, ok)
+	}
+	now = now.Add(diagnosisCacheTTL + time.Nanosecond)
+	if _, ok := coordinator.cached("ttl"); ok {
+		t.Fatal("expired cache entry should not be returned")
+	}
+
+	coordinator.mu.Lock()
+	for i := 0; i < diagnosisCacheMaxEntries+1; i++ {
+		coordinator.storeCacheLocked(fmt.Sprintf("fp-%02d", i), diagnosisOutcome{Result: tools.ToolResult{Content: "ok"}})
+	}
+	if len(coordinator.cache) > diagnosisCacheMaxEntries {
+		t.Fatalf("cache size = %d, want <= %d", len(coordinator.cache), diagnosisCacheMaxEntries)
+	}
+	if _, ok := coordinator.cache["fp-00"]; ok {
+		t.Fatal("oldest cache entry should be evicted")
+	}
+	coordinator.mu.Unlock()
+
+	var calls int32
+	for i := 0; i < 2; i++ {
+		outcome := coordinator.run(context.Background(), "fp-error", func() (tools.ToolResult, error) {
+			atomic.AddInt32(&calls, 1)
+			return tools.ToolResult{}, errors.New("transport failed")
+		})
+		if outcome.Err == nil {
+			t.Fatal("expected execution error")
+		}
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("error calls = %d, want 2 because errors are not cached", got)
+	}
+	if _, ok := coordinator.cached("fp-error"); ok {
+		t.Fatal("error outcome should not be cached")
+	}
+}
+
+func TestDiagnosisCoordinatorFastFeedback(t *testing.T) {
+	t.Setenv(DiagFastResponseDisableEnv, "")
+
+	prepared := preparedDiagnosisRequest{
+		SanitizedCommand:  "missingcmd",
+		SanitizedErrorLog: "missingcmd: command not found",
+	}
+	manual := &bytes.Buffer{}
+	renderDiagnosisInitialFeedback(manual, prepared, false)
+	if text := manual.String(); !strings.Contains(text, "NeoCode Diagnosis") || !strings.Contains(text, "0.55") {
+		t.Fatalf("manual feedback = %q, want diagnosis header and capped confidence", text)
+	}
+
+	auto := &bytes.Buffer{}
+	renderDiagnosisInitialFeedback(auto, prepared, true)
+	if text := auto.String(); !strings.Contains(text, "NeoCode Diagnosis") || !strings.Contains(text, "0.55") {
+		t.Fatalf("auto feedback = %q, want quick hint for known pattern", text)
+	}
+
+	autoWithoutHint := &bytes.Buffer{}
+	renderDiagnosisInitialFeedback(autoWithoutHint, preparedDiagnosisRequest{SanitizedErrorLog: "random failure"}, true)
+	if autoWithoutHint.Len() != 0 {
+		t.Fatalf("auto feedback without hint = %q, want empty", autoWithoutHint.String())
+	}
+
+	t.Setenv(DiagFastResponseDisableEnv, "1")
+	disabled := &bytes.Buffer{}
+	renderDiagnosisInitialFeedback(disabled, prepared, false)
+	if disabled.Len() != 0 {
+		t.Fatalf("disabled feedback = %q, want empty", disabled.String())
+	}
+}
+
+func TestRunSingleDiagnosisWithCoordinatorUsesCachedResult(t *testing.T) {
+	t.Setenv(DiagCacheDisableEnv, "")
+	t.Setenv(DiagFastResponseDisableEnv, "")
+
+	buffer := NewUTF8RingBuffer(1024)
+	_, _ = buffer.Write([]byte("fallback log"))
+	options := ManualShellOptions{Workdir: t.TempDir(), Shell: "/bin/bash"}
+	trigger := diagnoseTrigger{CommandText: "go test ./...", ExitCode: 1, OutputText: "fatal"}
+	prepared, err := prepareDiagnoseRequest(buffer, options, "/tmp/diag.sock", trigger)
+	if err != nil {
+		t.Fatalf("prepareDiagnoseRequest() error = %v", err)
+	}
+
+	coordinator := newDiagnosisCoordinator()
+	coordinator.mu.Lock()
+	coordinator.storeCacheLocked(prepared.Fingerprint, diagnosisOutcome{
+		Result: tools.ToolResult{
+			Content: `{"confidence":0.91,"root_cause":"cached root","fix_commands":["echo fix"],"investigation_commands":["echo inv"]}`,
+		},
+	})
+	coordinator.mu.Unlock()
+
+	output := &bytes.Buffer{}
+	err = runSingleDiagnosisWithCoordinator(
+		context.Background(),
+		coordinator,
+		nil,
+		output,
+		buffer,
+		options,
+		"/tmp/diag.sock",
+		trigger,
+		false,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("runSingleDiagnosisWithCoordinator() error = %v", err)
+	}
+	if text := output.String(); !strings.Contains(text, "cached root") || !strings.Contains(text, "NeoCode Diagnosis") {
+		t.Fatalf("output = %q, want cached diagnosis result", text)
+	}
+}

--- a/internal/ptyproxy/idm_controller.go
+++ b/internal/ptyproxy/idm_controller.go
@@ -584,7 +584,7 @@ func (c *idmController) sendAIMessage(question string) error {
 		return errors.New("idm session id is empty")
 	}
 
-	streamCtx, streamCancel := context.WithTimeout(context.Background(), diagnoseCallTimeout)
+	streamCtx, streamCancel := context.WithCancel(context.Background())
 	c.mu.Lock()
 	if !c.active {
 		c.mu.Unlock()

--- a/internal/ptyproxy/idm_controller.go
+++ b/internal/ptyproxy/idm_controller.go
@@ -824,6 +824,7 @@ func (c *idmController) currentSessionID() string {
 // waitRunStream 负责 waitRunStream 相关逻辑。
 func (c *idmController) waitRunStream(ctx context.Context, sessionID string, runID string) error {
 	var markdownBuffer strings.Builder
+	streamedChunks := false
 	for {
 		select {
 		case <-ctx.Done():
@@ -851,16 +852,20 @@ func (c *idmController) waitRunStream(ctx context.Context, sessionID string, run
 			switch eventType {
 			case "agent_chunk":
 				chunk := stringifyRuntimePayload(payload)
-				if strings.TrimSpace(chunk) == "" {
+				if chunk == "" {
 					continue
 				}
 				markdownBuffer.WriteString(chunk)
+				c.renderIDMStreamChunk(chunk)
+				streamedChunks = true
 			case "agent_done":
 				answer := markdownBuffer.String()
 				if strings.TrimSpace(answer) == "" {
 					answer = extractIDMDonePayloadText(payload)
 				}
-				c.renderIDMAnswer(answer)
+				if !streamedChunks {
+					c.renderIDMAnswer(answer)
+				}
 				c.writeRawOutput([]byte("\r\n"))
 				return nil
 			case "run_canceled":
@@ -1185,6 +1190,16 @@ func extractIDMTextFromMap(container map[string]any) string {
 		builder.WriteString(text)
 	}
 	return strings.TrimSpace(builder.String())
+}
+
+// renderIDMStreamChunk 将模型流式片段直接写入终端，避免等待完整 Markdown 渲染完成。
+func (c *idmController) renderIDMStreamChunk(rawText string) {
+	if c == nil || rawText == "" {
+		return
+	}
+	c.writeRawOutput([]byte(idmAIColor))
+	c.writeRawOutput([]byte(proxyOutputLineEndingNormalizer.Replace(rawText)))
+	c.writeRawOutput([]byte(idmColorReset))
 }
 
 // renderIDMAnswer 将模型回复按 Markdown 渲染后输出，渲染失败时回退原始文本。

--- a/internal/ptyproxy/idm_controller.go
+++ b/internal/ptyproxy/idm_controller.go
@@ -38,6 +38,7 @@ const (
 	idmSessionPrefix              = "idm-"
 	idmSessionRunAskPrefix        = "idm-ask"
 	idmMarkdownWrapWidth          = 96
+	idmPlanMode                   = "plan"
 )
 
 var idmRunSequence atomic.Uint64
@@ -64,6 +65,8 @@ the user.
   You cannot and must not gather additional information yourself.
 - Base your analysis solely on the provided error log. Do not speculate
   about content that does not appear in the log.
+- Do NOT output plan_spec, summary_candidate, or any planning JSON.
+- Do NOT perform build or write actions. Return diagnosis text only.
 - If the log appears heavily truncated or information is insufficient,
   lower your confidence. You may suggest commands for the user to run
   manually in next_actions to gather more context, but do not pretend
@@ -581,7 +584,7 @@ func (c *idmController) sendAIMessage(question string) error {
 		return errors.New("idm session id is empty")
 	}
 
-	streamCtx, streamCancel := context.WithCancel(context.Background())
+	streamCtx, streamCancel := context.WithTimeout(context.Background(), diagnoseCallTimeout)
 	c.mu.Lock()
 	if !c.active {
 		c.mu.Unlock()
@@ -634,6 +637,7 @@ func (c *idmController) sendAIMessage(question string) error {
 			RunID:     runID,
 			InputText: question,
 			Workdir:   c.workdir,
+			Mode:      resolveIDMRunMode(),
 		},
 		&runAck,
 		gatewayclient.GatewayRPCCallOptions{
@@ -645,6 +649,10 @@ func (c *idmController) sendAIMessage(question string) error {
 		finishStreaming()
 		return err
 	}
+	if err := validateIDMAckFrame(runAck, "run"); err != nil {
+		finishStreaming()
+		return err
+	}
 
 	waitErr := c.waitRunStream(streamCtx, sessionID, runID)
 	c.cancelRun(sessionID, runID)
@@ -653,6 +661,34 @@ func (c *idmController) sendAIMessage(question string) error {
 		return waitErr
 	}
 	c.writePrompt()
+	return nil
+}
+
+// resolveIDMRunMode 返回 IDM @ai 本次运行应注入的 Runtime mode。
+func resolveIDMRunMode() string {
+	if !IsIDMPlanModeEnabledFromEnv() {
+		return ""
+	}
+	return idmPlanMode
+}
+
+// validateIDMAckFrame 校验 IDM RPC 调用返回的 ACK 语义，避免失败后继续等待流事件。
+func validateIDMAckFrame(frame gateway.MessageFrame, operation string) error {
+	operation = strings.TrimSpace(operation)
+	if operation == "" {
+		operation = "operation"
+	}
+	if frame.Type == gateway.FrameTypeError && frame.Error != nil {
+		return fmt.Errorf(
+			"gateway %s failed (%s): %s",
+			operation,
+			strings.TrimSpace(frame.Error.Code),
+			strings.TrimSpace(frame.Error.Message),
+		)
+	}
+	if frame.Type != gateway.FrameTypeAck {
+		return fmt.Errorf("unexpected gateway frame type for %s: %s", operation, frame.Type)
+	}
 	return nil
 }
 
@@ -820,7 +856,11 @@ func (c *idmController) waitRunStream(ctx context.Context, sessionID string, run
 				}
 				markdownBuffer.WriteString(chunk)
 			case "agent_done":
-				c.renderIDMAnswer(markdownBuffer.String())
+				answer := markdownBuffer.String()
+				if strings.TrimSpace(answer) == "" {
+					answer = extractIDMDonePayloadText(payload)
+				}
+				c.renderIDMAnswer(answer)
 				c.writeRawOutput([]byte("\r\n"))
 				return nil
 			case "run_canceled":
@@ -1087,6 +1127,64 @@ func stringifyRuntimePayload(payload any) string {
 		}
 		return string(encoded)
 	}
+}
+
+// extractIDMDonePayloadText 从 agent_done 负载中提取可展示文本，兜底无 chunk 的完成事件。
+func extractIDMDonePayloadText(payload any) string {
+	switch typed := payload.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(typed)
+	case map[string]any:
+		return extractIDMTextFromMap(typed)
+	default:
+		raw, err := json.Marshal(typed)
+		if err != nil {
+			return strings.TrimSpace(fmt.Sprint(typed))
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			return strings.TrimSpace(fmt.Sprint(typed))
+		}
+		return extractIDMTextFromMap(decoded)
+	}
+}
+
+// extractIDMTextFromMap 按 Runtime message 常见结构读取 text/content/parts 文本。
+func extractIDMTextFromMap(container map[string]any) string {
+	if container == nil {
+		return ""
+	}
+	for _, key := range []string{"text", "content", "summary"} {
+		if value := strings.TrimSpace(readMapStringValue(container, key)); value != "" {
+			return value
+		}
+	}
+	parts, ok := readMapAnyValue(container, "parts")
+	if !ok {
+		return ""
+	}
+	items, ok := parts.([]any)
+	if !ok {
+		return ""
+	}
+	var builder strings.Builder
+	for _, item := range items {
+		part, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		text := readMapStringValue(part, "text")
+		if strings.TrimSpace(text) == "" {
+			text = readMapStringValue(part, "content")
+		}
+		if strings.TrimSpace(text) == "" {
+			continue
+		}
+		builder.WriteString(text)
+	}
+	return strings.TrimSpace(builder.String())
 }
 
 // renderIDMAnswer 将模型回复按 Markdown 渲染后输出，渲染失败时回退原始文本。

--- a/internal/ptyproxy/idm_controller_branches_test.go
+++ b/internal/ptyproxy/idm_controller_branches_test.go
@@ -692,7 +692,8 @@ func TestIDMControllerPhase4RunModeAndAckFailures(t *testing.T) {
 		if err := controller.waitRunStream(ctx, "session-fallback", "run-fallback"); err != nil {
 			t.Fatalf("waitRunStream() error = %v", err)
 		}
-		if !strings.Contains(output.String(), "done payload fallback") {
+		visibleOutput := normalizeWhitespace(stripANSI(output.String()))
+		if !strings.Contains(visibleOutput, "done payload fallback") {
 			t.Fatalf("output = %q, want done payload fallback", output.String())
 		}
 	})

--- a/internal/ptyproxy/idm_controller_branches_test.go
+++ b/internal/ptyproxy/idm_controller_branches_test.go
@@ -697,6 +697,69 @@ func TestIDMControllerPhase4RunModeAndAckFailures(t *testing.T) {
 		}
 	})
 
+	t.Run("chunk renders before done", func(t *testing.T) {
+		client := &gatewayclient.GatewayRPCClient{}
+		notifications := make(chan gatewayclient.Notification, 4)
+		setGatewayClientNotifications(client, notifications)
+		output := &synchronizedBuffer{}
+		controller := newIDMController(idmControllerOptions{Output: output, RPCClient: client})
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		waitDone := make(chan error, 1)
+		go func() {
+			waitDone <- controller.waitRunStream(ctx, "session-stream", "run-stream")
+		}()
+
+		notifications <- gatewayclient.Notification{
+			Method: protocol.MethodGatewayEvent,
+			Params: mustMarshalJSON(t, gateway.MessageFrame{
+				Type:      gateway.FrameTypeEvent,
+				SessionID: "session-stream",
+				RunID:     "run-stream",
+				Payload: map[string]any{
+					"runtime_event_type": "agent_chunk",
+					"payload":            "streaming chunk",
+				},
+			}),
+		}
+
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case err := <-waitDone:
+				t.Fatalf("waitRunStream returned before agent_done: %v", err)
+			case <-ticker.C:
+				if strings.Contains(output.String(), "streaming chunk") {
+					goto chunkRendered
+				}
+			case <-ctx.Done():
+				t.Fatal("chunk was not rendered before agent_done")
+			}
+		}
+
+	chunkRendered:
+		notifications <- gatewayclient.Notification{
+			Method: protocol.MethodGatewayEvent,
+			Params: mustMarshalJSON(t, gateway.MessageFrame{
+				Type:      gateway.FrameTypeEvent,
+				SessionID: "session-stream",
+				RunID:     "run-stream",
+				Payload:   map[string]any{"runtime_event_type": "agent_done"},
+			}),
+		}
+
+		select {
+		case err := <-waitDone:
+			if err != nil {
+				t.Fatalf("waitRunStream() error = %v", err)
+			}
+		case <-ctx.Done():
+			t.Fatal("waitRunStream did not finish after agent_done")
+		}
+	})
+
 	t.Run("run mode follows env and run ack failures reset state", func(t *testing.T) {
 		tests := []struct {
 			name     string
@@ -866,6 +929,23 @@ type failingWriter struct {
 
 func (w failingWriter) Write(_ []byte) (int, error) {
 	return 0, w.err
+}
+
+type synchronizedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *synchronizedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *synchronizedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 func mustMarshalJSON(t *testing.T, value any) json.RawMessage {

--- a/internal/ptyproxy/idm_controller_branches_test.go
+++ b/internal/ptyproxy/idm_controller_branches_test.go
@@ -662,6 +662,204 @@ func TestIDMControllerUtilityBranches(t *testing.T) {
 	})
 }
 
+func TestIDMControllerPhase4RunModeAndAckFailures(t *testing.T) {
+	t.Run("done payload fallback renders answer", func(t *testing.T) {
+		client := &gatewayclient.GatewayRPCClient{}
+		notifications := make(chan gatewayclient.Notification, 4)
+		setGatewayClientNotifications(client, notifications)
+		output := &bytes.Buffer{}
+		controller := newIDMController(idmControllerOptions{Output: output, RPCClient: client})
+
+		notifications <- gatewayclient.Notification{
+			Method: protocol.MethodGatewayEvent,
+			Params: mustMarshalJSON(t, gateway.MessageFrame{
+				Type:      gateway.FrameTypeEvent,
+				SessionID: "session-fallback",
+				RunID:     "run-fallback",
+				Payload: map[string]any{
+					"runtime_event_type": "agent_done",
+					"payload": map[string]any{
+						"parts": []any{
+							map[string]any{"kind": "text", "text": "done payload fallback"},
+						},
+					},
+				},
+			}),
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := controller.waitRunStream(ctx, "session-fallback", "run-fallback"); err != nil {
+			t.Fatalf("waitRunStream() error = %v", err)
+		}
+		if !strings.Contains(output.String(), "done payload fallback") {
+			t.Fatalf("output = %q, want done payload fallback", output.String())
+		}
+	})
+
+	t.Run("run mode follows env and run ack failures reset state", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			envValue string
+			runFrame gateway.MessageFrame
+			wantMode string
+			wantErr  string
+		}{
+			{
+				name:     "plan enabled with run error",
+				envValue: "",
+				runFrame: gateway.MessageFrame{
+					Type:  gateway.FrameTypeError,
+					Error: &gateway.FrameError{Code: "bad_run", Message: "run failed"},
+				},
+				wantMode: idmPlanMode,
+				wantErr:  "gateway run failed",
+			},
+			{
+				name:     "plan disabled with run error",
+				envValue: "1",
+				runFrame: gateway.MessageFrame{
+					Type:  gateway.FrameTypeError,
+					Error: &gateway.FrameError{Code: "bad_run", Message: "run failed"},
+				},
+				wantMode: "",
+				wantErr:  "gateway run failed",
+			},
+			{
+				name:     "unexpected run frame",
+				envValue: "",
+				runFrame: gateway.MessageFrame{
+					Type: gateway.FrameTypeEvent,
+				},
+				wantMode: idmPlanMode,
+				wantErr:  "unexpected gateway frame type for run",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Setenv(IDMSessionPlanModeDisableEnv, tt.envValue)
+				modeSeen := make(chan string, 1)
+				client, cleanup := newAuthenticatedIDMRPCClient(t, func(decoder *json.Decoder, encoder *json.Encoder) error {
+					bindReq, err := readRPCRequest(decoder)
+					if err != nil {
+						return err
+					}
+					if bindReq.Method != protocol.MethodGatewayBindStream {
+						return fmt.Errorf("unexpected bind method %s", bindReq.Method)
+					}
+					if err := writeRPCResult(encoder, bindReq.ID, gateway.MessageFrame{
+						Type:   gateway.FrameTypeAck,
+						Action: gateway.FrameActionBindStream,
+					}); err != nil {
+						return err
+					}
+
+					runReq, err := readRPCRequest(decoder)
+					if err != nil {
+						return err
+					}
+					if runReq.Method != protocol.MethodGatewayRun {
+						return fmt.Errorf("unexpected run method %s", runReq.Method)
+					}
+					var runParams protocol.RunParams
+					if err := json.Unmarshal(runReq.Params, &runParams); err != nil {
+						return fmt.Errorf("unmarshal run params: %w", err)
+					}
+					modeSeen <- runParams.Mode
+					return writeRPCResult(encoder, runReq.ID, tt.runFrame)
+				})
+				defer cleanup()
+
+				controller := newIDMController(idmControllerOptions{Output: &bytes.Buffer{}, RPCClient: client, Workdir: "/tmp"})
+				controller.mu.Lock()
+				controller.active = true
+				controller.sessionID = "session-send"
+				controller.sessionReady = true
+				controller.mu.Unlock()
+
+				err := controller.sendAIMessage("please analyze")
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("sendAIMessage() error = %v, want contains %q", err, tt.wantErr)
+				}
+				if got := <-modeSeen; got != tt.wantMode {
+					t.Fatalf("run mode = %q, want %q", got, tt.wantMode)
+				}
+				controller.mu.Lock()
+				defer controller.mu.Unlock()
+				if controller.mode != idmModeIdle || controller.currentRunID != "" || controller.streamCancel != nil {
+					t.Fatalf(
+						"controller did not reset streaming state: mode=%q run_id=%q cancel_nil=%v",
+						controller.mode,
+						controller.currentRunID,
+						controller.streamCancel == nil,
+					)
+				}
+			})
+		}
+	})
+
+	t.Run("bind ack failures reset state", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			frame   gateway.MessageFrame
+			wantErr string
+		}{
+			{
+				name: "bind error frame",
+				frame: gateway.MessageFrame{
+					Type:  gateway.FrameTypeError,
+					Error: &gateway.FrameError{Code: "bad_bind", Message: "bind failed"},
+				},
+				wantErr: "gateway bind_stream failed",
+			},
+			{
+				name:    "unexpected bind frame",
+				frame:   gateway.MessageFrame{Type: gateway.FrameTypeEvent},
+				wantErr: "unexpected gateway frame type for bind_stream",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				client, cleanup := newAuthenticatedIDMRPCClient(t, func(decoder *json.Decoder, encoder *json.Encoder) error {
+					bindReq, err := readRPCRequest(decoder)
+					if err != nil {
+						return err
+					}
+					if bindReq.Method != protocol.MethodGatewayBindStream {
+						return fmt.Errorf("unexpected bind method %s", bindReq.Method)
+					}
+					return writeRPCResult(encoder, bindReq.ID, tt.frame)
+				})
+				defer cleanup()
+
+				controller := newIDMController(idmControllerOptions{Output: &bytes.Buffer{}, RPCClient: client, Workdir: "/tmp"})
+				controller.mu.Lock()
+				controller.active = true
+				controller.sessionID = "session-bind"
+				controller.sessionReady = true
+				controller.mu.Unlock()
+
+				err := controller.sendAIMessage("please analyze")
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("sendAIMessage() error = %v, want contains %q", err, tt.wantErr)
+				}
+				controller.mu.Lock()
+				defer controller.mu.Unlock()
+				if controller.mode != idmModeIdle || controller.currentRunID != "" || controller.streamCancel != nil {
+					t.Fatalf(
+						"controller did not reset streaming state: mode=%q run_id=%q cancel_nil=%v",
+						controller.mode,
+						controller.currentRunID,
+						controller.streamCancel == nil,
+					)
+				}
+			})
+		}
+	})
+}
+
 type failingWriter struct {
 	err error
 }

--- a/internal/ptyproxy/options.go
+++ b/internal/ptyproxy/options.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -13,6 +14,14 @@ const (
 	DiagSocketEnv = "NEOCODE_DIAG_SOCKET"
 	// IDMDiagSocketEnv 是 shell 子进程内用于定位 IDM 诊断 socket 的环境变量名。
 	IDMDiagSocketEnv = "NEOCODE_IDM_SOCKET"
+	// DiagAltScreenGuardDisableEnv 用于快速禁用全屏抑制逻辑，便于紧急回滚。
+	DiagAltScreenGuardDisableEnv = "NEOCODE_DIAG_ALTSCREEN_GUARD_DISABLED"
+	// IDMSessionPlanModeDisableEnv 用于关闭 IDM @ai 的 plan 模式注入，便于紧急回滚。
+	IDMSessionPlanModeDisableEnv = "NEOCODE_IDM_PLAN_MODE_DISABLED"
+	// DiagFastResponseDisableEnv 用于关闭诊断快速首响，便于对比和回滚。
+	DiagFastResponseDisableEnv = "NEOCODE_DIAG_FAST_RESPONSE_DISABLED"
+	// DiagCacheDisableEnv 用于关闭诊断缓存和 in-flight 合并，便于对比和回滚。
+	DiagCacheDisableEnv = "NEOCODE_DIAG_CACHE_DISABLED"
 	// DefaultRingBufferCapacity 定义诊断日志缓存窗口的默认字节上限（64KB）。
 	DefaultRingBufferCapacity = 64 * 1024
 )
@@ -79,4 +88,46 @@ func MergeEnvVar(environment []string, key string, value string) []string {
 	}
 	merged = append(merged, trimmedKey+"="+normalizedValue)
 	return merged
+}
+
+// IsAltScreenGuardEnabledFromEnv 根据环境变量决定是否开启全屏抑制逻辑。
+func IsAltScreenGuardEnabledFromEnv() bool {
+	value := strings.TrimSpace(os.Getenv(DiagAltScreenGuardDisableEnv))
+	if value == "" {
+		return true
+	}
+	disabled, err := strconv.ParseBool(value)
+	if err == nil {
+		return !disabled
+	}
+	// 兼容运维兜底：只要显式设置了无法解析的非空值，也视为禁用。
+	return false
+}
+
+// IsIDMPlanModeEnabledFromEnv 根据环境变量决定 IDM @ai 是否显式进入 plan 模式。
+func IsIDMPlanModeEnabledFromEnv() bool {
+	return !isTruthyEnv(IDMSessionPlanModeDisableEnv)
+}
+
+// IsDiagFastResponseEnabledFromEnv 根据环境变量决定是否输出诊断快速首响。
+func IsDiagFastResponseEnabledFromEnv() bool {
+	return !isTruthyEnv(DiagFastResponseDisableEnv)
+}
+
+// IsDiagCacheEnabledFromEnv 根据环境变量决定是否开启诊断缓存与 in-flight 合并。
+func IsDiagCacheEnabledFromEnv() bool {
+	return !isTruthyEnv(DiagCacheDisableEnv)
+}
+
+// isTruthyEnv 以宽松布尔语义识别回滚开关是否开启。
+func isTruthyEnv(name string) bool {
+	value := strings.TrimSpace(os.Getenv(strings.TrimSpace(name)))
+	if value == "" {
+		return false
+	}
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return true
+	}
+	return parsed
 }

--- a/internal/ptyproxy/options_test.go
+++ b/internal/ptyproxy/options_test.go
@@ -92,3 +92,54 @@ func TestNormalizeShellOptionsResolvesEmptyWorkdir(t *testing.T) {
 		t.Fatal("Workdir should not be empty after normalization")
 	}
 }
+
+func TestIsAltScreenGuardEnabledFromEnv(t *testing.T) {
+	t.Setenv(DiagAltScreenGuardDisableEnv, "")
+	if !IsAltScreenGuardEnabledFromEnv() {
+		t.Fatal("expected alt-screen guard enabled by default")
+	}
+
+	t.Setenv(DiagAltScreenGuardDisableEnv, "true")
+	if IsAltScreenGuardEnabledFromEnv() {
+		t.Fatal("expected alt-screen guard disabled when env=true")
+	}
+
+	t.Setenv(DiagAltScreenGuardDisableEnv, "false")
+	if !IsAltScreenGuardEnabledFromEnv() {
+		t.Fatal("expected alt-screen guard enabled when env=false")
+	}
+
+	t.Setenv(DiagAltScreenGuardDisableEnv, "invalid")
+	if IsAltScreenGuardEnabledFromEnv() {
+		t.Fatal("expected alt-screen guard disabled for non-empty invalid env")
+	}
+}
+
+func TestFeatureRollbackEnvs(t *testing.T) {
+	t.Setenv(IDMSessionPlanModeDisableEnv, "")
+	if !IsIDMPlanModeEnabledFromEnv() {
+		t.Fatal("expected IDM plan mode enabled by default")
+	}
+	t.Setenv(IDMSessionPlanModeDisableEnv, "1")
+	if IsIDMPlanModeEnabledFromEnv() {
+		t.Fatal("expected IDM plan mode disabled when env=1")
+	}
+
+	t.Setenv(DiagFastResponseDisableEnv, "")
+	if !IsDiagFastResponseEnabledFromEnv() {
+		t.Fatal("expected fast response enabled by default")
+	}
+	t.Setenv(DiagFastResponseDisableEnv, "invalid")
+	if IsDiagFastResponseEnabledFromEnv() {
+		t.Fatal("expected invalid non-empty fast response env to disable feature")
+	}
+
+	t.Setenv(DiagCacheDisableEnv, "")
+	if !IsDiagCacheEnabledFromEnv() {
+		t.Fatal("expected diagnosis cache enabled by default")
+	}
+	t.Setenv(DiagCacheDisableEnv, "true")
+	if IsDiagCacheEnabledFromEnv() {
+		t.Fatal("expected diagnosis cache disabled when env=true")
+	}
+}

--- a/internal/ptyproxy/proxy_unix.go
+++ b/internal/ptyproxy/proxy_unix.go
@@ -14,7 +14,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -24,9 +23,7 @@ import (
 	"github.com/creack/pty"
 	"golang.org/x/term"
 
-	"neo-code/internal/gateway"
 	gatewayclient "neo-code/internal/gateway/client"
-	"neo-code/internal/gateway/protocol"
 	"neo-code/internal/tools"
 )
 
@@ -222,6 +219,7 @@ func RunManualShell(ctx context.Context, options ManualShellOptions) error {
 	var diagWG sync.WaitGroup
 	diagWG.Add(1)
 	autoDiagFatalCh := make(chan error, 1)
+	diagCoordinator := newDiagnosisCoordinator()
 	go func() {
 		defer diagWG.Done()
 		consumeDiagSignals(
@@ -242,6 +240,7 @@ func RunManualShell(ctx context.Context, options ManualShellOptions) error {
 				default:
 				}
 			},
+			diagCoordinator,
 		)
 	}()
 
@@ -1028,7 +1027,11 @@ func consumeDiagSignals(
 	socketPath string,
 	autoState *autoRuntimeState,
 	onAutoDiagnoseFailure func(error),
+	coordinator *diagnosisCoordinator,
 ) {
+	var autoWG sync.WaitGroup
+	autoSlots := make(chan struct{}, 1)
+	defer autoWG.Wait()
 	for {
 		select {
 		case <-ctx.Done():
@@ -1037,12 +1040,59 @@ func consumeDiagSignals(
 			if !ok {
 				return
 			}
-			diagnoseErr := runSingleDiagnosis(rpcClient, output, buffer, options, socketPath, job.Trigger, job.IsAuto, autoState)
-			if job.IsAuto && diagnoseErr != nil && onAutoDiagnoseFailure != nil && shouldTerminateShellOnAutoDiagnoseError(diagnoseErr) {
-				onAutoDiagnoseFailure(diagnoseErr)
+			if job.IsAuto {
+				if coordinator != nil {
+					prepared, prepareErr := prepareDiagnoseRequest(buffer, options, socketPath, job.Trigger)
+					if prepareErr == nil && coordinator.shouldDropAuto(prepared.Fingerprint) {
+						continue
+					}
+				}
+				select {
+				case autoSlots <- struct{}{}:
+				case <-ctx.Done():
+					return
+				default:
+					continue
+				}
+				autoWG.Add(1)
+				go func(autoJob diagnoseJob) {
+					defer autoWG.Done()
+					defer func() { <-autoSlots }()
+					diagnoseErr := runSingleDiagnosisWithCoordinator(
+						ctx,
+						coordinator,
+						rpcClient,
+						output,
+						buffer,
+						options,
+						socketPath,
+						autoJob.Trigger,
+						true,
+						autoState,
+					)
+					if diagnoseErr != nil && onAutoDiagnoseFailure != nil && shouldTerminateShellOnAutoDiagnoseError(diagnoseErr) {
+						onAutoDiagnoseFailure(diagnoseErr)
+					}
+				}(job)
+				continue
 			}
+			diagnoseErr := runSingleDiagnosisWithCoordinator(
+				ctx,
+				coordinator,
+				rpcClient,
+				output,
+				buffer,
+				options,
+				socketPath,
+				job.Trigger,
+				false,
+				autoState,
+			)
 			if job.Done != nil {
 				job.Done <- diagIPCResponse{OK: true, AutoEnabled: autoState.Enabled.Load(), Message: "diagnosis completed"}
+			}
+			if diagnoseErr != nil {
+				continue
 			}
 		}
 	}
@@ -1089,25 +1139,85 @@ func runSingleDiagnosis(
 	isAuto bool,
 	autoState *autoRuntimeState,
 ) error {
+	return runSingleDiagnosisWithCoordinator(
+		context.Background(),
+		nil,
+		rpcClient,
+		output,
+		buffer,
+		options,
+		socketPath,
+		trigger,
+		isAuto,
+		autoState,
+	)
+}
+
+// runSingleDiagnosisWithCoordinator 执行一次诊断，并按需复用快速首响、缓存与 in-flight 合并。
+func runSingleDiagnosisWithCoordinator(
+	ctx context.Context,
+	coordinator *diagnosisCoordinator,
+	rpcClient *gatewayclient.GatewayRPCClient,
+	output io.Writer,
+	buffer *UTF8RingBuffer,
+	options ManualShellOptions,
+	socketPath string,
+	trigger diagnoseTrigger,
+	isAuto bool,
+	autoState *autoRuntimeState,
+) error {
 	if output == nil {
 		return nil
 	}
+	if isAuto && autoState != nil && !autoState.Enabled.Load() {
+		return nil
+	}
+
+	prepared, prepareErr := prepareDiagnoseRequest(buffer, options, socketPath, trigger)
+	if prepareErr != nil {
+		if options.Stderr != nil {
+			writeProxyf(options.Stderr, "neocode diag: build diagnose payload failed: %v\n", prepareErr)
+		}
+		err := errors.New("诊断请求构建失败，请稍后重试")
+		writeProxyf(output, "\n\033[31m[NeoCode Diagnosis]\033[0m %s\n", strings.TrimSpace(err.Error()))
+		return err
+	}
+
+	if coordinator != nil {
+		if cached, ok := coordinator.cached(prepared.Fingerprint); ok {
+			if cached.Err != nil {
+				writeProxyf(output, "\n\033[31m[NeoCode Diagnosis]\033[0m %s\n", strings.TrimSpace(cached.Err.Error()))
+				return cached.Err
+			}
+			if !isAuto {
+				writeProxyLine(output, "\n\033[36m[NeoCode Diagnosis]\033[0m 使用最近一次缓存诊断结果。")
+			}
+			renderDiagnosis(output, cached.Result.Content, cached.Result.IsError)
+			return nil
+		}
+	}
+
+	renderDiagnosisInitialFeedback(output, prepared, isAuto)
 
 	var (
 		result tools.ToolResult
 		err    error
 	)
+	execute := func(timeout time.Duration) diagnosisOutcome {
+		if coordinator == nil {
+			result, callErr := executePreparedDiagnoseToolWithTimeout(rpcClient, options, prepared, timeout)
+			return diagnosisOutcome{Result: result, Err: callErr}
+		}
+		return coordinator.run(ctx, prepared.Fingerprint, func() (tools.ToolResult, error) {
+			return executePreparedDiagnoseToolWithTimeout(rpcClient, options, prepared, timeout)
+		})
+	}
 	if isAuto {
-		result, err = callDiagnoseToolWithTimeout(
-			rpcClient,
-			buffer,
-			options,
-			socketPath,
-			trigger,
-			autoDiagnoseCallTimeout,
-		)
+		outcome := execute(autoDiagnoseCallTimeout)
+		result, err = outcome.Result, outcome.Err
 	} else {
-		result, err = callDiagnoseTool(rpcClient, buffer, options, socketPath, trigger)
+		outcome := execute(diagnoseCallTimeout)
+		result, err = outcome.Result, outcome.Err
 	}
 	if err != nil {
 		writeProxyf(output, "\n\033[31m[NeoCode Diagnosis]\033[0m %s\n", strings.TrimSpace(err.Error()))
@@ -1140,90 +1250,14 @@ func callDiagnoseToolWithTimeout(
 	trigger diagnoseTrigger,
 	timeout time.Duration,
 ) (tools.ToolResult, error) {
-	if rpcClient == nil {
-		return tools.ToolResult{}, errors.New("诊断服务未就绪，请确认 gateway 已连接后重试")
-	}
-
-	logSnapshot := buffer.SnapshotString()
-	if strings.TrimSpace(trigger.OutputText) != "" {
-		logSnapshot = trigger.OutputText
-	}
-	sanitizedErrorLog := SanitizeDiagnosisText(logSnapshot, defaultDiagnosisPayloadMaxBytes)
-	if strings.TrimSpace(sanitizedErrorLog) == "" {
-		sanitizedErrorLog = "no terminal output captured"
-	}
-	sanitizedCommand := SanitizeDiagnosisText(trigger.CommandText, 1024)
-
-	requestArgs := diagnoseToolArgs{
-		ErrorLog: sanitizedErrorLog,
-		OSEnv: map[string]string{
-			"os":     runtime.GOOS,
-			"shell":  resolveShellPath(options.Shell),
-			"cwd":    options.Workdir,
-			"socket": socketPath,
-		},
-		CommandText: sanitizedCommand,
-		ExitCode:    trigger.ExitCode,
-	}
-
-	requestPayload, err := json.Marshal(requestArgs)
+	prepared, err := prepareDiagnoseRequest(buffer, options, socketPath, trigger)
 	if err != nil {
 		if options.Stderr != nil {
 			writeProxyf(options.Stderr, "neocode diag: build diagnose payload failed: %v\n", err)
 		}
 		return tools.ToolResult{}, errors.New("诊断请求构建失败，请稍后重试")
 	}
-
-	callContext, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	var frame gateway.MessageFrame
-	if err := rpcClient.CallWithOptions(
-		callContext,
-		protocol.MethodGatewayExecuteSystemTool,
-		protocol.ExecuteSystemToolParams{
-			Workdir:   options.Workdir,
-			ToolName:  tools.ToolNameDiagnose,
-			Arguments: requestPayload,
-		},
-		&frame,
-		gatewayclient.GatewayRPCCallOptions{
-			Timeout: timeout,
-			Retries: 1,
-		},
-	); err != nil {
-		if options.Stderr != nil {
-			writeProxyf(options.Stderr, "neocode diag: executeSystemTool rpc failed: %v\n", err)
-		}
-		return tools.ToolResult{}, errors.New("诊断调用失败，请检查 gateway 连接后重试，或使用 `neocode diag -i` 继续排查")
-	}
-
-	if frame.Type == gateway.FrameTypeError && frame.Error != nil {
-		if options.Stderr != nil {
-			writeProxyf(
-				options.Stderr,
-				"neocode diag: gateway returned frame error code=%s message=%s\n",
-				strings.TrimSpace(frame.Error.Code),
-				strings.TrimSpace(frame.Error.Message),
-			)
-		}
-		return tools.ToolResult{}, errors.New("诊断服务暂不可用，请稍后重试，或使用 `neocode diag -i` 继续排查")
-	}
-	if frame.Type != gateway.FrameTypeAck {
-		if options.Stderr != nil {
-			writeProxyf(options.Stderr, "neocode diag: unexpected gateway frame type: %s\n", frame.Type)
-		}
-		return tools.ToolResult{}, errors.New("诊断服务返回异常响应，请稍后重试")
-	}
-
-	toolResult, err := decodeToolResult(frame.Payload)
-	if err != nil {
-		if options.Stderr != nil {
-			writeProxyf(options.Stderr, "neocode diag: decode diagnose payload failed: %v\n", err)
-		}
-		return tools.ToolResult{}, errors.New("诊断结果解析失败，请重试或更新 NeoCode")
-	}
-	return toolResult, nil
+	return executePreparedDiagnoseToolWithTimeout(rpcClient, options, prepared, timeout)
 }
 
 // decodeToolResult 负责 decodeToolResult 相关逻辑。

--- a/internal/ptyproxy/proxy_unix.go
+++ b/internal/ptyproxy/proxy_unix.go
@@ -1301,6 +1301,7 @@ func streamPTYOutputWithIDM(
 		return
 	}
 	parser := &OSC133Parser{}
+	altScreen := newAltScreenState(IsAltScreenGuardEnabledFromEnv())
 	collectingCommand := false
 	pendingTrigger := (*diagnoseTrigger)(nil)
 	fallbackCommandBuffer := NewUTF8RingBuffer(DefaultRingBufferCapacity / 2)
@@ -1309,6 +1310,7 @@ func streamPTYOutputWithIDM(
 	for {
 		readBytes, err := ptyReader.Read(buffer)
 		if readBytes > 0 {
+			altScreen.Observe(buffer[:readBytes])
 			cleanOutput, events := parser.Feed(buffer[:readBytes])
 			if idm != nil && len(cleanOutput) > 0 {
 				cleanOutput = idm.FilterPTYOutput(cleanOutput)
@@ -1328,6 +1330,11 @@ func streamPTYOutputWithIDM(
 				case ShellEventPromptReady:
 					autoState.OSCReady.Store(true)
 					if pendingTrigger != nil && autoState.Enabled.Load() {
+						if altScreen.ShouldSuppressAutoTrigger(true) {
+							pendingTrigger = nil
+							fallbackCommandBuffer.Reset()
+							continue
+						}
 						select {
 						case autoTriggerCh <- *pendingTrigger:
 						default:
@@ -1351,6 +1358,10 @@ func streamPTYOutputWithIDM(
 						outputText = fallbackCommandBuffer.SnapshotString()
 					}
 					if ShouldTriggerAutoDiagnosis(event.ExitCode, commandText, outputText) {
+						if altScreen.ShouldSuppressAutoTrigger(true) {
+							pendingTrigger = nil
+							continue
+						}
 						pendingTrigger = &diagnoseTrigger{
 							CommandText: commandText,
 							ExitCode:    event.ExitCode,

--- a/internal/ptyproxy/proxy_unix_test.go
+++ b/internal/ptyproxy/proxy_unix_test.go
@@ -1691,7 +1691,7 @@ func TestConsumeDiagSignalsAndBannerPaths(t *testing.T) {
 		autoState := &autoRuntimeState{}
 		autoState.Enabled.Store(true)
 
-		consumeDiagSignals(ctx, nil, jobCh, output, NewUTF8RingBuffer(1024), ManualShellOptions{}, "/tmp/diag.sock", autoState, nil)
+		consumeDiagSignals(ctx, nil, jobCh, output, NewUTF8RingBuffer(1024), ManualShellOptions{}, "/tmp/diag.sock", autoState, nil, nil)
 		select {
 		case response := <-doneCh:
 			if !response.OK {
@@ -1752,6 +1752,7 @@ func TestConsumeDiagSignalsAndBannerPaths(t *testing.T) {
 			"/tmp/diag.sock",
 			autoState,
 			func(err error) { callbackTriggered <- err },
+			nil,
 		)
 
 		select {
@@ -1865,7 +1866,7 @@ func TestConsumeDiagSignalsClosedChannelReturns(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		consumeDiagSignals(ctx, nil, jobCh, &bytes.Buffer{}, NewUTF8RingBuffer(1024), ManualShellOptions{}, "/tmp/diag.sock", &autoRuntimeState{}, nil)
+		consumeDiagSignals(ctx, nil, jobCh, &bytes.Buffer{}, NewUTF8RingBuffer(1024), ManualShellOptions{}, "/tmp/diag.sock", &autoRuntimeState{}, nil, nil)
 	}()
 
 	select {

--- a/internal/ptyproxy/proxy_unix_test.go
+++ b/internal/ptyproxy/proxy_unix_test.go
@@ -1183,13 +1183,8 @@ drainLoop:
 func TestStreamPTYOutputAltScreenGuardDisabledByEnv(t *testing.T) {
 	t.Setenv(DiagAltScreenGuardDisableEnv, "true")
 
-	payload := strings.NewReader(
-		"\x1b[?1049h" +
-			"\x1b]133;C\x07" +
-			"fatal: guard disabled should still trigger\n" +
-			"\x1b]133;D;1\x07" +
-			"\x1b]133;A\x07",
-	)
+	payloadReader, payloadWriter := io.Pipe()
+	defer payloadReader.Close()
 	output := &bytes.Buffer{}
 	commandLog := NewUTF8RingBuffer(1024)
 	tracker := &commandTracker{}
@@ -1198,15 +1193,32 @@ func TestStreamPTYOutputAltScreenGuardDisabledByEnv(t *testing.T) {
 	autoState := &autoRuntimeState{}
 	autoState.Enabled.Store(true)
 
-	streamPTYOutput(payload, output, commandLog, tracker, autoTriggers, autoState)
+	streamDone := make(chan struct{})
+	go func() {
+		defer close(streamDone)
+		streamPTYOutput(payloadReader, output, commandLog, tracker, autoTriggers, autoState)
+	}()
+	go func() {
+		_, _ = payloadWriter.Write([]byte("\x1b[?1049h"))
+		_, _ = payloadWriter.Write([]byte("\x1b]133;C\x07"))
+		_, _ = payloadWriter.Write([]byte("fatal: guard disabled should still trigger\n"))
+		_, _ = payloadWriter.Write([]byte("\x1b]133;D;1\x07"))
+		_, _ = payloadWriter.Write([]byte("\x1b]133;A\x07"))
+		_ = payloadWriter.Close()
+	}()
 
 	select {
 	case trigger := <-autoTriggers:
 		if !strings.Contains(trigger.OutputText, "guard disabled should still trigger") {
 			t.Fatalf("trigger output = %q, want guard-disabled failure text", trigger.OutputText)
 		}
-	default:
+	case <-time.After(time.Second):
 		t.Fatal("expected trigger when alt-screen guard is disabled by env")
+	}
+	select {
+	case <-streamDone:
+	case <-time.After(time.Second):
+		t.Fatal("streamPTYOutput did not finish")
 	}
 	if !strings.Contains(output.String(), "guard disabled should still trigger") {
 		t.Fatalf("output = %q, want contains failure text", output.String())

--- a/internal/ptyproxy/proxy_unix_test.go
+++ b/internal/ptyproxy/proxy_unix_test.go
@@ -1092,6 +1092,127 @@ func TestStreamPTYOutputPromptReadyKeepsUserAutoSwitch(t *testing.T) {
 	}
 }
 
+func TestStreamPTYOutputSuppressesTriggerInAltScreen(t *testing.T) {
+	t.Setenv(DiagAltScreenGuardDisableEnv, "")
+
+	payload := strings.NewReader(
+		"\x1b[?1049h" +
+			"\x1b]133;C\x07" +
+			"fatal: build failed in alt screen\n" +
+			"\x1b]133;D;1\x07" +
+			"\x1b]133;A\x07",
+	)
+	output := &bytes.Buffer{}
+	commandLog := NewUTF8RingBuffer(1024)
+	tracker := &commandTracker{}
+	tracker.Observe([]byte("go test ./...\r"))
+	autoTriggers := make(chan diagnoseTrigger, 1)
+	autoState := &autoRuntimeState{}
+	autoState.Enabled.Store(true)
+
+	streamPTYOutput(payload, output, commandLog, tracker, autoTriggers, autoState)
+
+	select {
+	case trigger := <-autoTriggers:
+		t.Fatalf("unexpected trigger in alt screen: %#v", trigger)
+	default:
+	}
+	if !strings.Contains(output.String(), "fatal: build failed in alt screen") {
+		t.Fatalf("output = %q, want contains alt-screen error text", output.String())
+	}
+}
+
+func TestStreamPTYOutputSuppressesFirstTriggerAfterAltExitOnly(t *testing.T) {
+	t.Setenv(DiagAltScreenGuardDisableEnv, "")
+
+	payloadReader, payloadWriter := io.Pipe()
+	defer payloadReader.Close()
+	output := &bytes.Buffer{}
+	commandLog := NewUTF8RingBuffer(1024)
+	tracker := &commandTracker{}
+	tracker.Observe([]byte("go test ./...\r"))
+	autoTriggers := make(chan diagnoseTrigger, 4)
+	autoState := &autoRuntimeState{}
+	autoState.Enabled.Store(true)
+	autoState.OSCReady.Store(false)
+
+	streamDone := make(chan struct{})
+	go func() {
+		defer close(streamDone)
+		streamPTYOutput(payloadReader, output, commandLog, tracker, autoTriggers, autoState)
+	}()
+	go func() {
+		_, _ = payloadWriter.Write([]byte("\x1b[?1049h"))
+		_, _ = payloadWriter.Write([]byte("\x1b]133;C\x07"))
+		_, _ = payloadWriter.Write([]byte("fatal first failure\n"))
+		_, _ = payloadWriter.Write([]byte("\x1b[?1049l"))
+		_, _ = payloadWriter.Write([]byte("\x1b]133;D;1\x07"))
+		_, _ = payloadWriter.Write([]byte("\x1b]133;A\x07"))
+
+		_, _ = payloadWriter.Write([]byte("\x1b]133;C\x07"))
+		_, _ = payloadWriter.Write([]byte("fatal second failure\n"))
+		_, _ = payloadWriter.Write([]byte("\x1b]133;D;1\x07"))
+		_, _ = payloadWriter.Write([]byte("\x1b]133;A\x07"))
+		_ = payloadWriter.Close()
+	}()
+
+	select {
+	case <-streamDone:
+	case <-time.After(time.Second):
+		t.Fatal("streamPTYOutput did not finish")
+	}
+
+	triggers := make([]diagnoseTrigger, 0, 2)
+drainLoop:
+	for {
+		select {
+		case trigger := <-autoTriggers:
+			triggers = append(triggers, trigger)
+		default:
+			break drainLoop
+		}
+	}
+	if len(triggers) != 1 {
+		t.Fatalf("trigger count = %d, want 1", len(triggers))
+	}
+	if !strings.Contains(triggers[0].OutputText, "fatal second failure") {
+		t.Fatalf("trigger output = %q, want second failure", triggers[0].OutputText)
+	}
+}
+
+func TestStreamPTYOutputAltScreenGuardDisabledByEnv(t *testing.T) {
+	t.Setenv(DiagAltScreenGuardDisableEnv, "true")
+
+	payload := strings.NewReader(
+		"\x1b[?1049h" +
+			"\x1b]133;C\x07" +
+			"fatal: guard disabled should still trigger\n" +
+			"\x1b]133;D;1\x07" +
+			"\x1b]133;A\x07",
+	)
+	output := &bytes.Buffer{}
+	commandLog := NewUTF8RingBuffer(1024)
+	tracker := &commandTracker{}
+	tracker.Observe([]byte("go test ./...\r"))
+	autoTriggers := make(chan diagnoseTrigger, 1)
+	autoState := &autoRuntimeState{}
+	autoState.Enabled.Store(true)
+
+	streamPTYOutput(payload, output, commandLog, tracker, autoTriggers, autoState)
+
+	select {
+	case trigger := <-autoTriggers:
+		if !strings.Contains(trigger.OutputText, "guard disabled should still trigger") {
+			t.Fatalf("trigger output = %q, want guard-disabled failure text", trigger.OutputText)
+		}
+	default:
+		t.Fatal("expected trigger when alt-screen guard is disabled by env")
+	}
+	if !strings.Contains(output.String(), "guard disabled should still trigger") {
+		t.Fatalf("output = %q, want contains failure text", output.String())
+	}
+}
+
 func TestDecodeToolResult(t *testing.T) {
 	result, err := decodeToolResult(map[string]any{
 		"Content": "ok",

--- a/internal/ptyproxy/screen_state.go
+++ b/internal/ptyproxy/screen_state.go
@@ -1,0 +1,180 @@
+package ptyproxy
+
+import "strings"
+
+const maxAltScreenLeftover = maxOSCLeftover
+
+// altScreenState 维护备用屏幕识别与自动诊断抑制窗口状态。
+type altScreenState struct {
+	guardEnabled              bool
+	inAltScreen               bool
+	suppressNextAutoAfterExit bool
+	leftover                  []byte
+}
+
+// newAltScreenState 创建全屏抑制状态机实例。
+func newAltScreenState(guardEnabled bool) *altScreenState {
+	return &altScreenState{guardEnabled: guardEnabled}
+}
+
+// Observe 扫描 PTY 原始字节流，识别备用屏幕切换序列并更新状态。
+func (s *altScreenState) Observe(payload []byte) {
+	if s == nil || !s.guardEnabled || len(payload) == 0 {
+		return
+	}
+	buffer := append(append([]byte(nil), s.leftover...), payload...)
+	s.leftover = nil
+
+	for index := 0; index < len(buffer); {
+		if hasPrefixAt(buffer, index, tmuxDCSOpen) {
+			end, ok := findESCBackslash(buffer, index+len(tmuxDCSOpen))
+			if !ok {
+				s.leftover = keepAltScreenLeftover(buffer[index:])
+				return
+			}
+			s.observeTmuxPassthrough(buffer[index+len(tmuxDCSOpen) : end])
+			index = end + 2
+			continue
+		}
+
+		if buffer[index] == oscEscape && index+1 < len(buffer) && buffer[index+1] == '[' {
+			next, complete := s.consumeCSISequence(buffer, index)
+			if !complete {
+				s.leftover = keepAltScreenLeftover(buffer[index:])
+				return
+			}
+			index = next
+			continue
+		}
+		index++
+	}
+}
+
+// ShouldSuppressAutoTrigger 判断当前是否应屏蔽自动诊断，并按需消耗一次性退出保护窗口。
+func (s *altScreenState) ShouldSuppressAutoTrigger(consume bool) bool {
+	if s == nil || !s.guardEnabled {
+		return false
+	}
+	if s.inAltScreen {
+		return true
+	}
+	if s.suppressNextAutoAfterExit {
+		if consume {
+			s.suppressNextAutoAfterExit = false
+		}
+		return true
+	}
+	return false
+}
+
+// observeTmuxPassthrough 处理 tmux DCS passthrough 中的备用屏幕控制序列。
+func (s *altScreenState) observeTmuxPassthrough(inner []byte) {
+	if s == nil || len(inner) == 0 {
+		return
+	}
+	decoded := decodeTmuxEscapedSequence(inner)
+	s.scanCSIWithoutLeftover(decoded)
+}
+
+// decodeTmuxEscapedSequence 还原 tmux passthrough 中双 ESC 转义的原始序列。
+func decodeTmuxEscapedSequence(inner []byte) []byte {
+	if len(inner) == 0 {
+		return nil
+	}
+	decoded := make([]byte, 0, len(inner))
+	for index := 0; index < len(inner); index++ {
+		current := inner[index]
+		if current == oscEscape && index+1 < len(inner) && inner[index+1] == oscEscape {
+			decoded = append(decoded, oscEscape)
+			index++
+			continue
+		}
+		decoded = append(decoded, current)
+	}
+	return decoded
+}
+
+// scanCSIWithoutLeftover 解析完整缓冲区中的 CSI 序列，不维护跨包残留状态。
+func (s *altScreenState) scanCSIWithoutLeftover(buffer []byte) {
+	for index := 0; index < len(buffer); {
+		if buffer[index] == oscEscape && index+1 < len(buffer) && buffer[index+1] == '[' {
+			next, complete := s.consumeCSISequence(buffer, index)
+			if !complete {
+				return
+			}
+			index = next
+			continue
+		}
+		index++
+	}
+}
+
+// consumeCSISequence 解析一段 CSI 序列并据此更新备用屏幕状态。
+func (s *altScreenState) consumeCSISequence(buffer []byte, start int) (int, bool) {
+	cursor := start + 2
+	for cursor < len(buffer) {
+		current := buffer[cursor]
+		if current >= 0x40 && current <= 0x7e {
+			s.updateFromCSI(buffer[start+2:cursor], current)
+			return cursor + 1, true
+		}
+		// CSI 参数区与中间区允许范围为 0x20~0x3f。
+		if current < 0x20 || current > 0x3f {
+			return start + 1, true
+		}
+		cursor++
+	}
+	return start, false
+}
+
+// updateFromCSI 提取 `CSI ? 47/1047/1049 h/l` 并推进状态机。
+func (s *altScreenState) updateFromCSI(params []byte, final byte) {
+	if s == nil {
+		return
+	}
+	if final != 'h' && final != 'l' {
+		return
+	}
+	if len(params) == 0 || params[0] != '?' {
+		return
+	}
+	if !containsAltScreenMode(string(params[1:])) {
+		return
+	}
+
+	if final == 'h' {
+		s.inAltScreen = true
+		// 新一轮全屏会话开始后，旧的一次性保护窗口失效。
+		s.suppressNextAutoAfterExit = false
+		return
+	}
+
+	wasInAltScreen := s.inAltScreen
+	s.inAltScreen = false
+	if wasInAltScreen {
+		s.suppressNextAutoAfterExit = true
+	}
+}
+
+// containsAltScreenMode 判断参数中是否包含备用屏幕模式编号。
+func containsAltScreenMode(raw string) bool {
+	if strings.TrimSpace(raw) == "" {
+		return false
+	}
+	parts := strings.Split(raw, ";")
+	for _, part := range parts {
+		switch strings.TrimSpace(part) {
+		case "47", "1047", "1049":
+			return true
+		}
+	}
+	return false
+}
+
+// keepAltScreenLeftover 控制备用屏幕序列残留缓冲上限，避免异常流导致内存增长。
+func keepAltScreenLeftover(raw []byte) []byte {
+	if len(raw) <= maxAltScreenLeftover {
+		return append([]byte(nil), raw...)
+	}
+	return append([]byte(nil), raw[len(raw)-maxAltScreenLeftover:]...)
+}

--- a/internal/ptyproxy/screen_state.go
+++ b/internal/ptyproxy/screen_state.go
@@ -48,6 +48,7 @@ func (s *altScreenState) Observe(payload []byte) {
 		}
 		index++
 	}
+	s.leftover = trailingAltScreenPrefix(buffer)
 }
 
 // ShouldSuppressAutoTrigger 判断当前是否应屏蔽自动诊断，并按需消耗一次性退出保护窗口。
@@ -177,4 +178,27 @@ func keepAltScreenLeftover(raw []byte) []byte {
 		return append([]byte(nil), raw...)
 	}
 	return append([]byte(nil), raw[len(raw)-maxAltScreenLeftover:]...)
+}
+
+// trailingAltScreenPrefix 保留跨 PTY read 被切开的备用屏幕控制序列前缀。
+func trailingAltScreenPrefix(buffer []byte) []byte {
+	maxPrefixLength := len(tmuxDCSOpen) - 1
+	if len(buffer) < maxPrefixLength {
+		maxPrefixLength = len(buffer)
+	}
+	for length := maxPrefixLength; length > 0; length-- {
+		suffix := buffer[len(buffer)-length:]
+		if isPartialAltScreenPrefix(suffix) {
+			return keepAltScreenLeftover(suffix)
+		}
+	}
+	return nil
+}
+
+// isPartialAltScreenPrefix 判断尾部字节是否可能是下一次 read 才补齐的控制序列前缀。
+func isPartialAltScreenPrefix(candidate []byte) bool {
+	if len(candidate) == 0 {
+		return false
+	}
+	return strings.HasPrefix(tmuxDCSOpen, string(candidate)) || strings.HasPrefix("\x1b[", string(candidate))
 }

--- a/internal/ptyproxy/screen_state_test.go
+++ b/internal/ptyproxy/screen_state_test.go
@@ -1,0 +1,100 @@
+package ptyproxy
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestAltScreenStateTracksEnterExitAndSuppressWindow(t *testing.T) {
+	state := newAltScreenState(true)
+	state.Observe([]byte("\x1b[?1049h"))
+	if !state.inAltScreen {
+		t.Fatal("expected inAltScreen=true after enter sequence")
+	}
+	if !state.ShouldSuppressAutoTrigger(false) {
+		t.Fatal("expected suppression while in alt-screen")
+	}
+
+	state.Observe([]byte("\x1b[?1049l"))
+	if state.inAltScreen {
+		t.Fatal("expected inAltScreen=false after exit sequence")
+	}
+	if !state.ShouldSuppressAutoTrigger(false) {
+		t.Fatal("expected post-exit suppression window")
+	}
+	if !state.ShouldSuppressAutoTrigger(true) {
+		t.Fatal("expected consume=true still returns suppression on first consume")
+	}
+	if state.ShouldSuppressAutoTrigger(false) {
+		t.Fatal("expected suppression window to be consumed")
+	}
+}
+
+func TestAltScreenStateSupportsChunkedCSISequence(t *testing.T) {
+	state := newAltScreenState(true)
+	state.Observe([]byte("\x1b[?10"))
+	if state.inAltScreen {
+		t.Fatal("inAltScreen should remain false before sequence is complete")
+	}
+	state.Observe([]byte("49h"))
+	if !state.inAltScreen {
+		t.Fatal("expected inAltScreen=true after chunked enter sequence")
+	}
+}
+
+func TestAltScreenStateSupportsMode47And1047(t *testing.T) {
+	state := newAltScreenState(true)
+	state.Observe([]byte("\x1b[?47h"))
+	if !state.inAltScreen {
+		t.Fatal("expected mode 47 to enter alt-screen")
+	}
+	state.Observe([]byte("\x1b[?47l"))
+	if state.inAltScreen {
+		t.Fatal("expected mode 47 to leave alt-screen")
+	}
+
+	state.Observe([]byte("\x1b[?1047h"))
+	if !state.inAltScreen {
+		t.Fatal("expected mode 1047 to enter alt-screen")
+	}
+	state.Observe([]byte("\x1b[?1047l"))
+	if state.inAltScreen {
+		t.Fatal("expected mode 1047 to leave alt-screen")
+	}
+}
+
+func TestAltScreenStateSupportsTmuxPassthrough(t *testing.T) {
+	state := newAltScreenState(true)
+	enter := []byte("x\x1bPtmux;\x1b\x1b[?1049h\x1b\\y")
+	exit := []byte("\x1bPtmux;\x1b\x1b[?1049l\x1b\\")
+	state.Observe(enter)
+	if !state.inAltScreen {
+		t.Fatal("expected tmux passthrough enter sequence to be recognized")
+	}
+	state.Observe(exit)
+	if state.inAltScreen {
+		t.Fatal("expected tmux passthrough exit sequence to be recognized")
+	}
+	if !state.ShouldSuppressAutoTrigger(false) {
+		t.Fatal("expected suppress window after tmux passthrough exit")
+	}
+}
+
+func TestAltScreenStateGuardDisabled(t *testing.T) {
+	state := newAltScreenState(false)
+	state.Observe([]byte("\x1b[?1049h"))
+	if state.inAltScreen {
+		t.Fatal("expected disabled guard to skip state updates")
+	}
+	if state.ShouldSuppressAutoTrigger(false) {
+		t.Fatal("expected disabled guard to never suppress auto trigger")
+	}
+}
+
+func TestKeepAltScreenLeftoverBounded(t *testing.T) {
+	raw := bytes.Repeat([]byte("a"), maxAltScreenLeftover+256)
+	kept := keepAltScreenLeftover(raw)
+	if len(kept) != maxAltScreenLeftover {
+		t.Fatalf("len(kept) = %d, want %d", len(kept), maxAltScreenLeftover)
+	}
+}

--- a/internal/ptyproxy/screen_state_test.go
+++ b/internal/ptyproxy/screen_state_test.go
@@ -42,6 +42,18 @@ func TestAltScreenStateSupportsChunkedCSISequence(t *testing.T) {
 	}
 }
 
+func TestAltScreenStateSupportsChunkedBareEscapeCSISequence(t *testing.T) {
+	state := newAltScreenState(true)
+	state.Observe([]byte("\x1b"))
+	if state.inAltScreen {
+		t.Fatal("inAltScreen should remain false before CSI prefix is complete")
+	}
+	state.Observe([]byte("[?1049h"))
+	if !state.inAltScreen {
+		t.Fatal("expected inAltScreen=true after bare ESC and CSI suffix")
+	}
+}
+
 func TestAltScreenStateSupportsMode47And1047(t *testing.T) {
 	state := newAltScreenState(true)
 	state.Observe([]byte("\x1b[?47h"))
@@ -77,6 +89,18 @@ func TestAltScreenStateSupportsTmuxPassthrough(t *testing.T) {
 	}
 	if !state.ShouldSuppressAutoTrigger(false) {
 		t.Fatal("expected suppress window after tmux passthrough exit")
+	}
+}
+
+func TestAltScreenStateSupportsChunkedTmuxPassthroughPrefix(t *testing.T) {
+	state := newAltScreenState(true)
+	state.Observe([]byte("\x1bPtm"))
+	if state.inAltScreen {
+		t.Fatal("inAltScreen should remain false before tmux prefix is complete")
+	}
+	state.Observe([]byte("ux;\x1b\x1b[?1049h\x1b\\"))
+	if !state.inAltScreen {
+		t.Fatal("expected chunked tmux passthrough enter sequence to be recognized")
 	}
 }
 

--- a/internal/tools/manager_test.go
+++ b/internal/tools/manager_test.go
@@ -126,7 +126,11 @@ func TestDefaultManagerListAvailableSpecsReadOnlyFiltersWriteTools(t *testing.T)
 	if err != nil {
 		t.Fatalf("list specs: %v", err)
 	}
-	if len(specs) != 1 || specs[0].Name != ToolNameFilesystemReadFile {
+	gotNames := make(map[string]bool, len(specs))
+	for _, spec := range specs {
+		gotNames[spec.Name] = true
+	}
+	if len(specs) != 2 || !gotNames[ToolNameFilesystemReadFile] || !gotNames[ToolNameTodoWrite] {
 		t.Fatalf("unexpected read-only specs: %+v", specs)
 	}
 }

--- a/internal/tools/manager_test.go
+++ b/internal/tools/manager_test.go
@@ -471,6 +471,38 @@ func TestDefaultManagerExecuteBlocksWriteToolInReadOnlyMode(t *testing.T) {
 	}
 }
 
+func TestDefaultManagerExecuteAllowsTodoWriteInReadOnlyMode(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	todoTool := &managerStubTool{name: ToolNameTodoWrite, content: "ok"}
+	registry.Register(todoTool)
+
+	manager, err := NewManager(registry, mustAllowEngine(t), nil)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	result, execErr := manager.Execute(context.Background(), ToolCallInput{
+		ID:        "call-readonly-todo-write",
+		Name:      ToolNameTodoWrite,
+		Arguments: []byte(`{"id":"todo-1","action":"update"}`),
+		ReadOnly:  true,
+	})
+	if execErr != nil {
+		t.Fatalf("expected todo_write to execute in read-only mode, got %v", execErr)
+	}
+	if result.Content != "ok" {
+		t.Fatalf("result.Content = %q, want ok", result.Content)
+	}
+	if todoTool.callCount != 1 {
+		t.Fatalf("expected todo_write to execute once, got %d", todoTool.callCount)
+	}
+	if !todoTool.lastCall.ReadOnly {
+		t.Fatal("expected read-only flag to be preserved on todo_write call")
+	}
+}
+
 func TestDefaultManagerSandboxOutsideWriteSessionMemory(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tools/manager_test.go
+++ b/internal/tools/manager_test.go
@@ -112,6 +112,7 @@ func TestDefaultManagerListAvailableSpecsReadOnlyFiltersWriteTools(t *testing.T)
 	registry.Register(&managerStubTool{name: ToolNameFilesystemReadFile})
 	registry.Register(&managerStubTool{name: ToolNameFilesystemWriteFile})
 	registry.Register(&managerStubTool{name: ToolNameBash})
+	registry.Register(&managerStubTool{name: ToolNameTodoWrite})
 
 	manager, err := NewManager(registry, mustAllowEngine(t), nil)
 	if err != nil {

--- a/internal/tools/mode_filter.go
+++ b/internal/tools/mode_filter.go
@@ -14,7 +14,8 @@ func isReadOnlyVisibleTool(name string) bool {
 		ToolNameFilesystemGlob,
 		ToolNameWebFetch,
 		ToolNameMemoRecall,
-		ToolNameMemoList:
+		ToolNameMemoList,
+		ToolNameTodoWrite:
 		return true
 	default:
 		return false

--- a/internal/tools/mode_filter.go
+++ b/internal/tools/mode_filter.go
@@ -24,5 +24,9 @@ func isReadOnlyVisibleTool(name string) bool {
 
 // isReadOnlyActionAllowed 判断当前权限动作是否属于只读阶段允许执行的范围。
 func isReadOnlyActionAllowed(action security.Action) bool {
-	return action.Type == security.ActionTypeRead
+	if action.Type == security.ActionTypeRead {
+		return true
+	}
+	return action.Type == security.ActionTypeWrite &&
+		strings.EqualFold(strings.TrimSpace(action.Payload.Operation), ToolNameTodoWrite)
 }

--- a/internal/tools/mode_filter.go
+++ b/internal/tools/mode_filter.go
@@ -14,8 +14,7 @@ func isReadOnlyVisibleTool(name string) bool {
 		ToolNameFilesystemGlob,
 		ToolNameWebFetch,
 		ToolNameMemoRecall,
-		ToolNameMemoList,
-		ToolNameTodoWrite:
+		ToolNameMemoList:
 		return true
 	default:
 		return false


### PR DESCRIPTION

## Summary

本 PR 落地 Phase4 终端诊断可用性改进，重点解决三个问题：

- 自动诊断在全屏终端程序中误触发。
- IDM 模式下 `@ai` 失败后可能卡死、等待提示不及时。
- 手动/自动诊断首响慢、重复诊断消耗高、用户体感较差。

本阶段保持主链路不变：诊断仍通过 `gateway.executeSystemTool(diagnose)`，IDM 仍通过 Gateway 调 Runtime，不新增公共 Gateway RPC schema，也不修改现有诊断超时预算常量。

Closes #532 

## Key Changes

### 1. Phase4 回滚开关

新增 Phase4 相关环境变量开关，方便线上快速回退：

- `NEOCODE_DIAG_ALTSCREEN_GUARD_DISABLED=1`
- `NEOCODE_IDM_PLAN_MODE_DISABLED=1`
- `NEOCODE_DIAG_FAST_RESPONSE_DISABLED=1`
- `NEOCODE_DIAG_CACHE_DISABLED=1`

### 2. 全屏保护

新增备用屏幕状态追踪，识别终端进入/退出全屏程序的控制序列：

- 支持 `CSI ? 1049 h/l`
- 支持 `CSI ? 47 h/l`
- 支持 `CSI ? 1047 h/l`
- 支持分片输入
- 支持 tmux passthrough 场景

自动诊断触发前会检查当前是否处于全屏状态：

- 全屏期间不派发 auto 诊断。
- 刚退出全屏后吞掉一次 pending auto，避免退出瞬间误诊断。
- 之后恢复正常自动诊断。

### 3. IDM 防卡死与 plan 模式接入

IDM `@ai` 请求接入 Runtime `plan` 模式：

- 默认在 `gateway.run` 中传入 `Mode: "plan"`。
- 可通过 `NEOCODE_IDM_PLAN_MODE_DISABLED=1` 回退。
- 保持 plan 模式原有能力，不破坏 `todo_write` 可见性。

修复 IDM 卡死问题：

- 校验 `bind_stream` ACK / ERROR / 非预期帧。
- 校验 `gateway.run` ACK / ERROR / 非预期帧。
- 失败时立即恢复 IDM 状态，不再继续等待不存在的流式事件。
- `agent_done` 无 chunk 时，从 done payload 中兜底提取文本展示。
- `permission_requested` 继续自动 reject，并保持状态清理。
- `Ctrl+C` cancel 行为不回归。

### 4. IDM 流式显示

此前 IDM 虽然收到 gateway 的 `agent_chunk`，但会先缓存，直到 `agent_done` 才统一 Markdown 渲染显示。

本 PR 改为：

- 收到 `agent_chunk` 立即输出到终端。
- 输出时做终端换行规范化，并保持 IDM AI 输出颜色。
- 如果已经流式输出过，`agent_done` 不再重复渲染完整答案。
- 如果没有收到任何 chunk，继续使用完整 Markdown 渲染和 done payload fallback。

这能显著降低 IDM `@ai` 的等待感。

### 5. 诊断响应提速

新增 `diagnosisCoordinator`，用于诊断请求调度与复用：

- 使用脱敏后的命令、退出码、错误日志生成 fingerprint。
- 相同 fingerprint 的 in-flight 诊断会合并，不重复发起。
- 成功诊断结果进入 5 分钟短 TTL 缓存。
- 缓存最多保留 64 条。
- 失败或 transport error 不写入缓存。
- auto 相同 fingerprint 短窗去抖。
- manual 诊断优先，auto 诊断限制并发，避免阻塞手动诊断。

新增快速首响：

- manual 诊断立即输出“正在诊断”。
- auto 诊断仅在命中明确模式时输出低干扰快速预判。
- 快速预判置信度上限固定为 0.55。
- 最终模型诊断结果仍然作为权威结果展示。

## Test Plan

已通过本地验证：

```bash
go test -count=1 ./internal/ptyproxy ./internal/tools ./internal/runtime
```

覆盖重点：

- 全屏期间 auto 诊断不触发。
- 退出全屏后只吞掉一次 pending auto。
- alt-screen 回滚开关有效。
- IDM `bind_stream` / `gateway.run` 异常帧不会卡死。
- IDM `agent_done` payload fallback 可展示。
- IDM chunk 在 `agent_done` 前即可流式显示。
- IDM plan 模式 env 开关有效。
- plan/read-only 下 `todo_write` 保持可见。
- 诊断 fingerprint、in-flight 合并、TTL 缓存、auto 去抖、快速首响行为正确。

## Risk & Rollback

风险主要集中在终端输出体验和诊断调度策略：

- 不同终端/复用器对备用屏幕序列支持可能存在差异。
- IDM 流式输出当前采用纯文本流式显示，最终不再重复 Markdown 渲染，避免重复输出。
- 诊断缓存只保存成功结果，避免错误结果污染后续诊断。

可通过以下环境变量逐项回滚：

```bash
NEOCODE_DIAG_ALTSCREEN_GUARD_DISABLED=1
NEOCODE_IDM_PLAN_MODE_DISABLED=1
NEOCODE_DIAG_FAST_RESPONSE_DISABLED=1
NEOCODE_DIAG_CACHE_DISABLED=1
```
