### PR TITLE
feat(hooks): 开放用户 http observe hooks 与 Clawd 接入文档

### DIFF
--- a/docs/examples/user-hooks-config.yaml
+++ b/docs/examples/user-hooks-config.yaml
@@ -40,4 +40,4 @@ runtime:
           method: POST
           headers:
             X-Source: neocode
-          include_metadata: true
+          include_metadata: false

--- a/docs/examples/user-hooks-config.yaml
+++ b/docs/examples/user-hooks-config.yaml
@@ -28,3 +28,16 @@ runtime:
         params:
           tool_names: ["bash"]
           message: "执行 bash 前请确认命令不会破坏工作区。"
+
+      - id: user-http-observe
+        enabled: true
+        point: after_tool_result
+        scope: user
+        kind: http
+        mode: observe
+        params:
+          url: "http://127.0.0.1:3101/hook"
+          method: POST
+          headers:
+            X-Source: neocode
+          include_metadata: true

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -131,7 +131,7 @@ context:
 | `priority` | 同一 hook point 内执行优先级，数值越大越先执行 |
 | `timeout_sec` | 覆盖默认超时；未配置时继承 `runtime.hooks.default_timeout_sec` |
 | `failure_policy` | 覆盖默认失败策略；未配置时继承 `runtime.hooks.default_failure_policy` |
-| `params` | `builtin` 为 handler 参数；`http` 至少包含 `url`（可选 `method`、`headers`、`include_metadata`） |
+| `params` | `builtin` 为 handler 参数；`http` 至少包含 `url`（可选 `method`、`headers`、`include_metadata`，默认 `false`） |
 
 > 注意：`warn_only` 在 runtime 内部映射为 `fail_open`，表示记录失败但不阻断主链。
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -113,7 +113,7 @@ context:
 | `runtime.hooks.user_hooks_enabled` | user hooks 开关；关闭后不加载 `runtime.hooks.items` |
 | `runtime.hooks.default_timeout_sec` | user hook 默认超时秒数，需 `> 0` |
 | `runtime.hooks.default_failure_policy` | 默认失败策略，支持 `warn_only` / `fail_open` / `fail_closed` |
-| `runtime.hooks.items` | user builtin hooks 列表；仅支持 `scope=user`、`kind=builtin`、`mode=sync` |
+| `runtime.hooks.items` | user hooks 列表；支持 `builtin/sync` 与 `http/observe` 两种子类型 |
 | `runtime.assets.max_session_asset_bytes` | 单个 `session_asset` 最大原始字节数，默认 `20971520`（20 MiB）；`0` 或未配置时回退默认值 |
 | `runtime.assets.max_session_assets_total_bytes` | 单次请求可携带的 `session_asset` 原始总字节上限，默认 `20971520`（20 MiB）；`0` 或未配置时回退默认值 |
 
@@ -125,13 +125,13 @@ context:
 | `enabled` | 是否启用该 hook，默认 `true` |
 | `point` | 支持 `before_tool_call` / `after_tool_result` / `before_completion_decision` / `before_permission_decision` / `after_tool_failure` / `session_start` / `session_end` / `user_prompt_submit` / `pre_compact` / `post_compact` / `subagent_start` / `subagent_stop` |
 | `scope` | P2 固定为 `user` |
-| `kind` | P2 固定为 `builtin` |
-| `mode` | P2 固定为 `sync` |
-| `handler` | 仅支持 `require_file_exists` / `warn_on_tool_call` / `add_context_note` |
+| `kind` | 支持 `builtin` 或 `http` |
+| `mode` | `builtin` 固定 `sync`；`http` 固定 `observe` |
+| `handler` | `builtin` 必填（`require_file_exists` / `warn_on_tool_call` / `add_context_note`）；`http` 必须留空 |
 | `priority` | 同一 hook point 内执行优先级，数值越大越先执行 |
 | `timeout_sec` | 覆盖默认超时；未配置时继承 `runtime.hooks.default_timeout_sec` |
 | `failure_policy` | 覆盖默认失败策略；未配置时继承 `runtime.hooks.default_failure_policy` |
-| `params` | handler 参数；不同 handler 使用不同键 |
+| `params` | `builtin` 为 handler 参数；`http` 至少包含 `url`（可选 `method`、`headers`、`include_metadata`） |
 
 > 注意：`warn_only` 在 runtime 内部映射为 `fail_open`，表示记录失败但不阻断主链。
 
@@ -177,7 +177,7 @@ trust store 示例：
 
 - `runtime.hooks.enabled=false` 会关闭全部 hooks（internal/user/repo）。
 - repo hooks 仅支持 builtin 子集（上述 points + 3 个 handlers）。
-- P6-lite 阶段会显式拒绝 external kinds（`command/http/prompt/agent`），报错并且不会注册执行。
+- P6-lite 阶段仅放开 `kind=http + mode=observe`；`command/prompt/agent` 仍会显式拒绝。
 - 执行顺序固定：`internal -> user -> repo`。
 - 跨来源同 ID 允许并存；同来源内重复 ID 会报错。
 - trust store 缺失/空文件/损坏 JSON/结构错误时，按 untrusted 处理并发出 `repo_hooks_trust_store_invalid` 事件，不阻断启动。

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -131,7 +131,7 @@ context:
 | `priority` | 同一 hook point 内执行优先级，数值越大越先执行 |
 | `timeout_sec` | 覆盖默认超时；未配置时继承 `runtime.hooks.default_timeout_sec` |
 | `failure_policy` | 覆盖默认失败策略；未配置时继承 `runtime.hooks.default_failure_policy` |
-| `params` | `builtin` 为 handler 参数；`http` 至少包含 `url`（可选 `method`、`headers`、`include_metadata`，默认 `false`） |
+| `params` | `builtin` 为 handler 参数；`http` 至少包含 `url`（仅允许 loopback 主机，且为绝对 `http/https`；可选 `method`、`headers`、`include_metadata`，默认 `false`） |
 
 > 注意：`warn_only` 在 runtime 内部映射为 `fail_open`，表示记录失败但不阻断主链。
 

--- a/docs/runtime-hooks-design.md
+++ b/docs/runtime-hooks-design.md
@@ -30,6 +30,7 @@ P2 仅支持：
   `session_start`、`session_end`、`user_prompt_submit`、`post_compact`、`subagent_stop`
 - handler：`require_file_exists`、`warn_on_tool_call`、`add_context_note`
 - `kind=http + mode=observe`：允许发送 HTTP 观测回调（不支持 block）
+- `http observe` 默认不携带 metadata（`include_metadata=false`）；即使显式开启也会剥离 `result_content_preview`、`execution_error`
 - external kinds 中 `command/prompt/agent` 在 P6-lite 阶段显式拒绝，不会半生效
 
 当前（P3）明确不支持：

--- a/docs/runtime-hooks-design.md
+++ b/docs/runtime-hooks-design.md
@@ -31,6 +31,7 @@ P2 仅支持：
 - handler：`require_file_exists`、`warn_on_tool_call`、`add_context_note`
 - `kind=http + mode=observe`：允许发送 HTTP 观测回调（不支持 block）
 - `http observe` 默认不携带 metadata（`include_metadata=false`）；即使显式开启也会剥离 `result_content_preview`、`execution_error`
+- `http observe` 回调端点仅允许 loopback 地址（`localhost` / `127.0.0.1` / `::1`），避免误配为公网外发
 - external kinds 中 `command/prompt/agent` 在 P6-lite 阶段显式拒绝，不会半生效
 
 当前（P3）明确不支持：

--- a/docs/runtime-hooks-design.md
+++ b/docs/runtime-hooks-design.md
@@ -12,10 +12,11 @@
 - P3：repo hooks（`<workspace>/.neocode/hooks.yaml`）+ workspace trust gate（`~/.neocode/trusted-workspaces.json`）
 - P4：生命周期点位扩展（permission/session/compact/subagent）+ 点位能力矩阵
 - P5：internal hooks 支持 `async/async_rewake` + run 内存通知队列（ephemeral 注入）
+- P6-lite：user `http/observe` hooks（仅观测回调）
 
 当前未实现能力：
 
-- command/http/prompt/agent hooks（P6）
+- command/prompt/agent hooks（P6）
 
 ## P2 user hooks 边界
 
@@ -28,7 +29,8 @@ P2 仅支持：
   `before_tool_call`、`after_tool_result`、`before_completion_decision`、`after_tool_failure`、
   `session_start`、`session_end`、`user_prompt_submit`、`post_compact`、`subagent_stop`
 - handler：`require_file_exists`、`warn_on_tool_call`、`add_context_note`
-- external kinds（`command/http/prompt/agent`）在 P6-lite 阶段显式拒绝，不会半生效
+- `kind=http + mode=observe`：允许发送 HTTP 观测回调（不支持 block）
+- external kinds 中 `command/prompt/agent` 在 P6-lite 阶段显式拒绝，不会半生效
 
 当前（P3）明确不支持：
 
@@ -46,7 +48,7 @@ repo hooks 文件路径固定为：
 ```
 
 仅支持与 P2 相同的 builtin 子集（`kind=builtin`、`mode=sync`、`UserAllowed=true` points、3 个 handlers）。
-external kinds（`command/http/prompt/agent`）在 P6-lite 阶段显式拒绝，不会加载执行。
+repo hooks 暂不支持 `kind=http`，external kinds（`command/http/prompt/agent`）在 repo 侧仍显式拒绝。
 
 执行顺序固定为：
 

--- a/internal/config/runtime_hooks.go
+++ b/internal/config/runtime_hooks.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 )
 
@@ -23,7 +24,9 @@ const (
 const (
 	runtimeHookScopeUser   = "user"
 	runtimeHookKindBuiltIn = "builtin"
+	runtimeHookKindHTTP    = "http"
 	runtimeHookModeSync    = "sync"
+	runtimeHookModeObserve = "observe"
 )
 
 var runtimeHookExternalKinds = map[string]struct{}{
@@ -221,7 +224,11 @@ func (c *RuntimeHookItemConfig) ApplyDefaults(defaults RuntimeHooksConfig) {
 		c.Kind = runtimeHookKindBuiltIn
 	}
 	if strings.TrimSpace(c.Mode) == "" {
-		c.Mode = runtimeHookModeSync
+		if strings.EqualFold(strings.TrimSpace(c.Kind), runtimeHookKindHTTP) {
+			c.Mode = runtimeHookModeObserve
+		} else {
+			c.Mode = runtimeHookModeSync
+		}
 	}
 	if c.TimeoutSec <= 0 {
 		c.TimeoutSec = defaults.DefaultTimeoutSec
@@ -260,17 +267,18 @@ func (c RuntimeHookItemConfig) Validate(defaultFailurePolicy string) error {
 	if normalizedScope := strings.ToLower(strings.TrimSpace(c.Scope)); normalizedScope != runtimeHookScopeUser {
 		return fmt.Errorf("scope %q is not supported", c.Scope)
 	}
-	if normalizedKind := strings.ToLower(strings.TrimSpace(c.Kind)); normalizedKind != runtimeHookKindBuiltIn {
+	normalizedKind := strings.ToLower(strings.TrimSpace(c.Kind))
+	switch normalizedKind {
+	case runtimeHookKindBuiltIn:
+	case runtimeHookKindHTTP:
+	default:
 		if _, external := runtimeHookExternalKinds[normalizedKind]; external {
 			return fmt.Errorf(
-				"external hook kind %q is not supported in P6-lite; only builtin hooks are enabled",
+				"external hook kind %q is not supported in P6-lite; only builtin/http-observe hooks are enabled",
 				c.Kind,
 			)
 		}
 		return fmt.Errorf("kind %q is not supported", c.Kind)
-	}
-	if normalizedMode := strings.ToLower(strings.TrimSpace(c.Mode)); normalizedMode != runtimeHookModeSync {
-		return fmt.Errorf("mode %q is not supported", c.Mode)
 	}
 	if c.TimeoutSec <= 0 {
 		return fmt.Errorf("timeout_sec must be greater than 0")
@@ -282,15 +290,74 @@ func (c RuntimeHookItemConfig) Validate(defaultFailurePolicy string) error {
 	if err := validateRuntimeHookFailurePolicy(policy); err != nil {
 		return fmt.Errorf("failure_policy: %w", err)
 	}
-
-	handler := strings.ToLower(strings.TrimSpace(c.Handler))
-	switch handler {
-	case runtimeHookHandlerRequireFileExists, runtimeHookHandlerWarnOnToolCall, runtimeHookHandlerAddContextNote:
-	default:
-		return fmt.Errorf("handler %q is not supported", c.Handler)
+	normalizedMode := strings.ToLower(strings.TrimSpace(c.Mode))
+	switch normalizedKind {
+	case runtimeHookKindBuiltIn:
+		if normalizedMode != runtimeHookModeSync {
+			return fmt.Errorf("mode %q is not supported", c.Mode)
+		}
+		handler := strings.ToLower(strings.TrimSpace(c.Handler))
+		switch handler {
+		case runtimeHookHandlerRequireFileExists, runtimeHookHandlerWarnOnToolCall, runtimeHookHandlerAddContextNote:
+		default:
+			return fmt.Errorf("handler %q is not supported", c.Handler)
+		}
+		if handler == runtimeHookHandlerWarnOnToolCall && !hasWarnOnToolCallTargets(c.Params) {
+			return fmt.Errorf("handler %q requires params.tool_name or params.tool_names", c.Handler)
+		}
+	case runtimeHookKindHTTP:
+		if normalizedMode != runtimeHookModeObserve {
+			return fmt.Errorf("mode %q is not supported for kind http (only observe)", c.Mode)
+		}
+		if err := validateRuntimeHTTPObserveItem(c, policy); err != nil {
+			return err
+		}
 	}
-	if handler == runtimeHookHandlerWarnOnToolCall && !hasWarnOnToolCallTargets(c.Params) {
-		return fmt.Errorf("handler %q requires params.tool_name or params.tool_names", c.Handler)
+	return nil
+}
+
+// validateRuntimeHTTPObserveItem 校验 http observe hook 的最小安全与可执行约束。
+func validateRuntimeHTTPObserveItem(c RuntimeHookItemConfig, policy string) error {
+	if strings.TrimSpace(c.Handler) != "" {
+		return fmt.Errorf("handler must be empty for kind http")
+	}
+	if strings.EqualFold(strings.TrimSpace(policy), runtimeHookFailurePolicyFailClose) {
+		return fmt.Errorf("failure_policy %q is not supported for kind http observe", policy)
+	}
+	rawURL := strings.TrimSpace(readRuntimeHookParamString(c.Params, "url"))
+	if rawURL == "" {
+		return fmt.Errorf("kind http requires params.url")
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || !parsed.IsAbs() {
+		return fmt.Errorf("kind http requires absolute params.url")
+	}
+	switch strings.ToLower(strings.TrimSpace(parsed.Scheme)) {
+	case "http", "https":
+	default:
+		return fmt.Errorf("kind http only supports http/https params.url")
+	}
+	method := strings.ToUpper(strings.TrimSpace(readRuntimeHookParamString(c.Params, "method")))
+	if method != "" {
+		switch method {
+		case "GET", "POST", "PUT", "PATCH", "DELETE":
+		default:
+			return fmt.Errorf("kind http params.method %q is not supported", method)
+		}
+	}
+	if headers, ok := c.Params["headers"]; ok && headers != nil {
+		typed, ok := headers.(map[string]any)
+		if !ok {
+			return fmt.Errorf("kind http params.headers must be a map")
+		}
+		for key, value := range typed {
+			if strings.TrimSpace(key) == "" {
+				return fmt.Errorf("kind http params.headers contains empty header name")
+			}
+			if strings.TrimSpace(fmt.Sprintf("%v", value)) == "" {
+				return fmt.Errorf("kind http params.headers[%q] is empty", key)
+			}
+		}
 	}
 	return nil
 }
@@ -358,6 +425,23 @@ func hasWarnOnToolCallTargets(params map[string]any) bool {
 		}
 	}
 	return false
+}
+
+// readRuntimeHookParamString 以兼容方式读取 runtime hook 参数中的字符串值。
+func readRuntimeHookParamString(params map[string]any, key string) string {
+	if len(params) == 0 {
+		return ""
+	}
+	value, ok := params[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	default:
+		return fmt.Sprintf("%v", typed)
+	}
 }
 
 func runtimeHookPointUserAllowed(point string) bool {

--- a/internal/config/runtime_hooks.go
+++ b/internal/config/runtime_hooks.go
@@ -67,7 +67,7 @@ type RuntimeHooksConfig struct {
 	Items                []RuntimeHookItemConfig `yaml:"items,omitempty"`
 }
 
-// RuntimeHookItemConfig 描述单个 user builtin hook 配置项。
+// RuntimeHookItemConfig 描述单个 user hook 配置项（当前支持 builtin 与 http observe）。
 type RuntimeHookItemConfig struct {
 	ID            string         `yaml:"id,omitempty"`
 	Enabled       *bool          `yaml:"enabled,omitempty"`

--- a/internal/config/runtime_hooks.go
+++ b/internal/config/runtime_hooks.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 )
@@ -337,6 +338,9 @@ func validateRuntimeHTTPObserveItem(c RuntimeHookItemConfig, policy string) erro
 	default:
 		return fmt.Errorf("kind http only supports http/https params.url")
 	}
+	if !isRuntimeHookHTTPObserveLoopbackHost(parsed.Hostname()) {
+		return fmt.Errorf("kind http params.url host %q is not allowed (loopback only)", parsed.Hostname())
+	}
 	method := strings.ToUpper(strings.TrimSpace(readRuntimeHookParamString(c.Params, "method")))
 	if method != "" {
 		switch method {
@@ -360,6 +364,19 @@ func validateRuntimeHTTPObserveItem(c RuntimeHookItemConfig, policy string) erro
 		}
 	}
 	return nil
+}
+
+// isRuntimeHookHTTPObserveLoopbackHost 判断 http observe 回调域名是否属于本地回环地址。
+func isRuntimeHookHTTPObserveLoopbackHost(host string) bool {
+	normalized := strings.TrimSpace(strings.ToLower(host))
+	if normalized == "" {
+		return false
+	}
+	if normalized == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(normalized)
+	return ip != nil && ip.IsLoopback()
 }
 
 // IsEnabled 返回单条 hook item 是否启用。

--- a/internal/config/runtime_hooks_test.go
+++ b/internal/config/runtime_hooks_test.go
@@ -516,3 +516,138 @@ func TestRuntimeHooksConfigEdgeBranches(t *testing.T) {
 		}
 	})
 }
+
+func TestRuntimeHTTPObserveValidationHelpers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("allow localhost variants", func(t *testing.T) {
+		t.Parallel()
+		for _, rawURL := range []string{
+			"http://localhost:19090/hook",
+			"http://[::1]:19090/hook",
+		} {
+			item := RuntimeHookItemConfig{
+				ID:    "observe-http",
+				Point: runtimeHookPointBeforeToolCall,
+				Scope: runtimeHookScopeUser,
+				Kind:  runtimeHookKindHTTP,
+				Mode:  runtimeHookModeObserve,
+				Params: map[string]any{
+					"url":     rawURL,
+					"method":  "PATCH",
+					"headers": map[string]any{"X-Test": 7},
+				},
+			}
+			if err := validateRuntimeHTTPObserveItem(item, runtimeHookFailurePolicyWarnOnly); err != nil {
+				t.Fatalf("validateRuntimeHTTPObserveItem(%q) error = %v", rawURL, err)
+			}
+		}
+	})
+
+	t.Run("reject malformed headers and urls", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name string
+			item RuntimeHookItemConfig
+		}{
+			{
+				name: "invalid absolute url",
+				item: RuntimeHookItemConfig{
+					ID:    "observe-http",
+					Point: runtimeHookPointBeforeToolCall,
+					Scope: runtimeHookScopeUser,
+					Kind:  runtimeHookKindHTTP,
+					Mode:  runtimeHookModeObserve,
+					Params: map[string]any{
+						"url": "://bad",
+					},
+				},
+			},
+			{
+				name: "headers must be map",
+				item: RuntimeHookItemConfig{
+					ID:    "observe-http",
+					Point: runtimeHookPointBeforeToolCall,
+					Scope: runtimeHookScopeUser,
+					Kind:  runtimeHookKindHTTP,
+					Mode:  runtimeHookModeObserve,
+					Params: map[string]any{
+						"url":     "http://127.0.0.1:19090/hook",
+						"headers": "bad",
+					},
+				},
+			},
+			{
+				name: "empty header name",
+				item: RuntimeHookItemConfig{
+					ID:    "observe-http",
+					Point: runtimeHookPointBeforeToolCall,
+					Scope: runtimeHookScopeUser,
+					Kind:  runtimeHookKindHTTP,
+					Mode:  runtimeHookModeObserve,
+					Params: map[string]any{
+						"url":     "http://127.0.0.1:19090/hook",
+						"headers": map[string]any{" ": "x"},
+					},
+				},
+			},
+			{
+				name: "empty header value",
+				item: RuntimeHookItemConfig{
+					ID:    "observe-http",
+					Point: runtimeHookPointBeforeToolCall,
+					Scope: runtimeHookScopeUser,
+					Kind:  runtimeHookKindHTTP,
+					Mode:  runtimeHookModeObserve,
+					Params: map[string]any{
+						"url":     "http://127.0.0.1:19090/hook",
+						"headers": map[string]any{"X-Test": "   "},
+					},
+				},
+			},
+		}
+		for _, tc := range tests {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				if err := validateRuntimeHTTPObserveItem(tc.item, runtimeHookFailurePolicyWarnOnly); err == nil {
+					t.Fatalf("expected validation error for %+v", tc.item.Params)
+				}
+			})
+		}
+	})
+
+	t.Run("helper functions", func(t *testing.T) {
+		t.Parallel()
+		if !isRuntimeHookHTTPObserveLoopbackHost("localhost") {
+			t.Fatal("localhost should be treated as loopback")
+		}
+		if !isRuntimeHookHTTPObserveLoopbackHost("::1") {
+			t.Fatal("::1 should be treated as loopback")
+		}
+		if isRuntimeHookHTTPObserveLoopbackHost("") {
+			t.Fatal("empty host should not be loopback")
+		}
+		if isRuntimeHookHTTPObserveLoopbackHost("example.com") {
+			t.Fatal("remote host should not be loopback")
+		}
+		if got := readRuntimeHookParamString(nil, "x"); got != "" {
+			t.Fatalf("readRuntimeHookParamString(nil) = %q", got)
+		}
+		if got := readRuntimeHookParamString(map[string]any{"x": 123}, "x"); got != "123" {
+			t.Fatalf("readRuntimeHookParamString(non-string) = %q", got)
+		}
+		if !runtimeHookPointUserAllowed(runtimeHookPointBeforeToolCall) {
+			t.Fatal("before_tool_call should allow user hooks")
+		}
+		for _, point := range []string{
+			runtimeHookPointBeforePermissionDecision,
+			runtimeHookPointPreCompact,
+			runtimeHookPointSubAgentStart,
+		} {
+			if runtimeHookPointUserAllowed(point) {
+				t.Fatalf("%s should be rejected for user hooks", point)
+			}
+		}
+	})
+}

--- a/internal/config/runtime_hooks_test.go
+++ b/internal/config/runtime_hooks_test.go
@@ -105,7 +105,7 @@ func TestRuntimeHooksConfigValidateRejectsExternalKindsWithP6LiteMessage(t *test
 		DefaultTimeoutSec:    2,
 		DefaultFailurePolicy: runtimeHookFailurePolicyWarnOnly,
 	}
-	externalKinds := []string{"command", "http", "prompt", "agent"}
+	externalKinds := []string{"command", "prompt", "agent"}
 	for _, kind := range externalKinds {
 		kind := kind
 		t.Run(kind, func(t *testing.T) {
@@ -128,6 +128,111 @@ func TestRuntimeHooksConfigValidateRejectsExternalKindsWithP6LiteMessage(t *test
 			}
 			if !strings.Contains(err.Error(), "not supported in P6-lite") {
 				t.Fatalf("error=%q, want contains not supported in P6-lite", err.Error())
+			}
+		})
+	}
+}
+
+func TestRuntimeHooksConfigValidateAllowsHTTPObserve(t *testing.T) {
+	t.Parallel()
+
+	cfg := RuntimeHooksConfig{
+		Enabled:              boolPtr(true),
+		UserHooksEnabled:     boolPtr(true),
+		DefaultTimeoutSec:    2,
+		DefaultFailurePolicy: runtimeHookFailurePolicyWarnOnly,
+		Items: []RuntimeHookItemConfig{
+			{
+				ID:    "observe-http",
+				Point: runtimeHookPointBeforeToolCall,
+				Scope: runtimeHookScopeUser,
+				Kind:  runtimeHookKindHTTP,
+				Params: map[string]any{
+					"url": "http://127.0.0.1:19090/hook",
+				},
+			},
+		},
+	}
+	cfg.ApplyDefaults(defaultRuntimeHooksConfig())
+	if cfg.Items[0].Mode != runtimeHookModeObserve {
+		t.Fatalf("mode=%q, want observe default", cfg.Items[0].Mode)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected http observe to pass, got err=%v", err)
+	}
+}
+
+func TestRuntimeHooksConfigValidateRejectsInvalidHTTPObserveConfig(t *testing.T) {
+	t.Parallel()
+
+	base := RuntimeHookItemConfig{
+		ID:    "observe-http",
+		Point: runtimeHookPointBeforeToolCall,
+		Scope: runtimeHookScopeUser,
+		Kind:  runtimeHookKindHTTP,
+		Mode:  runtimeHookModeObserve,
+		Params: map[string]any{
+			"url": "http://127.0.0.1:19090/hook",
+		},
+	}
+	tests := []struct {
+		name string
+		edit func(*RuntimeHookItemConfig)
+	}{
+		{
+			name: "sync mode not allowed",
+			edit: func(item *RuntimeHookItemConfig) {
+				item.Mode = runtimeHookModeSync
+			},
+		},
+		{
+			name: "fail closed not allowed",
+			edit: func(item *RuntimeHookItemConfig) {
+				item.FailurePolicy = runtimeHookFailurePolicyFailClose
+			},
+		},
+		{
+			name: "handler must be empty",
+			edit: func(item *RuntimeHookItemConfig) {
+				item.Handler = runtimeHookHandlerAddContextNote
+			},
+		},
+		{
+			name: "missing url",
+			edit: func(item *RuntimeHookItemConfig) {
+				item.Params = map[string]any{}
+			},
+		},
+		{
+			name: "bad scheme",
+			edit: func(item *RuntimeHookItemConfig) {
+				item.Params = map[string]any{"url": "file:///tmp/hook"}
+			},
+		},
+		{
+			name: "bad method",
+			edit: func(item *RuntimeHookItemConfig) {
+				item.Params = map[string]any{"url": "http://127.0.0.1:19090/hook", "method": "TRACE"}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			item := base.Clone()
+			tc.edit(&item)
+			cfg := RuntimeHooksConfig{
+				Enabled:              boolPtr(true),
+				UserHooksEnabled:     boolPtr(true),
+				DefaultTimeoutSec:    2,
+				DefaultFailurePolicy: runtimeHookFailurePolicyWarnOnly,
+				Items:                []RuntimeHookItemConfig{item},
+			}
+			cfg.ApplyDefaults(defaultRuntimeHooksConfig())
+			if err := cfg.Validate(); err == nil {
+				t.Fatalf("expected invalid http observe config to fail: %+v", item)
 			}
 		})
 	}

--- a/internal/config/runtime_hooks_test.go
+++ b/internal/config/runtime_hooks_test.go
@@ -215,6 +215,12 @@ func TestRuntimeHooksConfigValidateRejectsInvalidHTTPObserveConfig(t *testing.T)
 				item.Params = map[string]any{"url": "http://127.0.0.1:19090/hook", "method": "TRACE"}
 			},
 		},
+		{
+			name: "remote host not allowed",
+			edit: func(item *RuntimeHookItemConfig) {
+				item.Params = map[string]any{"url": "https://example.com/hook"}
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/runtime/hooks/types.go
+++ b/internal/runtime/hooks/types.go
@@ -91,7 +91,7 @@ const (
 	HookKindFunction HookKind = "function"
 	// HookKindCommand 表示命令型 hook（P6 预留）。
 	HookKindCommand HookKind = "command"
-	// HookKindHTTP 表示 HTTP 型 hook（P6 预留）。
+	// HookKindHTTP 表示 HTTP 型 hook（当前用于 observe 回调适配）。
 	HookKindHTTP HookKind = "http"
 	// HookKindPrompt 表示 prompt 型 hook（P6 预留）。
 	HookKindPrompt HookKind = "prompt"
@@ -173,8 +173,10 @@ func (s HookSpec) normalizeAndValidate() (HookSpec, error) {
 	if s.Kind == "" {
 		s.Kind = HookKindFunction
 	}
-	if s.Kind != HookKindFunction {
-		return HookSpec{}, wrapInvalidSpec("kind %q is not supported in P0", s.Kind)
+	switch s.Kind {
+	case HookKindFunction, HookKindHTTP:
+	default:
+		return HookSpec{}, wrapInvalidSpec("kind %q is not supported in current stage", s.Kind)
 	}
 	if s.Mode == "" {
 		s.Mode = HookModeSync

--- a/internal/runtime/hooks/types.go
+++ b/internal/runtime/hooks/types.go
@@ -181,7 +181,11 @@ func (s HookSpec) normalizeAndValidate() (HookSpec, error) {
 		return HookSpec{}, wrapInvalidSpec("kind %q is not supported in current stage", s.Kind)
 	}
 	if s.Mode == "" {
-		s.Mode = HookModeSync
+		if s.Kind == HookKindHTTP {
+			s.Mode = HookModeObserve
+		} else {
+			s.Mode = HookModeSync
+		}
 	}
 	switch s.Mode {
 	case HookModeSync, HookModeObserve, HookModeAsync, HookModeAsyncRewake:

--- a/internal/runtime/hooks/types.go
+++ b/internal/runtime/hooks/types.go
@@ -105,6 +105,8 @@ type HookMode string
 const (
 	// HookModeSync 表示同步执行。
 	HookModeSync HookMode = "sync"
+	// HookModeObserve 表示只观测模式（不参与主链阻断决策）。
+	HookModeObserve HookMode = "observe"
 	// HookModeAsync 表示异步执行（P5 预留）。
 	HookModeAsync HookMode = "async"
 	// HookModeAsyncRewake 表示异步回灌执行（P5 预留）。
@@ -182,12 +184,17 @@ func (s HookSpec) normalizeAndValidate() (HookSpec, error) {
 		s.Mode = HookModeSync
 	}
 	switch s.Mode {
-	case HookModeSync, HookModeAsync, HookModeAsyncRewake:
+	case HookModeSync, HookModeObserve, HookModeAsync, HookModeAsyncRewake:
 	default:
 		return HookSpec{}, wrapInvalidSpec("mode %q is not supported in current stage", s.Mode)
 	}
-	if (s.Scope == HookScopeUser || s.Scope == HookScopeRepo) && s.Mode != HookModeSync {
-		return HookSpec{}, wrapInvalidSpec("scope %q only supports sync mode", s.Scope)
+	if s.Scope == HookScopeUser || s.Scope == HookScopeRepo {
+		if s.Kind == HookKindHTTP && s.Mode != HookModeObserve {
+			return HookSpec{}, wrapInvalidSpec("scope %q with kind http only supports observe mode", s.Scope)
+		}
+		if s.Kind != HookKindHTTP && s.Mode != HookModeSync {
+			return HookSpec{}, wrapInvalidSpec("scope %q only supports sync mode", s.Scope)
+		}
 	}
 	if s.FailurePolicy == "" {
 		s.FailurePolicy = FailurePolicyFailOpen

--- a/internal/runtime/hooks/types_test.go
+++ b/internal/runtime/hooks/types_test.go
@@ -54,6 +54,25 @@ func TestHookSpecNormalizeAndValidateAllowsHTTPKind(t *testing.T) {
 	}
 }
 
+func TestHookSpecNormalizeAndValidateAllowsUserHTTPObserve(t *testing.T) {
+	t.Parallel()
+
+	spec, err := (HookSpec{
+		ID:      "hook-http-observe",
+		Point:   HookPointBeforeToolCall,
+		Scope:   HookScopeUser,
+		Kind:    HookKindHTTP,
+		Mode:    HookModeObserve,
+		Handler: func(context.Context, HookContext) HookResult { return HookResult{} },
+	}).normalizeAndValidate()
+	if err != nil {
+		t.Fatalf("normalizeAndValidate() error = %v", err)
+	}
+	if spec.Mode != HookModeObserve {
+		t.Fatalf("Mode = %q, want %q", spec.Mode, HookModeObserve)
+	}
+}
+
 func TestHookSpecNormalizeAndValidateErrors(t *testing.T) {
 	t.Parallel()
 
@@ -145,6 +164,17 @@ func TestHookSpecNormalizeAndValidateErrors(t *testing.T) {
 				Point:   HookPointBeforeToolCall,
 				Scope:   HookScopeRepo,
 				Mode:    HookModeAsyncRewake,
+				Handler: handler,
+			},
+		},
+		{
+			name: "user http sync not allowed",
+			spec: HookSpec{
+				ID:      "hook-1",
+				Point:   HookPointBeforeToolCall,
+				Scope:   HookScopeUser,
+				Kind:    HookKindHTTP,
+				Mode:    HookModeSync,
 				Handler: handler,
 			},
 		},

--- a/internal/runtime/hooks/types_test.go
+++ b/internal/runtime/hooks/types_test.go
@@ -52,6 +52,9 @@ func TestHookSpecNormalizeAndValidateAllowsHTTPKind(t *testing.T) {
 	if spec.Kind != HookKindHTTP {
 		t.Fatalf("Kind = %q, want %q", spec.Kind, HookKindHTTP)
 	}
+	if spec.Mode != HookModeObserve {
+		t.Fatalf("Mode = %q, want %q for http default", spec.Mode, HookModeObserve)
+	}
 }
 
 func TestHookSpecNormalizeAndValidateAllowsUserHTTPObserve(t *testing.T) {

--- a/internal/runtime/hooks/types_test.go
+++ b/internal/runtime/hooks/types_test.go
@@ -37,6 +37,23 @@ func TestHookSpecNormalizeAndValidateDefaults(t *testing.T) {
 	}
 }
 
+func TestHookSpecNormalizeAndValidateAllowsHTTPKind(t *testing.T) {
+	t.Parallel()
+
+	spec, err := (HookSpec{
+		ID:      "hook-http",
+		Point:   HookPointBeforeToolCall,
+		Kind:    HookKindHTTP,
+		Handler: func(context.Context, HookContext) HookResult { return HookResult{} },
+	}).normalizeAndValidate()
+	if err != nil {
+		t.Fatalf("normalizeAndValidate() error = %v", err)
+	}
+	if spec.Kind != HookKindHTTP {
+		t.Fatalf("Kind = %q, want %q", spec.Kind, HookKindHTTP)
+	}
+}
+
 func TestHookSpecNormalizeAndValidateErrors(t *testing.T) {
 	t.Parallel()
 
@@ -98,7 +115,7 @@ func TestHookSpecNormalizeAndValidateErrors(t *testing.T) {
 			spec: HookSpec{
 				ID:      "hook-1",
 				Point:   HookPointBeforeToolCall,
-				Kind:    HookKindHTTP,
+				Kind:    HookKindPrompt,
 				Handler: handler,
 			},
 		},

--- a/internal/runtime/user_hooks.go
+++ b/internal/runtime/user_hooks.go
@@ -25,6 +25,11 @@ const (
 	configuredHookModeObserve = "observe"
 )
 
+var httpObserveSensitiveMetadataKeys = map[string]struct{}{
+	"result_content_preview": {},
+	"execution_error":        {},
+}
+
 // ConfigureRuntimeHooks 根据配置装配 runtime hook 执行器；当 hooks 被关闭时会禁用执行器。
 func ConfigureRuntimeHooks(service *Service, cfg config.Config) error {
 	return configureRuntimeHooksFromConfig(service, cfg)
@@ -362,7 +367,7 @@ func buildUserHTTPObserveHookHandler(item config.RuntimeHookItemConfig) (runtime
 	if err != nil {
 		return nil, err
 	}
-	includeMetadata := readHookParamBool(item.Params, "include_metadata", true)
+	includeMetadata := readHookParamBool(item.Params, "include_metadata", false)
 	hookID := strings.TrimSpace(item.ID)
 	point := strings.TrimSpace(item.Point)
 
@@ -378,7 +383,7 @@ func buildUserHTTPObserveHookHandler(item config.RuntimeHookItemConfig) (runtime
 			"triggered_at": time.Now().UTC().Format(time.RFC3339Nano),
 		}
 		if includeMetadata && len(input.Metadata) > 0 {
-			payload["metadata"] = input.Metadata
+			payload["metadata"] = sanitizeHTTPObserveMetadata(input.Metadata)
 		}
 		body, err := json.Marshal(payload)
 		if err != nil {
@@ -401,7 +406,7 @@ func buildUserHTTPObserveHookHandler(item config.RuntimeHookItemConfig) (runtime
 			detail := fmt.Sprintf("http observe request failed: %v", err)
 			return runtimehooks.HookResult{Status: runtimehooks.HookResultFailed, Message: detail, Error: detail}
 		}
-		defer resp.Body.Close()
+		defer drainAndCloseHTTPResponseBody(resp)
 		if resp.StatusCode >= http.StatusBadRequest {
 			preview, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 			detail := fmt.Sprintf("http observe response status=%d", resp.StatusCode)
@@ -413,6 +418,31 @@ func buildUserHTTPObserveHookHandler(item config.RuntimeHookItemConfig) (runtime
 		}
 		return runtimehooks.HookResult{Status: runtimehooks.HookResultPass}
 	}, nil
+}
+
+// sanitizeHTTPObserveMetadata 对外发 payload 前剥离敏感预览字段，避免意外外传。
+func sanitizeHTTPObserveMetadata(metadata map[string]any) map[string]any {
+	if len(metadata) == 0 {
+		return nil
+	}
+	sanitized := make(map[string]any, len(metadata))
+	for key, value := range metadata {
+		normalized := strings.ToLower(strings.TrimSpace(key))
+		if _, blocked := httpObserveSensitiveMetadataKeys[normalized]; blocked {
+			continue
+		}
+		sanitized[key] = value
+	}
+	return sanitized
+}
+
+// drainAndCloseHTTPResponseBody 在关闭前尽量读到 EOF，以提升 keep-alive 复用概率。
+func drainAndCloseHTTPResponseBody(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
 }
 
 // buildHTTPObserveHeaders 从 params.headers 读取并归一化 HTTP 头配置。

--- a/internal/runtime/user_hooks.go
+++ b/internal/runtime/user_hooks.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -23,6 +25,8 @@ const (
 	configuredHookKindHTTP    = "http"
 	configuredHookModeSync    = "sync"
 	configuredHookModeObserve = "observe"
+	// httpObserveDrainLimitBytes 用于限制成功路径响应体的最大清空字节，避免被大响应拖慢。
+	httpObserveDrainLimitBytes = 64 * 1024
 )
 
 var httpObserveSensitiveMetadataKeys = map[string]struct{}{
@@ -194,6 +198,7 @@ func buildConfiguredHookSpec(
 	}
 	kind := strings.ToLower(strings.TrimSpace(item.Kind))
 	specKind := runtimehooks.HookKindFunction
+	specMode := runtimehooks.HookModeSync
 	var (
 		handler runtimehooks.HookHandler
 		err     error
@@ -202,9 +207,11 @@ func buildConfiguredHookSpec(
 	case configuredHookKindBuiltin:
 		handler, err = buildUserBuiltinHookHandler(strings.TrimSpace(item.Handler), item.Params, defaultWorkdir)
 		specKind = runtimehooks.HookKindFunction
+		specMode = runtimehooks.HookModeSync
 	case configuredHookKindHTTP:
 		handler, err = buildUserHTTPObserveHookHandler(item)
 		specKind = runtimehooks.HookKindHTTP
+		specMode = runtimehooks.HookModeObserve
 	default:
 		return runtimehooks.HookSpec{}, fmt.Errorf("kind %q is not supported", item.Kind)
 	}
@@ -217,7 +224,7 @@ func buildConfiguredHookSpec(
 		Scope:         scope,
 		Source:        source,
 		Kind:          specKind,
-		Mode:          runtimehooks.HookModeSync,
+		Mode:          specMode,
 		Priority:      item.Priority,
 		Timeout:       time.Duration(item.TimeoutSec) * time.Second,
 		FailurePolicy: mapRuntimeHookFailurePolicy(item.FailurePolicy),
@@ -359,6 +366,9 @@ func buildUserHTTPObserveHookHandler(item config.RuntimeHookItemConfig) (runtime
 	if endpoint == "" {
 		return nil, fmt.Errorf("kind http requires params.url")
 	}
+	if err := validateHTTPObserveEndpoint(endpoint); err != nil {
+		return nil, err
+	}
 	method := strings.ToUpper(strings.TrimSpace(readHookParamString(item.Params, "method")))
 	if method == "" {
 		method = http.MethodPost
@@ -441,8 +451,37 @@ func drainAndCloseHTTPResponseBody(resp *http.Response) {
 	if resp == nil || resp.Body == nil {
 		return
 	}
-	_, _ = io.Copy(io.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, httpObserveDrainLimitBytes))
 	_ = resp.Body.Close()
+}
+
+// validateHTTPObserveEndpoint 校验 observe 回调地址，仅允许本机回环地址。
+func validateHTTPObserveEndpoint(endpoint string) error {
+	parsed, err := url.Parse(strings.TrimSpace(endpoint))
+	if err != nil || parsed == nil || !parsed.IsAbs() {
+		return fmt.Errorf("kind http requires absolute params.url")
+	}
+	scheme := strings.ToLower(strings.TrimSpace(parsed.Scheme))
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("kind http only supports http/https params.url")
+	}
+	if !isHTTPObserveLoopbackHost(parsed.Hostname()) {
+		return fmt.Errorf("kind http params.url host %q is not allowed (loopback only)", parsed.Hostname())
+	}
+	return nil
+}
+
+// isHTTPObserveLoopbackHost 判断目标地址是否为回环主机，避免误配为公网外发。
+func isHTTPObserveLoopbackHost(host string) bool {
+	normalized := strings.TrimSpace(strings.ToLower(host))
+	if normalized == "" {
+		return false
+	}
+	if normalized == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(normalized)
+	return ip != nil && ip.IsLoopback()
 }
 
 // buildHTTPObserveHeaders 从 params.headers 读取并归一化 HTTP 头配置。

--- a/internal/runtime/user_hooks.go
+++ b/internal/runtime/user_hooks.go
@@ -251,6 +251,10 @@ func validateConfiguredHookItemForP6Lite(item config.RuntimeHookItemConfig, scop
 		if mode != configuredHookModeObserve {
 			return fmt.Errorf("mode %q is not supported for kind http (only observe)", item.Mode)
 		}
+		policy := strings.ToLower(strings.TrimSpace(item.FailurePolicy))
+		if policy == "fail_closed" {
+			return fmt.Errorf("failure_policy %q is not supported for kind http observe", item.FailurePolicy)
+		}
 	default:
 		if isExternalHookKind(kind) {
 			return fmt.Errorf(

--- a/internal/runtime/user_hooks.go
+++ b/internal/runtime/user_hooks.go
@@ -166,7 +166,7 @@ func runHookExecutorSafely(
 	return executor.Run(ctx, point, input)
 }
 
-// buildUserHookSpec 将 user builtin hook 配置转换为 runtime 可执行 HookSpec。
+// buildUserHookSpec 将 user hook 配置转换为 runtime 可执行 HookSpec。
 func buildUserHookSpec(item config.RuntimeHookItemConfig, defaultWorkdir string) (runtimehooks.HookSpec, error) {
 	return buildConfiguredHookSpec(
 		item,
@@ -176,7 +176,7 @@ func buildUserHookSpec(item config.RuntimeHookItemConfig, defaultWorkdir string)
 	)
 }
 
-// buildRepoHookSpec 将 repo builtin hook 配置转换为 runtime 可执行 HookSpec。
+// buildRepoHookSpec 将 repo hook 配置转换为 runtime 可执行 HookSpec。
 func buildRepoHookSpec(item config.RuntimeHookItemConfig, defaultWorkdir string) (runtimehooks.HookSpec, error) {
 	return buildConfiguredHookSpec(
 		item,
@@ -186,7 +186,7 @@ func buildRepoHookSpec(item config.RuntimeHookItemConfig, defaultWorkdir string)
 	)
 }
 
-// buildConfiguredHookSpec 按给定 scope/source 构建 builtin hook 执行定义。
+// buildConfiguredHookSpec 按给定 scope/source 构建配置化 hook 执行定义。
 func buildConfiguredHookSpec(
 	item config.RuntimeHookItemConfig,
 	defaultWorkdir string,
@@ -450,7 +450,7 @@ func sanitizeHTTPObserveMetadata(metadata map[string]any) map[string]any {
 	return sanitized
 }
 
-// drainAndCloseHTTPResponseBody 在关闭前尽量读到 EOF，以提升 keep-alive 复用概率。
+// drainAndCloseHTTPResponseBody 在关闭前执行有上限 drain，兼顾连接复用与响应体放大风险控制。
 func drainAndCloseHTTPResponseBody(resp *http.Response) {
 	if resp == nil || resp.Body == nil {
 		return

--- a/internal/runtime/user_hooks.go
+++ b/internal/runtime/user_hooks.go
@@ -1,8 +1,12 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -12,6 +16,13 @@ import (
 
 	"neo-code/internal/config"
 	runtimehooks "neo-code/internal/runtime/hooks"
+)
+
+const (
+	configuredHookKindBuiltin = "builtin"
+	configuredHookKindHTTP    = "http"
+	configuredHookModeSync    = "sync"
+	configuredHookModeObserve = "observe"
 )
 
 // ConfigureRuntimeHooks 根据配置装配 runtime hook 执行器；当 hooks 被关闭时会禁用执行器。
@@ -176,7 +187,22 @@ func buildConfiguredHookSpec(
 	if err := validateConfiguredHookItemForP6Lite(item, scope); err != nil {
 		return runtimehooks.HookSpec{}, err
 	}
-	handler, err := buildUserBuiltinHookHandler(strings.TrimSpace(item.Handler), item.Params, defaultWorkdir)
+	kind := strings.ToLower(strings.TrimSpace(item.Kind))
+	specKind := runtimehooks.HookKindFunction
+	var (
+		handler runtimehooks.HookHandler
+		err     error
+	)
+	switch kind {
+	case configuredHookKindBuiltin:
+		handler, err = buildUserBuiltinHookHandler(strings.TrimSpace(item.Handler), item.Params, defaultWorkdir)
+		specKind = runtimehooks.HookKindFunction
+	case configuredHookKindHTTP:
+		handler, err = buildUserHTTPObserveHookHandler(item)
+		specKind = runtimehooks.HookKindHTTP
+	default:
+		return runtimehooks.HookSpec{}, fmt.Errorf("kind %q is not supported", item.Kind)
+	}
 	if err != nil {
 		return runtimehooks.HookSpec{}, err
 	}
@@ -185,7 +211,7 @@ func buildConfiguredHookSpec(
 		Point:         runtimehooks.HookPoint(strings.TrimSpace(item.Point)),
 		Scope:         scope,
 		Source:        source,
-		Kind:          runtimehooks.HookKindFunction,
+		Kind:          specKind,
 		Mode:          runtimehooks.HookModeSync,
 		Priority:      item.Priority,
 		Timeout:       time.Duration(item.TimeoutSec) * time.Second,
@@ -203,19 +229,24 @@ func validateConfiguredHookItemForP6Lite(item config.RuntimeHookItemConfig, scop
 	}
 
 	kind := strings.ToLower(strings.TrimSpace(item.Kind))
-	if kind != "builtin" {
+	mode := strings.ToLower(strings.TrimSpace(item.Mode))
+	switch kind {
+	case configuredHookKindBuiltin:
+		if mode != configuredHookModeSync {
+			return fmt.Errorf("mode %q is not supported", item.Mode)
+		}
+	case configuredHookKindHTTP:
+		if mode != configuredHookModeObserve {
+			return fmt.Errorf("mode %q is not supported for kind http (only observe)", item.Mode)
+		}
+	default:
 		if isExternalHookKind(kind) {
 			return fmt.Errorf(
-				"external hook kind %q is not supported in P6-lite; only builtin hooks are enabled",
+				"external hook kind %q is not supported in P6-lite; only builtin/http-observe hooks are enabled",
 				item.Kind,
 			)
 		}
 		return fmt.Errorf("kind %q is not supported", item.Kind)
-	}
-
-	mode := strings.ToLower(strings.TrimSpace(item.Mode))
-	if mode != "sync" {
-		return fmt.Errorf("mode %q is not supported", item.Mode)
 	}
 	return nil
 }
@@ -314,6 +345,133 @@ func buildUserBuiltinHookHandler(
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported user builtin handler %q", handlerName)
+	}
+}
+
+// buildUserHTTPObserveHookHandler 将 kind=http 的 observe 配置转换为观测回调处理器。
+func buildUserHTTPObserveHookHandler(item config.RuntimeHookItemConfig) (runtimehooks.HookHandler, error) {
+	endpoint := strings.TrimSpace(readHookParamString(item.Params, "url"))
+	if endpoint == "" {
+		return nil, fmt.Errorf("kind http requires params.url")
+	}
+	method := strings.ToUpper(strings.TrimSpace(readHookParamString(item.Params, "method")))
+	if method == "" {
+		method = http.MethodPost
+	}
+	headers, err := buildHTTPObserveHeaders(item.Params)
+	if err != nil {
+		return nil, err
+	}
+	includeMetadata := readHookParamBool(item.Params, "include_metadata", true)
+	hookID := strings.TrimSpace(item.ID)
+	point := strings.TrimSpace(item.Point)
+
+	return func(ctx context.Context, input runtimehooks.HookContext) runtimehooks.HookResult {
+		payload := map[string]any{
+			"hook_id":      hookID,
+			"point":        point,
+			"scope":        "user",
+			"kind":         configuredHookKindHTTP,
+			"mode":         configuredHookModeObserve,
+			"run_id":       strings.TrimSpace(input.RunID),
+			"session_id":   strings.TrimSpace(input.SessionID),
+			"triggered_at": time.Now().UTC().Format(time.RFC3339Nano),
+		}
+		if includeMetadata && len(input.Metadata) > 0 {
+			payload["metadata"] = input.Metadata
+		}
+		body, err := json.Marshal(payload)
+		if err != nil {
+			detail := fmt.Sprintf("http observe marshal payload failed: %v", err)
+			return runtimehooks.HookResult{Status: runtimehooks.HookResultFailed, Message: detail, Error: detail}
+		}
+		req, err := http.NewRequestWithContext(ctx, method, endpoint, bytes.NewReader(body))
+		if err != nil {
+			detail := fmt.Sprintf("http observe build request failed: %v", err)
+			return runtimehooks.HookResult{Status: runtimehooks.HookResultFailed, Message: detail, Error: detail}
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", "neocode-hook-observe/1.0")
+		for key, value := range headers {
+			req.Header.Set(key, value)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			detail := fmt.Sprintf("http observe request failed: %v", err)
+			return runtimehooks.HookResult{Status: runtimehooks.HookResultFailed, Message: detail, Error: detail}
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= http.StatusBadRequest {
+			preview, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+			detail := fmt.Sprintf("http observe response status=%d", resp.StatusCode)
+			errText := detail
+			if trimmed := strings.TrimSpace(string(preview)); trimmed != "" {
+				errText = detail + ": " + trimmed
+			}
+			return runtimehooks.HookResult{Status: runtimehooks.HookResultFailed, Message: detail, Error: errText}
+		}
+		return runtimehooks.HookResult{Status: runtimehooks.HookResultPass}
+	}, nil
+}
+
+// buildHTTPObserveHeaders 从 params.headers 读取并归一化 HTTP 头配置。
+func buildHTTPObserveHeaders(params map[string]any) (map[string]string, error) {
+	if len(params) == 0 {
+		return nil, nil
+	}
+	rawHeaders, ok := params["headers"]
+	if !ok || rawHeaders == nil {
+		return nil, nil
+	}
+	typed, ok := rawHeaders.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("kind http params.headers must be a map")
+	}
+	headers := make(map[string]string, len(typed))
+	for key, value := range typed {
+		normalizedKey := strings.TrimSpace(key)
+		if normalizedKey == "" {
+			return nil, fmt.Errorf("kind http params.headers contains empty header name")
+		}
+		normalizedValue := strings.TrimSpace(fmt.Sprintf("%v", value))
+		if normalizedValue == "" {
+			return nil, fmt.Errorf("kind http params.headers[%q] is empty", normalizedKey)
+		}
+		headers[normalizedKey] = normalizedValue
+	}
+	return headers, nil
+}
+
+// readHookParamBool 按默认值读取布尔参数，兼容 bool/string/number 输入。
+func readHookParamBool(params map[string]any, key string, defaultValue bool) bool {
+	if len(params) == 0 {
+		return defaultValue
+	}
+	value, ok := params[key]
+	if !ok || value == nil {
+		return defaultValue
+	}
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		switch strings.ToLower(strings.TrimSpace(typed)) {
+		case "true", "1", "yes", "on":
+			return true
+		case "false", "0", "no", "off":
+			return false
+		default:
+			return defaultValue
+		}
+	case int:
+		return typed != 0
+	case int64:
+		return typed != 0
+	case float64:
+		return typed != 0
+	default:
+		return defaultValue
 	}
 }
 

--- a/internal/runtime/user_hooks_test.go
+++ b/internal/runtime/user_hooks_test.go
@@ -100,6 +100,9 @@ func TestBuildUserHookSpecAllowsHTTPObserve(t *testing.T) {
 	if spec.Kind != runtimehooks.HookKindHTTP {
 		t.Fatalf("kind = %q, want %q", spec.Kind, runtimehooks.HookKindHTTP)
 	}
+	if spec.Mode != runtimehooks.HookModeObserve {
+		t.Fatalf("mode = %q, want %q", spec.Mode, runtimehooks.HookModeObserve)
+	}
 	result := spec.Handler(context.Background(), runtimehooks.HookContext{
 		RunID:     "run-http-observe",
 		SessionID: "session-http-observe",
@@ -152,6 +155,29 @@ func TestBuildUserHTTPObserveHandlerReturnsFailedOnHTTPError(t *testing.T) {
 	}
 	if !strings.Contains(result.Error, "status=400") {
 		t.Fatalf("error = %q, want contains status=400", result.Error)
+	}
+}
+
+func TestBuildUserHookSpecRejectsHTTPObserveRemoteHost(t *testing.T) {
+	t.Parallel()
+
+	item := config.RuntimeHookItemConfig{
+		ID:         "http-observe-remote",
+		Point:      "after_tool_result",
+		Scope:      "user",
+		Kind:       "http",
+		Mode:       "observe",
+		TimeoutSec: 2,
+		Params: map[string]any{
+			"url": "https://example.com/hook",
+		},
+	}
+	_, err := buildUserHookSpec(item, t.TempDir())
+	if err == nil {
+		t.Fatal("expected remote host to be rejected for http observe")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "loopback only") {
+		t.Fatalf("error=%q, want contains loopback only", err.Error())
 	}
 }
 

--- a/internal/runtime/user_hooks_test.go
+++ b/internal/runtime/user_hooks_test.go
@@ -181,6 +181,30 @@ func TestBuildUserHookSpecRejectsHTTPObserveRemoteHost(t *testing.T) {
 	}
 }
 
+func TestBuildUserHookSpecRejectsHTTPObserveFailClosedPolicy(t *testing.T) {
+	t.Parallel()
+
+	item := config.RuntimeHookItemConfig{
+		ID:            "http-observe-fail-closed",
+		Point:         "after_tool_result",
+		Scope:         "user",
+		Kind:          "http",
+		Mode:          "observe",
+		TimeoutSec:    2,
+		FailurePolicy: "fail_closed",
+		Params: map[string]any{
+			"url": "http://127.0.0.1:19090/hook",
+		},
+	}
+	_, err := buildUserHookSpec(item, t.TempDir())
+	if err == nil {
+		t.Fatal("expected fail_closed to be rejected for http observe")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "failure_policy") {
+		t.Fatalf("error=%q, want contains failure_policy", err.Error())
+	}
+}
+
 func TestBuildUserHookSpecHTTPObserveCanIncludeSanitizedMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/user_hooks_test.go
+++ b/internal/runtime/user_hooks_test.go
@@ -893,6 +893,289 @@ func TestBuildUserBuiltinHookHandlerEdgeCases(t *testing.T) {
 
 }
 
+func TestBuildConfiguredHookSpecAndValidationHelpers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("build repo http observe spec", func(t *testing.T) {
+		t.Parallel()
+		item := config.RuntimeHookItemConfig{
+			ID:            "repo-http-observe",
+			Point:         "after_tool_result",
+			Scope:         "repo",
+			Kind:          "http",
+			Mode:          "observe",
+			TimeoutSec:    3,
+			FailurePolicy: "warn_only",
+			Params: map[string]any{
+				"url": "http://localhost:19090/hook",
+			},
+		}
+		spec, err := buildRepoHookSpec(item, t.TempDir())
+		if err != nil {
+			t.Fatalf("buildRepoHookSpec() error = %v", err)
+		}
+		if spec.Scope != runtimehooks.HookScopeRepo || spec.Source != runtimehooks.HookSourceRepo {
+			t.Fatalf("unexpected repo spec scope/source: %+v", spec)
+		}
+		if spec.Kind != runtimehooks.HookKindHTTP || spec.Mode != runtimehooks.HookModeObserve {
+			t.Fatalf("unexpected repo spec kind/mode: %+v", spec)
+		}
+	})
+
+	t.Run("validation rejects unsupported combinations", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name  string
+			item  config.RuntimeHookItemConfig
+			scope runtimehooks.HookScope
+		}{
+			{
+				name:  "scope mismatch",
+				scope: runtimehooks.HookScopeUser,
+				item: config.RuntimeHookItemConfig{
+					ID:    "bad-scope",
+					Scope: "repo",
+					Kind:  "builtin",
+					Mode:  "sync",
+				},
+			},
+			{
+				name:  "builtin bad mode",
+				scope: runtimehooks.HookScopeUser,
+				item: config.RuntimeHookItemConfig{
+					ID:    "bad-mode",
+					Scope: "user",
+					Kind:  "builtin",
+					Mode:  "observe",
+				},
+			},
+			{
+				name:  "http bad mode",
+				scope: runtimehooks.HookScopeUser,
+				item: config.RuntimeHookItemConfig{
+					ID:    "bad-http-mode",
+					Scope: "user",
+					Kind:  "http",
+					Mode:  "sync",
+				},
+			},
+			{
+				name:  "http fail closed",
+				scope: runtimehooks.HookScopeUser,
+				item: config.RuntimeHookItemConfig{
+					ID:            "bad-http-policy",
+					Scope:         "user",
+					Kind:          "http",
+					Mode:          "observe",
+					FailurePolicy: "fail_closed",
+				},
+			},
+			{
+				name:  "external kind",
+				scope: runtimehooks.HookScopeUser,
+				item: config.RuntimeHookItemConfig{
+					ID:    "bad-external",
+					Scope: "user",
+					Kind:  "prompt",
+					Mode:  "sync",
+				},
+			},
+			{
+				name:  "unknown kind",
+				scope: runtimehooks.HookScopeUser,
+				item: config.RuntimeHookItemConfig{
+					ID:    "bad-kind",
+					Scope: "user",
+					Kind:  "custom",
+					Mode:  "sync",
+				},
+			},
+		}
+		for _, tc := range tests {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				if err := validateConfiguredHookItemForP6Lite(tc.item, tc.scope); err == nil {
+					t.Fatalf("expected validation error for %+v", tc.item)
+				}
+			})
+		}
+	})
+
+	t.Run("external kind helper", func(t *testing.T) {
+		t.Parallel()
+		for _, kind := range []string{"command", "http", "prompt", "agent"} {
+			if !isExternalHookKind(kind) {
+				t.Fatalf("%q should be treated as external kind", kind)
+			}
+		}
+		if isExternalHookKind("builtin") {
+			t.Fatal("builtin should not be treated as external kind")
+		}
+	})
+}
+
+func TestHTTPObserveHelperBranches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bool and metadata helpers", func(t *testing.T) {
+		t.Parallel()
+		if !readHookParamBool(map[string]any{"x": true}, "x", false) {
+			t.Fatal("bool true should be preserved")
+		}
+		if readHookParamBool(map[string]any{"x": "off"}, "x", true) {
+			t.Fatal("string off should decode to false")
+		}
+		if !readHookParamBool(map[string]any{"x": "yes"}, "x", false) {
+			t.Fatal("string yes should decode to true")
+		}
+		if readHookParamBool(map[string]any{"x": 0}, "x", true) {
+			t.Fatal("int 0 should decode to false")
+		}
+		if !readHookParamBool(map[string]any{"x": int64(2)}, "x", false) {
+			t.Fatal("int64 non-zero should decode to true")
+		}
+		if readHookParamBool(map[string]any{"x": float64(0)}, "x", true) {
+			t.Fatal("float64 0 should decode to false")
+		}
+		if !readHookParamBool(map[string]any{"x": struct{}{}}, "x", true) {
+			t.Fatal("unsupported type should return default")
+		}
+		if sanitizeHTTPObserveMetadata(nil) != nil {
+			t.Fatal("nil metadata should stay nil")
+		}
+		if sanitizeHTTPObserveMetadata(map[string]any{}) != nil {
+			t.Fatal("empty metadata should stay nil")
+		}
+	})
+
+	t.Run("endpoint and header validation", func(t *testing.T) {
+		t.Parallel()
+		validURLs := []string{
+			"http://localhost:19090/hook",
+			"https://127.0.0.1:19090/hook",
+			"http://[::1]:19090/hook",
+		}
+		for _, rawURL := range validURLs {
+			if err := validateHTTPObserveEndpoint(rawURL); err != nil {
+				t.Fatalf("validateHTTPObserveEndpoint(%q) error = %v", rawURL, err)
+			}
+		}
+		for _, rawURL := range []string{"", "://bad", "file:///tmp/x", "https://example.com/hook"} {
+			if err := validateHTTPObserveEndpoint(rawURL); err == nil {
+				t.Fatalf("expected endpoint %q to fail validation", rawURL)
+			}
+		}
+		if !isHTTPObserveLoopbackHost("127.0.0.1") || !isHTTPObserveLoopbackHost("::1") {
+			t.Fatal("loopback IPs should be allowed")
+		}
+		if isHTTPObserveLoopbackHost("example.com") {
+			t.Fatal("remote host should not be allowed")
+		}
+
+		headers, err := buildHTTPObserveHeaders(map[string]any{"headers": map[string]any{"X-Test": 9}})
+		if err != nil {
+			t.Fatalf("buildHTTPObserveHeaders() error = %v", err)
+		}
+		if headers["X-Test"] != "9" {
+			t.Fatalf("header value = %q, want %q", headers["X-Test"], "9")
+		}
+		if headers, err := buildHTTPObserveHeaders(nil); err != nil || headers != nil {
+			t.Fatalf("nil headers should return nil,nil, got %#v err=%v", headers, err)
+		}
+		for _, params := range []map[string]any{
+			{"headers": "bad"},
+			{"headers": map[string]any{" ": "x"}},
+			{"headers": map[string]any{"X-Test": " "}},
+		} {
+			if _, err := buildHTTPObserveHeaders(params); err == nil {
+				t.Fatalf("expected buildHTTPObserveHeaders error for %+v", params)
+			}
+		}
+	})
+
+	t.Run("handler failure branches", func(t *testing.T) {
+		t.Parallel()
+		item := config.RuntimeHookItemConfig{
+			ID:    "observe-http",
+			Point: "after_tool_result",
+			Params: map[string]any{
+				"url":              "http://127.0.0.1:1/hook",
+				"include_metadata": "yes",
+			},
+		}
+		handler, err := buildUserHTTPObserveHookHandler(item)
+		if err != nil {
+			t.Fatalf("buildUserHTTPObserveHookHandler() error = %v", err)
+		}
+		result := handler(context.Background(), runtimehooks.HookContext{Metadata: map[string]any{"tool_name": "bash"}})
+		if result.Status != runtimehooks.HookResultFailed || !strings.Contains(result.Error, "request failed") {
+			t.Fatalf("unexpected request failure result: %+v", result)
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			writer.WriteHeader(http.StatusBadRequest)
+		}))
+		defer server.Close()
+		item.Params["url"] = server.URL
+		handler, err = buildUserHTTPObserveHookHandler(item)
+		if err != nil {
+			t.Fatalf("buildUserHTTPObserveHookHandler(server) error = %v", err)
+		}
+		result = handler(context.Background(), runtimehooks.HookContext{})
+		if result.Status != runtimehooks.HookResultFailed || result.Error != result.Message {
+			t.Fatalf("empty response body should reuse message as error, got %+v", result)
+		}
+
+		marshalItem := config.RuntimeHookItemConfig{
+			ID:    "observe-http-marshal",
+			Point: "after_tool_result",
+			Params: map[string]any{
+				"url":              server.URL,
+				"include_metadata": 1,
+			},
+		}
+		handler, err = buildUserHTTPObserveHookHandler(marshalItem)
+		if err != nil {
+			t.Fatalf("buildUserHTTPObserveHookHandler(marshal) error = %v", err)
+		}
+		result = handler(context.Background(), runtimehooks.HookContext{
+			Metadata: map[string]any{"bad": func() {}},
+		})
+		if result.Status != runtimehooks.HookResultFailed || !strings.Contains(result.Error, "marshal payload failed") {
+			t.Fatalf("unexpected marshal failure result: %+v", result)
+		}
+	})
+
+	t.Run("drain nil response", func(t *testing.T) {
+		t.Parallel()
+		drainAndCloseHTTPResponseBody(nil)
+		drainAndCloseHTTPResponseBody(&http.Response{})
+	})
+}
+
+func TestResolveHookPathWithinWorkdirRejectsSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	workdir := t.TempDir()
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "escape.txt")
+	if err := os.WriteFile(outsideFile, []byte("escape"), 0o644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+	link := filepath.Join(workdir, "escape-link.txt")
+	if err := os.Symlink(outsideFile, link); err != nil {
+		if gruntime.GOOS == "windows" &&
+			(errors.Is(err, os.ErrPermission) || strings.Contains(strings.ToLower(err.Error()), "privilege")) {
+			t.Skipf("skip symlink escape test without Windows symlink privilege: %v", err)
+		}
+		t.Fatalf("create symlink escape: %v", err)
+	}
+	if _, err := resolveHookPathWithinWorkdir(workdir, "escape-link.txt"); err == nil {
+		t.Fatal("expected symlink escaping workdir to be rejected")
+	}
+}
+
 func TestConfigureRuntimeHooksRejectsExternalKindAndDoesNotRegister(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/user_hooks_test.go
+++ b/internal/runtime/user_hooks_test.go
@@ -2,7 +2,10 @@ package runtime
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	gruntime "runtime"
@@ -53,6 +56,98 @@ func TestBuildUserHookSpecMapsFailurePolicyAndScope(t *testing.T) {
 	}
 	if spec.Timeout != 7*time.Second {
 		t.Fatalf("timeout = %v, want 7s", spec.Timeout)
+	}
+}
+
+func TestBuildUserHookSpecAllowsHTTPObserve(t *testing.T) {
+	t.Parallel()
+
+	var called atomic.Int32
+	var captured map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		called.Add(1)
+		if request.Method != http.MethodPost {
+			t.Fatalf("method = %q, want POST", request.Method)
+		}
+		if got := request.Header.Get("X-Hook-Test"); got != "ok" {
+			t.Fatalf("header X-Hook-Test = %q, want ok", got)
+		}
+		if err := json.NewDecoder(request.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	item := config.RuntimeHookItemConfig{
+		ID:            "http-observe",
+		Point:         "before_tool_call",
+		Scope:         "user",
+		Kind:          "http",
+		Mode:          "observe",
+		TimeoutSec:    2,
+		FailurePolicy: "warn_only",
+		Params: map[string]any{
+			"url":     server.URL,
+			"headers": map[string]any{"X-Hook-Test": "ok"},
+		},
+	}
+	spec, err := buildUserHookSpec(item, t.TempDir())
+	if err != nil {
+		t.Fatalf("buildUserHookSpec() error = %v", err)
+	}
+	if spec.Kind != runtimehooks.HookKindHTTP {
+		t.Fatalf("kind = %q, want %q", spec.Kind, runtimehooks.HookKindHTTP)
+	}
+	result := spec.Handler(context.Background(), runtimehooks.HookContext{
+		RunID:     "run-http-observe",
+		SessionID: "session-http-observe",
+		Metadata:  map[string]any{"tool_name": "bash"},
+	})
+	if result.Status != runtimehooks.HookResultPass {
+		t.Fatalf("status = %q, want pass", result.Status)
+	}
+	if called.Load() != 1 {
+		t.Fatalf("called = %d, want 1", called.Load())
+	}
+	if mode, _ := captured["mode"].(string); mode != "observe" {
+		t.Fatalf("payload.mode = %v, want observe", captured["mode"])
+	}
+	if hookID, _ := captured["hook_id"].(string); hookID != "http-observe" {
+		t.Fatalf("payload.hook_id = %v, want http-observe", captured["hook_id"])
+	}
+}
+
+func TestBuildUserHTTPObserveHandlerReturnsFailedOnHTTPError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusBadRequest)
+		_, _ = writer.Write([]byte("invalid payload"))
+	}))
+	defer server.Close()
+
+	item := config.RuntimeHookItemConfig{
+		ID:         "http-observe-error",
+		Point:      "before_tool_call",
+		Scope:      "user",
+		Kind:       "http",
+		Mode:       "observe",
+		TimeoutSec: 2,
+		Params: map[string]any{
+			"url": server.URL,
+		},
+	}
+	spec, err := buildUserHookSpec(item, t.TempDir())
+	if err != nil {
+		t.Fatalf("buildUserHookSpec() error = %v", err)
+	}
+	result := spec.Handler(context.Background(), runtimehooks.HookContext{})
+	if result.Status != runtimehooks.HookResultFailed {
+		t.Fatalf("status = %q, want failed", result.Status)
+	}
+	if !strings.Contains(result.Error, "status=400") {
+		t.Fatalf("error = %q, want contains status=400", result.Error)
 	}
 }
 

--- a/internal/runtime/user_hooks_test.go
+++ b/internal/runtime/user_hooks_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -116,6 +117,9 @@ func TestBuildUserHookSpecAllowsHTTPObserve(t *testing.T) {
 	if hookID, _ := captured["hook_id"].(string); hookID != "http-observe" {
 		t.Fatalf("payload.hook_id = %v, want http-observe", captured["hook_id"])
 	}
+	if _, exists := captured["metadata"]; exists {
+		t.Fatalf("metadata should be omitted by default for http observe, got=%v", captured["metadata"])
+	}
 }
 
 func TestBuildUserHTTPObserveHandlerReturnsFailedOnHTTPError(t *testing.T) {
@@ -150,6 +154,97 @@ func TestBuildUserHTTPObserveHandlerReturnsFailedOnHTTPError(t *testing.T) {
 		t.Fatalf("error = %q, want contains status=400", result.Error)
 	}
 }
+
+func TestBuildUserHookSpecHTTPObserveCanIncludeSanitizedMetadata(t *testing.T) {
+	t.Parallel()
+
+	var captured map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if err := json.NewDecoder(request.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	item := config.RuntimeHookItemConfig{
+		ID:            "http-observe-with-metadata",
+		Point:         "after_tool_result",
+		Scope:         "user",
+		Kind:          "http",
+		Mode:          "observe",
+		TimeoutSec:    2,
+		FailurePolicy: "warn_only",
+		Params: map[string]any{
+			"url":              server.URL,
+			"include_metadata": true,
+		},
+	}
+	spec, err := buildUserHookSpec(item, t.TempDir())
+	if err != nil {
+		t.Fatalf("buildUserHookSpec() error = %v", err)
+	}
+	result := spec.Handler(context.Background(), runtimehooks.HookContext{
+		RunID:     "run-meta",
+		SessionID: "session-meta",
+		Metadata: map[string]any{
+			"tool_name":              "bash",
+			"result_content_preview": "should_not_leak",
+			"execution_error":        "should_not_leak",
+		},
+	})
+	if result.Status != runtimehooks.HookResultPass {
+		t.Fatalf("status = %q, want pass", result.Status)
+	}
+	rawMeta, ok := captured["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("metadata type = %T, want map[string]any", captured["metadata"])
+	}
+	if toolName, _ := rawMeta["tool_name"].(string); toolName != "bash" {
+		t.Fatalf("metadata.tool_name = %v, want bash", rawMeta["tool_name"])
+	}
+	if _, exists := rawMeta["result_content_preview"]; exists {
+		t.Fatal("result_content_preview should be stripped from http observe payload metadata")
+	}
+	if _, exists := rawMeta["execution_error"]; exists {
+		t.Fatal("execution_error should be stripped from http observe payload metadata")
+	}
+}
+
+func TestDrainAndCloseHTTPResponseBody(t *testing.T) {
+	t.Parallel()
+
+	body := &trackingReadCloser{
+		reader: strings.NewReader("hello-response-body"),
+	}
+	resp := &http.Response{Body: body}
+	drainAndCloseHTTPResponseBody(resp)
+	if !body.closed {
+		t.Fatal("expected response body to be closed")
+	}
+	if body.readBytes == 0 {
+		t.Fatal("expected response body to be drained before close")
+	}
+}
+
+type trackingReadCloser struct {
+	reader    *strings.Reader
+	closed    bool
+	readBytes int
+}
+
+func (t *trackingReadCloser) Read(p []byte) (int, error) {
+	n, err := t.reader.Read(p)
+	t.readBytes += n
+	return n, err
+}
+
+func (t *trackingReadCloser) Close() error {
+	t.closed = true
+	return nil
+}
+
+var _ io.ReadCloser = (*trackingReadCloser)(nil)
 
 func TestRequireFileExistsHandler(t *testing.T) {
 	t.Parallel()

--- a/www/.vitepress/config.mts
+++ b/www/.vitepress/config.mts
@@ -108,6 +108,7 @@ export default defineConfig({
                 { text: "Skills 使用", link: "/guide/skills" },
                 { text: "飞书远程接入配置", link: "/guide/feishu-remote-setup" },
                 { text: "Hooks 使用", link: "/guide/hooks" },
+                { text: "Clawd 桌宠接入示例", link: "/guide/hooks-clawd-integration" },
               ],
             },
             {
@@ -203,6 +204,8 @@ export default defineConfig({
               items: [
                 { text: "MCP Tools", link: "/en/guide/mcp" },
                 { text: "Skills", link: "/en/guide/skills" },
+                { text: "Hooks", link: "/en/guide/hooks" },
+                { text: "NeoCode x Clawd", link: "/en/guide/hooks-clawd-integration" },
               ],
             },
             {

--- a/www/en/guide/hooks-clawd-integration.md
+++ b/www/en/guide/hooks-clawd-integration.md
@@ -47,7 +47,7 @@ runtime:
         params:
           url: "http://127.0.0.1:3101/neocode-hook"
           method: POST
-          include_metadata: true
+          include_metadata: false
 
       - id: clawd-before-tool
         enabled: true
@@ -58,7 +58,7 @@ runtime:
         params:
           url: "http://127.0.0.1:3101/neocode-hook"
           method: POST
-          include_metadata: true
+          include_metadata: false
 
       - id: clawd-after-tool
         enabled: true
@@ -69,7 +69,7 @@ runtime:
         params:
           url: "http://127.0.0.1:3101/neocode-hook"
           method: POST
-          include_metadata: true
+          include_metadata: false
 
       - id: clawd-session-end
         enabled: true
@@ -80,7 +80,7 @@ runtime:
         params:
           url: "http://127.0.0.1:3101/neocode-hook"
           method: POST
-          include_metadata: true
+          include_metadata: false
 ```
 
 ## Step 2: Start a local bridge
@@ -164,4 +164,3 @@ Will callback failures stop my run?
 2. Set request body size limits
 3. Dedupe repeated events (`run_id + point + ts`)
 4. Forward only fields needed by Clawd
-

--- a/www/en/guide/hooks-clawd-integration.md
+++ b/www/en/guide/hooks-clawd-integration.md
@@ -1,0 +1,167 @@
+---
+title: NeoCode x Clawd Integration Example
+description: Minimal setup using HTTP observe hooks to drive Clawd desktop-pet state.
+---
+
+# NeoCode x Clawd Integration Example
+
+This is the minimal production-friendly approach:
+
+- keep NeoCode core flow unchanged
+- avoid opening dangerous execution hooks
+- use `http + observe` only for lifecycle event delivery
+
+## Architecture
+
+```text
+NeoCode runtime hooks
+  -> http observe (POST JSON)
+  -> local bridge service
+  -> Clawd hook/event endpoint
+```
+
+Why use a bridge service:
+
+1. Clawd protocol changes do not require NeoCode config rewrites
+2. You can map, throttle, or dedupe events safely
+3. Bridge failures won't block NeoCode runs
+
+## Step 1: Configure NeoCode hooks
+
+Add this to `~/.neocode/config.yaml`:
+
+```yaml
+runtime:
+  hooks:
+    enabled: true
+    user_hooks_enabled: true
+    default_timeout_sec: 2
+    default_failure_policy: warn_only
+    items:
+      - id: clawd-session-start
+        enabled: true
+        point: session_start
+        scope: user
+        kind: http
+        mode: observe
+        params:
+          url: "http://127.0.0.1:3101/neocode-hook"
+          method: POST
+          include_metadata: true
+
+      - id: clawd-before-tool
+        enabled: true
+        point: before_tool_call
+        scope: user
+        kind: http
+        mode: observe
+        params:
+          url: "http://127.0.0.1:3101/neocode-hook"
+          method: POST
+          include_metadata: true
+
+      - id: clawd-after-tool
+        enabled: true
+        point: after_tool_result
+        scope: user
+        kind: http
+        mode: observe
+        params:
+          url: "http://127.0.0.1:3101/neocode-hook"
+          method: POST
+          include_metadata: true
+
+      - id: clawd-session-end
+        enabled: true
+        point: session_end
+        scope: user
+        kind: http
+        mode: observe
+        params:
+          url: "http://127.0.0.1:3101/neocode-hook"
+          method: POST
+          include_metadata: true
+```
+
+## Step 2: Start a local bridge
+
+Example Node.js bridge:
+
+```js
+// bridge.js
+import express from "express";
+import fetch from "node-fetch";
+
+const app = express();
+app.use(express.json({ limit: "256kb" }));
+
+const CLAWD_ENDPOINT = process.env.CLAWD_ENDPOINT || "http://127.0.0.1:3111/hook";
+
+function mapEvent(payload) {
+  const point = payload?.point || "unknown";
+  const toolName = payload?.metadata?.tool_name || "";
+
+  if (point === "session_start") return { state: "working", detail: "task started" };
+  if (point === "before_tool_call") return { state: "tool_running", detail: toolName || "tool call" };
+  if (point === "after_tool_result") return { state: "tool_done", detail: toolName || "tool result" };
+  if (point === "session_end") return { state: "idle", detail: "task finished" };
+  return { state: "working", detail: point };
+}
+
+app.post("/neocode-hook", async (req, res) => {
+  try {
+    const payload = req.body || {};
+    const mapped = mapEvent(payload);
+
+    await fetch(CLAWD_ENDPOINT, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        source: "neocode",
+        run_id: payload.run_id || "",
+        session_id: payload.session_id || "",
+        point: payload.point || "",
+        state: mapped.state,
+        detail: mapped.detail,
+        ts: payload.triggered_at || new Date().toISOString(),
+      }),
+    });
+
+    res.status(204).end();
+  } catch (err) {
+    console.error("bridge error:", err);
+    res.status(500).json({ error: "bridge failed" });
+  }
+});
+
+app.listen(3101, "127.0.0.1", () => {
+  console.log("NeoCode -> Clawd bridge on http://127.0.0.1:3101");
+});
+```
+
+## Step 3: Validate end-to-end
+
+1. Start bridge service (`127.0.0.1:3101`)
+2. Run a NeoCode task that calls at least one tool
+3. Verify bridge receives `POST /neocode-hook`
+4. Verify Clawd state transitions (`working -> tool_running -> tool_done -> idle`)
+
+## Troubleshooting
+
+If no callback arrives:
+
+1. confirm `runtime.hooks.enabled=true`
+2. confirm `kind=http` and `mode=observe`
+3. confirm `params.url` is absolute `http/https`
+
+Will callback failures stop my run?
+
+- No. `http observe` is designed as non-blocking with `warn_only`.
+
+## Security baseline
+
+1. Bind bridge to `127.0.0.1` only
+2. Set request body size limits
+3. Dedupe repeated events (`run_id + point + ts`)
+4. Forward only fields needed by Clawd
+

--- a/www/en/guide/hooks.md
+++ b/www/en/guide/hooks.md
@@ -77,7 +77,7 @@ runtime:
           method: POST
           headers:
             X-Source: neocode
-          include_metadata: true
+          include_metadata: false
 ```
 
 ## HTTP observe fields
@@ -89,12 +89,13 @@ runtime:
 | `params.url` | Yes | Absolute `http/https` URL |
 | `params.method` | No | Default `POST` |
 | `params.headers` | No | Custom request headers |
-| `params.include_metadata` | No | Include metadata payload (`true` by default) |
+| `params.include_metadata` | No | Include metadata payload (`false` by default) |
 
 Notes:
 
 - `http observe` is non-blocking by design.
 - `failure_policy: fail_closed` is not allowed for `http observe`.
+- Even when enabled, sensitive fields (`result_content_preview`, `execution_error`) are stripped from callback metadata.
 
 ## Callback payload
 
@@ -128,4 +129,3 @@ See the step-by-step walkthrough:
 - Supported for user hooks: `builtin/sync` and `http/observe`
 - Not supported yet: `command`, `prompt`, `agent`
 - Hook params use `params` (not `with`)
-

--- a/www/en/guide/hooks.md
+++ b/www/en/guide/hooks.md
@@ -96,6 +96,7 @@ Notes:
 - `http observe` is non-blocking by design.
 - `failure_policy: fail_closed` is not allowed for `http observe`.
 - Even when enabled, sensitive fields (`result_content_preview`, `execution_error`) are stripped from callback metadata.
+- `params.url` is restricted to loopback hosts (`localhost`, `127.0.0.1`, `::1`) to prevent accidental public exfiltration.
 
 ## Callback payload
 

--- a/www/en/guide/hooks.md
+++ b/www/en/guide/hooks.md
@@ -1,0 +1,131 @@
+---
+title: Hooks Guide
+description: Configure runtime hooks with safe builtin handlers and HTTP observe callbacks.
+---
+
+# Hooks Guide
+
+Hooks let you add runtime rules and observability callbacks to NeoCode.
+
+Today, two user-facing types are supported:
+
+- `builtin + sync`: guardrails and reminders
+- `http + observe`: event callbacks to local components (like desktop pets or status dashboards)
+
+## When to use hooks
+
+| Need | Use |
+|---|---|
+| Add stable instruction every run | `add_context_note` |
+| Warn before specific tool calls | `warn_on_tool_call` |
+| Require file existence before completion | `require_file_exists` |
+| Push lifecycle events to another app | `kind: http` + `mode: observe` |
+
+## Config locations
+
+Global config:
+
+```text
+~/.neocode/config.yaml
+```
+
+Repo-level config:
+
+```text
+<workspace>/.neocode/hooks.yaml
+```
+
+## Quick template
+
+```yaml
+runtime:
+  hooks:
+    enabled: true
+    user_hooks_enabled: true
+    items:
+      - id: user-note
+        enabled: true
+        point: user_prompt_submit
+        scope: user
+        kind: builtin
+        mode: sync
+        handler: add_context_note
+        params:
+          note: "Prefer minimal safe changes."
+
+      - id: user-warn-bash
+        enabled: true
+        point: before_tool_call
+        scope: user
+        kind: builtin
+        mode: sync
+        handler: warn_on_tool_call
+        params:
+          tool_name: bash
+          message: "Confirm the bash command is safe before execution."
+
+      - id: user-http-observe
+        enabled: true
+        point: after_tool_result
+        scope: user
+        kind: http
+        mode: observe
+        timeout_sec: 2
+        failure_policy: warn_only
+        params:
+          url: "http://127.0.0.1:3101/hook"
+          method: POST
+          headers:
+            X-Source: neocode
+          include_metadata: true
+```
+
+## HTTP observe fields
+
+| Field | Required | Notes |
+|---|---|---|
+| `kind` | Yes | Must be `http` |
+| `mode` | Yes | Must be `observe` |
+| `params.url` | Yes | Absolute `http/https` URL |
+| `params.method` | No | Default `POST` |
+| `params.headers` | No | Custom request headers |
+| `params.include_metadata` | No | Include metadata payload (`true` by default) |
+
+Notes:
+
+- `http observe` is non-blocking by design.
+- `failure_policy: fail_closed` is not allowed for `http observe`.
+
+## Callback payload
+
+NeoCode sends JSON similar to:
+
+```json
+{
+  "hook_id": "user-http-observe",
+  "point": "after_tool_result",
+  "scope": "user",
+  "kind": "http",
+  "mode": "observe",
+  "run_id": "run_xxx",
+  "session_id": "session_xxx",
+  "triggered_at": "2026-05-11T08:00:00Z",
+  "metadata": {
+    "tool_name": "bash",
+    "stop_reason": "accepted"
+  }
+}
+```
+
+## Clawd integration
+
+See the step-by-step walkthrough:
+
+- [NeoCode x Clawd Integration Example](./hooks-clawd-integration)
+
+## Current limits
+
+- Supported for user hooks: `builtin/sync` and `http/observe`
+- Not supported yet: `command`, `prompt`, `agent`
+- Hook params use `params` (not `with`)
+

--- a/www/en/guide/index.md
+++ b/www/en/guide/index.md
@@ -38,6 +38,8 @@ NeoCode is a local terminal AI coding assistant. It works around your workspace,
 
 - [Skills](./skills)
 - [MCP Tools](./mcp)
+- [Hooks](./hooks)
+- [NeoCode x Clawd Integration Example](./hooks-clawd-integration)
 
 ## Troubleshooting
 

--- a/www/guide/hooks-clawd-integration.md
+++ b/www/guide/hooks-clawd-integration.md
@@ -1,0 +1,187 @@
+---
+title: NeoCode x Clawd 桌宠接入示例
+description: 用 http observe hooks 把 NeoCode 生命周期事件推送给 Clawd 桌宠组件的最小接入方案。
+---
+
+# NeoCode x Clawd 桌宠接入示例
+
+这篇文档讲的是“最小可用接入”：
+
+- 不改 NeoCode 主链路
+- 不开放危险执行能力
+- 只通过 `http + observe` 把运行状态推送给桌宠
+
+如果你只想“让桌宠看到 NeoCode 在忙什么”，按本文即可。
+
+## 先理解整体链路
+
+```text
+NeoCode runtime hooks
+  -> http observe (POST JSON)
+  -> 本地桥接服务（你自己起一个小服务）
+  -> Clawd 的 hook/event 接口
+```
+
+为什么推荐“桥接服务”而不是直接写死到桌宠？
+
+1. 桌宠接口变更时，你只改桥接，不动 NeoCode 配置
+2. 可以做字段映射与节流，避免事件风暴
+3. 出错时不会影响 NeoCode 主任务
+
+## 第一步：配置 NeoCode hooks
+
+在 `~/.neocode/config.yaml` 里增加：
+
+```yaml
+runtime:
+  hooks:
+    enabled: true
+    user_hooks_enabled: true
+    default_timeout_sec: 2
+    default_failure_policy: warn_only
+    items:
+      - id: clawd-session-start
+        enabled: true
+        point: session_start
+        scope: user
+        kind: http
+        mode: observe
+        params:
+          url: "http://127.0.0.1:3101/neocode-hook"
+          method: POST
+          headers:
+            X-Event-Source: neocode
+          include_metadata: true
+
+      - id: clawd-before-tool
+        enabled: true
+        point: before_tool_call
+        scope: user
+        kind: http
+        mode: observe
+        params:
+          url: "http://127.0.0.1:3101/neocode-hook"
+          method: POST
+          include_metadata: true
+
+      - id: clawd-after-tool
+        enabled: true
+        point: after_tool_result
+        scope: user
+        kind: http
+        mode: observe
+        params:
+          url: "http://127.0.0.1:3101/neocode-hook"
+          method: POST
+          include_metadata: true
+
+      - id: clawd-session-end
+        enabled: true
+        point: session_end
+        scope: user
+        kind: http
+        mode: observe
+        params:
+          url: "http://127.0.0.1:3101/neocode-hook"
+          method: POST
+          include_metadata: true
+```
+
+这四个点位基本覆盖了“开始任务 -> 调工具 -> 完成任务”的常见展示需求。
+
+## 第二步：起一个本地桥接服务
+
+下面给一个最小 Node.js 示例（你也可以用 Go/Python）：
+
+```js
+// bridge.js
+import express from "express";
+import fetch from "node-fetch";
+
+const app = express();
+app.use(express.json({ limit: "256kb" }));
+
+// 你需要替换成 Clawd 实际接收地址
+const CLAWD_ENDPOINT = process.env.CLAWD_ENDPOINT || "http://127.0.0.1:3111/hook";
+
+function mapNeoCodeEvent(payload) {
+  const point = payload?.point || "unknown";
+  const toolName = payload?.metadata?.tool_name || "";
+
+  // 统一映射成桌宠更容易消费的状态
+  if (point === "session_start") return { state: "working", detail: "task started" };
+  if (point === "before_tool_call") return { state: "tool_running", detail: toolName || "tool call" };
+  if (point === "after_tool_result") return { state: "tool_done", detail: toolName || "tool result" };
+  if (point === "session_end") return { state: "idle", detail: "task finished" };
+  return { state: "working", detail: point };
+}
+
+app.post("/neocode-hook", async (req, res) => {
+  try {
+    const payload = req.body || {};
+    const mapped = mapNeoCodeEvent(payload);
+
+    await fetch(CLAWD_ENDPOINT, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        source: "neocode",
+        run_id: payload.run_id || "",
+        session_id: payload.session_id || "",
+        point: payload.point || "",
+        state: mapped.state,
+        detail: mapped.detail,
+        ts: payload.triggered_at || new Date().toISOString(),
+      }),
+    });
+
+    res.status(204).end();
+  } catch (err) {
+    console.error("bridge error:", err);
+    res.status(500).json({ error: "bridge failed" });
+  }
+});
+
+app.listen(3101, "127.0.0.1", () => {
+  console.log("NeoCode -> Clawd bridge listening on http://127.0.0.1:3101");
+});
+```
+
+## 第三步：联调检查
+
+按这个顺序做：
+
+1. 启动桥接服务（确保 `127.0.0.1:3101` 可访问）
+2. 启动 NeoCode，执行一次会触发工具调用的任务
+3. 检查桥接日志是否有 `POST /neocode-hook`
+4. 检查 Clawd 是否收到状态变化（working -> tool_running -> tool_done -> idle）
+
+## 常见问题
+
+### 1) 我看不到任何回调
+
+先查三件事：
+
+1. `runtime.hooks.enabled` 是否为 `true`
+2. `kind=http` + `mode=observe` 是否写对
+3. `params.url` 是否是绝对 `http/https` 地址
+
+### 2) 回调失败会不会影响主任务
+
+不会。`http observe` 设计为观测通道，建议搭配 `warn_only`，即使桥接服务挂了，NeoCode 主链路也继续执行。
+
+### 3) 会不会把敏感内容都发给桌宠
+
+建议只保留必要字段，特别是桥接层不要把完整文本、密钥相关内容透传到外部服务。  
+如果需要，可以在桥接服务里做二次过滤后再转发。
+
+## 建议的生产实践
+
+1. 桥接只监听 `127.0.0.1`
+2. 给桥接服务加请求大小限制（如 256KB）
+3. 对重复事件做去重（`run_id + point + ts`）
+4. 桌宠端只消费状态，不依赖完整业务语义
+5. 桥接崩溃时自动拉起（pm2 / systemd / NSSM）
+
+这样做可以把“可观测性”开放给用户，同时保持 NeoCode 主链路稳定、安全、可控。
+

--- a/www/guide/hooks-clawd-integration.md
+++ b/www/guide/hooks-clawd-integration.md
@@ -51,7 +51,7 @@ runtime:
           method: POST
           headers:
             X-Event-Source: neocode
-          include_metadata: true
+          include_metadata: false
 
       - id: clawd-before-tool
         enabled: true
@@ -62,7 +62,7 @@ runtime:
         params:
           url: "http://127.0.0.1:3101/neocode-hook"
           method: POST
-          include_metadata: true
+          include_metadata: false
 
       - id: clawd-after-tool
         enabled: true
@@ -73,7 +73,7 @@ runtime:
         params:
           url: "http://127.0.0.1:3101/neocode-hook"
           method: POST
-          include_metadata: true
+          include_metadata: false
 
       - id: clawd-session-end
         enabled: true
@@ -84,7 +84,7 @@ runtime:
         params:
           url: "http://127.0.0.1:3101/neocode-hook"
           method: POST
-          include_metadata: true
+          include_metadata: false
 ```
 
 这四个点位基本覆盖了“开始任务 -> 调工具 -> 完成任务”的常见展示需求。
@@ -184,4 +184,3 @@ app.listen(3101, "127.0.0.1", () => {
 5. 桥接崩溃时自动拉起（pm2 / systemd / NSSM）
 
 这样做可以把“可观测性”开放给用户，同时保持 NeoCode 主链路稳定、安全、可控。
-

--- a/www/guide/hooks.md
+++ b/www/guide/hooks.md
@@ -84,7 +84,7 @@ runtime:
           method: POST
           headers:
             X-Source: neocode
-          include_metadata: true
+          include_metadata: false
 ```
 
 ## 字段怎么填（通俗版）
@@ -107,12 +107,13 @@ runtime:
 | `params.url` | 是 | 绝对 `http/https` 地址 |
 | `params.method` | 否 | 默认 `POST` |
 | `params.headers` | 否 | 自定义请求头 |
-| `params.include_metadata` | 否 | 是否带上 metadata（默认 `true`） |
+| `params.include_metadata` | 否 | 是否带上 metadata（默认 `false`） |
 
 注意：
 
 - `http observe` 只做观测回调，不会阻断主链。
 - `failure_policy` 不能用 `fail_closed`，建议用 `warn_only`。
+- 即使开启 `include_metadata`，`result_content_preview` 与 `execution_error` 也会被自动剥离。
 
 ## 支持哪些 builtin handler
 

--- a/www/guide/hooks.md
+++ b/www/guide/hooks.md
@@ -114,6 +114,7 @@ runtime:
 - `http observe` 只做观测回调，不会阻断主链。
 - `failure_policy` 不能用 `fail_closed`，建议用 `warn_only`。
 - 即使开启 `include_metadata`，`result_content_preview` 与 `execution_error` 也会被自动剥离。
+- `params.url` 只允许回环地址（`localhost` / `127.0.0.1` / `::1`），避免误发到公网。
 
 ## 支持哪些 builtin handler
 

--- a/www/guide/hooks.md
+++ b/www/guide/hooks.md
@@ -1,19 +1,20 @@
 ---
 title: Hooks 使用指南
-description: 通过安全 builtin hooks 在 runtime 生命周期点配置用户/项目规则。
+description: 通过 runtime hooks 配置可观测规则，支持 builtin 与 http observe。
 ---
 
 # Hooks 使用指南
 
-Hooks 是给 NeoCode 加“运行规则”的方式。
+Hooks 是给 NeoCode 加“运行规则”和“状态回调”的方式。
 
-它不是任意脚本执行器。你只能在固定点位配置内置能力（builtin handler）。
+它不是任意脚本执行器。当前只支持两类安全配置：
 
-如果你是第一次接触，可以把它理解成三件事：
+- `builtin + sync`：做提醒/检查（例如调用 `bash` 前提醒）
+- `http + observe`：把运行状态推送到本地组件（例如桌宠、状态面板）
 
-1. 在任务开始时给模型补一条规则（例如“优先最小改动”）  
-2. 在调用某些工具时给提醒（例如调用 `bash` 前提醒）  
-3. 在任务完成前做简单检查（例如 `README.md` 必须存在）
+如果你第一次接触，可以先记住下面一句话：
+
+`builtin` 用来“约束行为”，`http observe` 用来“对外广播状态”。
 
 ## 什么时候用 Hooks
 
@@ -22,7 +23,8 @@ Hooks 是给 NeoCode 加“运行规则”的方式。
 | 每次都想提醒模型遵守同一条习惯 | 用 `add_context_note` |
 | 调用某些工具时想打提示 | 用 `warn_on_tool_call` |
 | 完成前需要一个文件存在 | 用 `require_file_exists` |
-| 想执行自定义脚本或 HTTP 回调 | 当前不支持（见下文） |
+| 想把运行状态推送给本地组件（桌宠/看板） | 用 `kind: http` + `mode: observe` |
+| 想执行自定义脚本 | 当前不支持（见下文） |
 
 ## 配置放在哪里
 
@@ -38,9 +40,9 @@ Hooks 是给 NeoCode 加“运行规则”的方式。
 <workspace>/.neocode/hooks.yaml
 ```
 
-## 先抄可用模板
+## 快速开始（推荐直接复制）
 
-### A. 全局规则（推荐先用）
+下面这份示例同时包含 `builtin` 与 `http observe`：
 
 ```yaml
 runtime:
@@ -68,9 +70,59 @@ runtime:
         params:
           tool_names: ["bash"]
           message: "执行 bash 前请确认命令不会破坏工作区。"
+
+      - id: user-http-observe
+        enabled: true
+        point: after_tool_result
+        scope: user
+        kind: http
+        mode: observe
+        timeout_sec: 2
+        failure_policy: warn_only
+        params:
+          url: "http://127.0.0.1:3101/hook"
+          method: POST
+          headers:
+            X-Source: neocode
+          include_metadata: true
 ```
 
-### B. 项目完成前检查
+## 字段怎么填（通俗版）
+
+### 1. `builtin + sync`
+
+| 字段 | 必填 | 说明 |
+|---|---|---|
+| `kind` | 是 | 固定 `builtin` |
+| `mode` | 是 | 固定 `sync` |
+| `handler` | 是 | `add_context_note` / `warn_on_tool_call` / `require_file_exists` |
+| `params` | 视 handler 而定 | 比如 `tool_name`、`note`、`path` |
+
+### 2. `http + observe`
+
+| 字段 | 必填 | 说明 |
+|---|---|---|
+| `kind` | 是 | 固定 `http` |
+| `mode` | 是 | 固定 `observe` |
+| `params.url` | 是 | 绝对 `http/https` 地址 |
+| `params.method` | 否 | 默认 `POST` |
+| `params.headers` | 否 | 自定义请求头 |
+| `params.include_metadata` | 否 | 是否带上 metadata（默认 `true`） |
+
+注意：
+
+- `http observe` 只做观测回调，不会阻断主链。
+- `failure_policy` 不能用 `fail_closed`，建议用 `warn_only`。
+
+## 支持哪些 builtin handler
+
+| handler | 作用 | 常见点位 |
+|---|---|---|
+| `add_context_note` | 给本轮任务补充一条规则说明 | `user_prompt_submit` |
+| `warn_on_tool_call` | 调用指定工具时给提醒 | `before_tool_call` |
+| `require_file_exists` | 完成前检查文件是否存在 | `before_completion_decision` |
+
+## 仓库级 hooks（repo）示例
 
 在 `<workspace>/.neocode/hooks.yaml`：
 
@@ -89,21 +141,28 @@ hooks:
         message: "请先补齐 README.md。"
 ```
 
-## 支持哪些内置能力
+## 回调会发什么（http observe）
 
-当前只支持 3 个 builtin handler：
+回调 body 是 JSON，常见字段如下：
 
-| handler | 作用 | 常见点位 |
-|---|---|---|
-| `add_context_note` | 给本轮任务补充一条规则说明 | `user_prompt_submit` |
-| `warn_on_tool_call` | 调用指定工具时给提醒 | `before_tool_call` |
-| `require_file_exists` | 完成前检查文件是否存在 | `before_completion_decision` |
+```json
+{
+  "hook_id": "user-http-observe",
+  "point": "after_tool_result",
+  "scope": "user",
+  "kind": "http",
+  "mode": "observe",
+  "run_id": "run_xxx",
+  "session_id": "session_xxx",
+  "triggered_at": "2026-05-11T08:00:00Z",
+  "metadata": {
+    "tool_name": "bash",
+    "stop_reason": "accepted"
+  }
+}
+```
 
-字段说明（最常用）：
-
-- `params.note` / `params.message`：`add_context_note` 文案
-- `params.tool_name` 或 `params.tool_names`：`warn_on_tool_call` 目标工具
-- `params.path`：`require_file_exists` 要检查的文件
+你可以把它理解成“在某个生命周期点位，NeoCode 主动推一条状态通知给你”。
 
 ## repo hooks 为什么有时不生效
 
@@ -146,16 +205,23 @@ trust 文件路径：
 hook_finished source=user point=user_prompt_submit hook_id=user-context-note message="优先最小改动..."
 ```
 
+如果是 `http observe`，还可以在你的回调服务日志里看到 `POST /hook` 的请求记录。
+
+## Clawd 桌宠接入
+
+已经单独整理为实战文档，直接看：
+
+- [NeoCode x Clawd 桌宠接入示例](./hooks-clawd-integration)
+
 ## 你需要知道的限制
 
-- 目前只支持 `kind: builtin`。
-- `command` / `http` / `prompt` / `agent` 暂不支持。
-- `mode` 对用户配置仅支持 `sync`。
+- 用户 hooks 支持 `kind: builtin`（`mode: sync`）和 `kind: http`（`mode: observe`）。
+- `command` / `prompt` / `agent` 暂不支持。
 - 配置字段是 `params`，不是 `with`。
 - Hooks 主要用于“补充规则、提醒、检查”，不是最终裁决器。
 
 如果配置了不支持的 kind，会看到类似报错：
 
 ```text
-external hook kind "command" is not supported in P6-lite; only builtin hooks are enabled
+external hook kind "command" is not supported in P6-lite; only builtin/http-observe hooks are enabled
 ```

--- a/www/guide/index.md
+++ b/www/guide/index.md
@@ -39,7 +39,8 @@ NeoCode 是一个在终端里运行的本地 AI 编码助手。它不是云端 S
 - [Skills 使用](./skills) — 用 `SKILL.md` 固化当前任务的工作方式
 - [MCP 工具接入](./mcp) — 把外部工具接入 NeoCode
 - [飞书远程接入配置指南](./feishu-remote-setup) — 飞书消息到本地执行的回调与长连接配置
-- [Hooks 使用](./hooks) — 在 runtime 生命周期点配置安全 builtin 规则
+- [Hooks 使用](./hooks) — 在 runtime 生命周期点配置 `builtin` 与 `http observe`
+- [NeoCode x Clawd 桌宠接入示例](./hooks-clawd-integration) — 用 observe 事件驱动桌宠状态
 
 ## 遇到问题
 


### PR DESCRIPTION
## 变更摘要
本 PR 以“最小可用、默认安全”为原则，开放用户可配置的 `http observe` hooks（`kind: http` + `mode: observe`），并补齐面向用户的接入文档（含 Clawd 桌宠示例）。

## 具体改动
### 1）运行时能力开放（代码）
- 允许 `runtime.hooks.items` 配置：
  - `kind: http`
  - `mode: observe`
- 仍然拒绝 `command` / `prompt` / `agent`，避免能力面误扩张。
- `http observe` 保持“只观测、不阻断”语义：
  - 禁止 `failure_policy=fail_closed`
  - 要求 `params.url` 为绝对 `http/https` 地址
  - 校验 `method` / `headers` 配置合法性
- 新增 HTTP observe 执行 handler：向目标地址发送 JSON 回调（可选携带 metadata）。

### 2）测试补齐
- 配置层：新增 `http/observe` 的通过与失败场景校验。
- runtime hooks 类型层：补充 `HookKindHTTP` 的规范化与验证测试。
- 运行时行为层：补充 HTTP 回调成功与非 2xx 失败路径测试。
- 回归保障：确认 `command/prompt/agent` 仍被拒绝。

### 3）文档更新（仓库文档 + 文档站）
- 更新 `docs/` 配置与设计文档，明确当前能力边界：
  - 用户 hooks 支持 `builtin/sync` 与 `http/observe`
  - 其他 external kinds 暂不支持
- 新增/更新 `www/` 用户文档：
  - 中文 Hooks 使用教程（含 http observe）
  - 中文 NeoCode x Clawd 接入实战
  - 英文 Hooks 指南
  - 英文 NeoCode x Clawd 接入示例
- 中英文导航均已接入对应入口。

## 用户价值
### 对普通用户
- 用户可通过配置直接把 NeoCode 生命周期状态推送到桌宠/状态看板等本地组件，不需要改源码。

### 对稳定性
- 在开放可观测能力的同时，不把 hooks 变成通用执行入口。
- 回调链路异常不会阻断主任务执行，降低误伤风险。

### 对接入效率
- 提供可复制配置与桥接示例，降低第三方组件接入门槛，减少试错成本。

## 本地验证
已执行并通过以下测试：
- `go test ./internal/config -run "RuntimeHooks" -count=1`
- `go test ./internal/runtime/hooks -run "HookSpecNormalizeAndValidate" -count=1`
- `go test ./internal/runtime -run "HTTPObserve|ConfigureRuntimeHooksRejectsExternalKind|BuildUserHookSpecAllowsHTTPObserve" -count=1`
