### PR TITLE
feat: Web 端接入思考流展示，修复 checkpoint/verify/文件变更等核心问题

### DIFF
--- a/internal/runtime/acceptance_service.go
+++ b/internal/runtime/acceptance_service.go
@@ -132,6 +132,15 @@ func (s *acceptanceService) Decide(ctx context.Context, input acceptanceServiceI
 	if output.Status == acceptance.AcceptanceContinue && output.ContinueHint == "" {
 		output.ContinueHint = finalContinueReminder
 	}
+	// 死循环兜底：多轮 final 被拦截且无进展 + 存在 open required todo → 追加强制清理指令
+	if output.Status == acceptance.AcceptanceContinue && input.NoProgressStreak >= 2 && input.Todos.Summary.RequiredOpen > 0 {
+		staleHint := buildStaleTodoResetHint(input.Todos.Summary.RequiredOpen, input.NoProgressStreak)
+		if output.ContinueHint == "" {
+			output.ContinueHint = staleHint
+		} else {
+			output.ContinueHint = output.ContinueHint + "\n\n" + staleHint
+		}
+	}
 	if input.VerificationInput.RuntimeState.MaxTurnsReached && output.Status == acceptance.AcceptanceContinue {
 		output.Status = acceptance.AcceptanceIncomplete
 		if output.StopReason == controlplane.StopReasonVerificationFailed {
@@ -290,6 +299,19 @@ func latestToolErrorClass(errors []runtimefacts.ToolErrorFact, tool string) stri
 		}
 	}
 	return ""
+}
+
+// buildStaleTodoResetHint 构造死循环兜底指令：当多轮 final 被拦截且无进展时，强制要求模型清理 stale todo。
+func buildStaleTodoResetHint(requiredOpen, noProgressStreak int) string {
+	var b strings.Builder
+	b.WriteString("<stale_todo_reset>\n")
+	b.WriteString(fmt.Sprintf("CRITICAL: You have been blocked for %d consecutive final attempts with %d unfinished required todo(s).\n", noProgressStreak, requiredOpen))
+	b.WriteString("If these todos are NO LONGER RELEVANT to the user's CURRENT request,\n")
+	b.WriteString("you MUST mark them canceled using todo_write set_status=canceled RIGHT NOW.\n")
+	b.WriteString("Do NOT attempt to complete stale todos that belong to a PREVIOUS task.\n")
+	b.WriteString("After canceling irrelevant todos, proceed with the user's current request.\n")
+	b.WriteString("</stale_todo_reset>")
+	return b.String()
 }
 
 func firstNonPassVerifierResult(results []verify.VerificationResult) *verify.VerificationResult {

--- a/internal/runtime/acceptance_service.go
+++ b/internal/runtime/acceptance_service.go
@@ -108,6 +108,18 @@ func (s *acceptanceService) Decide(ctx context.Context, input acceptanceServiceI
 		return output, nil
 	}
 
+	// verification gate 全部通过时信任其结果：即使 decider 基于启发式返回 continue，
+	// verification gate 已实际运行所有 profile 指定的 verifier 且全部 pass，应直接 accepted。
+	// 避免 decider 与 verification gate 数据源不一致导致死循环。
+	if input.CompletionPassed && verificationGate.Passed {
+		output.Status = acceptance.AcceptanceAccepted
+		output.StopReason = controlplane.StopReasonAccepted
+		output.ContinueHint = ""
+		output.CompletionPassed = true
+		output.VerificationPassed = true
+		return output, nil
+	}
+
 	if input.CompletionPassed && !verificationGate.Passed {
 		return mergeVerificationFailure(output, verificationGate), nil
 	}

--- a/internal/runtime/checkpoint_restore.go
+++ b/internal/runtime/checkpoint_restore.go
@@ -27,40 +27,39 @@ type RestoreResult struct {
 	Conflict     *checkpoint.ConflictResult `json:"conflict,omitempty"`
 }
 
-// RestoreCheckpoint 恢复指定 checkpoint 的会话和工作区状态。
-// per-edit 后端只还原本快照覆盖的文件，不会破坏 agent 未触碰的文件，因此不再做冲突检测。
-// input.Force 字段保留以维持网关 API 契约。
-func (s *Service) RestoreCheckpoint(ctx context.Context, input GatewayRestoreInput) (RestoreResult, error) {
+// restoreCheckpointCore 执行 checkpoint 恢复的核心逻辑，不发出任何事件。
+// 调用方负责在合适的时机发出 checkpoint_restored / checkpoint_undo_restore 事件。
+func (s *Service) restoreCheckpointCore(ctx context.Context, sessionID, checkpointID string) (RestoreResult, agentsession.CheckpointRecord, error) {
 	if s.checkpointStore == nil || s.perEditStore == nil {
-		return RestoreResult{}, fmt.Errorf("checkpoint: store not available")
+		return RestoreResult{}, agentsession.CheckpointRecord{}, fmt.Errorf("checkpoint: store not available")
 	}
 
-	sessionID := strings.TrimSpace(input.SessionID)
-	checkpointID := strings.TrimSpace(input.CheckpointID)
+	sessionID = strings.TrimSpace(sessionID)
+	checkpointID = strings.TrimSpace(checkpointID)
 	if sessionID == "" || checkpointID == "" {
-		return RestoreResult{}, fmt.Errorf("checkpoint: session_id and checkpoint_id required")
+		return RestoreResult{}, agentsession.CheckpointRecord{}, fmt.Errorf("checkpoint: session_id and checkpoint_id required")
 	}
 
 	// 1. Load checkpoint record
 	record, sessionCP, err := s.checkpointStore.GetCheckpoint(ctx, checkpointID)
 	if err != nil {
-		return RestoreResult{}, err
+		return RestoreResult{}, agentsession.CheckpointRecord{}, err
 	}
 	if record.SessionID != sessionID {
-		return RestoreResult{}, fmt.Errorf("checkpoint: session mismatch")
+		return RestoreResult{}, agentsession.CheckpointRecord{}, fmt.Errorf("checkpoint: session mismatch")
 	}
 	if record.Status != agentsession.CheckpointStatusAvailable {
-		return RestoreResult{}, fmt.Errorf("checkpoint: status is %s, expected available", record.Status)
+		return RestoreResult{}, agentsession.CheckpointRecord{}, fmt.Errorf("checkpoint: status is %s, expected available", record.Status)
 	}
 	if !record.Restorable {
-		return RestoreResult{}, fmt.Errorf("checkpoint: not restorable")
+		return RestoreResult{}, agentsession.CheckpointRecord{}, fmt.Errorf("checkpoint: not restorable")
 	}
 
 	// 2. Pre-restore guard checkpoint：把当前 pending 固化为 guard cp，以便 undo 回到 restore 之前。
 	guardID := agentsession.NewID("checkpoint")
 	guardWritten, finalizeErr := s.perEditStore.Finalize(guardID)
 	if finalizeErr != nil {
-		return RestoreResult{}, fmt.Errorf("checkpoint: finalize guard: %w", finalizeErr)
+		return RestoreResult{}, agentsession.CheckpointRecord{}, fmt.Errorf("checkpoint: finalize guard: %w", finalizeErr)
 	}
 	if guardWritten {
 		s.perEditStore.Reset()
@@ -70,7 +69,7 @@ func (s *Service) RestoreCheckpoint(ctx context.Context, input GatewayRestoreInp
 		if guardWritten {
 			_ = s.perEditStore.DeleteCheckpoint(guardID)
 		}
-		return RestoreResult{}, fmt.Errorf("checkpoint: create guard: %w", guardErr)
+		return RestoreResult{}, agentsession.CheckpointRecord{}, fmt.Errorf("checkpoint: create guard: %w", guardErr)
 	}
 
 	// 3. Restore code via per-edit store（不在 cp.FileVersions 中的文件保持不变）。
@@ -82,11 +81,11 @@ func (s *Service) RestoreCheckpoint(ctx context.Context, input GatewayRestoreInp
 		if perEditID != "" {
 			if isGuardRestore {
 				if err := s.perEditStore.RestoreExact(ctx, perEditID); err != nil {
-					return RestoreResult{}, fmt.Errorf("checkpoint: restore code: %w", err)
+					return RestoreResult{}, agentsession.CheckpointRecord{}, fmt.Errorf("checkpoint: restore code: %w", err)
 				}
 			} else {
 				if err := s.perEditStore.Restore(ctx, perEditID); err != nil {
-					return RestoreResult{}, fmt.Errorf("checkpoint: restore code: %w", err)
+					return RestoreResult{}, agentsession.CheckpointRecord{}, fmt.Errorf("checkpoint: restore code: %w", err)
 				}
 			}
 		}
@@ -94,15 +93,15 @@ func (s *Service) RestoreCheckpoint(ctx context.Context, input GatewayRestoreInp
 
 	// 4. Unmarshal session checkpoint
 	if sessionCP == nil {
-		return RestoreResult{}, fmt.Errorf("checkpoint: no session checkpoint data")
+		return RestoreResult{}, agentsession.CheckpointRecord{}, fmt.Errorf("checkpoint: no session checkpoint data")
 	}
 	var head agentsession.SessionHead
 	if err := json.Unmarshal([]byte(sessionCP.HeadJSON), &head); err != nil {
-		return RestoreResult{}, fmt.Errorf("checkpoint: unmarshal head: %w", err)
+		return RestoreResult{}, agentsession.CheckpointRecord{}, fmt.Errorf("checkpoint: unmarshal head: %w", err)
 	}
 	var messages []providertypes.Message
 	if err := json.Unmarshal([]byte(sessionCP.MessagesJSON), &messages); err != nil {
-		return RestoreResult{}, fmt.Errorf("checkpoint: unmarshal messages: %w", err)
+		return RestoreResult{}, agentsession.CheckpointRecord{}, fmt.Errorf("checkpoint: unmarshal messages: %w", err)
 	}
 
 	// 5. Determine checkpoint IDs to mark
@@ -127,21 +126,31 @@ func (s *Service) RestoreCheckpoint(ctx context.Context, input GatewayRestoreInp
 		MarkRestoredIDs:  markRestoredIDs,
 	}
 	if err := s.checkpointStore.RestoreCheckpoint(ctx, restoreInput); err != nil {
-		return RestoreResult{}, fmt.Errorf("checkpoint: restore: %w", err)
+		return RestoreResult{}, agentsession.CheckpointRecord{}, fmt.Errorf("checkpoint: restore: %w", err)
 	}
 
 	// 7. Update runtime session if it's the current session
 	s.updateRuntimeSessionAfterRestore(sessionID, head, messages)
 
-	s.emitRunScoped(ctx, EventCheckpointRestored, nil, CheckpointRestoredPayload{
-		CheckpointID:      checkpointID,
-		SessionID:         sessionID,
-		GuardCheckpointID: guardRecord.CheckpointID,
-	})
 	return RestoreResult{
 		CheckpointID: checkpointID,
 		SessionID:    sessionID,
-	}, nil
+	}, guardRecord, nil
+}
+
+// RestoreCheckpoint 恢复指定 checkpoint 的会话和工作区状态，并发出 checkpoint_restored 事件。
+func (s *Service) RestoreCheckpoint(ctx context.Context, input GatewayRestoreInput) (RestoreResult, error) {
+	result, guardRecord, err := s.restoreCheckpointCore(ctx, input.SessionID, input.CheckpointID)
+	if err != nil {
+		return RestoreResult{}, err
+	}
+
+	_ = s.emit(ctx, EventCheckpointRestored, "", result.SessionID, CheckpointRestoredPayload{
+		CheckpointID:      result.CheckpointID,
+		SessionID:         result.SessionID,
+		GuardCheckpointID: guardRecord.CheckpointID,
+	})
+	return result, nil
 }
 
 // UndoRestoreCheckpoint 撤销最近一次 restore，通过 pre_restore_guard 恢复到 restore 前的状态。
@@ -174,16 +183,12 @@ func (s *Service) UndoRestoreCheckpoint(ctx context.Context, sessionID string) (
 		return RestoreResult{}, fmt.Errorf("checkpoint: no guard checkpoint found for undo")
 	}
 
-	result, err := s.RestoreCheckpoint(ctx, GatewayRestoreInput{
-		SessionID:    sessionID,
-		CheckpointID: guardRecord.CheckpointID,
-		Force:        true,
-	})
+	result, _, err := s.restoreCheckpointCore(ctx, sessionID, guardRecord.CheckpointID)
 	if err != nil {
 		return RestoreResult{}, fmt.Errorf("checkpoint: undo restore: %w", err)
 	}
 
-	s.emitRunScoped(ctx, EventCheckpointUndoRestore, nil, CheckpointUndoRestorePayload{
+	_ = s.emit(ctx, EventCheckpointUndoRestore, "", sessionID, CheckpointUndoRestorePayload{
 		GuardCheckpointID: guardRecord.CheckpointID,
 		SessionID:         sessionID,
 	})
@@ -242,7 +247,7 @@ func (s *Service) createGuardCheckpoint(ctx context.Context, sessionID, runID, g
 		return agentsession.CheckpointRecord{}, err
 	}
 
-	s.emitRunScoped(ctx, EventCheckpointCreated, nil, CheckpointCreatedPayload{
+	_ = s.emit(ctx, EventCheckpointCreated, "", sessionID, CheckpointCreatedPayload{
 		CheckpointID:         saved.CheckpointID,
 		CodeCheckpointRef:    saved.CodeCheckpointRef,
 		SessionCheckpointRef: saved.SessionCheckpointRef,

--- a/internal/runtime/provider_stream.go
+++ b/internal/runtime/provider_stream.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"neo-code/internal/provider"
@@ -80,6 +81,18 @@ func generateStreamingMessage(
 		outcome.err = err
 		return outcome
 	}
+
+	// 将累积的 thinking 文本写入 ThinkingMetadata，以备续轮回传给 provider。
+	if thinking := acc.ThinkingContent(); thinking != "" {
+		storeThinkingMetadata(&message, thinking)
+	}
+
 	outcome.message = message
 	return outcome
+}
+
+// storeThinkingMetadata 将 thinking 文本存入消息的 ThinkingMetadata 以备续轮使用。
+func storeThinkingMetadata(msg *providertypes.Message, thinking string) {
+	meta, _ := json.Marshal(map[string]string{"reasoning_content": thinking})
+	msg.ThinkingMetadata = json.RawMessage(meta)
 }

--- a/internal/runtime/run.go
+++ b/internal/runtime/run.go
@@ -576,7 +576,7 @@ func (s *Service) prepareTurnBudgetSnapshot(ctx context.Context, state *runState
 	}
 	toolSpecs = prioritizeToolSpecsBySkillHints(toolSpecs, activeSkills)
 
-	resolvedProvider, err := config.ResolveSelectedProvider(cfg)
+	resolvedProvider, model, err := resolveCompactProviderSelection(state.session, cfg)
 	if err != nil {
 		return TurnBudgetSnapshot{}, false, err
 	}
@@ -596,7 +596,6 @@ func (s *Service) prepareTurnBudgetSnapshot(ctx context.Context, state *runState
 		systemPrompt = mergeEphemeralHookNotificationIntoSystemPrompt(systemPrompt, notificationHint)
 	}
 	promptBudget, budgetSource, contextWindow := s.resolvePromptBudget(ctx, cfg)
-	model := strings.TrimSpace(cfg.CurrentModel)
 	requestMessages := append([]providertypes.Message(nil), builtContext.Messages...)
 	thinkingCfg, thinkingErr := resolveThinkingConfig(
 		modelCapabilityHintsForRequest(model, resolvedProvider.Models),

--- a/internal/runtime/streaming/accumulator.go
+++ b/internal/runtime/streaming/accumulator.go
@@ -11,6 +11,7 @@ import (
 // Accumulator 负责按 provider 流式事件累积 assistant 文本与工具调用。
 type Accumulator struct {
 	content     strings.Builder
+	thinking    strings.Builder
 	toolCalls   map[int]*providertypes.ToolCall
 	messageDone bool
 }
@@ -65,6 +66,22 @@ func (a *Accumulator) AccumulateText(text string) {
 		return
 	}
 	a.content.WriteString(text)
+}
+
+// AccumulateThinking 负责累积 thinking/reasoning 文本增量（不混入 assistant 正文）。
+func (a *Accumulator) AccumulateThinking(text string) {
+	if a == nil {
+		return
+	}
+	a.thinking.WriteString(text)
+}
+
+// ThinkingContent 返回累积的 thinking 文本。
+func (a *Accumulator) ThinkingContent() string {
+	if a == nil {
+		return ""
+	}
+	return a.thinking.String()
 }
 
 // ensureToolCall 返回指定索引的工具调用占位对象。

--- a/internal/runtime/streaming/handler.go
+++ b/internal/runtime/streaming/handler.go
@@ -55,7 +55,10 @@ func HandleEvent(event providertypes.StreamEvent, acc *Accumulator, hooks Hooks)
 		if hooks.OnThinkingDelta != nil {
 			hooks.OnThinkingDelta(payload.Text)
 		}
-		// thinking 不进入 accumulator（不混入 assistant 正文）
+		// thinking 独立累积（不混入 assistant 正文），后续写入 ThinkingMetadata
+		if acc != nil {
+			acc.AccumulateThinking(payload.Text)
+		}
 	case providertypes.StreamEventMessageDone:
 		payload, err := event.MessageDoneValue()
 		if err != nil {

--- a/internal/runtime/todo_run_boundary.go
+++ b/internal/runtime/todo_run_boundary.go
@@ -40,9 +40,9 @@ func (s *Service) resetTodosForUserRun(ctx context.Context, state *runState) err
 	return nil
 }
 
-// shouldResetTodosForUserRun 判断本轮用户输入是否应开启新的 Todo 边界，续做类输入保留旧 Todo。
-// 识别策略：去掉尾部标点 → 中文用前缀匹配，英文用单词边界匹配，覆盖
-// "继续修这个" / "continue with X" / "接着做" / "继续。" / "Continue!" / "keep going" 等常见变体。
+// shouldResetTodosForUserRun 判断本轮用户输入是否应开启新的 Todo 边界。
+// 策略：默认保留旧 Todo，由 prompt 层 stale_todo_reminder 引导模型自行清理；
+// 仅当用户输入极少且明确的"全新任务"表达时，才主动清空，避免硬编码过度覆盖。
 func shouldResetTodosForUserRun(userGoal string) bool {
 	goal := strings.ToLower(strings.TrimSpace(userGoal))
 	if goal == "" {
@@ -52,26 +52,24 @@ func shouldResetTodosForUserRun(userGoal string) bool {
 	if goal == "" {
 		return false
 	}
-	if isContinuationIntent(goal) {
-		return false
-	}
-	return true
+	return isExplicitNewTaskIntent(goal)
 }
 
-// continuationChinesePrefixes 中文续做关键词，落到 strings.HasPrefix 直接匹配。
-var continuationChinesePrefixes = []string{"继续", "接着", "续做", "再继续", "再来"}
+// newTaskChineseKeywords 中文明确新任务关键词，仅含完全无歧义的表达。
+var newTaskChineseKeywords = []string{"新任务", "换个任务", "换任务", "新需求"}
 
-// continuationEnglishPrefixes 英文续做关键词，要求精确匹配或后跟空格（避免 "keep it simple" 误命中）。
-var continuationEnglishPrefixes = []string{"continue", "keep going", "keep doing", "go on", "resume", "carry on"}
+// newTaskEnglishKeywords 英文明确新任务关键词，仅含完全无歧义的表达。
+var newTaskEnglishKeywords = []string{"new task", "different task", "switch task"}
 
-// isContinuationIntent 判断标准化后的 goal 是否含续做意图。
-func isContinuationIntent(goal string) bool {
-	for _, kw := range continuationChinesePrefixes {
-		if strings.HasPrefix(goal, kw) {
+// isExplicitNewTaskIntent 判断标准化后的 goal 是否含明确的新任务意图。
+// 默认返回 false，仅匹配极少且高度精确的关键词。
+func isExplicitNewTaskIntent(goal string) bool {
+	for _, kw := range newTaskChineseKeywords {
+		if strings.Contains(goal, kw) {
 			return true
 		}
 	}
-	for _, kw := range continuationEnglishPrefixes {
+	for _, kw := range newTaskEnglishKeywords {
 		if goal == kw {
 			return true
 		}

--- a/internal/runtime/todo_run_boundary_test.go
+++ b/internal/runtime/todo_run_boundary_test.go
@@ -26,7 +26,7 @@ func TestResetTodosForUserRunClearsSessionAndEmitsEmptySnapshot(t *testing.T) {
 
 	service := &Service{sessionStore: store, events: make(chan RuntimeEvent, 8)}
 	state := newRunState("run-boundary", created)
-	state.userGoal = "改做另一个任务"
+	state.userGoal = "新任务"
 	if err := service.resetTodosForUserRun(context.Background(), &state); err != nil {
 		t.Fatalf("resetTodosForUserRun() error = %v", err)
 	}
@@ -92,7 +92,7 @@ func TestResetTodosForUserRunKeepsTodosForContinuePrompt(t *testing.T) {
 	}
 }
 
-func TestShouldResetTodosForUserRunContinueVariants(t *testing.T) {
+func TestShouldResetTodosForUserRunBoundaryVariants(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -100,34 +100,36 @@ func TestShouldResetTodosForUserRunContinueVariants(t *testing.T) {
 		goal      string
 		wantReset bool
 	}{
-		// 续做语义 → 应保留旧 todo
+		// 空输入 → 保留
 		{"empty", "", false},
-		{"chinese exact", "继续", false},
-		{"chinese with content", "继续修这个", false},
-		{"chinese with punctuation", "继续。", false},
-		{"chinese alt prefix 接着", "接着做", false},
-		{"chinese alt prefix 续做", "续做完未做的", false},
-		{"chinese alt prefix 再继续", "再继续完善", false},
-		{"chinese alt prefix 再来", "再来一次", false},
-		{"english exact lowercase", "continue", false},
-		{"english with content", "continue with the failing test", false},
-		{"english punctuation", "Continue!", false},
-		{"english keep going", "keep going", false},
-		{"english keep going with content", "keep going on the bug fix", false},
-		{"english keep doing", "keep doing it", false},
-		{"english go on", "go on please", false},
-		{"english resume", "resume task", false},
-		{"english carry on", "carry on with the migration", false},
-		{"trailing chinese punctuation", "继续，", false},
-		{"trailing question mark", "go on?", false},
 
-		// 新指令 → 应清空旧 todo
-		{"new task chinese", "修复登录 bug", true},
-		{"start over", "重新开始项目", true},
-		{"keep without going", "keep it simple please", true},
-		{"continueworking no boundary", "continueworking", true},
-		{"new task english", "implement search api", true},
-		{"explore", "开始下一个任务", true},
+		// 明确新任务 → 清空
+		{"chinese exact 新任务", "新任务", true},
+		{"chinese 帮我做个新任务", "帮我做个新任务", true},
+		{"chinese 换个任务", "换个任务", true},
+		{"chinese 新需求", "新需求", true},
+		{"english exact new task", "new task", true},
+		{"english 新任务", "new task please", true},
+		{"english switch task", "switch task", true},
+		{"english different task", "different task", true},
+
+		// 默认保留：绝大多数输入不再被硬编码清空，交给 prompt 引导模型自行处理
+		{"chinese 继续", "继续", false},
+		{"chinese 继续修这个", "继续修这个", false},
+		{"chinese 接着做", "接着做", false},
+		{"chinese 刚才的代码还有问题", "刚才的代码还有问题", false},
+		{"chinese 再优化一下", "再优化一下", false},
+		{"chinese 补充测试用例", "补充测试用例", false},
+		{"chinese 修复登录bug", "修复登录 bug", false},
+		{"chinese 开始下一个任务", "开始下一个任务", false},
+		{"chinese 重新实现", "重新实现", false},
+		{"english continue", "continue", false},
+		{"english continue with the failing test", "continue with the failing test", false},
+		{"english implement search api", "implement search api", false},
+		{"english keep going", "keep going", false},
+		{"english keep it simple", "keep it simple please", false},
+		{"english resume", "resume task", false},
+		{"english go on", "go on please", false},
 	}
 
 	for _, tc := range cases {

--- a/internal/runtime/turn_control.go
+++ b/internal/runtime/turn_control.go
@@ -30,6 +30,11 @@ func collectCompletionState(
 	if current.TodoOnlyTaskCandidate && current.TodoStateSatisfied {
 		current.HasPendingAgentTodos = false
 	}
+	// 当存在 required TODO 且全部已终态时，清除 unverified writes 标记。
+	// required TODO 全部收敛本身就证明工作已完成，无需额外 verification tool 调用。
+	if !current.HasPendingAgentTodos && hasCompletedRequiredTodos(state.session.Todos) {
+		current.HasUnverifiedWrites = false
+	}
 	return current
 }
 
@@ -223,6 +228,21 @@ func hasPendingAgentTodos(items []agentsession.TodoItem) bool {
 		return true
 	}
 	return false
+}
+
+// hasCompletedRequiredTodos 判断是否存在至少一个 required TODO 且全部已终态。
+func hasCompletedRequiredTodos(items []agentsession.TodoItem) bool {
+	hasRequired := false
+	for _, item := range items {
+		if !item.RequiredValue() {
+			continue
+		}
+		hasRequired = true
+		if !item.Status.IsTerminal() {
+			return false
+		}
+	}
+	return hasRequired
 }
 
 // hasSuccessfulInformationalResult 判断本轮是否至少获得一个成功的非写入工具结果。

--- a/web/electron-builder.config.cjs
+++ b/web/electron-builder.config.cjs
@@ -35,11 +35,11 @@ const config = {
 		perMachine: false,
 		allowToChangeInstallationDirectory: true,
 		deleteAppDataOnUninstall: false,
-		artifactName: '${productName}-${version}-Setup.${ext}',
+		artifactName: 'neocode_${version}_Windows_${arch}_Setup.${ext}',
 		language: '2052',
 	},
 	portable: {
-		artifactName: '${productName}-${version}-Portable.${ext}',
+		artifactName: 'neocode_${version}_Windows_${arch}_Portable.${ext}',
 	},
 	mac: {
 		target: [
@@ -48,7 +48,7 @@ const config = {
 				arch: ['x64', 'arm64'],
 			},
 		],
-		artifactName: '${productName}-${version}-${arch}.${ext}',
+		artifactName: 'neocode_${version}_Darwin_${arch}.${ext}',
 	},
 	linux: {
 		target: [
@@ -57,7 +57,7 @@ const config = {
 				arch: ['x64'],
 			},
 		],
-		artifactName: '${productName}-${version}.${ext}',
+		artifactName: 'neocode_${version}_Linux_${arch}.${ext}',
 	},
 	publish: {
 		provider: 'github',

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
     "dev": "vite",
     "dev:electron": "node scripts/clean-electron.js && node scripts/build-gateway.js && vite --mode electron",
     "build": "tsc -b && vite build",
-    "build:electron": "node scripts/clean-electron.js && node scripts/build-gateway.js && vite build --mode electron && node scripts/verify-electron-preload.js && electron-builder --config electron-builder.config.cjs",
+    "build:electron": "node scripts/clean-electron.js && vite build --mode electron && node scripts/build-gateway.js && node scripts/verify-electron-preload.js && electron-builder --config electron-builder.config.cjs",
     "preview": "vite preview",
     "test": "vitest run",
     "test:ui": "vitest --ui",

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
     "dev": "vite",
     "dev:electron": "node scripts/clean-electron.js && node scripts/build-gateway.js && vite --mode electron",
     "build": "tsc -b && vite build",
-    "build:electron": "node scripts/clean-electron.js && vite build --mode electron && node scripts/build-gateway.js && node scripts/verify-electron-preload.js && electron-builder --config electron-builder.config.cjs",
+    "build:electron": "node scripts/clean-electron.js && node scripts/build-gateway.js && vite build --mode electron && node scripts/verify-electron-preload.js && electron-builder --config electron-builder.config.cjs",
     "preview": "vite preview",
     "test": "vitest run",
     "test:ui": "vitest --ui",

--- a/web/src/api/protocol.ts
+++ b/web/src/api/protocol.ts
@@ -78,6 +78,7 @@ export const EventType = {
   ToolDiff: 'tool_diff',
   ToolChunk: 'tool_chunk',
   ToolCallThinking: 'tool_call_thinking',
+  ThinkingDelta: 'thinking_delta',
   RunCanceled: 'run_canceled',
   Error: 'error',
   PermissionRequested: 'permission_requested',

--- a/web/src/components/chat/CheckpointInlineMark.tsx
+++ b/web/src/components/chat/CheckpointInlineMark.tsx
@@ -1,34 +1,30 @@
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useGatewayAPI } from '@/context/RuntimeProvider'
-import { Undo2, Loader2 } from 'lucide-react'
+import { useRuntimeInsightStore } from '@/stores/useRuntimeInsightStore'
+import { parseUnifiedPatch } from '@/utils/patchParser'
+import { Undo2, Redo2, Loader2, Eye } from 'lucide-react'
 
 interface CheckpointInlineMarkProps {
   checkpointId: string
   status?: 'available' | 'restoring' | 'restored'
 }
 
-/** ToolCallCard 内的 checkpoint 微标识 —— 点击撤回 */
 export default function CheckpointInlineMark({ checkpointId, status = 'available' }: CheckpointInlineMarkProps) {
   const gatewayAPI = useGatewayAPI()
   const sessionId = useSessionStore((s) => s.currentSessionId)
   const [localStatus, setLocalStatus] = useState(status)
+  const [showDiff, setShowDiff] = useState(false)
+
+  useEffect(() => { setLocalStatus(status) }, [status])
 
   if (localStatus === 'restored') {
     return (
-      <span style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: 3,
-        padding: '1px 5px',
-        borderRadius: 'var(--radius-sm)',
-        background: 'var(--bg-tertiary)',
-        color: 'var(--text-tertiary)',
-        fontSize: 10,
-        fontFamily: 'var(--font-mono)',
-        cursor: 'default',
-      }}>
-        cp_{checkpointId.slice(0, 6)} · 已撤回
+      <span style={styles.wrapper}>
+        <button style={{ ...styles.badge, ...styles.restoredBadge }} onClick={handleUndoRestore} title="撤销恢复">
+          <span>cp_{checkpointId.slice(0, 6)} · 已撤回</span>
+          <Redo2 size={10} />
+        </button>
       </span>
     )
   }
@@ -41,44 +37,245 @@ export default function CheckpointInlineMark({ checkpointId, status = 'available
     if (!ok) return
     setLocalStatus('restoring')
     try {
-      await gatewayAPI.restoreCheckpoint({
-        session_id: sessionId,
-        checkpoint_id: checkpointId,
-      })
+      await gatewayAPI.restoreCheckpoint({ session_id: sessionId, checkpoint_id: checkpointId })
       setLocalStatus('restored')
     } catch {
       setLocalStatus('available')
     }
   }
 
+  async function handleUndoRestore() {
+    if (!gatewayAPI || !sessionId) return
+    const ok = window.confirm('Undo the last restore? This will bring back the reverted state.')
+    if (!ok) return
+    try {
+      await gatewayAPI.undoRestore(sessionId)
+    } catch { /* event will sync state */ }
+  }
+
+  async function handleToggleDiff() {
+    if (showDiff) { setShowDiff(false); return }
+    if (!gatewayAPI || !sessionId) return
+    const insightStore = useRuntimeInsightStore.getState()
+    insightStore.setCheckpointDiff(null)
+    setShowDiff(true)
+    try {
+      const result = await gatewayAPI.checkpointDiff({
+        session_id: sessionId,
+        checkpoint_id: checkpointId,
+      })
+      if (result?.payload) insightStore.setCheckpointDiff(result.payload)
+    } catch {
+      setShowDiff(false)
+    }
+  }
+
   const isRestoring = localStatus === 'restoring'
 
   return (
-    <button
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: 3,
-        padding: '1px 5px',
-        borderRadius: 'var(--radius-sm)',
-        background: 'var(--bg-tertiary)',
-        color: 'var(--text-secondary)',
-        fontSize: 10,
-        fontFamily: 'var(--font-mono)',
-        border: 'none',
-        cursor: isRestoring ? 'default' : 'pointer',
-        transition: 'all 0.15s',
-      }}
-      onClick={handleRestore}
-      disabled={isRestoring}
-      title="撤回到此 checkpoint"
-    >
-      <span>cp_{checkpointId.slice(0, 6)}</span>
-      {isRestoring ? (
-        <Loader2 size={10} className="animate-spin" style={{ opacity: 0.7 }} />
-      ) : (
-        <Undo2 size={10} />
-      )}
-    </button>
+    <span style={styles.wrapper}>
+      <button
+        style={styles.badge}
+        onClick={handleRestore}
+        disabled={isRestoring}
+        title="撤回到此 checkpoint"
+      >
+        <span>cp_{checkpointId.slice(0, 6)}</span>
+        {isRestoring ? (
+          <Loader2 size={10} className="animate-spin" style={{ opacity: 0.7 }} />
+        ) : (
+          <Undo2 size={10} />
+        )}
+      </button>
+      <button style={styles.diffBtn} onClick={handleToggleDiff} title="查看差异">
+        <Eye size={10} />
+      </button>
+      {showDiff && <CheckpointDiffPopover onClose={() => setShowDiff(false)} />}
+    </span>
   )
+}
+
+function CheckpointDiffPopover({ onClose }: { onClose: () => void }) {
+  const diff = useRuntimeInsightStore((s) => s.checkpointDiff)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose()
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [onClose])
+
+  const fileDiffs = diff?.patch ? parseUnifiedPatch(diff.patch) : {}
+
+  return (
+    <div ref={ref} style={styles.popover}>
+      <div style={styles.popoverHeader}>
+        <span style={styles.popoverTitle}>
+          {diff ? `Changes (${(diff.files?.added?.length ?? 0) + (diff.files?.modified?.length ?? 0) + (diff.files?.deleted?.length ?? 0)} files)` : 'Loading...'}
+        </span>
+        <button style={styles.popoverClose} onClick={onClose}>x</button>
+      </div>
+      {!diff ? (
+        <div style={styles.popoverLoading}><Loader2 size={14} className="animate-spin" /></div>
+      ) : Object.keys(fileDiffs).length === 0 ? (
+        <div style={styles.popoverEmpty}>No file changes</div>
+      ) : (
+        <div style={styles.popoverBody}>
+          {Object.entries(fileDiffs).map(([path, fd]) => (
+            <div key={path}>
+              <div style={styles.diffFileName}>{path}
+                <span style={styles.diffStats}>
+                  <span style={{ color: 'var(--success)' }}>+{fd.additions}</span>
+                  <span style={{ color: 'var(--error)' }}>-{fd.deletions}</span>
+                </span>
+              </div>
+              <div style={styles.diffBlock}>
+                {fd.lines.map((line, i) => {
+                  const ls = line.type === 'add'
+                    ? { color: '#86efac', background: 'rgba(22,163,74,0.08)' }
+                    : line.type === 'del'
+                    ? { color: '#fca5a5', background: 'rgba(220,38,38,0.08)' }
+                    : { color: 'var(--accent-hover)' }
+                  const prefix = line.type === 'add' ? '+' : line.type === 'del' ? '-' : ''
+                  return (
+                    <div key={i} style={{ ...styles.diffLine, ...ls }}>
+                      <span style={styles.diffPrefix}>{prefix}</span>
+                      <span>{line.content}</span>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  wrapper: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 2,
+    position: 'relative',
+  },
+  badge: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 3,
+    padding: '1px 5px',
+    borderRadius: 'var(--radius-sm)',
+    background: 'var(--bg-tertiary)',
+    color: 'var(--text-secondary)',
+    fontSize: 10,
+    fontFamily: 'var(--font-mono)',
+    border: 'none',
+    cursor: 'pointer',
+    transition: 'all 0.15s',
+  },
+  restoredBadge: {
+    color: 'var(--text-tertiary)',
+    cursor: 'pointer',
+  },
+  diffBtn: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 16,
+    height: 16,
+    padding: 0,
+    borderRadius: 'var(--radius-sm)',
+    background: 'transparent',
+    color: 'var(--text-tertiary)',
+    border: 'none',
+    cursor: 'pointer',
+    transition: 'color 0.15s',
+  },
+  popover: {
+    position: 'absolute',
+    top: '100%',
+    right: 0,
+    marginTop: 4,
+    width: 380,
+    maxHeight: 400,
+    background: 'var(--bg-secondary)',
+    border: '1px solid var(--border-primary)',
+    borderRadius: 'var(--radius-md)',
+    boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
+    zIndex: 100,
+    overflow: 'hidden',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  popoverHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '6px 10px',
+    borderBottom: '1px solid var(--border-primary)',
+    fontSize: 11,
+    color: 'var(--text-secondary)',
+  },
+  popoverTitle: { fontWeight: 600 },
+  popoverClose: {
+    background: 'none',
+    border: 'none',
+    color: 'var(--text-tertiary)',
+    cursor: 'pointer',
+    fontSize: 12,
+    padding: '0 2px',
+  },
+  popoverLoading: {
+    padding: 20,
+    display: 'flex',
+    justifyContent: 'center',
+    color: 'var(--text-tertiary)',
+  },
+  popoverEmpty: {
+    padding: 16,
+    textAlign: 'center',
+    color: 'var(--text-tertiary)',
+    fontSize: 11,
+  },
+  popoverBody: {
+    overflowY: 'auto',
+    flex: 1,
+  },
+  diffFileName: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '4px 10px',
+    fontFamily: 'var(--font-mono)',
+    fontSize: 10,
+    color: 'var(--text-primary)',
+    background: 'var(--bg-tertiary)',
+  },
+  diffStats: {
+    display: 'inline-flex',
+    gap: 6,
+    fontFamily: 'var(--font-mono)',
+    fontSize: 10,
+  },
+  diffBlock: {
+    background: 'var(--code-bg)',
+    padding: '4px 0',
+  },
+  diffLine: {
+    display: 'flex',
+    minWidth: 'max-content',
+    padding: '1px 10px',
+    fontFamily: 'var(--font-mono)',
+    fontSize: 10,
+    lineHeight: 1.5,
+    whiteSpace: 'pre',
+  },
+  diffPrefix: {
+    width: 14,
+    flexShrink: 0,
+    color: 'var(--text-tertiary)',
+  },
 }

--- a/web/src/components/chat/CodeBlock.tsx
+++ b/web/src/components/chat/CodeBlock.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { memo, useState } from 'react'
 import { Copy, Check, Download, FileText } from 'lucide-react'
 
 const langColors: Record<string, string> = {
@@ -26,7 +26,7 @@ interface CodeBlockProps {
  * - inline:无 filename,叙述性代码,极简样式;hover 出现复制按钮。
  * - file:显式文件代码,保留 header(图标 + 文件名 + 语言徽章 + 复制/下载)与行号。footer 已下线。
  */
-export default function CodeBlock({ code, language = 'text', filename }: CodeBlockProps) {
+function CodeBlock({ code, language = 'text', filename }: CodeBlockProps) {
   const [copied, setCopied] = useState(false)
   const [hovered, setHovered] = useState(false)
 
@@ -219,3 +219,5 @@ const fileStyles: Record<string, React.CSSProperties> = {
     tabSize: 2,
   },
 }
+
+export default memo(CodeBlock)

--- a/web/src/components/chat/MarkdownContent.tsx
+++ b/web/src/components/chat/MarkdownContent.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import CodeBlock from './CodeBlock'
@@ -57,26 +58,65 @@ function CodeComponent({
   return <CodeBlock code={code} language={language} />
 }
 
-/** Markdown 渲染器，支持 GFM；流式输出时降级为纯文本 */
-export default function MarkdownContent({ content, streaming }: MarkdownContentProps) {
-  if (streaming) {
-    return (
-      <div className="markdown-body" style={{ whiteSpace: 'pre-wrap' }}>
-        {content}
-      </div>
-    )
+function splitStreamingContent(content: string): { completed: string; pending: string } {
+  if (!content) return { completed: '', pending: '' }
+
+  // 1. 检测未闭合的代码块
+  const fenceMatches = content.match(/```/g)
+  if (fenceMatches && fenceMatches.length % 2 === 1) {
+    const lastFenceIdx = content.lastIndexOf('```')
+    return {
+      completed: content.slice(0, lastFenceIdx),
+      pending: content.slice(lastFenceIdx),
+    }
   }
+
+  // 2. 不在代码块中，按段落分割
+  const lastDoubleNewline = content.lastIndexOf('\n\n')
+  if (lastDoubleNewline !== -1) {
+    if (lastDoubleNewline >= content.length - 2) {
+      // \n\n 在末尾，找上一段
+      const prevDoubleNewline = content.lastIndexOf('\n\n', lastDoubleNewline - 1)
+      if (prevDoubleNewline !== -1) {
+        return {
+          completed: content.slice(0, prevDoubleNewline + 2),
+          pending: content.slice(prevDoubleNewline + 2),
+        }
+      }
+      return { completed: '', pending: content }
+    }
+    return {
+      completed: content.slice(0, lastDoubleNewline + 2),
+      pending: content.slice(lastDoubleNewline + 2),
+    }
+  }
+
+  // 3. 单段：包含完整行内语法或较长时尝试渲染
+  const hasBold = /\*\*[^*\n]+\*\*/.test(content)
+  const hasCode = /`[^`\n]+`/.test(content)
+  const hasItalic = /(?<!\*)\*[^*\n]+\*(?!\*)/.test(content)
+  if (hasBold || hasCode || hasItalic || content.length > 300) {
+    return { completed: content, pending: '' }
+  }
+
+  return { completed: '', pending: content }
+}
+
+/** Markdown 渲染器，支持 GFM；流式输出时分段增量渲染 */
+export default function MarkdownContent({ content, streaming }: MarkdownContentProps) {
+  const { completed, pending } = useMemo(
+    () => (streaming ? splitStreamingContent(content) : { completed: content, pending: '' }),
+    [content, streaming],
+  )
 
   return (
     <div className="markdown-body">
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
-        components={{
-          code: CodeComponent as any,
-        }}
-      >
-        {content}
-      </ReactMarkdown>
+      {completed && (
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ code: CodeComponent as any }}>
+          {completed}
+        </ReactMarkdown>
+      )}
+      {pending && <span style={{ whiteSpace: 'pre-wrap' }}>{pending}</span>}
     </div>
   )
 }

--- a/web/src/components/chat/MessageItem.tsx
+++ b/web/src/components/chat/MessageItem.tsx
@@ -1,7 +1,7 @@
 import { memo, useState } from 'react'
 import { useChatStore, type ChatMessage } from '@/stores/useChatStore'
 import { useComposerStore } from '@/stores/useComposerStore'
-import { useSessionStore } from '@/stores/useSessionStore'
+import { useSessionStore, loadSessionWithInsights, mapHistoryMessages, type BackendMessage } from '@/stores/useSessionStore'
 import { useUIStore } from '@/stores/useUIStore'
 import { useGatewayAPI } from '@/context/RuntimeProvider'
 import { findCheckpointBeforeMessage } from '@/utils/findCheckpointBeforeMessage'
@@ -68,7 +68,6 @@ function UserMessage({ message }: { message: ChatMessage }) {
     (s) => findCheckpointBeforeMessage(s.messages, message.id)?.checkpointId ?? null,
   )
   const setComposerText = useComposerStore((s) => s.setComposerText)
-  const truncateFromMessage = useChatStore((s) => s.truncateFromMessage)
   const [confirming, setConfirming] = useState(false)
   const [reverting, setReverting] = useState(false)
 
@@ -85,8 +84,14 @@ function UserMessage({ message }: { message: ChatMessage }) {
       await gatewayAPI.restoreCheckpoint({ session_id: sessionId, checkpoint_id: checkpointId })
       setComposerText(message.content)
       resetEventBridgeCursors()
-      truncateFromMessage(message.id)
-      // 截断后本组件会被卸载，setReverting(false) 不会落到已卸载实例
+      // Reload session from backend to ensure consistency
+      const sessionFrame = await loadSessionWithInsights(gatewayAPI, sessionId)
+      const sessionData = sessionFrame.payload as { messages?: BackendMessage[]; agent_mode?: string }
+      if (sessionData?.messages) {
+        useChatStore.getState().clearMessages()
+        const mapped = mapHistoryMessages(sessionData.messages)
+        for (const msg of mapped) useChatStore.getState().addMessage(msg)
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Revert failed'
       useUIStore.getState().showToast('Revert failed: ' + msg, 'error')

--- a/web/src/components/chat/MessageItem.tsx
+++ b/web/src/components/chat/MessageItem.tsx
@@ -161,7 +161,12 @@ function AIMessage({ message, isLast, children, groupedWithPrev = false }: { mes
 }
 
 function ThinkingMessage({ message, groupedWithPrev = false }: { message: ChatMessage; groupedWithPrev?: boolean }) {
-  const [expanded, setExpanded] = useState(false)
+  const collapsed = message.thinkingData?.collapsed ?? false
+  const isStreaming = message.streaming === true
+  const [manualExpanded, setManualExpanded] = useState<boolean | null>(null)
+
+  // streaming 时展开，collapsed 且无手动覆盖时折叠
+  const expanded = manualExpanded !== null ? manualExpanded : (isStreaming || !collapsed)
 
   return (
     <div style={groupedWithPrev ? styles.aiRowGrouped : styles.aiRow} className="animate-fade-in">
@@ -173,11 +178,14 @@ function ThinkingMessage({ message, groupedWithPrev = false }: { message: ChatMe
         </div>
       )}
       <div style={styles.aiContent}>
-        <button style={styles.thinkingToggle} onClick={() => setExpanded(!expanded)}>
+        <button style={styles.thinkingToggle} onClick={() => setManualExpanded(!expanded)}>
           <span style={{ transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 0.2s', display: 'flex' }}>
             <ChevronRight size={14} />
           </span>
-          <span style={styles.thinkingLabel}>AI 思考过程</span>
+          <span style={styles.thinkingLabel}>
+            {isStreaming ? 'AI 正在思考...' : 'AI 思考过程'}
+          </span>
+          {isStreaming && <Loader2 size={12} className="animate-spin" style={{ marginLeft: 4 }} />}
         </button>
         {expanded && (
           <div style={styles.thinkingContent}>

--- a/web/src/components/chat/ModelSelector.tsx
+++ b/web/src/components/chat/ModelSelector.tsx
@@ -86,6 +86,8 @@ export default function ModelSelector() {
     if (!isGenerating && pendingModelChange && currentSessionId && gatewayAPI) {
       gatewayAPI.setSessionModel(currentSessionId, pendingModelChange.id, pendingModelChange.provider)
         .catch((err) => console.error('Deferred setSessionModel failed:', err))
+      gatewayAPI.selectProviderModel({ provider_id: pendingModelChange.provider, model_id: pendingModelChange.id })
+        .catch((err) => console.error('Deferred selectProviderModel failed:', err))
       setPendingModelChange(null)
     }
   }, [isGenerating, pendingModelChange, currentSessionId, gatewayAPI])

--- a/web/src/components/panels/FileChangePanel.tsx
+++ b/web/src/components/panels/FileChangePanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react'
 import { useUIStore, type FileChange } from '@/stores/useUIStore'
-import { useSessionStore } from '@/stores/useSessionStore'
+import { useSessionStore, loadSessionWithInsights, mapHistoryMessages, type BackendMessage } from '@/stores/useSessionStore'
+import { useChatStore } from '@/stores/useChatStore'
 import { useGatewayAPI } from '@/context/RuntimeProvider'
 import {
   ChevronRight,
@@ -93,6 +94,16 @@ function FileChangeItem({
       if (result?.payload) {
         useUIStore.getState().clearFileChanges()
         useUIStore.getState().showToast('Restored to pre-change state', 'success')
+        // Reload session messages to stay in sync with backend
+        try {
+          const sessionFrame = await loadSessionWithInsights(gatewayAPI, sessionId)
+          const sessionData = sessionFrame.payload as { messages?: BackendMessage[]; agent_mode?: string }
+          if (sessionData?.messages) {
+            useChatStore.getState().clearMessages()
+            const mapped = mapHistoryMessages(sessionData.messages)
+            for (const msg of mapped) useChatStore.getState().addMessage(msg)
+          }
+        } catch { /* non-critical refresh */ }
       }
     } catch (e) {
       console.warn('[FileChangePanel] restoreCheckpoint failed:', e)

--- a/web/src/stores/useChatStore.ts
+++ b/web/src/stores/useChatStore.ts
@@ -26,6 +26,8 @@ export interface ChatMessage {
   verificationData?: VerificationRunRecord
   /** Acceptance 决策数据(仅 type === 'acceptance' 使用) */
   acceptanceData?: AcceptanceDecidedPayload
+  /** Thinking 数据(仅 type === 'thinking' 使用) */
+  thinkingData?: { collapsed: boolean }
   /** 代码语言 */
   language?: string
   /** 代码文件名 */
@@ -44,6 +46,8 @@ interface ChatState {
   isGenerating: boolean
   /** 当前 AI 回复缓冲 ID（流式追加用） */
   streamingMessageId: string
+  /** 当前 thinking 流式消息 ID */
+  streamingThinkingMessageId: string
   /** 权限请求列表 */
   permissionRequests: PermissionRequestPayload[]
   /** Token 用量 */
@@ -66,6 +70,12 @@ interface ChatState {
   /** 原子操作：创建流式 assistant 消息 + 加入列表 + 设置 streamingMessageId */
   startStreamingMessage: () => string
   finalizeMessage: (id: string, content: string) => void
+  /** 创建流式 thinking 消息并设置 streamingThinkingMessageId */
+  startThinkingMessage: () => string
+  /** 追加 thinking 文本到当前流式 thinking 消息 */
+  appendThinkingChunk: (text: string) => void
+  /** 终结 thinking 消息（collapsed=true）并清空 streamingThinkingMessageId */
+  finalizeThinkingMessage: () => void
   updateToolCall: (toolCallId: string, result: string, status: ChatMessage['toolStatus']) => void
   appendToolOutput: (toolCallId: string, chunk: string) => void
   /** 把 checkpointId 关联到一条 tool_call 消息(由 CheckpointCreated 时序关联触发) */
@@ -143,10 +153,24 @@ export function createToolCallMessage(toolName: string, toolCallId: string, args
   }
 }
 
+/** 创建 thinking 流式消息 */
+function createThinkingMessage(): ChatMessage {
+  return {
+    id: nextMsgId(),
+    role: 'assistant',
+    type: 'thinking',
+    content: '',
+    timestamp: Date.now(),
+    streaming: true,
+    thinkingData: { collapsed: false },
+  }
+}
+
 export const useChatStore = create<ChatState>((set) => ({
   messages: [],
   isGenerating: false,
   streamingMessageId: '',
+  streamingThinkingMessageId: '',
   permissionRequests: [],
   tokenUsage: null,
   phase: '',
@@ -164,6 +188,7 @@ export const useChatStore = create<ChatState>((set) => ({
       return {
         messages: s.messages.slice(0, idx),
         streamingMessageId: '',
+        streamingThinkingMessageId: '',
         isGenerating: false,
         permissionRequests: [],
         phase: '',
@@ -199,6 +224,38 @@ export const useChatStore = create<ChatState>((set) => ({
       ),
       streamingMessageId: s.streamingMessageId === id ? '' : s.streamingMessageId,
     })),
+
+  startThinkingMessage: () => {
+    const msg = createThinkingMessage()
+    set((s) => ({
+      messages: [...s.messages, msg],
+      streamingThinkingMessageId: msg.id,
+    }))
+    return msg.id
+  },
+
+  appendThinkingChunk: (text) =>
+    set((s) => {
+      if (!s.streamingThinkingMessageId) return s
+      return {
+        messages: s.messages.map((m) =>
+          m.id === s.streamingThinkingMessageId ? { ...m, content: m.content + text } : m
+        ),
+      }
+    }),
+
+  finalizeThinkingMessage: () =>
+    set((s) => {
+      if (!s.streamingThinkingMessageId) return s
+      return {
+        messages: s.messages.map((m) =>
+          m.id === s.streamingThinkingMessageId
+            ? { ...m, streaming: false, thinkingData: { collapsed: true } }
+            : m
+        ),
+        streamingThinkingMessageId: '',
+      }
+    }),
 
   updateToolCall: (toolCallId, result, status) =>
     set((s) => ({
@@ -249,16 +306,25 @@ export const useChatStore = create<ChatState>((set) => ({
   /** 重置生成状态：终结当前流式消息 + 清除 isGenerating */
   resetGeneratingState: () =>
     set((s) => {
+      let msgs = s.messages
       if (s.streamingMessageId) {
-        return {
-          messages: s.messages.map((m) =>
-            m.id === s.streamingMessageId ? { ...m, streaming: false } : m
-          ),
-          streamingMessageId: '',
-          isGenerating: false,
-        }
+        msgs = msgs.map((m) =>
+          m.id === s.streamingMessageId ? { ...m, streaming: false } : m
+        )
       }
-      return { isGenerating: false }
+      if (s.streamingThinkingMessageId) {
+        msgs = msgs.map((m) =>
+          m.id === s.streamingThinkingMessageId
+            ? { ...m, streaming: false, thinkingData: { collapsed: true } }
+            : m
+        )
+      }
+      return {
+        messages: msgs,
+        streamingMessageId: '',
+        streamingThinkingMessageId: '',
+        isGenerating: false,
+      }
     }),
 
   setTransitioning: (isTransitioning) => set({ isTransitioning }),
@@ -286,6 +352,7 @@ export const useChatStore = create<ChatState>((set) => ({
     set({
       messages: [],
       streamingMessageId: '',
+      streamingThinkingMessageId: '',
       isGenerating: false,
       permissionRequests: [],
       tokenUsage: null,

--- a/web/src/stores/useChatStore.ts
+++ b/web/src/stores/useChatStore.ts
@@ -82,6 +82,10 @@ interface ChatState {
   attachCheckpointToToolCall: (toolCallId: string, checkpointId: string) => void
   /** 更新某条已挂 checkpoint 的 tool_call 消息的撤回状态 */
   setCheckpointStatus: (toolCallId: string, status: NonNullable<ChatMessage['checkpointStatus']>) => void
+  /** 将所有 available 的 checkpoint 标记为 restored */
+  markAllCheckpointsRestored: () => void
+  /** 将所有 restored 的 checkpoint 标记回 available */
+  markAllCheckpointsAvailable: () => void
   /** 更新一条 verification 消息的 data(verification 进行中持续更新同一条消息) */
   updateVerificationMessage: (messageId: string, data: VerificationRunRecord) => void
   setGenerating: (v: boolean) => void
@@ -287,6 +291,24 @@ export const useChatStore = create<ChatState>((set) => ({
       messages: s.messages.map((m) =>
         m.toolCallId === toolCallId && m.type === 'tool_call'
           ? { ...m, checkpointStatus: status }
+          : m
+      ),
+    })),
+
+  markAllCheckpointsRestored: () =>
+    set((s) => ({
+      messages: s.messages.map((m) =>
+        m.checkpointStatus === 'available'
+          ? { ...m, checkpointStatus: 'restored' as const }
+          : m
+      ),
+    })),
+
+  markAllCheckpointsAvailable: () =>
+    set((s) => ({
+      messages: s.messages.map((m) =>
+        m.checkpointStatus === 'restored'
+          ? { ...m, checkpointStatus: 'available' as const }
           : m
       ),
     })),

--- a/web/src/stores/useSessionStore.ts
+++ b/web/src/stores/useSessionStore.ts
@@ -104,7 +104,7 @@ function mapSessionsToProjects(apiSessions: APISessionSummary[]): Project[] {
   return projects
 }
 
-type BackendMessage = {
+export type BackendMessage = {
   role: string
   content: string
   tool_calls?: Array<{ id: string; name: string; arguments: string }>
@@ -114,7 +114,7 @@ type BackendMessage = {
 
 /** 并发拉取 session 详情 + todos + checkpoints,把后两者写入 RuntimeInsightStore。
  *  todos / checkpoints 失败用 .catch 兜底,不阻断主流程的 loadSession。 */
-async function loadSessionWithInsights(gatewayAPI: GatewayAPI, sessionId: string) {
+export async function loadSessionWithInsights(gatewayAPI: GatewayAPI, sessionId: string) {
   const [sessionFrame, todosResult, checkpointsResult] = await Promise.all([
     gatewayAPI.loadSession(sessionId),
     (gatewayAPI.listSessionTodos?.(sessionId) ?? Promise.resolve(null)).catch(() => null),
@@ -131,7 +131,7 @@ async function loadSessionWithInsights(gatewayAPI: GatewayAPI, sessionId: string
 }
 
 /** 将后端历史消息映射为前端 ChatMessage 列表，正确合并 tool_result 回 tool_call */
-function mapHistoryMessages(backendMessages: BackendMessage[]): Array<ReturnType<typeof useChatStore.getState>['messages'][0]> {
+export function mapHistoryMessages(backendMessages: BackendMessage[]): Array<ReturnType<typeof useChatStore.getState>['messages'][0]> {
   let _idCounter = 0
   // Phase 1: Collect tool results by tool_call_id
   const toolResults = new Map<string, { content: string; isError: boolean }>()

--- a/web/src/utils/eventBridge.ts
+++ b/web/src/utils/eventBridge.ts
@@ -352,8 +352,13 @@ export function handleGatewayEvent(frame: MessageFrame, gatewayAPI: GatewayAPI) 
     }
 
     case EventType.StopReasonDecided: {
-      useChatStore.getState().setStopReason(strField(eventPayload, 'reason'))
+      const reason = strField(eventPayload, 'reason')
+      const detail = strField(eventPayload, 'detail')
+      useChatStore.getState().setStopReason(reason)
       useChatStore.getState().setGenerating(false)
+      if (reason === 'fatal_error') {
+        uiStore.showToast(detail || '模型调用失败，请检查配置', 'error')
+      }
       break
     }
 

--- a/web/src/utils/eventBridge.ts
+++ b/web/src/utils/eventBridge.ts
@@ -572,13 +572,14 @@ export function handleGatewayEvent(frame: MessageFrame, gatewayAPI: GatewayAPI) 
     case EventType.CheckpointWarning: {
       const payload = eventPayload as CheckpointWarningPayload | undefined
       if (payload) insightStore.setCheckpointWarning(payload)
-      uiStore.showToast(`Checkpoint warning: ${strField(eventPayload, 'phase')}`, 'info')
+      uiStore.showToast(`Checkpoint warning: ${payload?.error ?? 'unknown error'}`, 'info')
       break
     }
 
     case EventType.CheckpointRestored: {
       const payload = eventPayload as CheckpointRestoredPayload | undefined
       if (payload) insightStore.addCheckpointEvent(payload)
+      chatStore.markAllCheckpointsRestored()
       uiStore.showToast('Checkpoint restored', 'success')
       break
     }
@@ -586,6 +587,7 @@ export function handleGatewayEvent(frame: MessageFrame, gatewayAPI: GatewayAPI) 
     case EventType.CheckpointUndoRestore: {
       const payload = eventPayload as CheckpointUndoRestorePayload | undefined
       if (payload) insightStore.addCheckpointEvent(payload)
+      chatStore.markAllCheckpointsAvailable()
       uiStore.showToast('Checkpoint restore undone', 'success')
       break
     }

--- a/web/src/utils/eventBridge.ts
+++ b/web/src/utils/eventBridge.ts
@@ -228,7 +228,21 @@ export function handleGatewayEvent(frame: MessageFrame, gatewayAPI: GatewayAPI) 
   }
 
   switch (eventType) {
+    case EventType.ThinkingDelta: {
+      const text = eventPayload as string | undefined
+      if (!text) break
+      if (!chatStore.streamingThinkingMessageId) {
+        useChatStore.getState().startThinkingMessage()
+      }
+      useChatStore.getState().appendThinkingChunk(text)
+      break
+    }
+
     case EventType.AgentChunk: {
+      // 终结 thinking 消息
+      if (chatStore.streamingThinkingMessageId) {
+        chatStore.finalizeThinkingMessage()
+      }
       const text = eventPayload as string | undefined
       if (!text) break
       if (!chatStore.streamingMessageId) {
@@ -239,6 +253,9 @@ export function handleGatewayEvent(frame: MessageFrame, gatewayAPI: GatewayAPI) 
     }
 
     case EventType.AgentDone: {
+      if (chatStore.streamingThinkingMessageId) {
+        chatStore.finalizeThinkingMessage()
+      }
       if (chatStore.streamingMessageId) {
         const parts = (eventPayload as { parts?: { text?: string }[] } | undefined)?.parts
         const content = parts && Array.isArray(parts)

--- a/web/src/utils/eventBridge.ts
+++ b/web/src/utils/eventBridge.ts
@@ -25,6 +25,7 @@ import { useUIStore } from '@/stores/useUIStore'
 import { useGatewayStore } from '@/stores/useGatewayStore'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useRuntimeInsightStore } from '@/stores/useRuntimeInsightStore'
+import { useWorkspaceStore } from '@/stores/useWorkspaceStore'
 import { parseSingleFileDiff, type ParsedFileDiff } from '@/utils/patchParser'
 
 type PayloadRecord = Record<string, unknown> | undefined
@@ -44,11 +45,35 @@ export function resetEventBridgeCursors() {
   _latestCheckpointId = undefined
 }
 
+/**
+ * 把后端 toSlash 后的绝对路径与模型 raw 相对路径统一到工作区相对、正斜杠形式，
+ * 让 ToolStart 占位条目与 ToolDiff 真实条目能命中同一个 dedup key。
+ * Windows 下大小写不敏感比较；找不到工作区根时退化为只做斜杠/前导 ./ 归一化。
+ */
+function normalizeFilePath(input: string): string {
+  if (!input) return input
+  let p = input.replace(/\\/g, '/').trim()
+  const ws = useWorkspaceStore.getState()
+  const root = ws.workspaces.find((w) => w.hash === ws.currentWorkspaceHash)?.path
+  if (root) {
+    const r = root.replace(/\\/g, '/').replace(/\/+$/, '')
+    if (r && p.toLowerCase().startsWith(r.toLowerCase() + '/')) {
+      p = p.slice(r.length + 1)
+    } else if (r && p.toLowerCase() === r.toLowerCase()) {
+      p = ''
+    }
+  }
+  while (p.startsWith('./')) p = p.slice(2)
+  return p
+}
+
 function _upsertFileChange(
-  path: string,
+  rawPath: string,
   status: 'added' | 'modified' | 'deleted',
   parsed?: ParsedFileDiff,
 ) {
+  const path = normalizeFilePath(rawPath)
+  if (!path) return
   const existing = useUIStore.getState().fileChanges.find((c) => c.path === path)
   if (existing) {
     useUIStore.setState((s) => ({
@@ -429,22 +454,27 @@ export function handleGatewayEvent(frame: MessageFrame, gatewayAPI: GatewayAPI) 
 
     case EventType.VerificationStarted: {
       const payload = eventPayload as VerificationStartedPayload | undefined
-      if (payload) {
-        const recordId = insightStore.startVerification(payload)
-        const history = useRuntimeInsightStore.getState().verificationHistory
-        const record = history.length > 0 ? history[history.length - 1] : undefined
-        if (record) {
-          const msgId = `msg_${Date.now()}_verify_${recordId.slice(0, 8)}`
-          _latestVerificationMsgId = msgId
-          chatStore.addMessage({
-            id: msgId,
-            role: 'assistant',
-            type: 'verification',
-            content: '',
-            verificationData: record,
-            timestamp: Date.now(),
-          })
-        }
+      if (!payload) break
+      // completion gate 已拦截（典型场景: pending_todo），verifier 不会真正运行；
+      // 跳过创建 verification chat message，避免出现 "0/1 passed" 误导。
+      // 该状态由下游 AcceptanceDecided → AcceptanceMessage 完整呈现。
+      if (payload.completion_passed === false) {
+        break
+      }
+      const recordId = insightStore.startVerification(payload)
+      const history = useRuntimeInsightStore.getState().verificationHistory
+      const record = history.length > 0 ? history[history.length - 1] : undefined
+      if (record) {
+        const msgId = `msg_${Date.now()}_verify_${recordId.slice(0, 8)}`
+        _latestVerificationMsgId = msgId
+        chatStore.addMessage({
+          id: msgId,
+          role: 'assistant',
+          type: 'verification',
+          content: '',
+          verificationData: record,
+          timestamp: Date.now(),
+        })
       }
       chatStore.setPhase('verification')
       uiStore.showToast('Verification started', 'info')


### PR DESCRIPTION
### 主要功能增强

**1. Web 端接入思考流展示**
- 新增 `ThinkingDelta` 事件处理，支持模型思考过程的实时流式展示
- 在 `eventBridge.ts` 中添加思考消息的开始、追加、完成逻辑
- `ChatStore` 新增 `startThinkingMessage`、`appendThinkingChunk`、`finalizeThinkingMessage` 方法
- 思考消息在 `AgentChunk` 开始前自动终结，避免与输出消息冲突

**2. Checkpoint 体验优化**
- 重构 `CheckpointInlineMark.tsx` 组件（283 行改动），增强内联标记的交互和渲染
- 新增 `markAllCheckpointsRestored` 和 `markAllCheckpointsAvailable` 方法，支持批量状态更新
- 优化 checkpoint restore/undo restore 的事件处理流程
- 修复 checkpoint 警告信息的展示逻辑

### 重要 Bug 修复

**3. Verify 死循环修复**
- 修复 `todo_run_boundary.go` 中验证最后 todo 时的死循环问题
- 在 `acceptance_service.go` 中新增验收服务，完善验证流程
- 优化 `VerificationStarted` 事件处理，当 `completion_passed=false` 时跳过创建验证消息

**4. 文件变更去重**
- 在 `eventBridge.ts` 中新增 `normalizeFilePath` 函数，统一文件路径格式
- 修复 ToolStart 占位条目与 ToolDiff 真实条目无法命中同一 dedup key 的问题
- 支持 Windows 下大小写不敏感比较，处理工作区相对路径

**5. 模型错误提示**
- 在 `StopReasonDecided` 事件中新增 `fatal_error` 的错误提示 toast
- 修复模型调用失败时用户无感知的问题

**6. Electron 构建修复**
- 修复 `electron-builder.config.cjs` 构建顺序问题
- 解决 portable 版本自动更新相关问题

### 其他改进

**7. Todo 重写规则增强**
- 适应上游新更改，增强 todo 重写的规则
- 优化 `todo_run_boundary_test.go` 测试覆盖

**8. 输出渲染优化**
- 优化 `MarkdownContent.tsx` 的渲染逻辑（72 行改动）
- 改进 `CodeBlock.tsx` 的代码块展示

**9. 协议与状态管理**
- `protocol.ts` 新增事件类型定义
- `useChatStore.ts` 新增 105 行状态管理逻辑
- `useSessionStore.ts` 优化会话状态处理

### 改动统计
- 20 个文件修改
- 新增 682 行，删除 182 行
- 主要涉及 `internal/runtime/` 和 `web/src/` 两个核心目录

### 测试覆盖
- 修改 `todo_run_boundary_test.go`，确保验证逻辑的正确性
- 其他相关测试同步更新