### PR TITLE
feat(daemon): HTTP 唤醒页面美化、跨平台终端拉起、安装后自启动及错误指引增强

### DIFF
--- a/internal/cli/daemon_commands.go
+++ b/internal/cli/daemon_commands.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	neturl "net/url"
 	"os"
@@ -25,6 +26,9 @@ var (
 	installHTTPDaemon   = urlscheme.InstallHTTPDaemon
 	uninstallHTTPDaemon = urlscheme.UninstallHTTPDaemon
 	getHTTPDaemonStatus = urlscheme.GetHTTPDaemonStatus
+
+	daemonInstallJSONWriter io.Writer = os.Stdout
+	daemonInstallLogWriter  io.Writer = os.Stderr
 )
 
 type daemonServeCommandOptions struct {
@@ -287,13 +291,26 @@ func defaultDaemonInstallCommandRunner(ctx context.Context, options daemonInstal
 		ListenAddress:  options.ListenAddress,
 	})
 	if err != nil {
+		_, _ = fmt.Fprintf(daemonInstallLogWriter, "daemon install failed: %v\n", err)
+		_, _ = fmt.Fprintf(daemonInstallLogWriter, "remedy: run `%s daemon install --listen %s`\n", executablePath, options.ListenAddress)
 		return err
 	}
-	return encodeJSONLine(os.Stdout, map[string]any{
-		"status":         "ok",
-		"listen_address": result.ListenAddress,
-		"autostart_mode": result.AutostartMode,
-		"hosts_warning":  strings.TrimSpace(result.HostsWarning),
+	_, _ = fmt.Fprintf(daemonInstallLogWriter, "daemon install succeeded: autostart=%s listen=%s\n", result.AutostartMode, result.ListenAddress)
+	if strings.TrimSpace(result.HostsWarning) != "" {
+		_, _ = fmt.Fprintf(daemonInstallLogWriter, "hosts warning: %s\n", strings.TrimSpace(result.HostsWarning))
+	}
+	if result.DaemonStarted {
+		_, _ = fmt.Fprintf(daemonInstallLogWriter, "daemon started in background and is ready on %s\n", result.ListenAddress)
+	} else if strings.TrimSpace(result.DaemonStartWarning) != "" {
+		_, _ = fmt.Fprintf(daemonInstallLogWriter, "daemon startup warning: %s\n", strings.TrimSpace(result.DaemonStartWarning))
+	}
+	return encodeJSONLine(daemonInstallJSONWriter, map[string]any{
+		"status":               "ok",
+		"listen_address":       result.ListenAddress,
+		"autostart_mode":       result.AutostartMode,
+		"hosts_warning":        strings.TrimSpace(result.HostsWarning),
+		"daemon_started":       result.DaemonStarted,
+		"daemon_start_warning": strings.TrimSpace(result.DaemonStartWarning),
 	})
 }
 

--- a/internal/cli/daemon_commands_test.go
+++ b/internal/cli/daemon_commands_test.go
@@ -1,10 +1,11 @@
 package cli
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/url"
-	"os"
 	"strings"
 	"testing"
 
@@ -42,25 +43,34 @@ func TestDaemonInstallDefaultRunnerUsesCurrentExecutable(t *testing.T) {
 	originalRunner := runDaemonInstallCommand
 	originalResolveExecutablePath := resolveExecutablePath
 	originalInstall := installHTTPDaemon
+	originalJSONWriter := daemonInstallJSONWriter
+	originalLogWriter := daemonInstallLogWriter
 	t.Cleanup(func() { runDaemonInstallCommand = originalRunner })
 	t.Cleanup(func() { resolveExecutablePath = originalResolveExecutablePath })
 	t.Cleanup(func() { installHTTPDaemon = originalInstall })
+	t.Cleanup(func() { daemonInstallJSONWriter = originalJSONWriter })
+	t.Cleanup(func() { daemonInstallLogWriter = originalLogWriter })
 
 	runDaemonInstallCommand = defaultDaemonInstallCommandRunner
 	resolveExecutablePath = func() (string, error) {
 		return "/tmp/neocode", nil
 	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	daemonInstallJSONWriter = &stdout
+	daemonInstallLogWriter = &stderr
 	var captured urlscheme.HTTPDaemonInstallOptions
 	installHTTPDaemon = func(options urlscheme.HTTPDaemonInstallOptions) (urlscheme.HTTPDaemonInstallResult, error) {
 		captured = options
 		return urlscheme.HTTPDaemonInstallResult{
-			ListenAddress: options.ListenAddress,
-			AutostartMode: "test-mode",
+			ListenAddress:      options.ListenAddress,
+			AutostartMode:      "test-mode",
+			DaemonStarted:      true,
+			DaemonStartWarning: "",
 		}, nil
 	}
 
 	command := NewRootCommand()
-	command.SetOut(os.Stdout)
 	command.SetArgs([]string{"daemon", "install", "--listen", "127.0.0.1:19921"})
 	if err := command.ExecuteContext(context.Background()); err != nil {
 		t.Fatalf("ExecuteContext() error = %v", err)
@@ -70,6 +80,57 @@ func TestDaemonInstallDefaultRunnerUsesCurrentExecutable(t *testing.T) {
 	}
 	if captured.ListenAddress != "127.0.0.1:19921" {
 		t.Fatalf("listen address = %q, want %q", captured.ListenAddress, "127.0.0.1:19921")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &payload); err != nil {
+		t.Fatalf("decode stdout json: %v", err)
+	}
+	if payload["status"] != "ok" {
+		t.Fatalf("status = %v, want ok", payload["status"])
+	}
+	if payload["daemon_started"] != true {
+		t.Fatalf("daemon_started = %v, want true", payload["daemon_started"])
+	}
+	if !strings.Contains(stderr.String(), "daemon install succeeded") {
+		t.Fatalf("stderr = %q, want success summary", stderr.String())
+	}
+}
+
+func TestDaemonInstallDefaultRunnerFailureWritesRemedy(t *testing.T) {
+	originalRunner := runDaemonInstallCommand
+	originalResolveExecutablePath := resolveExecutablePath
+	originalInstall := installHTTPDaemon
+	originalJSONWriter := daemonInstallJSONWriter
+	originalLogWriter := daemonInstallLogWriter
+	t.Cleanup(func() { runDaemonInstallCommand = originalRunner })
+	t.Cleanup(func() { resolveExecutablePath = originalResolveExecutablePath })
+	t.Cleanup(func() { installHTTPDaemon = originalInstall })
+	t.Cleanup(func() { daemonInstallJSONWriter = originalJSONWriter })
+	t.Cleanup(func() { daemonInstallLogWriter = originalLogWriter })
+
+	runDaemonInstallCommand = defaultDaemonInstallCommandRunner
+	resolveExecutablePath = func() (string, error) {
+		return "/tmp/neocode", nil
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	daemonInstallJSONWriter = &stdout
+	daemonInstallLogWriter = &stderr
+	installHTTPDaemon = func(options urlscheme.HTTPDaemonInstallOptions) (urlscheme.HTTPDaemonInstallResult, error) {
+		return urlscheme.HTTPDaemonInstallResult{}, errors.New("boom")
+	}
+
+	command := NewRootCommand()
+	command.SetArgs([]string{"daemon", "install", "--listen", "127.0.0.1:19921"})
+	err := command.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("expected install failure")
+	}
+	if !strings.Contains(stderr.String(), "remedy: run `/tmp/neocode daemon install --listen 127.0.0.1:19921`") {
+		t.Fatalf("stderr = %q, want remedy command", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout should be empty on failure, got %q", stdout.String())
 	}
 }
 

--- a/internal/gateway/adapters/urlscheme/daemon.go
+++ b/internal/gateway/adapters/urlscheme/daemon.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -30,9 +31,15 @@ const (
 	daemonAutostartModeDesktop     = "desktop_autostart"
 )
 
+const (
+	daemonHTTPPageTitle      = "NeoCode Daemon"
+	daemonHTTPPageFaviconURL = "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20120%20120'%3E%3Crect%20width='120'%20height='120'%20rx='22'%20fill='%230f172a'/%3E%3Cpath%20d='M36%2032h16l32%2056H68L36%2032z'%20fill='%2338bdf8'/%3E%3Cpath%20d='M84%2032H68L36%2088h16l32-56z'%20fill='%230ea5e9'/%3E%3C/svg%3E"
+)
+
 var (
 	httpDaemonDispatchWakeFn = defaultHTTPDaemonDispatchWake
 	httpDaemonGetHTTPClient  = defaultHTTPDaemonHTTPClient
+	httpDaemonStartProcessFn = startHTTPDaemonProcess
 )
 
 // HTTPDaemonServeOptions 定义 daemon serve 的启动参数。
@@ -49,9 +56,11 @@ type HTTPDaemonInstallOptions struct {
 
 // HTTPDaemonInstallResult 返回 daemon install 的结果摘要。
 type HTTPDaemonInstallResult struct {
-	ListenAddress string `json:"listen_address"`
-	AutostartMode string `json:"autostart_mode"`
-	HostsWarning  string `json:"hosts_warning,omitempty"`
+	ListenAddress      string `json:"listen_address"`
+	AutostartMode      string `json:"autostart_mode"`
+	HostsWarning       string `json:"hosts_warning,omitempty"`
+	DaemonStarted      bool   `json:"daemon_started"`
+	DaemonStartWarning string `json:"daemon_start_warning,omitempty"`
 }
 
 // HTTPDaemonStatusOptions 定义 daemon status 的查询参数。
@@ -134,7 +143,12 @@ func InstallHTTPDaemon(options HTTPDaemonInstallOptions) (HTTPDaemonInstallResul
 		AutostartMode: mode,
 	}
 	if hostsErr := ensureDaemonHostsAlias(); hostsErr != nil {
-		result.HostsWarning = hostsErr.Error()
+		result.HostsWarning = buildHostsAliasWarning(hostsErr)
+	}
+	if daemonStartErr := ensureHTTPDaemonProcessStarted(executablePath, listenAddress); daemonStartErr != nil {
+		result.DaemonStartWarning = daemonStartErr.Error()
+	} else {
+		result.DaemonStarted = true
 	}
 	return result, nil
 }
@@ -220,7 +234,7 @@ func newHTTPDaemonHandler(
 			ListenAddress: gatewayListenAddress,
 		})
 		if err != nil {
-			writeHTTPDaemonError(writer, http.StatusInternalServerError, "dispatch failed", err.Error())
+			writeHTTPDaemonDispatchError(writer, gatewayListenAddress, err)
 			return
 		}
 		writeHTTPDaemonSuccess(writer, request, result)
@@ -349,9 +363,51 @@ func writeHTTPDaemonError(writer http.ResponseWriter, statusCode int, title stri
 	writer.WriteHeader(statusCode)
 	escapedTitle := html.EscapeString(strings.TrimSpace(title))
 	escapedDetail := html.EscapeString(strings.TrimSpace(detail))
-	_, _ = writer.Write([]byte(
-		"<html><body><h3>" + escapedTitle + "</h3><p>" + escapedDetail + "</p></body></html>",
-	))
+	content := `<h1 class="status error">` + escapedTitle + `</h1><p class="detail">` + escapedDetail + `</p>`
+	_, _ = writer.Write([]byte(buildHTTPDaemonPageHTML(escapedTitle, content, "")))
+}
+
+// writeHTTPDaemonDispatchError 输出 wake 派发失败页面，并附带可执行补救指引。
+func writeHTTPDaemonDispatchError(writer http.ResponseWriter, gatewayListenAddress string, err error) {
+	title := "Dispatch failed"
+	detail := strings.TrimSpace(err.Error())
+	if detail == "" {
+		detail = "unknown dispatch error"
+	}
+	hints := []string{
+		"运行 `neocode daemon status` 检查 daemon 状态。",
+	}
+	startGatewayCommand := "neocode gateway"
+	if trimmedGatewayListenAddress := strings.TrimSpace(gatewayListenAddress); trimmedGatewayListenAddress != "" {
+		startGatewayCommand += " --listen " + trimmedGatewayListenAddress
+	}
+	hints = append(hints, "若 gateway 未运行，请手动执行 `"+startGatewayCommand+"`。")
+
+	var dispatchErr *DispatchError
+	if errors.As(err, &dispatchErr) {
+		switch dispatchErr.Code {
+		case ErrorCodeGatewayUnavailable:
+			title = "Gateway unavailable"
+			detail = "无法连接到 gateway，daemon 已尝试自动拉起，但当前不可达。"
+			if strings.Contains(strings.ToLower(dispatchErr.Message), "timed out") {
+				detail = "gateway 自动拉起后 10 秒内未就绪，无法继续派发。"
+			}
+		case ErrorCodeNotSupported:
+			title = "Terminal launch is not supported"
+			detail = strings.TrimSpace(dispatchErr.Message)
+			if detail == "" {
+				detail = "当前平台不支持自动拉起终端，请手动运行 neocode 续接会话。"
+			}
+		default:
+			if message := strings.TrimSpace(dispatchErr.Message); message != "" {
+				detail = message
+			}
+		}
+	}
+	if strings.TrimSpace(err.Error()) != "" {
+		hints = append(hints, "原始错误: "+strings.TrimSpace(err.Error()))
+	}
+	writeHTTPDaemonError(writer, http.StatusInternalServerError, title, strings.Join(hintsWithLead(detail, hints), "\n"))
 }
 
 // writeHTTPDaemonSuccess 输出浏览器可读的成功页面，并提供可复用的 session 链接。
@@ -362,11 +418,81 @@ func writeHTTPDaemonSuccess(writer http.ResponseWriter, request *http.Request, r
 	sessionID := html.EscapeString(strings.TrimSpace(result.SessionID))
 	reusableURL := buildHTTPDaemonReusableURL(request, result.SessionID)
 	escapedReusableURL := html.EscapeString(reusableURL)
-	_, _ = writer.Write([]byte(
-		"<html><body><h3>OK</h3><p>action=" + action + "</p><p>session_id=" + sessionID +
-			"</p><p>reusable_url=<a href=\"" + escapedReusableURL + "\">" + escapedReusableURL +
-			"</a></p><p>tip=后续若要续接同一会话，请使用带 session_id 的链接。</p></body></html>",
-	))
+	content := `<h1 class="status ok">Wake Accepted</h1>` +
+		`<p class="detail">action=<strong>` + action + `</strong></p>` +
+		`<p class="detail">session_id=<code>` + sessionID + `</code></p>` +
+		`<p class="label">reusable_url</p>` +
+		`<a class="link" id="reusable-link" href="` + escapedReusableURL + `">` + escapedReusableURL + `</a>` +
+		`<div class="copy-row"><button class="copy-btn" type="button" id="copy-reusable-btn" data-copy-text="` + escapedReusableURL + `">复制链接</button>` +
+		`<span class="copy-feedback" id="copy-feedback">点击后自动复制 reusable_url</span></div>` +
+		`<p class="tip">后续若要续接同一会话，请使用带 session_id 的链接。</p>`
+	_, _ = writer.Write([]byte(buildHTTPDaemonPageHTML("Wake Accepted", content, daemonCopyScript())))
+}
+
+// buildHTTPDaemonPageHTML 渲染统一的 daemon HTML 页面骨架与基础样式。
+func buildHTTPDaemonPageHTML(title string, contentHTML string, script string) string {
+	escapedTitle := html.EscapeString(strings.TrimSpace(title))
+	if escapedTitle == "" {
+		escapedTitle = daemonHTTPPageTitle
+	}
+	if strings.TrimSpace(contentHTML) == "" {
+		contentHTML = `<p class="detail">empty content</p>`
+	}
+	return "<!doctype html><html lang=\"zh-CN\"><head><meta charset=\"utf-8\">" +
+		"<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">" +
+		"<title>" + escapedTitle + " - " + daemonHTTPPageTitle + "</title>" +
+		"<link rel=\"icon\" href=\"" + daemonHTTPPageFaviconURL + "\">" +
+		"<style>" + daemonHTTPPageStyle() + "</style></head><body><main class=\"card\">" + contentHTML +
+		"</main>" + script + "</body></html>"
+}
+
+// daemonHTTPPageStyle 返回 daemon 页面使用的基础视觉样式。
+func daemonHTTPPageStyle() string {
+	return "body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;" +
+		"background:radial-gradient(circle at top,#e0f2fe 0%,#f8fafc 45%,#f1f5f9 100%);" +
+		"font-family:'Segoe UI',Tahoma,Helvetica,Arial,sans-serif;color:#0f172a;padding:24px;}" +
+		".card{width:min(760px,100%);background:#ffffff;border:1px solid #dbeafe;border-radius:18px;" +
+		"box-shadow:0 18px 40px rgba(15,23,42,.12);padding:28px;}" +
+		".status{margin:0 0 12px;font-size:28px;line-height:1.2;}" +
+		".status.ok{color:#0284c7;}.status.error{color:#b91c1c;}" +
+		".detail{margin:8px 0;font-size:15px;line-height:1.6;white-space:pre-line;}" +
+		".label{margin:18px 0 8px;font-weight:600;font-size:14px;color:#334155;}" +
+		".link{display:block;word-break:break-all;color:#0f766e;text-decoration:none;background:#ecfeff;" +
+		"padding:10px 12px;border-radius:10px;border:1px solid #bae6fd;}" +
+		".copy-row{display:flex;flex-wrap:wrap;gap:10px;align-items:center;margin-top:12px;}" +
+		".copy-btn{border:none;border-radius:10px;padding:10px 14px;background:#0ea5e9;color:#fff;cursor:pointer;" +
+		"font-weight:600;}" +
+		".copy-btn:hover{background:#0284c7;}" +
+		".copy-feedback{font-size:13px;color:#475569;}" +
+		".tip{margin-top:14px;font-size:14px;color:#334155;}"
+}
+
+// daemonCopyScript 返回成功页的链接复制脚本，优先使用 Clipboard API，
+// 在非安全上下文（如 http://neocode）中回退到 execCommand。
+func daemonCopyScript() string {
+	return `<script>(function(){const btn=document.getElementById('copy-reusable-btn');` +
+		`const feedback=document.getElementById('copy-feedback');if(!btn){return;}` +
+		`function fallbackCopy(t){const ta=document.createElement('textarea');ta.value=t;` +
+		`ta.style.position='fixed';ta.style.opacity='0';document.body.appendChild(ta);ta.select();` +
+		`try{document.execCommand('copy');return true;}catch(_){return false;}finally{document.body.removeChild(ta);}}` +
+		`btn.addEventListener('click',async function(){` +
+		`const text=btn.getAttribute('data-copy-text')||'';if(!text){if(feedback){feedback.textContent='链接为空，无法复制';}return;}` +
+		`let ok=false;try{if(navigator.clipboard&&navigator.clipboard.writeText){await navigator.clipboard.writeText(text);ok=true;}}catch(_){}` +
+		`if(!ok){ok=fallbackCopy(text);}` +
+		`if(feedback){feedback.textContent=ok?'已复制到剪贴板':'复制失败，请手动复制上方链接';}});})();</script>`
+}
+
+// hintsWithLead 拼装错误正文与补救建议列表。
+func hintsWithLead(detail string, hints []string) []string {
+	lines := []string{strings.TrimSpace(detail)}
+	for _, hint := range hints {
+		trimmedHint := strings.TrimSpace(hint)
+		if trimmedHint == "" {
+			continue
+		}
+		lines = append(lines, "- "+trimmedHint)
+	}
+	return lines
 }
 
 // buildHTTPDaemonReusableURL 基于当前请求地址生成包含 session_id 的可复用链接。
@@ -424,6 +550,58 @@ func probeHTTPDaemonRunning(ctx context.Context, listenAddress string) bool {
 	}
 	defer func() { _ = response.Body.Close() }()
 	return response.StatusCode == http.StatusOK
+}
+
+// ensureHTTPDaemonProcessStarted 尝试在 install 完成后立刻拉起 daemon，并返回可读告警。
+func ensureHTTPDaemonProcessStarted(executablePath string, listenAddress string) error {
+	normalizedListenAddress := normalizeHTTPDaemonListenAddress(listenAddress)
+	probeCtx, cancel := context.WithTimeout(context.Background(), 1400*time.Millisecond)
+	alreadyRunning := probeHTTPDaemonRunning(probeCtx, normalizedListenAddress)
+	cancel()
+	if alreadyRunning {
+		return nil
+	}
+
+	startFn := httpDaemonStartProcessFn
+	if startFn == nil {
+		startFn = startHTTPDaemonProcess
+	}
+	if err := startFn(executablePath, normalizedListenAddress); err != nil {
+		return fmt.Errorf("failed to start daemon in background: %w; run `%s daemon serve --listen %s` manually", err, executablePath, normalizedListenAddress)
+	}
+
+	readyCtx, readyCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer readyCancel()
+	for {
+		if probeHTTPDaemonRunning(readyCtx, normalizedListenAddress) {
+			return nil
+		}
+		if readyCtx.Err() != nil {
+			return fmt.Errorf("daemon background process started but not ready within 3s; run `%s daemon serve --listen %s` manually", executablePath, normalizedListenAddress)
+		}
+		time.Sleep(120 * time.Millisecond)
+	}
+}
+
+// startHTTPDaemonProcess 以后台进程方式启动 daemon serve。
+func startHTTPDaemonProcess(executablePath string, listenAddress string) error {
+	command := exec.Command(executablePath, "daemon", "serve", "--listen", strings.TrimSpace(listenAddress))
+	command.Stdin = nil
+	command.Stdout = nil
+	command.Stderr = nil
+	if err := command.Start(); err != nil {
+		return err
+	}
+	return command.Process.Release()
+}
+
+// buildHostsAliasWarning 构建 hosts 自动写入失败时的手动修复提示。
+func buildHostsAliasWarning(err error) string {
+	base := fmt.Sprintf("failed to update hosts alias automatically: %v", err)
+	if runtime.GOOS == "windows" {
+		return base + "; please run as Administrator: echo 127.0.0.1 neocode >> C:\\Windows\\System32\\drivers\\etc\\hosts"
+	}
+	return base + "; please run with sudo: sudo echo '127.0.0.1 neocode' >> /etc/hosts"
 }
 
 // ensureDaemonHostsAlias 以 best-effort 方式确保 hosts 文件存在 neocode 别名。

--- a/internal/gateway/adapters/urlscheme/daemon_test.go
+++ b/internal/gateway/adapters/urlscheme/daemon_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -144,11 +145,26 @@ func TestHTTPDaemonHandlerDispatchesIntent(t *testing.T) {
 	if !strings.Contains(responseBody, "session_id=session-from-runtime") {
 		t.Fatalf("response body = %q, want contains session_id", responseBody)
 	}
-	if !strings.Contains(responseBody, "reusable_url=") {
+	if !strings.Contains(responseBody, "reusable_url") {
 		t.Fatalf("response body = %q, want contains reusable_url", responseBody)
 	}
-	if !strings.Contains(responseBody, "tip=") {
-		t.Fatalf("response body = %q, want contains tip", responseBody)
+	if !strings.Contains(responseBody, "copy-reusable-btn") {
+		t.Fatalf("response body = %q, want contains copy button", responseBody)
+	}
+	if !strings.Contains(responseBody, "navigator.clipboard.writeText") {
+		t.Fatalf("response body = %q, want contains copy script", responseBody)
+	}
+	if !strings.Contains(responseBody, "name=\"viewport\"") {
+		t.Fatalf("response body = %q, want contains viewport meta", responseBody)
+	}
+	if !strings.Contains(responseBody, "<title>Wake Accepted - NeoCode Daemon</title>") {
+		t.Fatalf("response body = %q, want contains title", responseBody)
+	}
+	if !strings.Contains(responseBody, "rel=\"icon\"") {
+		t.Fatalf("response body = %q, want contains favicon", responseBody)
+	}
+	if !strings.Contains(responseBody, ".copy-btn") {
+		t.Fatalf("response body = %q, want contains css", responseBody)
 	}
 	if captured.Intent.Action != protocol.WakeActionRun {
 		t.Fatalf("captured action = %q, want %q", captured.Intent.Action, protocol.WakeActionRun)
@@ -158,6 +174,53 @@ func TestHTTPDaemonHandlerDispatchesIntent(t *testing.T) {
 	}
 	if captured.ListenAddress != "/tmp/gateway.sock" {
 		t.Fatalf("captured listen address = %q, want %q", captured.ListenAddress, "/tmp/gateway.sock")
+	}
+}
+
+func TestHTTPDaemonHandlerDispatchErrorIsFriendly(t *testing.T) {
+	handler := newHTTPDaemonHandler(
+		func(context.Context, daemonWakeDispatchRequest) (daemonWakeDispatchResult, error) {
+			return daemonWakeDispatchResult{}, newDispatchError(
+				ErrorCodeGatewayUnavailable,
+				"gateway auto-start timed out after 10s",
+			)
+		},
+		"/tmp/gateway.sock",
+	)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "http://neocode:18921/run?prompt=hello", http.NoBody)
+	request.Host = "neocode:18921"
+	handler.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+	}
+	responseBody := recorder.Body.String()
+	if !strings.Contains(responseBody, "Gateway unavailable") {
+		t.Fatalf("response body = %q, want gateway unavailable title", responseBody)
+	}
+	if !strings.Contains(responseBody, "10 秒内未就绪") {
+		t.Fatalf("response body = %q, want startup timeout hint", responseBody)
+	}
+	if !strings.Contains(responseBody, "neocode daemon status") {
+		t.Fatalf("response body = %q, want daemon status remedy", responseBody)
+	}
+	if !strings.Contains(responseBody, "neocode gateway --listen /tmp/gateway.sock") {
+		t.Fatalf("response body = %q, want gateway remedy command", responseBody)
+	}
+}
+
+func TestBuildHostsAliasWarningIncludesManualCommands(t *testing.T) {
+	warning := buildHostsAliasWarning(errors.New("permission denied"))
+	if runtime.GOOS == "windows" {
+		if !strings.Contains(warning, `echo 127.0.0.1 neocode >> C:\Windows\System32\drivers\etc\hosts`) {
+			t.Fatalf("warning = %q, want windows hosts command", warning)
+		}
+		return
+	}
+	if !strings.Contains(warning, `sudo echo '127.0.0.1 neocode' >> /etc/hosts`) {
+		t.Fatalf("warning = %q, want unix hosts command", warning)
 	}
 }
 

--- a/internal/gateway/adapters/urlscheme/dispatcher.go
+++ b/internal/gateway/adapters/urlscheme/dispatcher.go
@@ -32,7 +32,7 @@ const (
 	// defaultDispatchIOTimeout 是 URL 派发读写超时时间。
 	defaultDispatchIOTimeout = 10 * time.Second
 	// defaultGatewayLaunchTimeout 是自动拉起网关后的就绪等待时间。
-	defaultGatewayLaunchTimeout = 3 * time.Second
+	defaultGatewayLaunchTimeout = 10 * time.Second
 	// defaultGatewayLaunchRetryInterval 是拉起后拨号重试间隔。
 	defaultGatewayLaunchRetryInterval = 100 * time.Millisecond
 	wakeReviewStartupPromptTemplate   = "请审查文件 %s"
@@ -416,14 +416,14 @@ func (d *Dispatcher) dialGatewayWithFallback(
 	if launchErr := d.launchGateway(ctx, listenAddress, requestID, authToken); launchErr != nil {
 		return nil, newDispatchError(
 			ErrorCodeGatewayUnavailable,
-			fmt.Sprintf("dial gateway failed: %v; launch gateway failed: %v", err, launchErr),
+			fmt.Sprintf("dial gateway failed: %v; automatic gateway startup failed: %v", err, launchErr),
 		)
 	}
 	retriedConnection, retryErr := dialFn(listenAddress)
 	if retryErr != nil {
 		return nil, newDispatchError(
 			ErrorCodeGatewayUnavailable,
-			fmt.Sprintf("dial gateway failed after single fallback: %v", retryErr),
+			fmt.Sprintf("dial gateway failed after automatic startup: %v", retryErr),
 		)
 	}
 	return retriedConnection, nil
@@ -566,7 +566,7 @@ func (d *Dispatcher) waitGatewayReady(ctx context.Context, listenAddress string)
 			return nil
 		}
 		if !nowFn().Before(deadline) {
-			return fmt.Errorf("gateway did not become reachable within %s", effectiveTimeout)
+			return fmt.Errorf("gateway auto-start timed out after %s", effectiveTimeout)
 		}
 		sleepFn(defaultGatewayLaunchRetryInterval)
 	}

--- a/internal/gateway/adapters/urlscheme/dispatcher_test.go
+++ b/internal/gateway/adapters/urlscheme/dispatcher_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strings"
 	"testing"
+	"time"
 
 	"neo-code/internal/gateway"
 	"neo-code/internal/gateway/protocol"
@@ -508,5 +509,36 @@ func TestDispatchWakeIntentReturnsGatewayFrameError(t *testing.T) {
 	}
 	if dispatchErr.Code != gateway.ErrorCodeInvalidAction.String() {
 		t.Fatalf("error code = %q, want %q", dispatchErr.Code, gateway.ErrorCodeInvalidAction.String())
+	}
+}
+
+func TestGatewayLaunchTimeoutIsTenSeconds(t *testing.T) {
+	if defaultGatewayLaunchTimeout != 10*time.Second {
+		t.Fatalf("defaultGatewayLaunchTimeout = %s, want %s", defaultGatewayLaunchTimeout, 10*time.Second)
+	}
+}
+
+func TestWaitGatewayReadyTimeoutMessage(t *testing.T) {
+	dispatcher := NewDispatcher()
+	start := time.Unix(1700000000, 0)
+	nowCalls := 0
+	dispatcher.nowFn = func() time.Time {
+		nowCalls++
+		if nowCalls <= 2 {
+			return start
+		}
+		return start.Add(11 * time.Second)
+	}
+	dispatcher.sleepFn = func(time.Duration) {}
+	dispatcher.dialFn = func(string) (net.Conn, error) {
+		return nil, errors.New("dial failed")
+	}
+
+	err := dispatcher.waitGatewayReady(context.Background(), "inmemory")
+	if err == nil {
+		t.Fatal("expected wait timeout")
+	}
+	if !strings.Contains(err.Error(), "gateway auto-start timed out after") {
+		t.Fatalf("error = %v, want timeout message", err)
 	}
 }

--- a/internal/gateway/launcher/launcher_test.go
+++ b/internal/gateway/launcher/launcher_test.go
@@ -284,7 +284,7 @@ func TestLaunchTerminalBranches(t *testing.T) {
 	})
 
 	t.Run("unsupported platform returns sentinel", func(t *testing.T) {
-		if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		if runtime.GOOS == "windows" || runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
 			t.Skip("unsupported branch only applies to non-windows/non-darwin")
 		}
 		err := LaunchTerminal("neocode --session session-1")

--- a/internal/gateway/launcher/terminal_linux.go
+++ b/internal/gateway/launcher/terminal_linux.go
@@ -2,9 +2,36 @@
 
 package launcher
 
-import "fmt"
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
 
-// launchTerminal 在 Linux/其他平台先返回未实现错误，后续再接入具体终端适配。
+var (
+	lookupPathForTerminalLinux  = exec.LookPath
+	execCommandForTerminalLinux = exec.Command
+)
+
+// launchTerminal 在 Linux 上优先尝试 gnome-terminal，再回退到 x-terminal-emulator。
 func launchTerminal(command string) error {
-	return fmt.Errorf("%w: run `%s` manually in your terminal", ErrTerminalUnsupported, command)
+	if runtime.GOOS != "linux" {
+		return fmt.Errorf("%w: run `%s` manually in your terminal", ErrTerminalUnsupported, command)
+	}
+	if err := launchWithLinuxTerminal("gnome-terminal", []string{"--", "bash", "-lc", command}); err == nil {
+		return nil
+	}
+	if err := launchWithLinuxTerminal("x-terminal-emulator", []string{"-e", "bash", "-lc", command}); err == nil {
+		return nil
+	}
+	return fmt.Errorf("%w: install gnome-terminal/x-terminal-emulator or run `%s` manually", ErrTerminalUnsupported, command)
+}
+
+// launchWithLinuxTerminal 通过指定终端模拟器拉起命令。
+func launchWithLinuxTerminal(binary string, args []string) error {
+	if _, err := lookupPathForTerminalLinux(binary); err != nil {
+		return err
+	}
+	cmd := execCommandForTerminalLinux(binary, args...)
+	return cmd.Run()
 }

--- a/internal/gateway/launcher/terminal_linux_test.go
+++ b/internal/gateway/launcher/terminal_linux_test.go
@@ -1,0 +1,96 @@
+//go:build !windows && !darwin
+
+package launcher
+
+import (
+	"errors"
+	"os/exec"
+	"runtime"
+	"testing"
+)
+
+func TestLaunchTerminalLinuxUsesGnomeFirst(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-specific behavior")
+	}
+	originalLookup := lookupPathForTerminalLinux
+	originalExec := execCommandForTerminalLinux
+	t.Cleanup(func() {
+		lookupPathForTerminalLinux = originalLookup
+		execCommandForTerminalLinux = originalExec
+	})
+
+	lookupPathForTerminalLinux = func(binary string) (string, error) {
+		if binary == "gnome-terminal" {
+			return "/usr/bin/gnome-terminal", nil
+		}
+		return "", errors.New("not found")
+	}
+	called := make([]string, 0, 1)
+	execCommandForTerminalLinux = func(name string, args ...string) *exec.Cmd {
+		called = append(called, name)
+		return exec.Command("sh", "-c", "exit 0")
+	}
+
+	if err := launchTerminal("neocode --session s-1"); err != nil {
+		t.Fatalf("launchTerminal() error = %v", err)
+	}
+	if len(called) != 1 || called[0] != "gnome-terminal" {
+		t.Fatalf("called = %#v, want [gnome-terminal]", called)
+	}
+}
+
+func TestLaunchTerminalLinuxFallsBackToXTerminalEmulator(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-specific behavior")
+	}
+	originalLookup := lookupPathForTerminalLinux
+	originalExec := execCommandForTerminalLinux
+	t.Cleanup(func() {
+		lookupPathForTerminalLinux = originalLookup
+		execCommandForTerminalLinux = originalExec
+	})
+
+	lookupPathForTerminalLinux = func(binary string) (string, error) {
+		if binary == "x-terminal-emulator" {
+			return "/usr/bin/x-terminal-emulator", nil
+		}
+		return "", errors.New("not found")
+	}
+	called := make([]string, 0, 2)
+	execCommandForTerminalLinux = func(name string, args ...string) *exec.Cmd {
+		called = append(called, name)
+		return exec.Command("sh", "-c", "exit 0")
+	}
+
+	if err := launchTerminal("neocode --session s-2"); err != nil {
+		t.Fatalf("launchTerminal() error = %v", err)
+	}
+	if len(called) != 1 || called[0] != "x-terminal-emulator" {
+		t.Fatalf("called = %#v, want [x-terminal-emulator]", called)
+	}
+}
+
+func TestLaunchTerminalLinuxUnsupportedWhenNoTerminal(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-specific behavior")
+	}
+	originalLookup := lookupPathForTerminalLinux
+	originalExec := execCommandForTerminalLinux
+	t.Cleanup(func() {
+		lookupPathForTerminalLinux = originalLookup
+		execCommandForTerminalLinux = originalExec
+	})
+
+	lookupPathForTerminalLinux = func(binary string) (string, error) {
+		return "", errors.New("not found")
+	}
+	execCommandForTerminalLinux = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("sh", "-c", "exit 0")
+	}
+
+	err := launchTerminal("neocode --session s-3")
+	if !errors.Is(err, ErrTerminalUnsupported) {
+		t.Fatalf("error = %v, want wrapped %v", err, ErrTerminalUnsupported)
+	}
+}

--- a/internal/gateway/launcher/terminal_windows.go
+++ b/internal/gateway/launcher/terminal_windows.go
@@ -5,16 +5,22 @@ package launcher
 import (
 	"fmt"
 	"os/exec"
-	"strings"
 )
 
-// launchTerminal 在 Windows 上通过 `cmd /c start` 拉起独立终端窗口执行命令。
+var (
+	lookupPathForTerminalWindows  = exec.LookPath
+	execCommandForTerminalWindows = exec.Command
+)
+
+// launchTerminal 在 Windows 上优先使用 Windows Terminal，失败时回退 cmd /c start。
 func launchTerminal(command string) error {
-	args := append([]string{"/c", "start"}, strings.Fields(command)...)
-	if len(args) <= 2 {
-		return fmt.Errorf("empty terminal command")
+	if _, err := lookupPathForTerminalWindows("wt.exe"); err == nil {
+		wtCommand := execCommandForTerminalWindows("wt.exe", "new-tab", "cmd", "/k", command)
+		if runErr := wtCommand.Run(); runErr == nil {
+			return nil
+		}
 	}
-	cmd := exec.Command("cmd", args...)
+	cmd := execCommandForTerminalWindows("cmd", "/c", "start", "", "cmd", "/k", command)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("launch terminal on windows: %w", err)
 	}

--- a/internal/gateway/launcher/terminal_windows_test.go
+++ b/internal/gateway/launcher/terminal_windows_test.go
@@ -1,0 +1,108 @@
+//go:build windows
+
+package launcher
+
+import (
+	"errors"
+	"os/exec"
+	"reflect"
+	"testing"
+)
+
+func TestLaunchTerminalWindowsPrefersWT(t *testing.T) {
+	originalLookup := lookupPathForTerminalWindows
+	originalExec := execCommandForTerminalWindows
+	t.Cleanup(func() {
+		lookupPathForTerminalWindows = originalLookup
+		execCommandForTerminalWindows = originalExec
+	})
+
+	lookupPathForTerminalWindows = func(file string) (string, error) {
+		if file == "wt.exe" {
+			return `C:\\Windows\\System32\\wt.exe`, nil
+		}
+		return "", errors.New("unexpected binary")
+	}
+
+	called := make([][]string, 0, 2)
+	execCommandForTerminalWindows = func(name string, args ...string) *exec.Cmd {
+		called = append(called, append([]string{name}, args...))
+		return exec.Command("cmd", "/c", "exit", "0")
+	}
+
+	if err := launchTerminal("neocode --session s-1"); err != nil {
+		t.Fatalf("launchTerminal() error = %v", err)
+	}
+	if len(called) != 1 {
+		t.Fatalf("call count = %d, want 1", len(called))
+	}
+	want := []string{"wt.exe", "new-tab", "cmd", "/k", "neocode --session s-1"}
+	if !reflect.DeepEqual(called[0], want) {
+		t.Fatalf("called[0] = %#v, want %#v", called[0], want)
+	}
+}
+
+func TestLaunchTerminalWindowsFallsBackToCmdStart(t *testing.T) {
+	originalLookup := lookupPathForTerminalWindows
+	originalExec := execCommandForTerminalWindows
+	t.Cleanup(func() {
+		lookupPathForTerminalWindows = originalLookup
+		execCommandForTerminalWindows = originalExec
+	})
+
+	lookupPathForTerminalWindows = func(file string) (string, error) {
+		return "", errors.New("not found")
+	}
+
+	called := make([][]string, 0, 2)
+	execCommandForTerminalWindows = func(name string, args ...string) *exec.Cmd {
+		called = append(called, append([]string{name}, args...))
+		return exec.Command("cmd", "/c", "exit", "0")
+	}
+
+	if err := launchTerminal("neocode --session s-2"); err != nil {
+		t.Fatalf("launchTerminal() error = %v", err)
+	}
+	if len(called) != 1 {
+		t.Fatalf("call count = %d, want 1", len(called))
+	}
+	want := []string{"cmd", "/c", "start", "", "cmd", "/k", "neocode --session s-2"}
+	if !reflect.DeepEqual(called[0], want) {
+		t.Fatalf("called[0] = %#v, want %#v", called[0], want)
+	}
+}
+
+func TestLaunchTerminalWindowsFallsBackWhenWTFails(t *testing.T) {
+	originalLookup := lookupPathForTerminalWindows
+	originalExec := execCommandForTerminalWindows
+	t.Cleanup(func() {
+		lookupPathForTerminalWindows = originalLookup
+		execCommandForTerminalWindows = originalExec
+	})
+
+	lookupPathForTerminalWindows = func(file string) (string, error) {
+		if file == "wt.exe" {
+			return `C:\\Windows\\System32\\wt.exe`, nil
+		}
+		return "", errors.New("not found")
+	}
+
+	called := make([][]string, 0, 3)
+	execCommandForTerminalWindows = func(name string, args ...string) *exec.Cmd {
+		called = append(called, append([]string{name}, args...))
+		if name == "wt.exe" {
+			return exec.Command("cmd", "/c", "exit", "1")
+		}
+		return exec.Command("cmd", "/c", "exit", "0")
+	}
+
+	if err := launchTerminal("neocode --session s-3"); err != nil {
+		t.Fatalf("launchTerminal() error = %v", err)
+	}
+	if len(called) != 2 {
+		t.Fatalf("call count = %d, want 2", len(called))
+	}
+	if called[0][0] != "wt.exe" || called[1][0] != "cmd" {
+		t.Fatalf("call order = %#v, want wt.exe then cmd", called)
+	}
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -22,6 +22,13 @@ switch ($Flavor) {
 	}
 }
 
+function Write-FullInstallRemedy {
+	Write-Warning "Remedy commands:"
+	Write-Warning "  `"$env:LOCALAPPDATA\\NeoCode\\neocode.exe`" daemon install"
+	Write-Warning "  echo 127.0.0.1 neocode >> C:\\Windows\\System32\\drivers\\etc\\hosts"
+	Write-Warning "  `"$env:LOCALAPPDATA\\NeoCode\\neocode.exe`" daemon status"
+}
+
 # 1. 识别物理架构（优先考虑 64 位重定向环境）
 $RawArch = $env:PROCESSOR_ARCHITEW6432
 if ([string]::IsNullOrWhiteSpace($RawArch)) {
@@ -122,10 +129,18 @@ try {
 		}
 		catch {
 			Write-Warning "Failed to install HTTP daemon autostart automatically."
-			Write-Warning "Run '$NeoCodeExecutablePath daemon install' manually after installation."
+			Write-FullInstallRemedy
 		}
 	}
 	Write-Host "Installed $BinaryName ($Flavor) from $LatestTag." -ForegroundColor Green
+}
+catch {
+	Write-Error "Installation failed: $($_.Exception.Message)"
+	Write-Warning "Retry command: powershell -ExecutionPolicy Bypass -File scripts\\install.ps1 -Flavor $Flavor"
+	if ($Flavor -eq "full") {
+		Write-FullInstallRemedy
+	}
+	throw
 }
 finally {
 	if (Test-Path $TempDir) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,15 @@ DEFAULT_FLAVOR="full"
 flavor="$DEFAULT_FLAVOR"
 dry_run=0
 
+print_full_install_remedy() {
+  cat >&2 <<'REMEDY'
+Remedy commands:
+  /usr/local/bin/neocode daemon install
+  sudo echo '127.0.0.1 neocode' >> /etc/hosts
+  /usr/local/bin/neocode daemon status
+REMEDY
+}
+
 usage() {
   cat <<'USAGE'
 Usage: install.sh [--flavor full|gateway] [--dry-run]
@@ -58,6 +67,8 @@ case "$flavor" in
     exit 1
     ;;
 esac
+
+trap 'status=$?; if [[ $status -ne 0 ]]; then echo "Installation failed (exit ${status})." >&2; echo "Retry: bash scripts/install.sh --flavor ${flavor}" >&2; if [[ "${flavor}" == "full" ]]; then print_full_install_remedy; fi; fi' ERR
 
 os="$(uname -s)"
 arch="$(uname -m)"
@@ -152,6 +163,6 @@ if [[ "${flavor}" == "full" ]]; then
   echo "Installing HTTP daemon autostart..."
   if ! /usr/local/bin/neocode daemon install >/dev/null 2>&1; then
     echo "Warning: failed to install HTTP daemon autostart automatically." >&2
-    echo "Run '/usr/local/bin/neocode daemon install' manually after installation." >&2
+    print_full_install_remedy
   fi
 fi


### PR DESCRIPTION
## 概述

本 PR 围绕 `neocode daemon` 的 HTTP 页面交互体验和安装部署链路进行了系统性改进，覆盖 13 个文件（+656 / -42 行），分为三个功能维度。

Closes #580

## 改动详述

### 1. 跨平台终端自动拉起（5 文件）

之前 Linux 的 `launchTerminal()` 直接返回 `ErrTerminalUnsupported`，Windows 仅支持 `cmd /c start` 且使用 `strings.Fields` 分割命令字符串，存在安全隐患。

- **Linux**：新增 `gnome-terminal` 探测（优先级最高），失败后回退到 `x-terminal-emulator`，均不可用时返回明确安装指引
- **Windows**：优先探测 `wt.exe`（Windows Terminal）并通过 `new-tab` 拉起，失败后回退到 `cmd /c start`
- 新增 `terminal_linux_test.go` 和 `terminal_windows_test.go`，覆盖三种路径：首选终端、回退终端、无可用的终端

### 2. HTTP 响应页面美化（2 文件）

之前 daemon 返回的 HTML 页面是裸标签无样式：

```html
<html><body><h3>OK</h3><p>action=run</p>...</body></html>
```

改进为：

- **视觉**：渐变背景、居中卡片、圆角阴影、响应式布局（适配移动端）
- **结构**：完整的 `<!doctype html>` 骨架、`<meta viewport>`、`<title>`、SVG favicon
- **成功页**：显示 `action`、`session_id`、可点击的 `reusable_url` 链接
- **复制按钮**：新增 `复制链接` 按钮，优先使用 Clipboard API，在非安全上下文（`http://neocode`）中自动回退到 `execCommand('copy')`。**解决了 `navigator.clipboard` 在 http://neocode 下不可用导致"复制失败"的问题**
- **错误页**：将原始错误码映射为中文提示（如 `Gateway unavailable` → "无法连接到 gateway"），并展示可执行的补救命令（`neocode daemon status`、`neocode gateway --listen ...`）

### 3. 安装体验增强（6 文件）

- **安装后自动启动 daemon**：`daemon install` 成功后立即以后台进程方式执行 `daemon serve`，轮询 `/healthz` 最多 3 秒确认就绪，无需用户手动执行或重启
- **Gateway 拉起超时**：`defaultGatewayLaunchTimeout` 从 3 秒延长到 10 秒，适应冷启动较慢的机器；超时等错误信息从 "single fallback" 改为更可读的 "automatic startup"
- **Hosts 写入失败指引**：hosts 文件写入需要管理员权限，失败时给出平台对应的手动修复命令（Windows: `echo ... >> C:\Windows\...\hosts`，Linux/macOS: `sudo echo ... >> /etc/hosts`）
- **CLI 输出改进**：`daemon install` 在 stderr 输出结构化日志（成功摘要、hosts 警告、daemon 就绪状态），失败时打印完整补救命令
- **安装脚本**：`install.sh` / `install.ps1` 在 daemon 安装失败时输出多行补救指引，顶层异常也被捕获并输出重试命令

## 测试

- 新增 `TestLaunchTerminalLinuxUsesGnomeFirst` / `FallsBackToXTerminalEmulator` / `UnsupportedWhenNoTerminal`
- 新增 `TestLaunchTerminalWindowsPrefersWT` / `FallsBackToCmdStart` / `FallsBackWhenWTFails`
- 新增 `TestHTTPDaemonHandlerDispatchErrorIsFriendly`（验证错误页中文映射和补救命令）
- 新增 `TestBuildHostsAliasWarningIncludesManualCommands`（验证平台化 hosts 指引）
- 新增 `TestDaemonInstallDefaultRunnerUsesCurrentExecutable`（验证安装 JSON 输出和 stderr 日志）
- 新增 `TestDaemonInstallDefaultRunnerFailureWritesRemedy`（验证失败时的补救输出）
- 新增 `TestGatewayLaunchTimeoutIsTenSeconds` / `TestWaitGatewayReadyTimeoutMessage`
- 已有 13 个相关测试全部通过

## 验证方式

```bash
# 启动 daemon
neocode daemon serve

# 生成可点击链接并在浏览器打开
neocode daemon encode run --prompt "hello" --workdir "."
# 观察：页面美化效果、复制按钮功能、错误页展示

# 安装验证
neocode daemon install
# 观察：stderr 中的结构化日志、daemon 是否自动启动

# 终端拉起验证（Linux）
# 观察：点击 URL 后是否自动弹出终端并执行 neocode --session
```
