### PR TITLE
fix(web): 优化会话回放、compact 状态与文件回退刷新

### DIFF
--- a/internal/runtime/checkpoint_flow_test.go
+++ b/internal/runtime/checkpoint_flow_test.go
@@ -477,6 +477,70 @@ func TestRestoreCheckpointBaselineEmitsModeAndPaths(t *testing.T) {
 	}
 }
 
+func TestRestoreCheckpointBaselineRejectsPathsThatNormalizeEmpty(t *testing.T) {
+	fixture := newRuntimeCheckpointFixture(t)
+	target := filepath.Join(fixture.workdir, "baseline.txt")
+	if err := os.WriteFile(target, []byte("before baseline"), 0o644); err != nil {
+		t.Fatalf("WriteFile(before baseline) error = %v", err)
+	}
+	if _, err := fixture.perEditStore.CapturePreWrite(target); err != nil {
+		t.Fatalf("CapturePreWrite() error = %v", err)
+	}
+
+	state := newRunState("run-baseline-empty-paths", fixture.session)
+	if err := fixture.service.createStartOfTurnCheckpoint(context.Background(), &state); err != nil {
+		t.Fatalf("createStartOfTurnCheckpoint() error = %v", err)
+	}
+	records, err := fixture.checkpointStore.ListCheckpoints(context.Background(), fixture.session.ID, checkpoint.ListCheckpointOpts{})
+	if err != nil {
+		t.Fatalf("ListCheckpoints() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %#v, want 1", records)
+	}
+	cpRecord := records[0]
+	if err := fixture.checkpointStore.UpdateCheckpointStatus(context.Background(), cpRecord.CheckpointID, agentsession.CheckpointStatusAvailable); err != nil {
+		t.Fatalf("UpdateCheckpointStatus() error = %v", err)
+	}
+
+	_, err = fixture.service.restoreCheckpointBaseline(context.Background(), fixture.session.ID, cpRecord.CheckpointID, []string{"./", " . "})
+	if err == nil || !strings.Contains(err.Error(), "baseline restore paths required") {
+		t.Fatalf("restoreCheckpointBaseline() error = %v, want baseline restore paths required", err)
+	}
+}
+
+func TestRestoreCheckpointBaselineWrapsRestoreBaselineError(t *testing.T) {
+	fixture := newRuntimeCheckpointFixture(t)
+	target := filepath.Join(fixture.workdir, "baseline.txt")
+	if err := os.WriteFile(target, []byte("before baseline"), 0o644); err != nil {
+		t.Fatalf("WriteFile(before baseline) error = %v", err)
+	}
+	if _, err := fixture.perEditStore.CapturePreWrite(target); err != nil {
+		t.Fatalf("CapturePreWrite() error = %v", err)
+	}
+
+	state := newRunState("run-baseline-missing-path", fixture.session)
+	if err := fixture.service.createStartOfTurnCheckpoint(context.Background(), &state); err != nil {
+		t.Fatalf("createStartOfTurnCheckpoint() error = %v", err)
+	}
+	records, err := fixture.checkpointStore.ListCheckpoints(context.Background(), fixture.session.ID, checkpoint.ListCheckpointOpts{})
+	if err != nil {
+		t.Fatalf("ListCheckpoints() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %#v, want 1", records)
+	}
+	cpRecord := records[0]
+	if err := fixture.checkpointStore.UpdateCheckpointStatus(context.Background(), cpRecord.CheckpointID, agentsession.CheckpointStatusAvailable); err != nil {
+		t.Fatalf("UpdateCheckpointStatus() error = %v", err)
+	}
+
+	_, err = fixture.service.restoreCheckpointBaseline(context.Background(), fixture.session.ID, cpRecord.CheckpointID, []string{"missing.txt"})
+	if err == nil || !strings.Contains(err.Error(), "baseline restore code") || !strings.Contains(err.Error(), "missing.txt") {
+		t.Fatalf("restoreCheckpointBaseline() error = %v, want wrapped missing baseline path error", err)
+	}
+}
+
 func TestUndoRestoreCheckpoint_RestoresGuardState(t *testing.T) {
 	fixture := newRuntimeCheckpointFixture(t)
 	target := filepath.Join(fixture.workdir, "undo.txt")

--- a/internal/runtime/checkpoint_flow_test.go
+++ b/internal/runtime/checkpoint_flow_test.go
@@ -159,6 +159,25 @@ func (f runtimeCheckpointFixture) captureFile(t *testing.T, relPath string, cont
 	return abs
 }
 
+func readCheckpointRestoredPayload(t *testing.T, events <-chan RuntimeEvent) CheckpointRestoredPayload {
+	t.Helper()
+	for {
+		select {
+		case evt := <-events:
+			if evt.Type != EventCheckpointRestored {
+				continue
+			}
+			payload, ok := evt.Payload.(CheckpointRestoredPayload)
+			if !ok {
+				t.Fatalf("checkpoint restored payload type = %T", evt.Payload)
+			}
+			return payload
+		default:
+			t.Fatal("expected checkpoint restored event")
+		}
+	}
+}
+
 func TestCreateStartOfTurnCheckpoint_PendingWrite(t *testing.T) {
 	fixture := newRuntimeCheckpointFixture(t)
 	fixture.captureFile(t, "main.go", []byte("package main\nconst v = 1\n"))
@@ -391,6 +410,70 @@ func TestRestoreCheckpoint_RecoversCapturedFile(t *testing.T) {
 	}
 	if string(got) != "version one" {
 		t.Fatalf("restored content = %q, want %q", string(got), "version one")
+	}
+
+	payload := readCheckpointRestoredPayload(t, fixture.service.events)
+	if payload.Mode != "exact" {
+		t.Fatalf("restore payload mode = %q, want exact", payload.Mode)
+	}
+	if len(payload.Paths) != 0 {
+		t.Fatalf("restore payload paths = %#v, want empty", payload.Paths)
+	}
+	if payload.GuardCheckpointID == "" {
+		t.Fatal("restore payload guard checkpoint id is empty")
+	}
+}
+
+func TestRestoreCheckpointBaselineEmitsModeAndPaths(t *testing.T) {
+	fixture := newRuntimeCheckpointFixture(t)
+	target := filepath.Join(fixture.workdir, "baseline.txt")
+	if err := os.WriteFile(target, []byte("before baseline"), 0o644); err != nil {
+		t.Fatalf("WriteFile(before baseline) error = %v", err)
+	}
+	if _, err := fixture.perEditStore.CapturePreWrite(target); err != nil {
+		t.Fatalf("CapturePreWrite() error = %v", err)
+	}
+
+	state := newRunState("run-baseline", fixture.session)
+	if err := fixture.service.createStartOfTurnCheckpoint(context.Background(), &state); err != nil {
+		t.Fatalf("createStartOfTurnCheckpoint() error = %v", err)
+	}
+	records, err := fixture.checkpointStore.ListCheckpoints(context.Background(), fixture.session.ID, checkpoint.ListCheckpointOpts{})
+	if err != nil {
+		t.Fatalf("ListCheckpoints() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %#v, want 1", records)
+	}
+	cpRecord := records[0]
+	if err := fixture.checkpointStore.UpdateCheckpointStatus(context.Background(), cpRecord.CheckpointID, agentsession.CheckpointStatusAvailable); err != nil {
+		t.Fatalf("UpdateCheckpointStatus() error = %v", err)
+	}
+	if err := os.WriteFile(target, []byte("after baseline"), 0o644); err != nil {
+		t.Fatalf("WriteFile(after baseline) error = %v", err)
+	}
+
+	if _, err := fixture.service.RestoreCheckpoint(context.Background(), GatewayRestoreInput{
+		SessionID:    fixture.session.ID,
+		CheckpointID: cpRecord.CheckpointID,
+		Mode:         "baseline",
+		Paths:        []string{"./baseline.txt", "baseline.txt"},
+	}); err != nil {
+		t.Fatalf("RestoreCheckpoint(baseline) error = %v", err)
+	}
+	if got := string(mustReadRuntimeFile(t, target)); got != "before baseline" {
+		t.Fatalf("baseline restored content = %q, want before baseline", got)
+	}
+
+	payload := readCheckpointRestoredPayload(t, fixture.service.events)
+	if payload.Mode != "baseline" {
+		t.Fatalf("restore payload mode = %q, want baseline", payload.Mode)
+	}
+	if len(payload.Paths) != 1 || payload.Paths[0] != "baseline.txt" {
+		t.Fatalf("restore payload paths = %#v, want [baseline.txt]", payload.Paths)
+	}
+	if payload.GuardCheckpointID != "" {
+		t.Fatalf("baseline restore guard checkpoint id = %q, want empty", payload.GuardCheckpointID)
 	}
 }
 

--- a/internal/runtime/checkpoint_restore.go
+++ b/internal/runtime/checkpoint_restore.go
@@ -191,11 +191,13 @@ func (s *Service) RestoreCheckpoint(ctx context.Context, input GatewayRestoreInp
 			CheckpointID:      result.CheckpointID,
 			SessionID:         result.SessionID,
 			GuardCheckpointID: guardRecord.CheckpointID,
+			Mode:              "exact",
 		})
 		return result, nil
 	}
 	if mode == "baseline" {
-		result, err := s.restoreCheckpointBaseline(ctx, input.SessionID, input.CheckpointID, input.Paths)
+		paths := normalizeBaselineRestorePaths(input.Paths)
+		result, err := s.restoreCheckpointBaseline(ctx, input.SessionID, input.CheckpointID, paths)
 		if err != nil {
 			return RestoreResult{}, err
 		}
@@ -203,6 +205,8 @@ func (s *Service) RestoreCheckpoint(ctx context.Context, input GatewayRestoreInp
 			CheckpointID:      result.CheckpointID,
 			SessionID:         result.SessionID,
 			GuardCheckpointID: "",
+			Mode:              "baseline",
+			Paths:             paths,
 		})
 		return result, nil
 	}
@@ -351,7 +355,20 @@ func (s *Service) restoreCheckpointBaseline(
 	if perEditID == "" {
 		return RestoreResult{}, fmt.Errorf("checkpoint: %s has no code snapshot", checkpointID)
 	}
+	relPaths := normalizeBaselineRestorePaths(paths)
+	if len(relPaths) == 0 {
+		return RestoreResult{}, fmt.Errorf("checkpoint: baseline restore paths required")
+	}
+	if err := s.perEditStore.RestoreBaseline(ctx, perEditID, relPaths); err != nil {
+		return RestoreResult{}, fmt.Errorf("checkpoint: baseline restore code: %w", err)
+	}
+	return RestoreResult{CheckpointID: checkpointID, SessionID: sessionID}, nil
+}
+
+// normalizeBaselineRestorePaths 统一 baseline 文件回退路径，保证恢复执行与事件通知使用同一组相对路径。
+func normalizeBaselineRestorePaths(paths []string) []string {
 	relPaths := make([]string, 0, len(paths))
+	seen := make(map[string]struct{}, len(paths))
 	for _, path := range paths {
 		clean := filepath.ToSlash(strings.TrimSpace(path))
 		for strings.HasPrefix(clean, "./") {
@@ -360,15 +377,13 @@ func (s *Service) restoreCheckpointBaseline(
 		if clean == "" || clean == "." {
 			continue
 		}
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		seen[clean] = struct{}{}
 		relPaths = append(relPaths, clean)
 	}
-	if len(relPaths) == 0 {
-		return RestoreResult{}, fmt.Errorf("checkpoint: baseline restore paths required")
-	}
-	if err := s.perEditStore.RestoreBaseline(ctx, perEditID, relPaths); err != nil {
-		return RestoreResult{}, fmt.Errorf("checkpoint: baseline restore code: %w", err)
-	}
-	return RestoreResult{CheckpointID: checkpointID, SessionID: sessionID}, nil
+	return relPaths
 }
 
 // ListCheckpoints 查询指定会话的 checkpoint 列表。

--- a/internal/runtime/events.go
+++ b/internal/runtime/events.go
@@ -470,9 +470,11 @@ type CheckpointWarningPayload struct {
 
 // CheckpointRestoredPayload 描述 checkpoint 恢复成功事件。
 type CheckpointRestoredPayload struct {
-	CheckpointID      string `json:"checkpoint_id"`
-	SessionID         string `json:"session_id"`
-	GuardCheckpointID string `json:"guard_checkpoint_id"`
+	CheckpointID      string   `json:"checkpoint_id"`
+	SessionID         string   `json:"session_id"`
+	GuardCheckpointID string   `json:"guard_checkpoint_id"`
+	Mode              string   `json:"mode,omitempty"`
+	Paths             []string `json:"paths,omitempty"`
 }
 
 // CheckpointUndoRestorePayload 描述 restore 撤销事件。

--- a/internal/tui/services/gateway_stream_client_additional_test.go
+++ b/internal/tui/services/gateway_stream_client_additional_test.go
@@ -448,6 +448,82 @@ func TestRestoreRuntimePayloadAdditionalBranches(t *testing.T) {
 	}
 }
 
+func TestRestoreRuntimePayloadCheckpointRestoredKeepsBaselineFields(t *testing.T) {
+	t.Parallel()
+
+	payload, err := restoreRuntimePayload(EventCheckpointRestored, map[string]any{
+		"checkpoint_id":       "cp-baseline",
+		"session_id":          "session-1",
+		"guard_checkpoint_id": "",
+		"mode":                "baseline",
+		"paths":               []any{"a.txt", "nested/b.txt"},
+	})
+	if err != nil {
+		t.Fatalf("restoreRuntimePayload(CheckpointRestored) error = %v", err)
+	}
+	restored, ok := payload.(CheckpointRestoredPayload)
+	if !ok {
+		t.Fatalf("payload type = %T, want CheckpointRestoredPayload", payload)
+	}
+	if restored.CheckpointID != "cp-baseline" || restored.SessionID != "session-1" {
+		t.Fatalf("unexpected restored identity payload: %+v", restored)
+	}
+	if restored.Mode != "baseline" {
+		t.Fatalf("restored.Mode = %q, want baseline", restored.Mode)
+	}
+	if !reflect.DeepEqual(restored.Paths, []string{"a.txt", "nested/b.txt"}) {
+		t.Fatalf("restored.Paths = %#v, want [a.txt nested/b.txt]", restored.Paths)
+	}
+	if restored.GuardCheckpointID != "" {
+		t.Fatalf("restored.GuardCheckpointID = %q, want empty for baseline restore", restored.GuardCheckpointID)
+	}
+}
+
+func TestDecodeRuntimeEventCheckpointRestoredKeepsModeAndPaths(t *testing.T) {
+	t.Parallel()
+
+	notification := buildGatewayEventNotification(t, gateway.MessageFrame{
+		Type:      gateway.FrameTypeEvent,
+		Action:    gateway.FrameActionRun,
+		RunID:     "run-1",
+		SessionID: "session-1",
+		Payload: map[string]any{
+			"event_type": "run_progress",
+			"payload": map[string]any{
+				"runtime_event_type": string(EventCheckpointRestored),
+				"payload_version":    runtimeEventPayloadVersion,
+				"turn":               2,
+				"phase":              "restore",
+				"payload": map[string]any{
+					"checkpoint_id":       "cp-baseline",
+					"session_id":          "session-1",
+					"guard_checkpoint_id": "",
+					"mode":                "baseline",
+					"paths":               []string{"a.txt", "nested/b.txt"},
+				},
+			},
+		},
+	})
+
+	event, err := decodeRuntimeEventFromGatewayNotification(notification)
+	if err != nil {
+		t.Fatalf("decodeRuntimeEventFromGatewayNotification() error = %v", err)
+	}
+	if event.Type != EventCheckpointRestored || event.RunID != "run-1" || event.SessionID != "session-1" || event.Turn != 2 || event.Phase != "restore" {
+		t.Fatalf("unexpected event metadata: %+v", event)
+	}
+	restored, ok := event.Payload.(CheckpointRestoredPayload)
+	if !ok {
+		t.Fatalf("event.Payload type = %T, want CheckpointRestoredPayload", event.Payload)
+	}
+	if restored.CheckpointID != "cp-baseline" || restored.Mode != "baseline" {
+		t.Fatalf("unexpected checkpoint restored payload: %+v", restored)
+	}
+	if !reflect.DeepEqual(restored.Paths, []string{"a.txt", "nested/b.txt"}) {
+		t.Fatalf("restored.Paths = %#v, want [a.txt nested/b.txt]", restored.Paths)
+	}
+}
+
 func TestStreamHelperBranches(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/services/runtime_contract.go
+++ b/internal/tui/services/runtime_contract.go
@@ -618,9 +618,11 @@ type CheckpointWarningPayload struct {
 
 // CheckpointRestoredPayload 描述 checkpoint 恢复成功事件。
 type CheckpointRestoredPayload struct {
-	CheckpointID      string `json:"checkpoint_id"`
-	SessionID         string `json:"session_id"`
-	GuardCheckpointID string `json:"guard_checkpoint_id"`
+	CheckpointID      string   `json:"checkpoint_id"`
+	SessionID         string   `json:"session_id"`
+	GuardCheckpointID string   `json:"guard_checkpoint_id"`
+	Mode              string   `json:"mode,omitempty"`
+	Paths             []string `json:"paths,omitempty"`
 }
 
 // CheckpointUndoRestorePayload 描述 restore 撤销事件。

--- a/web/src/api/protocol.ts
+++ b/web/src/api/protocol.ts
@@ -521,6 +521,8 @@ export interface CheckpointRestoredPayload {
   checkpoint_id: string;
   session_id: string;
   guard_checkpoint_id: string;
+  mode?: "exact" | "baseline" | string;
+  paths?: string[];
 }
 
 export interface CheckpointUndoRestorePayload {

--- a/web/src/components/chat/ChatInput.test.tsx
+++ b/web/src/components/chat/ChatInput.test.tsx
@@ -73,6 +73,9 @@ describe('ChatInput', () => {
     useRuntimeInsightStore.getState().reset()
     useChatStore.setState({
       isGenerating: false,
+      isCompacting: false,
+      compactMode: '',
+      compactMessage: '',
       messages: [],
       permissionRequests: [],
       agentMode: 'build',
@@ -158,6 +161,60 @@ describe('ChatInput', () => {
     expect(screen.queryByTitle('附件文件')).not.toBeInTheDocument()
     expect(screen.queryByTitle('引用上下文')).not.toBeInTheDocument()
   })
+  it('shows inline compact status while compaction is running', () => {
+    useChatStore.getState().startCompacting('manual', 'Compacting context...')
+
+    render(<ChatInput />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Compacting context...')
+  })
+
+  it('blocks normal sends while compaction is running', async () => {
+    useChatStore.getState().startCompacting('manual', 'Compacting context...')
+    render(<ChatInput />)
+
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'hello' } })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(mockGatewayAPI.run).not.toHaveBeenCalled()
+    })
+    expect(useChatStore.getState().messages).toHaveLength(0)
+  })
+
+  it('blocks duplicate compact commands while compaction is running', async () => {
+    useSessionStore.setState({ currentSessionId: 'session-1' } as never)
+    useChatStore.getState().startCompacting('manual', 'Compacting context...')
+    render(<ChatInput />)
+
+    await submitSlashCommand('/compact')
+
+    await waitFor(() => {
+      expect(mockGatewayAPI.compact).not.toHaveBeenCalled()
+    })
+  })
+
+  it('sets compact state immediately when running /compact', async () => {
+    useSessionStore.setState({ currentSessionId: 'session-1' } as never)
+    let resolveCompact: (value: unknown) => void = () => {}
+    mockGatewayAPI.compact.mockReturnValueOnce(new Promise((resolve) => {
+      resolveCompact = resolve
+    }))
+    render(<ChatInput />)
+
+    await submitSlashCommand('/compact')
+
+    await waitFor(() => {
+      expect(useChatStore.getState().isCompacting).toBe(true)
+    })
+
+    resolveCompact({})
+    await waitFor(() => {
+      expect(useChatStore.getState().isCompacting).toBe(false)
+    })
+  })
+
   it('executes /memo without session id and shows payload.Content', async () => {
     mockGatewayAPI.executeSystemTool.mockResolvedValueOnce({
       payload: {

--- a/web/src/components/chat/ChatInput.test.tsx
+++ b/web/src/components/chat/ChatInput.test.tsx
@@ -4,6 +4,7 @@ import ChatInput from './ChatInput'
 import { useChatStore } from '@/stores/useChatStore'
 import { useComposerStore } from '@/stores/useComposerStore'
 import { useSessionStore } from '@/stores/useSessionStore'
+import { useRuntimeInsightStore } from '@/stores/useRuntimeInsightStore'
 
 const mockGatewayAPI = {
   listAvailableSkills: vi.fn(),
@@ -31,6 +32,21 @@ async function submitSlashCommand(command: string) {
   fireEvent.keyDown(textarea, { key: 'Enter' })
 }
 
+function renderWithBudget(input: {
+  action: string
+  estimated_input_tokens: number
+  prompt_budget: number
+  context_window?: number
+}) {
+  useRuntimeInsightStore.getState().setBudgetChecked({
+    attempt_seq: 1,
+    request_hash: 'budget-test',
+    ...input,
+  })
+  render(<ChatInput />)
+  return screen.getByTestId('budget-token-ring')
+}
+
 describe('ChatInput', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -54,12 +70,14 @@ describe('ChatInput', () => {
 
     useComposerStore.setState({ composerText: '' })
     useSessionStore.setState({ currentSessionId: '' } as never)
+    useRuntimeInsightStore.getState().reset()
     useChatStore.setState({
       isGenerating: false,
       messages: [],
       permissionRequests: [],
       agentMode: 'build',
       permissionMode: 'default',
+      tokenUsage: null,
     } as never)
   })
 
@@ -202,5 +220,70 @@ describe('ChatInput', () => {
     await waitFor(() => {
       expect(mockGatewayAPI.executeSystemTool).not.toHaveBeenCalled()
     })
+  })
+
+  it('shows a green budget ring below the warning threshold', () => {
+    const ring = renderWithBudget({
+      action: 'allow',
+      estimated_input_tokens: 80,
+      prompt_budget: 100,
+      context_window: 200,
+    })
+
+    expect(ring).toHaveAttribute('stroke', 'var(--success)')
+  })
+
+  it('shows a yellow budget ring near the automatic compact threshold', () => {
+    const ring = renderWithBudget({
+      action: 'allow',
+      estimated_input_tokens: 90,
+      prompt_budget: 100,
+      context_window: 200,
+    })
+
+    expect(ring).toHaveAttribute('stroke', 'var(--warning)')
+  })
+
+  it('shows a red budget ring near the context window limit', () => {
+    const ring = renderWithBudget({
+      action: 'allow',
+      estimated_input_tokens: 190,
+      prompt_budget: 100,
+      context_window: 200,
+    })
+
+    expect(ring).toHaveAttribute('stroke', 'var(--error)')
+  })
+
+  it('falls back to prompt budget as the limit when context window is missing', () => {
+    const ring = renderWithBudget({
+      action: 'allow',
+      estimated_input_tokens: 100,
+      prompt_budget: 100,
+    })
+
+    expect(ring).toHaveAttribute('stroke', 'var(--error)')
+  })
+
+  it('honors compact budget action as a yellow color override', () => {
+    const ring = renderWithBudget({
+      action: 'compact',
+      estimated_input_tokens: 20,
+      prompt_budget: 100,
+      context_window: 200,
+    })
+
+    expect(ring).toHaveAttribute('stroke', 'var(--warning)')
+  })
+
+  it('honors stop budget action as a red color override', () => {
+    const ring = renderWithBudget({
+      action: 'stop',
+      estimated_input_tokens: 20,
+      prompt_budget: 100,
+      context_window: 200,
+    })
+
+    expect(ring).toHaveAttribute('stroke', 'var(--error)')
   })
 })

--- a/web/src/components/chat/ChatInput.tsx
+++ b/web/src/components/chat/ChatInput.tsx
@@ -19,7 +19,7 @@ import {
 import SlashCommandMenu from './SlashCommandMenu'
 import SkillPicker from './SkillPicker'
 import ModelSelector from './ModelSelector'
-import { Send, Square } from 'lucide-react'
+import { LoaderCircle, Send, Square } from 'lucide-react'
 
 const slashMenuAnchorStyle: React.CSSProperties = {
   position: 'absolute',
@@ -129,6 +129,8 @@ export default function ChatInput() {
   const runCancelledRef = useRef(false)
   const composingRef = useRef(false)
   const isGenerating = useChatStore((state) => state.isGenerating)
+  const isCompacting = useChatStore((state) => state.isCompacting)
+  const compactMessage = useChatStore((state) => state.compactMessage)
   const addMessage = useChatStore((state) => state.addMessage)
   const addSystemMessage = useChatStore((state) => state.addSystemMessage)
   const setGenerating = useChatStore((state) => state.setGenerating)
@@ -188,6 +190,10 @@ export default function ChatInput() {
     const { command, argument } = parsed
     const currentSessionId = sessionId
     const api = gatewayAPI
+    if (isCompacting) {
+      useUIStore.getState().showToast('Context compaction is still running', 'info')
+      return true
+    }
     if (!api) {
       useUIStore.getState().showToast('Gateway not connected', 'error')
       return true
@@ -203,11 +209,17 @@ export default function ChatInput() {
           useUIStore.getState().showToast('Send a message first to start a session', 'error')
           return true
         }
+        useChatStore.getState().startCompacting('manual', 'Compacting context...')
         try {
           await api.compact(currentSessionId, '')
         } catch (err) {
           console.error('Compact failed:', err)
-          useUIStore.getState().showToast('Compaction failed', 'error')
+          if (useChatStore.getState().isCompacting) {
+            useChatStore.getState().finishCompacting()
+            useUIStore.getState().showToast('Compaction failed', 'error')
+          }
+        } finally {
+          useChatStore.getState().finishCompacting()
         }
         return true
       }
@@ -261,8 +273,8 @@ export default function ChatInput() {
         return true
       }
       default: {
-        if (isGenerating) {
-          useUIStore.getState().showToast('Cannot toggle skill while generating', 'info')
+        if (isGenerating || isCompacting) {
+          useUIStore.getState().showToast(isCompacting ? 'Context compaction is still running' : 'Cannot toggle skill while generating', 'info')
           return true
         }
         const skillCommand = availableSkillCommands.find((skill) => skill.usage === command)
@@ -287,11 +299,16 @@ export default function ChatInput() {
         return false
       }
     }
-  }, [gatewayAPI, sessionId, addSystemMessage, availableSkillCommands, isGenerating, allSlashCommands])
+  }, [gatewayAPI, sessionId, addSystemMessage, availableSkillCommands, isGenerating, isCompacting, allSlashCommands])
 
   async function handleSubmit() {
     const input = text.trim()
     if (!input) return
+
+    if (isCompacting) {
+      useUIStore.getState().showToast('Context compaction is still running', 'info')
+      return
+    }
 
     if (isGenerating) {
       if (isSlashCommand(input)) useUIStore.getState().showToast('Cannot run commands while generating', 'info')
@@ -419,6 +436,7 @@ export default function ChatInput() {
   }
 
   const isEmpty = !text.trim()
+  const controlsLocked = isGenerating || isCompacting
 
   return (
     <>
@@ -438,7 +456,13 @@ export default function ChatInput() {
               />
             </div>
           )}
-          <div className="input-box">
+          <div className={`input-box ${isCompacting ? 'compacting' : ''}`}>
+            {isCompacting && (
+              <div className="compact-status-row" role="status" aria-live="polite">
+                <LoaderCircle size={14} className="compact-status-spinner" />
+                <span>{compactMessage || 'Compacting context...'}</span>
+              </div>
+            )}
             <textarea
               ref={textareaRef}
               value={text}
@@ -454,7 +478,8 @@ export default function ChatInput() {
                 <button
                   className={`input-mode-toggle ${agentMode === 'plan' ? 'plan' : ''}`}
                   title={agentMode === 'plan' ? '规划模式' : '构建模式'}
-                  onClick={() => { if (!isGenerating) setAgentMode(agentMode === 'plan' ? 'build' : 'plan') }}
+                  disabled={controlsLocked}
+                  onClick={() => { if (!controlsLocked) setAgentMode(agentMode === 'plan' ? 'build' : 'plan') }}
                 >
                   {agentMode === 'plan' ? 'Plan' : 'Build'}
                 </button>
@@ -470,15 +495,16 @@ export default function ChatInput() {
                       padding: 2,
                       borderRadius: 'var(--radius-sm)',
                       background: 'var(--bg-hover)',
-                      opacity: isGenerating ? 0.5 : 1,
+                      opacity: controlsLocked ? 0.5 : 1,
                     }}
                   >
                     <button
                       type="button"
                       aria-pressed={permissionMode === 'default'}
+                      disabled={controlsLocked}
                       style={permissionModeButtonStyle(permissionMode === 'default')}
                       onClick={() => {
-                        if (isGenerating) return
+                        if (controlsLocked) return
                         setPermissionMode('default')
                       }}
                     >
@@ -487,9 +513,10 @@ export default function ChatInput() {
                     <button
                       type="button"
                       aria-pressed={permissionMode === 'bypass'}
+                      disabled={controlsLocked}
                       style={permissionModeButtonStyle(permissionMode === 'bypass')}
                       onClick={() => {
-                        if (isGenerating) return
+                        if (controlsLocked) return
                         setPermissionMode('bypass')
                       }}
                     >
@@ -503,8 +530,8 @@ export default function ChatInput() {
               <button
                 className={`input-send-btn ${isGenerating ? 'stop' : ''}`}
                 onClick={isGenerating ? handleCancel : handleSubmit}
-                disabled={isEmpty && !isGenerating}
-                title={isGenerating ? '停止生成' : '发送'}
+                disabled={isCompacting || (isEmpty && !isGenerating)}
+                title={isCompacting ? 'Context compaction is still running' : isGenerating ? '停止生成' : '发送'}
               >
                 {isGenerating ? <Square size={16} /> : <Send size={16} />}
               </button>

--- a/web/src/components/chat/ChatInput.tsx
+++ b/web/src/components/chat/ChatInput.tsx
@@ -28,6 +28,9 @@ const slashMenuAnchorStyle: React.CSSProperties = {
   zIndex: 100,
 }
 
+const budgetWarningThresholdRatio = 0.9
+const budgetDangerThresholdRatio = 0.95
+
 /** 将网关返回的技能列表转换成输入框使用的 slash 命令结构。 */
 function buildSkillSlashCommands(
   skills: Array<{ descriptor: { id: string; description?: string }; active?: boolean }>,
@@ -62,6 +65,59 @@ function extractSystemToolContent(result: unknown, fallback: string): string {
   const payload = (result as { payload?: { content?: string; Content?: string } } | null)?.payload
   const content = payload?.content ?? payload?.Content
   return content || fallback
+}
+
+/** 将预算事件转换为输入框圆环的语义状态，保持阈值和颜色判断集中。 */
+function resolveBudgetRingState(
+  budgetChecked: ReturnType<typeof useRuntimeInsightStore.getState>['budgetChecked'],
+  budgetEstimateFailed: ReturnType<typeof useRuntimeInsightStore.getState>['budgetEstimateFailed'],
+) {
+  if (budgetEstimateFailed) {
+    return {
+      color: 'var(--error)',
+      label: '预算估算失败',
+      ratio: 0,
+    }
+  }
+  if (!budgetChecked) {
+    return {
+      color: 'var(--text-tertiary)',
+      label: '暂无预算数据',
+      ratio: 0,
+    }
+  }
+
+  const estimatedTokens = Math.max(0, budgetChecked.estimated_input_tokens)
+  const promptBudget = Math.max(0, budgetChecked.prompt_budget)
+  const contextLimit = Math.max(0, budgetChecked.context_window || promptBudget)
+  const ringRatio = contextLimit > 0 ? Math.min(estimatedTokens / contextLimit, 1) : 0
+
+  if (
+    budgetChecked.action === 'stop' ||
+    (contextLimit > 0 && estimatedTokens >= contextLimit * budgetDangerThresholdRatio) ||
+    (!budgetChecked.context_window && promptBudget > 0 && estimatedTokens >= promptBudget)
+  ) {
+    return {
+      color: 'var(--error)',
+      label: '接近上下文上限',
+      ratio: ringRatio,
+    }
+  }
+  if (
+    budgetChecked.action === 'compact' ||
+    (promptBudget > 0 && estimatedTokens >= promptBudget * budgetWarningThresholdRatio)
+  ) {
+    return {
+      color: 'var(--warning)',
+      label: '接近自动压缩阈值',
+      ratio: ringRatio,
+    }
+  }
+  return {
+    color: 'var(--success)',
+    label: '正常',
+    ratio: ringRatio,
+  }
 }
 
 export default function ChatInput() {
@@ -471,16 +527,17 @@ function BudgetTokenStrip() {
   const [popoverStyle, setPopoverStyle] = useState<React.CSSProperties>({})
 
   const totalTokens = tokenUsage ? tokenUsage.input_tokens + tokenUsage.output_tokens : 0
-  const ratio = budgetUsageRatio ?? 0
+  const budgetRingState = resolveBudgetRingState(budgetChecked, budgetEstimateFailed)
+  const ratio = budgetRingState.ratio
+  const budgetPct = budgetUsageRatio ?? 0
   const pct = Math.min(Math.round(ratio * 100), 100)
+  const budgetThresholdPct = Math.min(Math.round(budgetPct * 100), 100)
 
   // SVG ring: radius 8, circumference ~50
   const r = 7
   const circ = 2 * Math.PI * r
   const dash = (ratio * circ).toFixed(1)
-  let ringColor = 'var(--text-tertiary)'
-  if (budgetEstimateFailed || ratio > 0.8) ringColor = 'var(--error)'
-  else if (ratio > 0.6) ringColor = 'var(--warning)'
+  const ringColor = budgetRingState.color
 
   // Click outside to close
   useEffect(() => {
@@ -542,6 +599,7 @@ function BudgetTokenStrip() {
           <circle cx={9} cy={9} r={r} fill="none" stroke="var(--bg-active)" strokeWidth="2" />
           {budgetChecked && (
             <circle
+              data-testid="budget-token-ring"
               cx={9}
               cy={9}
               r={r}
@@ -570,6 +628,10 @@ function BudgetTokenStrip() {
           ) : budgetChecked ? (
             <>
               <div className="budget-popover-row">
+                <span className="budget-popover-label">状态</span>
+                <span className="budget-popover-value" style={{ color: ringColor }}>{budgetRingState.label}</span>
+              </div>
+              <div className="budget-popover-row">
                 <span className="budget-popover-label">Budget</span>
                 <span className="budget-popover-value">{formatTokenCount(budgetChecked.prompt_budget)}</span>
               </div>
@@ -582,9 +644,15 @@ function BudgetTokenStrip() {
               <div className="budget-popover-row">
                 <span className="budget-popover-label">已用</span>
                 <span className="budget-popover-value">
-                  {formatTokenCount(budgetChecked.estimated_input_tokens)} ({pct}%)
+                  {formatTokenCount(budgetChecked.estimated_input_tokens)} ({budgetThresholdPct}%)
                 </span>
               </div>
+              {budgetChecked.context_window && (
+                <div className="budget-popover-row">
+                  <span className="budget-popover-label">上限占用</span>
+                  <span className="budget-popover-value">{pct}%</span>
+                </div>
+              )}
               {totalTokens > 0 && (
                 <div className="budget-popover-row">
                   <span className="budget-popover-label">本轮 Tokens</span>

--- a/web/src/components/chat/MessageItem.tsx
+++ b/web/src/components/chat/MessageItem.tsx
@@ -90,7 +90,7 @@ function UserMessage({ message }: { message: ChatMessage }) {
       if (sessionData?.messages) {
         useChatStore.getState().clearMessages()
         const mapped = mapHistoryMessages(sessionData.messages)
-        for (const msg of mapped) useChatStore.getState().addMessage(msg)
+        useChatStore.getState().setMessages(mapped)
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Revert failed'

--- a/web/src/components/chat/MessageList.test.tsx
+++ b/web/src/components/chat/MessageList.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import MessageList from './MessageList'
 import { useChatStore } from '@/stores/useChatStore'
 
@@ -10,8 +10,12 @@ vi.mock('./MessageItem', () => ({
 }))
 
 describe('MessageList', () => {
+	let scrollIntoViewMock: ReturnType<typeof vi.fn>
+
 	beforeEach(() => {
 		useChatStore.setState({ messages: [], isGenerating: false } as any)
+		scrollIntoViewMock = vi.fn()
+		window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock as unknown as typeof window.HTMLElement.prototype.scrollIntoView
 	})
 
 	it('renders empty state when no messages', () => {
@@ -32,5 +36,60 @@ describe('MessageList', () => {
 		render(<MessageList />)
 		const ids = screen.getAllByTestId(/msg-/).map((x) => x.textContent)
 		expect(ids).toEqual(['u1:solo', 't1:solo', 'a2:group', 'a1:group'])
+	})
+
+	it('scrolls instantly to the bottom when history messages first load', () => {
+		useChatStore.setState({
+			messages: [
+				{ id: 'u1', role: 'user', type: 'text', content: 'q', timestamp: 1 },
+				{ id: 'a1', role: 'assistant', type: 'text', content: 'answer', timestamp: 2 },
+			],
+			isGenerating: false,
+		} as any)
+
+		render(<MessageList />)
+
+		expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'instant' })
+	})
+
+	it('smoothly scrolls when the user sends a new message', () => {
+		useChatStore.setState({
+			messages: [{ id: 'a1', role: 'assistant', type: 'text', content: 'answer', timestamp: 1 }],
+			isGenerating: false,
+		} as any)
+		render(<MessageList />)
+		scrollIntoViewMock.mockClear()
+
+		act(() => {
+			useChatStore.setState({
+				messages: [
+					{ id: 'a1', role: 'assistant', type: 'text', content: 'answer', timestamp: 1 },
+					{ id: 'u1', role: 'user', type: 'text', content: 'follow-up', timestamp: 2 },
+				],
+			} as any)
+		})
+
+		expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth' })
+	})
+
+	it('keeps following generation when the user has not scrolled up', () => {
+		useChatStore.setState({
+			messages: [{ id: 'u1', role: 'user', type: 'text', content: 'q', timestamp: 1 }],
+			isGenerating: false,
+		} as any)
+		render(<MessageList />)
+		scrollIntoViewMock.mockClear()
+
+		act(() => {
+			useChatStore.setState({
+				messages: [
+					{ id: 'u1', role: 'user', type: 'text', content: 'q', timestamp: 1 },
+					{ id: 'a1', role: 'assistant', type: 'text', content: 'partial', timestamp: 2, streaming: true },
+				],
+				isGenerating: true,
+			} as any)
+		})
+
+		expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'instant' })
 	})
 })

--- a/web/src/components/chat/MessageList.tsx
+++ b/web/src/components/chat/MessageList.tsx
@@ -63,9 +63,11 @@ export default function MessageList() {
 
   // 条件滚动到底部
   useEffect(() => {
+    const prevMessagesLength = prevMessagesLengthRef.current
     const lastMsg = messages[messages.length - 1]
+    const loadedHistoryFromEmpty = prevMessagesLength === 0 && messages.length > 0
     const userJustSent =
-      messages.length > prevMessagesLengthRef.current && lastMsg?.role === 'user'
+      prevMessagesLength > 0 && messages.length > prevMessagesLength && lastMsg?.role === 'user'
     prevMessagesLengthRef.current = messages.length
 
     const scrollEl = getScrollEl()
@@ -83,6 +85,13 @@ export default function MessageList() {
         userScrolledUpRef.current = false
       }
       prevScrollTopRef.current = scrollTop
+    }
+
+    // 历史会话首次加载完成时直接定位到底部，避免进入会话后停留在顶部。
+    if (loadedHistoryFromEmpty) {
+      userScrolledUpRef.current = false
+      bottomRef.current?.scrollIntoView({ behavior: 'instant' })
+      return
     }
 
     // 用户发送新消息时重置暂停状态，强制滚到底部

--- a/web/src/components/layout/Sidebar.test.tsx
+++ b/web/src/components/layout/Sidebar.test.tsx
@@ -198,4 +198,52 @@ describe('Sidebar ProviderModal', () => {
     expect(showToast).not.toHaveBeenCalled()
     expect(screen.getByText('switch failed')).toBeInTheDocument()
   })
+
+  it('only shows the expanded workspace style on the current workspace', async () => {
+    const switchWorkspace = vi.fn().mockResolvedValue(undefined)
+    useWorkspaceStore.setState({
+      workspaces: [
+        { hash: 'w1', path: '/workspace-one', name: 'Workspace One', createdAt: '1', updatedAt: '1' },
+        { hash: 'w2', path: '/workspace-two', name: 'Workspace Two', createdAt: '1', updatedAt: '1' },
+      ],
+      currentWorkspaceHash: 'w1',
+      switchWorkspace,
+    } as any)
+
+    render(<Sidebar />)
+
+    const workspaceOne = screen.getByRole('button', { name: /Workspace One/i })
+    const workspaceTwo = screen.getByRole('button', { name: /Workspace Two/i })
+    const chevronFor = (button: HTMLElement) => {
+      const chevron = button.querySelector('.chevron')
+      if (!(chevron instanceof HTMLElement)) {
+        throw new Error('workspace chevron not found')
+      }
+      return chevron
+    }
+
+    await waitFor(() => {
+      expect(chevronFor(workspaceOne)).toHaveClass('expanded')
+    })
+
+    fireEvent.click(workspaceOne)
+    await waitFor(() => {
+      expect(chevronFor(workspaceOne)).not.toHaveClass('expanded')
+    })
+    fireEvent.click(workspaceOne)
+    await waitFor(() => {
+      expect(chevronFor(workspaceOne)).toHaveClass('expanded')
+    })
+
+    fireEvent.click(workspaceTwo)
+    await waitFor(() => {
+      expect(switchWorkspace).toHaveBeenCalledWith('w2', mockGatewayAPI)
+    })
+    useWorkspaceStore.setState({ currentWorkspaceHash: 'w2' } as any)
+
+    await waitFor(() => {
+      expect(chevronFor(workspaceOne)).not.toHaveClass('expanded')
+      expect(chevronFor(workspaceTwo)).toHaveClass('expanded')
+    })
+  })
 })

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -243,13 +243,14 @@ export default function Sidebar({ collapsed }: SidebarProps) {
         {filteredWorkspaces.map((ws) => {
           const expanded = expandedWorkspaces.has(ws.hash)
           const isCurrent = ws.hash === currentWorkspaceHash
+          const rowExpanded = isCurrent && expanded
           const sessionsForThisWorkspace = isCurrent ? filteredCurrentSessions : []
           const isRenaming = renamingWorkspaceHash === ws.hash
           return (
             <div key={ws.hash} style={{ marginBottom: 2 }}>
               <WorkspaceRow
                 workspace={ws}
-                expanded={expanded}
+                expanded={rowExpanded}
                 isCurrent={isCurrent}
                 isRenaming={isRenaming}
                 renameValue={workspaceRenameValue}
@@ -269,7 +270,7 @@ export default function Sidebar({ collapsed }: SidebarProps) {
                 }}
                 onDelete={() => handleDeleteWorkspace(ws.hash)}
               />
-              {expanded && isCurrent && (
+              {rowExpanded && (
                 <div className="session-list">
                   {sessionsForThisWorkspace.length === 0 && (
                     <div style={{ padding: '6px 12px', fontSize: 11, color: 'var(--text-tertiary)', fontStyle: 'italic' }}>暂无会话</div>

--- a/web/src/components/panels/FileChangePanel.test.tsx
+++ b/web/src/components/panels/FileChangePanel.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -264,6 +265,73 @@ describe("FileChangePanel", () => {
         mode: "baseline",
         paths: ["src/a.txt"],
       });
+    });
+  });
+
+  it("rolls back only remaining file changes after one file was already restored", async () => {
+    useUIStore.setState({
+      fileChanges: [
+        {
+          id: "fc-a",
+          path: "src/a.txt",
+          status: "modified",
+          additions: 1,
+          deletions: 0,
+          checkpoint_id: "cp-1",
+          rollback_checkpoint_id: "cp-rollback-1",
+          hunks: [],
+        },
+        {
+          id: "fc-b",
+          path: "src/b.txt",
+          status: "modified",
+          additions: 1,
+          deletions: 0,
+          checkpoint_id: "cp-1",
+          rollback_checkpoint_id: "cp-rollback-1",
+          hunks: [],
+        },
+      ],
+    } as never);
+
+    render(<FileChangePanel />);
+
+    act(() => {
+      useUIStore.setState({
+        fileChanges: [
+          {
+            id: "fc-b",
+            path: "src/b.txt",
+            status: "modified",
+            additions: 1,
+            deletions: 0,
+            checkpoint_id: "cp-1",
+            rollback_checkpoint_id: "cp-rollback-1",
+            hunks: [],
+          },
+        ],
+      } as never);
+    });
+
+    fireEvent.click(screen.getByTestId("restore-all-changes"));
+    const confirmButtons = screen.getAllByRole("button", {
+      name: "Rollback all",
+    });
+    fireEvent.click(confirmButtons[confirmButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(mockGatewayAPI.restoreCheckpoint).toHaveBeenCalledWith({
+        session_id: "sess-1",
+        checkpoint_id: "cp-rollback-1",
+        mode: "baseline",
+        paths: ["src/b.txt"],
+      });
+    });
+    expect(mockGatewayAPI.restoreCheckpoint).not.toHaveBeenCalledWith({
+      session_id: "sess-1",
+      checkpoint_id: "cp-rollback-1",
+      mode: "baseline",
+      paths: ["src/a.txt", "src/b.txt"],
     });
   });
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1153,6 +1153,26 @@ html, body, #root {
   transition: all var(--duration-fast) var(--ease-out);
 }
 .input-box:focus-within { background: var(--bg-elevated); border-color: var(--accent-muted); }
+.input-box.compacting {
+  border-color: var(--warning-muted);
+}
+.compact-status-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px 0;
+  color: var(--warning);
+  font-size: 12px;
+  font-weight: 500;
+}
+.compact-status-spinner {
+  flex-shrink: 0;
+  animation: compact-spin 900ms linear infinite;
+}
+@keyframes compact-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
 .input-box textarea {
   width: 100%;
   padding: 10px 14px 6px;

--- a/web/src/stores/useChatStore.test.ts
+++ b/web/src/stores/useChatStore.test.ts
@@ -5,6 +5,9 @@ beforeEach(() => {
   useChatStore.setState({
     messages: [],
     isGenerating: false,
+    isCompacting: false,
+    compactMode: '',
+    compactMessage: '',
     streamingMessageId: '',
     streamingThinkingMessageId: '',
     permissionRequests: [],
@@ -162,6 +165,32 @@ describe('useChatStore', () => {
     expect(useChatStore.getState().isGenerating).toBe(false)
   })
 
+  it('tracks compact state independently from generation', () => {
+    const store = useChatStore.getState()
+    store.setGenerating(true)
+    store.startCompacting('manual', 'Compacting context...')
+
+    expect(useChatStore.getState().isGenerating).toBe(true)
+    expect(useChatStore.getState().isCompacting).toBe(true)
+    expect(useChatStore.getState().compactMode).toBe('manual')
+    expect(useChatStore.getState().compactMessage).toBe('Compacting context...')
+
+    store.finishCompacting()
+
+    expect(useChatStore.getState().isGenerating).toBe(true)
+    expect(useChatStore.getState().isCompacting).toBe(false)
+    expect(useChatStore.getState().compactMode).toBe('')
+  })
+
+  it('resetGeneratingState clears stuck compact state', () => {
+    const store = useChatStore.getState()
+    store.startCompacting('manual', 'Compacting context...')
+    store.resetGeneratingState()
+
+    expect(useChatStore.getState().isCompacting).toBe(false)
+    expect(useChatStore.getState().compactMessage).toBe('')
+  })
+
   it('starts with default permission mode', () => {
     expect(useChatStore.getState().permissionMode).toBe('default')
   })
@@ -174,7 +203,9 @@ describe('useChatStore', () => {
   it('clearMessages resets permission mode to default', () => {
     const store = useChatStore.getState()
     store.setPermissionMode('bypass')
+    store.startCompacting('manual', 'Compacting context...')
     store.clearMessages()
     expect(useChatStore.getState().permissionMode).toBe('default')
+    expect(useChatStore.getState().isCompacting).toBe(false)
   })
 })

--- a/web/src/stores/useChatStore.test.ts
+++ b/web/src/stores/useChatStore.test.ts
@@ -30,6 +30,45 @@ describe('useChatStore', () => {
     expect(useChatStore.getState().messages[0].content).toBe('hello')
   })
 
+  it('setMessages replaces messages atomically', () => {
+    const store = useChatStore.getState()
+    store.addMessage({ id: 'old', role: 'user', content: 'old', type: 'text', timestamp: 1 })
+
+    store.setMessages([
+      { id: 'new-1', role: 'user', content: 'first', type: 'text', timestamp: 2 },
+      { id: 'new-2', role: 'assistant', content: 'second', type: 'text', timestamp: 3 },
+    ])
+
+    expect(useChatStore.getState().messages.map((m) => m.id)).toEqual(['new-1', 'new-2'])
+  })
+
+  it('setMessages preserves unrelated chat state', () => {
+    const store = useChatStore.getState()
+    store.setGenerating(true)
+    store.addPermissionRequest({
+      request_id: 'r1',
+      tool_name: 'filesystem_read_file',
+      tool_category: 'filesystem',
+      action_type: 'read',
+      operation: 'read',
+      target_type: 'file',
+      target: 'README.md',
+    } as any)
+    store.updateTokenUsage({ input_tokens: 1, output_tokens: 2, total_tokens: 3 } as any)
+    store.setPhase('running')
+    store.setStopReason('manual')
+
+    store.setMessages([{ id: 'hist', role: 'assistant', content: 'loaded', type: 'text', timestamp: 4 }])
+
+    const state = useChatStore.getState()
+    expect(state.messages.map((m) => m.id)).toEqual(['hist'])
+    expect(state.isGenerating).toBe(true)
+    expect(state.permissionRequests).toHaveLength(1)
+    expect(state.tokenUsage).toEqual({ input_tokens: 1, output_tokens: 2, total_tokens: 3 })
+    expect(state.phase).toBe('running')
+    expect(state.stopReason).toBe('manual')
+  })
+
   it('appendChunk concatenates to streaming message', () => {
     const store = useChatStore.getState()
     store.addMessage({ id: 'stream-1', role: 'assistant', content: 'Hel', type: 'text', timestamp: 1 })

--- a/web/src/stores/useChatStore.ts
+++ b/web/src/stores/useChatStore.ts
@@ -72,6 +72,7 @@ interface ChatState {
 
   // Actions
   addMessage: (msg: ChatMessage) => void
+  setMessages: (messages: ChatMessage[]) => void
   removeMessage: (id: string) => void
   /** 从指定消息（含）开始截断 messages 数组并清理生成相关状态 */
   truncateFromMessage: (messageId: string) => void
@@ -199,6 +200,7 @@ export const useChatStore = create<ChatState>((set) => ({
   permissionMode: 'default',
 
   addMessage: (msg) => set((s) => ({ messages: [...s.messages, msg] })),
+  setMessages: (messages) => set({ messages: [...messages] }),
   removeMessage: (id) => set((s) => ({ messages: s.messages.filter((m) => m.id !== id) })),
 
   truncateFromMessage: (messageId) =>

--- a/web/src/stores/useChatStore.ts
+++ b/web/src/stores/useChatStore.ts
@@ -49,6 +49,12 @@ interface ChatState {
   messages: ChatMessage[]
   /** 是否正在生成 */
   isGenerating: boolean
+  /** 当前会话是否正在执行上下文压缩。 */
+  isCompacting: boolean
+  /** 当前压缩触发模式，用于展示压缩来源。 */
+  compactMode: string
+  /** 压缩期间展示给用户的持续状态文案。 */
+  compactMessage: string
   /** 当前 AI 回复缓冲 ID（流式追加用） */
   streamingMessageId: string
   /** 当前 thinking 流式消息 ID */
@@ -101,6 +107,8 @@ interface ChatState {
   /** 更新一条 verification 消息的 data(verification 进行中持续更新同一条消息) */
   updateVerificationMessage: (messageId: string, data: VerificationRunRecord) => void
   setGenerating: (v: boolean) => void
+  startCompacting: (mode?: string, message?: string) => void
+  finishCompacting: () => void
   setStreamingMessageId: (id: string) => void
   /** 重置生成状态：终结当前流式消息 + 清除 isGenerating */
   resetGeneratingState: () => void
@@ -188,6 +196,9 @@ function createThinkingMessage(): ChatMessage {
 export const useChatStore = create<ChatState>((set) => ({
   messages: [],
   isGenerating: false,
+  isCompacting: false,
+  compactMode: '',
+  compactMessage: '',
   streamingMessageId: '',
   streamingThinkingMessageId: '',
   permissionRequests: [],
@@ -212,6 +223,9 @@ export const useChatStore = create<ChatState>((set) => ({
         streamingMessageId: '',
         streamingThinkingMessageId: '',
         isGenerating: false,
+        isCompacting: false,
+        compactMode: '',
+        compactMessage: '',
         permissionRequests: [],
         pendingUserQuestion: null,
         phase: '',
@@ -358,6 +372,18 @@ export const useChatStore = create<ChatState>((set) => ({
     })),
 
   setGenerating: (isGenerating) => set({ isGenerating }),
+  startCompacting: (compactMode = 'manual', compactMessage = 'Compacting context...') =>
+    set({
+      isCompacting: true,
+      compactMode,
+      compactMessage,
+    }),
+  finishCompacting: () =>
+    set({
+      isCompacting: false,
+      compactMode: '',
+      compactMessage: '',
+    }),
   setStreamingMessageId: (streamingMessageId) => set({ streamingMessageId }),
 
   /** 重置生成状态：终结当前流式消息 + 清除 isGenerating */
@@ -381,6 +407,9 @@ export const useChatStore = create<ChatState>((set) => ({
         streamingMessageId: '',
         streamingThinkingMessageId: '',
         isGenerating: false,
+        isCompacting: false,
+        compactMode: '',
+        compactMessage: '',
       }
     }),
 
@@ -429,6 +458,9 @@ export const useChatStore = create<ChatState>((set) => ({
       streamingMessageId: '',
       streamingThinkingMessageId: '',
       isGenerating: false,
+      isCompacting: false,
+      compactMode: '',
+      compactMessage: '',
       permissionRequests: [],
       pendingUserQuestion: null,
       tokenUsage: null,

--- a/web/src/stores/useSessionStore.test.ts
+++ b/web/src/stores/useSessionStore.test.ts
@@ -47,8 +47,36 @@ describe('useSessionStore', () => {
       },
     ])
 
+    expect(mapped.map((m) => m.content)).toEqual([
+      'normal assistant text',
+      'prefix <completion_blocked_reason>pending_todo</completion_blocked_reason>',
+    ])
+  })
+
+  it('mapHistoryMessages keeps tool results that contain acceptance-like text', () => {
+    const mapped = mapHistoryMessages([
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          { id: 'call-xml', name: 'filesystem_read_file', arguments: '{"path":"fixture.xml"}' },
+        ],
+      },
+      {
+        role: 'tool',
+        content: '<completion_blocked_reason>literal fixture</completion_blocked_reason>\n<todo_convergence />',
+        tool_call_id: 'call-xml',
+      },
+    ])
+
     expect(mapped).toHaveLength(1)
-    expect(mapped[0].content).toBe('normal assistant text')
+    expect(mapped[0]).toMatchObject({
+      role: 'tool',
+      type: 'tool_call',
+      toolCallId: 'call-xml',
+      toolResult: '<completion_blocked_reason>literal fixture</completion_blocked_reason>\n<todo_convergence />',
+      toolStatus: 'done',
+    })
   })
 
   it('mapHistoryMessages keeps normal messages and merges tool results', () => {

--- a/web/src/stores/useSessionStore.test.ts
+++ b/web/src/stores/useSessionStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { useSessionStore } from './useSessionStore'
+import { mapHistoryMessages, useSessionStore } from './useSessionStore'
 import { useChatStore } from './useChatStore'
 import { useGatewayStore } from './useGatewayStore'
 import { useRuntimeInsightStore } from './useRuntimeInsightStore'
@@ -12,6 +12,67 @@ beforeEach(() => {
 })
 
 describe('useSessionStore', () => {
+  it('mapHistoryMessages skips internal system acceptance reminders', () => {
+    const mapped = mapHistoryMessages([
+      { role: 'user', content: 'start' },
+      {
+        role: 'system',
+        content: [
+          '<acceptance_continue>',
+          '<completion_blocked_reason>pending_todo</completion_blocked_reason>',
+          '</acceptance_continue>',
+        ].join(''),
+      },
+      { role: 'assistant', content: 'visible answer' },
+    ])
+
+    expect(mapped.map((m) => m.content)).toEqual(['start', 'visible answer'])
+    expect(mapped.every((m) => m.content.includes('acceptance_continue') === false)).toBe(true)
+  })
+
+  it('mapHistoryMessages skips leaked assistant acceptance control text', () => {
+    const mapped = mapHistoryMessages([
+      {
+        role: 'assistant',
+        content: '<acceptance_continue><todo_convergence></todo_convergence></acceptance_continue>',
+      },
+      { role: 'assistant', content: 'normal assistant text' },
+      {
+        role: 'assistant',
+        content: 'prefix <completion_blocked_reason>pending_todo</completion_blocked_reason>',
+      },
+    ])
+
+    expect(mapped).toHaveLength(1)
+    expect(mapped[0].content).toBe('normal assistant text')
+  })
+
+  it('mapHistoryMessages keeps normal messages and merges tool results', () => {
+    const mapped = mapHistoryMessages([
+      { role: 'user', content: 'please inspect' },
+      {
+        role: 'assistant',
+        content: 'calling tool',
+        tool_calls: [
+          { id: 'call-1', name: 'filesystem_read_file', arguments: '{"path":"README.md"}' },
+        ],
+      },
+      { role: 'tool', content: 'file content', tool_call_id: 'call-1' },
+    ])
+
+    expect(mapped).toHaveLength(3)
+    expect(mapped[0]).toMatchObject({ role: 'user', type: 'text', content: 'please inspect' })
+    expect(mapped[1]).toMatchObject({ role: 'assistant', type: 'text', content: 'calling tool' })
+    expect(mapped[2]).toMatchObject({
+      role: 'tool',
+      type: 'tool_call',
+      toolName: 'filesystem_read_file',
+      toolCallId: 'call-1',
+      toolResult: 'file content',
+      toolStatus: 'done',
+    })
+  })
+
   it('createSession clears messages and resets session state', () => {
     useChatStore.getState().addMessage({ id: '1', role: 'user', content: 'hello', type: 'text', timestamp: 1 })
     useSessionStore.setState({ currentSessionId: 'sess-1' })

--- a/web/src/stores/useSessionStore.test.ts
+++ b/web/src/stores/useSessionStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mapHistoryMessages, useSessionStore } from './useSessionStore'
 import { useChatStore } from './useChatStore'
 import { useGatewayStore } from './useGatewayStore'
@@ -9,6 +9,10 @@ beforeEach(() => {
   useChatStore.setState({ messages: [], isGenerating: false, streamingMessageId: '', permissionRequests: [], tokenUsage: null, phase: '', stopReason: '' } as any)
   useGatewayStore.setState({ connectionState: 'disconnected', currentRunId: '', token: '', authenticated: false } as any)
   useRuntimeInsightStore.getState().reset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
 })
 
 describe('useSessionStore', () => {
@@ -115,6 +119,8 @@ describe('useSessionStore', () => {
   })
 
   it('switchSession binds stream and loads session data', async () => {
+    const setMessagesSpy = vi.spyOn(useChatStore.getState(), 'setMessages')
+    const addMessageSpy = vi.spyOn(useChatStore.getState(), 'addMessage')
     const mockBindStream = vi.fn().mockResolvedValue({})
     const mockLoadSession = vi.fn().mockResolvedValue({
       payload: {
@@ -128,11 +134,15 @@ describe('useSessionStore', () => {
     await useSessionStore.getState().switchSession('sess-2', mockAPI)
 
     expect(mockBindStream).toHaveBeenCalledWith({ session_id: 'sess-2', channel: 'all' })
+    expect(setMessagesSpy).toHaveBeenCalledTimes(1)
+    expect(addMessageSpy).not.toHaveBeenCalled()
     expect(useChatStore.getState().messages).toHaveLength(1)
     expect(useChatStore.getState().messages[0].role).toBe('user')
   })
 
   it('fetchSessions auto-selects first session and binds stream', async () => {
+    const setMessagesSpy = vi.spyOn(useChatStore.getState(), 'setMessages')
+    const addMessageSpy = vi.spyOn(useChatStore.getState(), 'addMessage')
     const mockListSessions = vi.fn().mockResolvedValue({
       payload: {
         sessions: [{
@@ -144,13 +154,18 @@ describe('useSessionStore', () => {
       },
     })
     const mockBindStream = vi.fn().mockResolvedValue({})
-    const mockLoadSession = vi.fn().mockResolvedValue({ payload: { messages: [] } })
+    const mockLoadSession = vi.fn().mockResolvedValue({
+      payload: { messages: [{ role: 'assistant', content: 'loaded history', tool_calls: [] }] },
+    })
     const mockAPI = { listSessions: mockListSessions, bindStream: mockBindStream, loadSession: mockLoadSession } as any
 
     await useSessionStore.getState().fetchSessions(mockAPI)
 
     expect(useSessionStore.getState().currentSessionId).toBe('sess-a')
     expect(mockBindStream).toHaveBeenCalledWith({ session_id: 'sess-a', channel: 'all' })
+    expect(setMessagesSpy).toHaveBeenCalled()
+    expect(addMessageSpy).not.toHaveBeenCalled()
+    expect(useChatStore.getState().messages[0]).toMatchObject({ role: 'assistant', content: 'loaded history' })
   })
 
   it('fetchSessions does not auto-select when current session is valid', async () => {

--- a/web/src/stores/useSessionStore.ts
+++ b/web/src/stores/useSessionStore.ts
@@ -160,13 +160,11 @@ export async function loadSessionWithInsights(gatewayAPI: GatewayAPI, sessionId:
 /** isInternalHistoryMessage 识别仅供 runtime/provider 续跑使用、不能回放到 Web 聊天流的内部控制消息。 */
 function isInternalHistoryMessage(msg: BackendMessage): boolean {
   const role = msg.role.trim().toLowerCase()
-  if (role === 'system') return true
+  if (role !== 'system' && role !== 'assistant') return false
 
   const content = msg.content.trim()
   if (!content) return false
-  return content.startsWith('<acceptance_continue>') ||
-    content.includes('<completion_blocked_reason>') ||
-    content.includes('<todo_convergence>')
+  return /^<acceptance_continue\b[\s\S]*<\/acceptance_continue>$/.test(content)
 }
 
 /** 将后端历史消息映射为前端 ChatMessage 列表，正确合并 tool_result 回 tool_call */

--- a/web/src/stores/useSessionStore.ts
+++ b/web/src/stores/useSessionStore.ts
@@ -157,12 +157,25 @@ export async function loadSessionWithInsights(gatewayAPI: GatewayAPI, sessionId:
   return sessionFrame
 }
 
+/** isInternalHistoryMessage 识别仅供 runtime/provider 续跑使用、不能回放到 Web 聊天流的内部控制消息。 */
+function isInternalHistoryMessage(msg: BackendMessage): boolean {
+  const role = msg.role.trim().toLowerCase()
+  if (role === 'system') return true
+
+  const content = msg.content.trim()
+  if (!content) return false
+  return content.startsWith('<acceptance_continue>') ||
+    content.includes('<completion_blocked_reason>') ||
+    content.includes('<todo_convergence>')
+}
+
 /** 将后端历史消息映射为前端 ChatMessage 列表，正确合并 tool_result 回 tool_call */
 export function mapHistoryMessages(backendMessages: BackendMessage[]): Array<ReturnType<typeof useChatStore.getState>['messages'][0]> {
   let _idCounter = 0
   // Phase 1: Collect tool results by tool_call_id
   const toolResults = new Map<string, { content: string; isError: boolean }>()
   for (const msg of backendMessages) {
+    if (isInternalHistoryMessage(msg)) continue
     if (msg.tool_call_id) {
       toolResults.set(msg.tool_call_id, { content: msg.content, isError: !!msg.is_error })
     }
@@ -171,6 +184,8 @@ export function mapHistoryMessages(backendMessages: BackendMessage[]): Array<Ret
   // Phase 2: Map messages, merging tool results into corresponding tool_calls
   const result: Array<ReturnType<typeof useChatStore.getState>['messages'][0]> = []
   for (const msg of backendMessages) {
+    if (isInternalHistoryMessage(msg)) continue
+
     // Skip bare tool result messages — they are merged into tool_call messages
     if (msg.tool_call_id) continue
 

--- a/web/src/stores/useSessionStore.ts
+++ b/web/src/stores/useSessionStore.ts
@@ -256,9 +256,7 @@ export async function reloadSessionAfterCheckpointRestore(
 
   if (sessionData.messages && sessionData.messages.length > 0) {
     const mapped = mapHistoryMessages(sessionData.messages)
-    for (const msg of mapped) {
-      useChatStore.getState().addMessage(msg)
-    }
+    useChatStore.getState().setMessages(mapped)
   }
 
   const restoredMode = sessionData.agent_mode === 'plan' ? 'plan' : 'build'
@@ -323,9 +321,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       // 5. Load messages and stop transitioning
       if (sessionData.messages && sessionData.messages.length > 0) {
         const mapped = mapHistoryMessages(sessionData.messages)
-        for (const msg of mapped) {
-          useChatStore.getState().addMessage(msg)
-        }
+        useChatStore.getState().setMessages(mapped)
       }
       // 恢复会话的 agent_mode
       const restoredMode = sessionData.agent_mode === 'plan' ? 'plan' : 'build'
@@ -419,9 +415,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
             const sessionData = sessionFrame.payload as { messages?: BackendMessage[]; agent_mode?: string }
             if (sessionData.messages && sessionData.messages.length > 0) {
               const mapped = mapHistoryMessages(sessionData.messages)
-              for (const msg of mapped) {
-                useChatStore.getState().addMessage(msg)
-              }
+              useChatStore.getState().setMessages(mapped)
             }
             const restoredMode = sessionData.agent_mode === 'plan' ? 'plan' : 'build'
             useChatStore.getState().setAgentMode(restoredMode)

--- a/web/src/utils/eventBridge.test.ts
+++ b/web/src/utils/eventBridge.test.ts
@@ -950,6 +950,196 @@ describe("eventBridge", () => {
     expect(useUIStore.getState().fileChanges).toHaveLength(0);
   });
 
+  it("baseline CheckpointRestored removes only restored file changes without reloading the session", async () => {
+    const loadSession = vi.fn(async () => ({
+      payload: {
+        id: "sess-1",
+        agent_mode: "build",
+        messages: [{ role: "assistant", content: "after restore" }],
+      },
+    }));
+    const api = createMockGatewayAPI({ loadSession });
+    useSessionStore.setState({ currentSessionId: "sess-1" } as any);
+    useUIStore.setState({
+      isRestoringCheckpoint: true,
+      fileChanges: [
+        {
+          id: "fc-1",
+          path: "src/a.txt",
+          status: "modified",
+          additions: 1,
+          deletions: 0,
+        },
+        {
+          id: "fc-2",
+          path: "src/b.txt",
+          status: "modified",
+          additions: 2,
+          deletions: 1,
+        },
+      ],
+    } as any);
+
+    handleGatewayEvent(
+      {
+        type: EventType.CheckpointRestored,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.CheckpointRestored,
+            payload: {
+              checkpoint_id: "cp1",
+              session_id: "sess-1",
+              guard_checkpoint_id: "",
+              mode: "baseline",
+              paths: ["./src/a.txt"],
+            },
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-1",
+      },
+      api,
+    );
+    await Promise.resolve();
+
+    expect(loadSession).not.toHaveBeenCalled();
+    expect(useUIStore.getState().isRestoringCheckpoint).toBe(false);
+    expect(useUIStore.getState().fileChanges.map((entry) => entry.path)).toEqual(
+      ["src/b.txt"],
+    );
+  });
+
+  it("baseline CheckpointRestored removes all paths from rollback all events", async () => {
+    const loadSession = vi.fn();
+    const api = createMockGatewayAPI({ loadSession });
+    useSessionStore.setState({ currentSessionId: "sess-1" } as any);
+    useUIStore.setState({
+      isRestoringCheckpoint: true,
+      fileChanges: [
+        {
+          id: "fc-1",
+          path: "src/a.txt",
+          status: "modified",
+          additions: 1,
+          deletions: 0,
+        },
+        {
+          id: "fc-2",
+          path: "src/b.txt",
+          status: "added",
+          additions: 2,
+          deletions: 0,
+        },
+      ],
+    } as any);
+
+    handleGatewayEvent(
+      {
+        type: EventType.CheckpointRestored,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.CheckpointRestored,
+            payload: {
+              checkpoint_id: "cp1",
+              session_id: "sess-1",
+              guard_checkpoint_id: "",
+              mode: "baseline",
+              paths: ["src/a.txt", "src/b.txt"],
+            },
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-1",
+      },
+      api,
+    );
+    await Promise.resolve();
+
+    expect(loadSession).not.toHaveBeenCalled();
+    expect(useUIStore.getState().fileChanges).toHaveLength(0);
+  });
+
+  it("baseline CheckpointRestored invalidates in-flight run-scoped file change refreshes", async () => {
+    let resolveDiff: ((value: unknown) => void) | undefined;
+    const checkpointDiff = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveDiff = resolve;
+        }),
+    );
+    const loadSession = vi.fn();
+    const api = createMockGatewayAPI({ checkpointDiff, loadSession });
+    useSessionStore.setState({ currentSessionId: "sess-1" } as any);
+    useGatewayStore.setState({ currentRunId: "run-1" } as any);
+    useUIStore.setState({
+      fileChanges: [
+        {
+          id: "fc-1",
+          path: "src/a.txt",
+          status: "modified",
+          additions: 1,
+          deletions: 0,
+        },
+      ],
+    } as any);
+
+    handleGatewayEvent(
+      {
+        type: EventType.CheckpointCreated,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.CheckpointCreated,
+            payload: {
+              checkpoint_id: "cp-end",
+              code_checkpoint_ref: "c",
+              session_checkpoint_ref: "s",
+              commit_hash: "",
+              reason: "end_of_turn",
+            },
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-1",
+      },
+      api,
+    );
+    expect(checkpointDiff).toHaveBeenCalled();
+
+    handleGatewayEvent(
+      {
+        type: EventType.CheckpointRestored,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.CheckpointRestored,
+            payload: {
+              checkpoint_id: "cp-end",
+              session_id: "sess-1",
+              guard_checkpoint_id: "",
+              mode: "baseline",
+              paths: ["src/a.txt"],
+            },
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-1",
+      },
+      api,
+    );
+
+    resolveDiff?.({
+      payload: {
+        checkpoint_id: "cp-end",
+        files: { modified: ["src/a.txt"] },
+        patch: "--- a/src/a.txt\n+++ b/src/a.txt\n@@ -1 +1 @@\n-old\n+new\n",
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(loadSession).not.toHaveBeenCalled();
+    expect(useUIStore.getState().fileChanges).toHaveLength(0);
+  });
+
   it("CheckpointRestored invalidates in-flight run-scoped file change refreshes", async () => {
     let resolveDiff: ((value: unknown) => void) | undefined;
     const checkpointDiff = vi.fn(

--- a/web/src/utils/eventBridge.test.ts
+++ b/web/src/utils/eventBridge.test.ts
@@ -25,6 +25,9 @@ beforeEach(() => {
   useChatStore.setState({
     messages: [],
     isGenerating: false,
+    isCompacting: false,
+    compactMode: "",
+    compactMessage: "",
     streamingMessageId: "",
     permissionRequests: [],
     pendingUserQuestion: null,
@@ -536,6 +539,85 @@ describe("eventBridge", () => {
       "allow",
     );
     expect(useRuntimeInsightStore.getState().budgetUsageRatio).toBe(0.8);
+  });
+
+  it("CompactStart sets persistent compact state without a toast", () => {
+    const api = createMockGatewayAPI();
+    handleGatewayEvent(
+      {
+        type: EventType.CompactStart,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.CompactStart,
+            payload: "manual",
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-1",
+      },
+      api,
+    );
+
+    expect(useChatStore.getState().isCompacting).toBe(true);
+    expect(useChatStore.getState().compactMode).toBe("manual");
+    expect(useChatStore.getState().compactMessage).toBe(
+      "Compacting context...",
+    );
+    expect(useUIStore.getState().toasts).toHaveLength(0);
+  });
+
+  it("CompactApplied clears compact state and shows completion toast", () => {
+    const api = createMockGatewayAPI();
+    useChatStore
+      .getState()
+      .startCompacting("manual", "Compacting context...");
+
+    handleGatewayEvent(
+      {
+        type: EventType.CompactApplied,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.CompactApplied,
+            payload: { applied: true },
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-1",
+      },
+      api,
+    );
+
+    expect(useChatStore.getState().isCompacting).toBe(false);
+    expect(useUIStore.getState().toasts.at(-1)?.message).toBe(
+      "Context compacted",
+    );
+  });
+
+  it("CompactError clears compact state and uses payload message", () => {
+    const api = createMockGatewayAPI();
+    useChatStore
+      .getState()
+      .startCompacting("manual", "Compacting context...");
+
+    handleGatewayEvent(
+      {
+        type: EventType.CompactError,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.CompactError,
+            payload: { message: "compact timed out" },
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-1",
+      },
+      api,
+    );
+
+    expect(useChatStore.getState().isCompacting).toBe(false);
+    expect(useUIStore.getState().toasts.at(-1)?.message).toBe(
+      "compact timed out",
+    );
   });
 
   it("VerificationStageFinished upserts verifier status", () => {

--- a/web/src/utils/eventBridge.ts
+++ b/web/src/utils/eventBridge.ts
@@ -409,6 +409,26 @@ function _refreshRunFileChanges(
     });
 }
 
+// applyBaselineCheckpointRestoreEvent 只同步文件级 baseline 回退，不刷新会话消息或 insight。
+function applyBaselineCheckpointRestoreEvent(payload: CheckpointRestoredPayload) {
+  const restoredPaths = new Set(
+    (payload.paths ?? []).map(normalizeFilePath).filter(Boolean),
+  );
+  _latestRunDiffRequestId += 1;
+  useUIStore.getState().setRestoringCheckpoint(false);
+  if (restoredPaths.size === 0) {
+    return;
+  }
+  for (const path of restoredPaths) {
+    _firstTouchRollbackCheckpointByPath.delete(path);
+  }
+  useUIStore.setState((state) => ({
+    fileChanges: state.fileChanges.filter(
+      (change) => !restoredPaths.has(normalizeFilePath(change.path)),
+    ),
+  }));
+}
+
 // refreshSessionAfterCheckpointRestoreEvent 仅在当前会话收到 restore/undo 事件时刷新会话与文件变更视图。
 function refreshSessionAfterCheckpointRestoreEvent(
   gatewayAPI: GatewayAPI,
@@ -1081,6 +1101,11 @@ export function handleGatewayEvent(
         if (
           payload.session_id === useSessionStore.getState().currentSessionId
         ) {
+          if (payload.mode === "baseline") {
+            applyBaselineCheckpointRestoreEvent(payload);
+            uiStore.showToast("File rollback completed", "success");
+            break;
+          }
           chatStore.markAllCheckpointsRestored();
           refreshSessionAfterCheckpointRestoreEvent(
             gatewayAPI,

--- a/web/src/utils/eventBridge.ts
+++ b/web/src/utils/eventBridge.ts
@@ -831,18 +831,31 @@ export function handleGatewayEvent(
       break;
 
     case EventType.CompactStart: {
-      uiStore.showToast("Compacting context...", "info");
+      const mode =
+        typeof eventPayload === "string"
+          ? eventPayload
+          : strField(eventPayload, "trigger_mode") ||
+            strField(eventPayload, "TriggerMode") ||
+            "manual";
+      useChatStore
+        .getState()
+        .startCompacting(mode, "Compacting context...");
       break;
     }
 
     case EventType.CompactApplied: {
+      useChatStore.getState().finishCompacting();
       uiStore.showToast("Context compacted", "success");
       break;
     }
 
     case EventType.CompactError: {
+      useChatStore.getState().finishCompacting();
       uiStore.showToast(
-        (eventPayload as string) ?? "Compaction failed",
+        strField(eventPayload, "message") ||
+          strField(eventPayload, "Message") ||
+          (typeof eventPayload === "string" ? eventPayload : "") ||
+          "Compaction failed",
         "error",
       );
       break;


### PR DESCRIPTION
## 背景

本次改动聚焦 Web 聊天体验与 checkpoint 文件级回退链路，修正历史会话回放、compact 状态展示、预算提示、工作区展开状态以及单文件回退后的前端刷新行为。

## 当前修改

- 修复历史会话首次加载后消息列表停留在顶部的问题，切换到已有会话时自动定位到底部，同时保留生成中用户手动上滚后的暂停跟随行为。
- 过滤仅供 runtime/provider 续跑使用的内部历史消息，避免旧的 acceptance/verify/todo 控制内容污染聊天区。
- 将会话历史重载改为一次性 `setMessages` 写入，覆盖切换会话、checkpoint 回退和首次自动绑定场景，减少逐条追加带来的中间态。
- 新增 compact 独立状态：compact 开始后在输入框上方展示持续状态，期间禁止发送消息、切换技能和切换权限模式，compact 成功或失败后正确收尾。
- 调整输入框预算圆环为正常 / 警告 / 危险三态，并在弹层中展示状态、预算占用和上下文上限占用。
- 修复工作区列表只应展开当前工作区的问题，避免非当前工作区仍显示展开态。
- 扩展 `CheckpointRestored` 事件契约，补充 `mode` 和 `paths` 字段；baseline 文件回退会规范化路径并随事件回传。
- Web 收到 baseline 文件回退事件后只清理对应文件的变更项并结束 restoring 状态，不再刷新整个会话或文件变更列表，避免单文件回退后界面被整页重载。
- 补充 runtime checkpoint、TUI gateway stream、ChatInput、MessageList、Sidebar、FileChangePanel、chat/session store 和 eventBridge 的回归测试。

## 验证

- `go test ./internal/runtime ./internal/tui/services`：通过。
- `cd web && npm test`：47 个测试文件、276 个测试通过。
- `cd web && npm run build`：TypeScript 与 Vite 构建通过。

## 风险与影响

- 改动保持在 Web UI、前端 store、checkpoint restore 事件契约和 runtime restore 通知范围内，没有改变 TUI / Gateway / Runtime / Provider / Tools 主链路职责边界。
- 历史消息过滤只作用于 Web 展示映射，不修改后端持久化消息，也不影响 runtime/provider 的续跑数据。
- baseline 文件回退事件新增字段为可选字段，旧事件消费者仍可按原字段解析。