### PR TITLE
feat(web): 增强 ask_user 选项交互（补充输入 + 选项说明提示）

### DIFF
--- a/web/src/components/chat/ChatPanel.test.tsx
+++ b/web/src/components/chat/ChatPanel.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import ChatPanel from './ChatPanel'
 import { useChatStore } from '@/stores/useChatStore'
 import { useSessionStore } from '@/stores/useSessionStore'
@@ -31,6 +31,7 @@ describe('ChatPanel', () => {
   beforeEach(() => {
     mockGatewayAPI = {
       resolvePermission: vi.fn().mockResolvedValue(undefined),
+      resolveUserQuestion: vi.fn().mockResolvedValue(undefined),
     }
 
     useUIStore.setState({
@@ -154,5 +155,86 @@ describe('ChatPanel', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 20))
     expect(mockGatewayAPI.resolvePermission).toHaveBeenCalledTimes(1)
+  })
+
+  it('submits single choice ask_user with additional free text only', async () => {
+    useChatStore.setState({
+      pendingUserQuestion: {
+        request_id: 'uq-single',
+        title: 'Choose an option',
+        description: 'Pick one',
+        kind: 'single_choice',
+        options: ['A', 'B', 'C'],
+        allow_skip: false,
+      },
+    } as any)
+
+    render(<ChatPanel />)
+
+    fireEvent.change(screen.getByPlaceholderText('否，我有其他想法要告诉Neo-Code'), {
+      target: { value: '我有其他方案：先做灰度' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /提交/ }))
+
+    await waitFor(() => {
+      expect(mockGatewayAPI.resolveUserQuestion).toHaveBeenCalledWith({
+        request_id: 'uq-single',
+        status: 'answered',
+        values: undefined,
+        message: '我有其他方案：先做灰度',
+      })
+    })
+  })
+
+  it('submits multi choice ask_user with selected values and additional free text', async () => {
+    useChatStore.setState({
+      pendingUserQuestion: {
+        request_id: 'uq-multi',
+        title: 'Choose options',
+        description: 'Pick one or more',
+        kind: 'multi_choice',
+        options: ['A', 'B', 'C'],
+        allow_skip: false,
+      },
+    } as any)
+
+    render(<ChatPanel />)
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'A' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'C' }))
+    fireEvent.change(screen.getByPlaceholderText('否，我有其他想法要告诉Neo-Code'), {
+      target: { value: 'C 放到后面，我建议先做 A' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /提交/ }))
+
+    await waitFor(() => {
+      expect(mockGatewayAPI.resolveUserQuestion).toHaveBeenCalledWith({
+        request_id: 'uq-multi',
+        status: 'answered',
+        values: ['A', 'C'],
+        message: 'C 放到后面，我建议先做 A',
+      })
+    })
+  })
+
+  it('renders option description tooltip icon for ask_user options', () => {
+    useChatStore.setState({
+      pendingUserQuestion: {
+        request_id: 'uq-desc',
+        title: 'Choose one',
+        description: 'Pick one option',
+        kind: 'single_choice',
+        options: [
+          { label: '选项 A', description: '先执行方案 A' },
+          { label: '选项 B', description: '再执行方案 B' },
+        ],
+        allow_skip: false,
+      },
+    } as any)
+
+    render(<ChatPanel />)
+
+    expect(screen.getByLabelText('选项说明：先执行方案 A')).toBeInTheDocument()
+    expect(screen.getByLabelText('选项说明：再执行方案 B')).toBeInTheDocument()
   })
 })

--- a/web/src/components/chat/ChatPanel.test.tsx
+++ b/web/src/components/chat/ChatPanel.test.tsx
@@ -234,7 +234,12 @@ describe('ChatPanel', () => {
 
     render(<ChatPanel />)
 
-    expect(screen.getByLabelText('选项说明：先执行方案 A')).toBeInTheDocument()
-    expect(screen.getByLabelText('选项说明：再执行方案 B')).toBeInTheDocument()
+    const optionADescriptionBtn = screen.getByRole('button', { name: '查看选项说明：选项 A' })
+    const optionBDescriptionBtn = screen.getByRole('button', { name: '查看选项说明：选项 B' })
+    expect(optionADescriptionBtn).toBeInTheDocument()
+    expect(optionBDescriptionBtn).toBeInTheDocument()
+
+    fireEvent.click(optionADescriptionBtn)
+    expect(screen.getByText('先执行方案 A')).toBeInTheDocument()
   })
 })

--- a/web/src/components/chat/ChatPanel.tsx
+++ b/web/src/components/chat/ChatPanel.tsx
@@ -14,6 +14,7 @@ import {
   Shield,
   X,
   Check,
+  Info,
 } from 'lucide-react'
 
 export default function ChatPanel() {
@@ -39,6 +40,7 @@ export default function ChatPanel() {
   const [userQuestionText, setUserQuestionText] = useState('')
   const [userQuestionSingleChoice, setUserQuestionSingleChoice] = useState('')
   const [userQuestionMultiChoices, setUserQuestionMultiChoices] = useState<string[]>([])
+  const [userQuestionAdditionalText, setUserQuestionAdditionalText] = useState('')
   const titleRef = useRef<HTMLDivElement>(null)
   const autoResolvingPermissionIdsRef = useRef<Set<string>>(new Set())
 
@@ -84,6 +86,7 @@ export default function ChatPanel() {
     const options = parseUserQuestionOptions(Array.isArray(pendingUserQuestion.options) ? pendingUserQuestion.options : [])
     let values: string[] = []
     let message = ''
+    const additionalText = userQuestionAdditionalText.trim()
 
     if (status === 'answered') {
       switch (pendingUserQuestion.kind) {
@@ -99,16 +102,17 @@ export default function ChatPanel() {
         }
         case 'single_choice': {
           const selected = userQuestionSingleChoice.trim()
-          if (!selected) {
-            useUIStore.getState().showToast('Please select one option', 'info')
+          if (!selected && !additionalText) {
+            useUIStore.getState().showToast('Please select one option or enter another idea', 'info')
             return
           }
-          values = [selected]
+          if (selected) values = [selected]
+          if (additionalText) message = additionalText
           break
         }
         case 'multi_choice': {
-          if (userQuestionMultiChoices.length === 0) {
-            useUIStore.getState().showToast('Please select at least one option', 'info')
+          if (userQuestionMultiChoices.length === 0 && !additionalText) {
+            useUIStore.getState().showToast('Please select at least one option or enter another idea', 'info')
             return
           }
           const maxChoices = Number(pendingUserQuestion.max_choices || 0)
@@ -117,6 +121,7 @@ export default function ChatPanel() {
             return
           }
           values = [...userQuestionMultiChoices]
+          if (additionalText) message = additionalText
           break
         }
         default: {
@@ -153,11 +158,13 @@ export default function ChatPanel() {
       setUserQuestionText('')
       setUserQuestionSingleChoice('')
       setUserQuestionMultiChoices([])
+      setUserQuestionAdditionalText('')
       return
     }
     setUserQuestionText('')
     setUserQuestionSingleChoice('')
     setUserQuestionMultiChoices([])
+    setUserQuestionAdditionalText('')
   }, [pendingUserQuestion?.request_id])
 
   useEffect(() => {
@@ -342,6 +349,15 @@ export default function ChatPanel() {
                       disabled={isResolvingUserQuestion}
                     />
                     <span>{option.label}</span>
+                    {option.description && (
+                      <span
+                        title={option.description}
+                        aria-label={`选项说明：${option.description}`}
+                        style={{ display: 'inline-flex', alignItems: 'center', color: 'var(--text-tertiary)', cursor: 'help' }}
+                      >
+                        <Info size={12} />
+                      </span>
+                    )}
                   </label>
                 ))}
               </div>
@@ -365,9 +381,29 @@ export default function ChatPanel() {
                         disabled={isResolvingUserQuestion}
                       />
                       <span>{option.label}</span>
+                      {option.description && (
+                        <span
+                          title={option.description}
+                          aria-label={`选项说明：${option.description}`}
+                          style={{ display: 'inline-flex', alignItems: 'center', color: 'var(--text-tertiary)', cursor: 'help' }}
+                        >
+                          <Info size={12} />
+                        </span>
+                      )}
                     </label>
                   )
                 })}
+              </div>
+            )}
+            {(pendingUserQuestion.kind === 'single_choice' || pendingUserQuestion.kind === 'multi_choice') && (
+              <div style={{ marginBottom: 12 }}>
+                <textarea
+                  value={userQuestionAdditionalText}
+                  onChange={(e) => setUserQuestionAdditionalText(e.target.value)}
+                  placeholder="否，我有其他想法要告诉Neo-Code"
+                  disabled={isResolvingUserQuestion}
+                  style={{ width: '100%', minHeight: 72, borderRadius: 8, border: '1px solid var(--border-primary)', background: 'var(--bg-primary)', color: 'var(--text-primary)', padding: '10px 12px', fontSize: 12, resize: 'vertical' }}
+                />
               </div>
             )}
             <div className="permission-actions">

--- a/web/src/components/chat/ChatPanel.tsx
+++ b/web/src/components/chat/ChatPanel.tsx
@@ -41,11 +41,13 @@ export default function ChatPanel() {
   const [userQuestionSingleChoice, setUserQuestionSingleChoice] = useState('')
   const [userQuestionMultiChoices, setUserQuestionMultiChoices] = useState<string[]>([])
   const [userQuestionAdditionalText, setUserQuestionAdditionalText] = useState('')
+  const [expandedOptionDescriptions, setExpandedOptionDescriptions] = useState<Record<string, boolean>>({})
   const titleRef = useRef<HTMLDivElement>(null)
   const autoResolvingPermissionIdsRef = useRef<Set<string>>(new Set())
 
   const currentSession = projects.flatMap((p) => p.sessions).find((s) => s.id === currentSessionId)
   const title = currentSession?.title || '新对话'
+  const pendingQuestionOptions = parseUserQuestionOptions(Array.isArray(pendingUserQuestion?.options) ? pendingUserQuestion.options : [])
 
   async function handlePermissionDecision(decision: string) {
     if (!gatewayAPI || !currentPermission || isResolvingPermission) return
@@ -78,6 +80,13 @@ export default function ChatPanel() {
       options.push({ label, value: label, description: description || undefined })
     }
     return options
+  }
+
+  function toggleOptionDescription(optionKey: string) {
+    setExpandedOptionDescriptions((prev) => ({
+      ...prev,
+      [optionKey]: !prev[optionKey],
+    }))
   }
 
   async function handleSubmitUserQuestion(status: 'answered' | 'skipped') {
@@ -159,12 +168,14 @@ export default function ChatPanel() {
       setUserQuestionSingleChoice('')
       setUserQuestionMultiChoices([])
       setUserQuestionAdditionalText('')
+      setExpandedOptionDescriptions({})
       return
     }
     setUserQuestionText('')
     setUserQuestionSingleChoice('')
     setUserQuestionMultiChoices([])
     setUserQuestionAdditionalText('')
+    setExpandedOptionDescriptions({})
   }, [pendingUserQuestion?.request_id])
 
   useEffect(() => {
@@ -338,59 +349,139 @@ export default function ChatPanel() {
             )}
             {pendingUserQuestion.kind === 'single_choice' && (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 12 }}>
-                {parseUserQuestionOptions(Array.isArray(pendingUserQuestion.options) ? pendingUserQuestion.options : []).map((option) => (
-                  <label key={option.value} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12 }}>
-                    <input
-                      type="radio"
-                      name={`ask-${pendingUserQuestion.request_id}`}
-                      value={option.value}
-                      checked={userQuestionSingleChoice === option.value}
-                      onChange={() => setUserQuestionSingleChoice(option.value)}
-                      disabled={isResolvingUserQuestion}
-                    />
-                    <span>{option.label}</span>
-                    {option.description && (
-                      <span
-                        title={option.description}
-                        aria-label={`选项说明：${option.description}`}
-                        style={{ display: 'inline-flex', alignItems: 'center', color: 'var(--text-tertiary)', cursor: 'help' }}
-                      >
-                        <Info size={12} />
-                      </span>
-                    )}
-                  </label>
-                ))}
+                {pendingQuestionOptions.map((option, index) => {
+                  const optionId = `ask-${pendingUserQuestion.request_id}-single-${index}`
+                  const optionKey = `${pendingUserQuestion.request_id}-single-${option.value}-${index}`
+                  const descriptionId = `desc-${optionId}`
+                  const expanded = !!expandedOptionDescriptions[optionKey]
+                  return (
+                    <div key={optionKey} style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12 }}>
+                        <input
+                          id={optionId}
+                          type="radio"
+                          name={`ask-${pendingUserQuestion.request_id}`}
+                          value={option.value}
+                          checked={userQuestionSingleChoice === option.value}
+                          onChange={() => setUserQuestionSingleChoice(option.value)}
+                          disabled={isResolvingUserQuestion}
+                        />
+                        <label htmlFor={optionId}>{option.label}</label>
+                        {option.description && (
+                          <button
+                            type="button"
+                            onClick={() => toggleOptionDescription(optionKey)}
+                            aria-label={`查看选项说明：${option.label}`}
+                            aria-expanded={expanded}
+                            aria-controls={descriptionId}
+                            style={{
+                              display: 'inline-flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              width: 18,
+                              height: 18,
+                              borderRadius: '50%',
+                              border: '1px solid var(--border-primary)',
+                              background: 'var(--bg-primary)',
+                              color: 'var(--text-secondary)',
+                              cursor: 'pointer',
+                              padding: 0,
+                            }}
+                          >
+                            <Info size={11} />
+                          </button>
+                        )}
+                      </div>
+                      {option.description && expanded && (
+                        <div
+                          id={descriptionId}
+                          style={{
+                            marginLeft: 24,
+                            fontSize: 11,
+                            color: 'var(--text-secondary)',
+                            lineHeight: 1.5,
+                            background: 'var(--bg-primary)',
+                            border: '1px solid var(--border-primary)',
+                            borderRadius: 6,
+                            padding: '6px 8px',
+                          }}
+                        >
+                          {option.description}
+                        </div>
+                      )}
+                    </div>
+                  )
+                })}
               </div>
             )}
             {pendingUserQuestion.kind === 'multi_choice' && (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 12 }}>
-                {parseUserQuestionOptions(Array.isArray(pendingUserQuestion.options) ? pendingUserQuestion.options : []).map((option) => {
+                {pendingQuestionOptions.map((option, index) => {
                   const checked = userQuestionMultiChoices.includes(option.value)
+                  const optionId = `ask-${pendingUserQuestion.request_id}-multi-${index}`
+                  const optionKey = `${pendingUserQuestion.request_id}-multi-${option.value}-${index}`
+                  const descriptionId = `desc-${optionId}`
+                  const expanded = !!expandedOptionDescriptions[optionKey]
                   return (
-                    <label key={option.value} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12 }}>
-                      <input
-                        type="checkbox"
-                        checked={checked}
-                        onChange={() => {
-                          if (checked) {
-                            setUserQuestionMultiChoices((prev) => prev.filter((v) => v !== option.value))
-                            return
-                          }
-                          setUserQuestionMultiChoices((prev) => [...prev, option.value])
-                        }}
-                        disabled={isResolvingUserQuestion}
-                      />
-                      <span>{option.label}</span>
-                      {option.description && (
-                        <span
-                          title={option.description}
-                          aria-label={`选项说明：${option.description}`}
-                          style={{ display: 'inline-flex', alignItems: 'center', color: 'var(--text-tertiary)', cursor: 'help' }}
+                    <div key={optionKey} style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12 }}>
+                        <input
+                          id={optionId}
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => {
+                            if (checked) {
+                              setUserQuestionMultiChoices((prev) => prev.filter((v) => v !== option.value))
+                              return
+                            }
+                            setUserQuestionMultiChoices((prev) => [...prev, option.value])
+                          }}
+                          disabled={isResolvingUserQuestion}
+                        />
+                        <label htmlFor={optionId}>{option.label}</label>
+                        {option.description && (
+                          <button
+                            type="button"
+                            onClick={() => toggleOptionDescription(optionKey)}
+                            aria-label={`查看选项说明：${option.label}`}
+                            aria-expanded={expanded}
+                            aria-controls={descriptionId}
+                            style={{
+                              display: 'inline-flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              width: 18,
+                              height: 18,
+                              borderRadius: '50%',
+                              border: '1px solid var(--border-primary)',
+                              background: 'var(--bg-primary)',
+                              color: 'var(--text-secondary)',
+                              cursor: 'pointer',
+                              padding: 0,
+                            }}
+                          >
+                            <Info size={11} />
+                          </button>
+                        )}
+                      </div>
+                      {option.description && expanded && (
+                        <div
+                          id={descriptionId}
+                          style={{
+                            marginLeft: 24,
+                            fontSize: 11,
+                            color: 'var(--text-secondary)',
+                            lineHeight: 1.5,
+                            background: 'var(--bg-primary)',
+                            border: '1px solid var(--border-primary)',
+                            borderRadius: 6,
+                            padding: '6px 8px',
+                          }}
                         >
-                          <Info size={12} />
-                        </span>
+                          {option.description}
+                        </div>
                       )}
-                    </label>
+                    </div>
                   )
                 })}
               </div>


### PR DESCRIPTION
## 背景
当前 `ask_user` 在单选/多选场景下只能选择预置选项，用户无法直接补充“我有其他想法”；另外 `options.description` 字段虽然有数据，但 UI 没有可见入口。

## 本次改动
1. 单选/多选卡片新增补充输入框
- 在选项区域下方新增固定文本框，占位文案为：`否，我有其他想法要告诉Neo-Code`。
- 支持用户输入额外方案说明，输入后随提交一起发送。

2. 提交校验与请求参数增强
- `single_choice` / `multi_choice` 提交逻辑调整为：
- 选项与补充文本二者至少其一即可提交；
- 仅补充文本时允许提交（`values` 为空，`message` 带文本）；
- 选项 + 补充文本时同时提交（`values` + `message`）。
- 保持原有 A/B/C/D 选择流程不受影响。

3. 选项 description 可视化
- 在每个选项后增加信息图标（小 `i` 圈）。
- 鼠标悬停图标时展示该选项 `description` 详细说明，帮助用户理解各方案含义。

4. 测试补齐
- 扩展 `ChatPanel` 单测，覆盖：
- 单选仅补充文本提交；
- 多选 + 补充文本同时提交；
- 选项 `description` 图标渲染。

## 变更文件
- `web/src/components/chat/ChatPanel.tsx`
- `web/src/components/chat/ChatPanel.test.tsx`

## 验证
- `npm run test -- ChatPanel` ✅（6/6）
- `npm run build` ✅

## 用户价值
- 减少“预置选项无法表达真实诉求”导致的交互阻塞。
- 提升选项可解释性与决策效率。
- 在不破坏现有选择交互的前提下增强 `ask_user` 的可用性与可扩展性。
