### PR TITLE
fix: 修复 memo 提取并优化 compact 状态 UI

### DIFF
--- a/internal/provider/generate.go
+++ b/internal/provider/generate.go
@@ -39,6 +39,13 @@ func GenerateText(ctx context.Context, p Provider, req providertypes.GenerateReq
 					continue
 				}
 				messageDone = true
+			case providertypes.StreamEventThinkingDelta:
+				if _, err := event.ThinkingDeltaValue(); err != nil {
+					if streamErr == nil {
+						streamErr = err
+					}
+					continue
+				}
 			default:
 				if streamErr == nil {
 					streamErr = fmt.Errorf("unexpected provider stream event %q", event.Type)

--- a/internal/provider/generate_test.go
+++ b/internal/provider/generate_test.go
@@ -77,6 +77,27 @@ func TestGenerateTextSuccess(t *testing.T) {
 	}
 }
 
+func TestGenerateTextIgnoresThinkingDelta(t *testing.T) {
+	providerStub := &stubTextGenProvider{
+		generate: func(ctx context.Context, req providertypes.GenerateRequest, events chan<- providertypes.StreamEvent) error {
+			events <- providertypes.NewThinkingDeltaStreamEvent("plan")
+			events <- providertypes.NewTextDeltaStreamEvent("[")
+			events <- providertypes.NewThinkingDeltaStreamEvent("more plan")
+			events <- providertypes.NewTextDeltaStreamEvent("]")
+			events <- providertypes.NewMessageDoneStreamEvent("stop", nil)
+			return nil
+		},
+	}
+
+	text, err := provider.GenerateText(context.Background(), providerStub, providertypes.GenerateRequest{})
+	if err != nil {
+		t.Fatalf("GenerateText() error = %v", err)
+	}
+	if text != "[]" {
+		t.Fatalf("text = %q, want %q", text, "[]")
+	}
+}
+
 func TestGenerateTextProviderError(t *testing.T) {
 	providerStub := &stubTextGenProvider{
 		generate: func(ctx context.Context, req providertypes.GenerateRequest, events chan<- providertypes.StreamEvent) error {
@@ -183,6 +204,22 @@ func TestGenerateTextRejectsTextDeltaWithNilPayload(t *testing.T) {
 
 	_, err := provider.GenerateText(context.Background(), providerStub, providertypes.GenerateRequest{})
 	if err == nil || !strings.Contains(err.Error(), "text_delta event payload is nil") {
+		t.Fatalf("GenerateText() error = %v", err)
+	}
+}
+
+func TestGenerateTextRejectsThinkingDeltaWithNilPayload(t *testing.T) {
+	providerStub := &stubTextGenProvider{
+		generate: func(ctx context.Context, req providertypes.GenerateRequest, events chan<- providertypes.StreamEvent) error {
+			events <- providertypes.StreamEvent{Type: providertypes.StreamEventThinkingDelta}
+			events <- providertypes.NewTextDeltaStreamEvent("partial")
+			events <- providertypes.NewMessageDoneStreamEvent("stop", nil)
+			return nil
+		},
+	}
+
+	_, err := provider.GenerateText(context.Background(), providerStub, providertypes.GenerateRequest{})
+	if err == nil || !strings.Contains(err.Error(), "thinking_delta event payload is nil") {
 		t.Fatalf("GenerateText() error = %v", err)
 	}
 }

--- a/web/src/components/chat/ChatInput.test.tsx
+++ b/web/src/components/chat/ChatInput.test.tsx
@@ -161,14 +161,6 @@ describe('ChatInput', () => {
     expect(screen.queryByTitle('附件文件')).not.toBeInTheDocument()
     expect(screen.queryByTitle('引用上下文')).not.toBeInTheDocument()
   })
-  it('shows inline compact status while compaction is running', () => {
-    useChatStore.getState().startCompacting('manual', 'Compacting context...')
-
-    render(<ChatInput />)
-
-    expect(screen.getByRole('status')).toHaveTextContent('Compacting context...')
-  })
-
   it('blocks normal sends while compaction is running', async () => {
     useChatStore.getState().startCompacting('manual', 'Compacting context...')
     render(<ChatInput />)

--- a/web/src/components/chat/ChatInput.tsx
+++ b/web/src/components/chat/ChatInput.tsx
@@ -19,7 +19,7 @@ import {
 import SlashCommandMenu from './SlashCommandMenu'
 import SkillPicker from './SkillPicker'
 import ModelSelector from './ModelSelector'
-import { LoaderCircle, Send, Square } from 'lucide-react'
+import { Send, Square } from 'lucide-react'
 
 const slashMenuAnchorStyle: React.CSSProperties = {
   position: 'absolute',
@@ -130,7 +130,6 @@ export default function ChatInput() {
   const composingRef = useRef(false)
   const isGenerating = useChatStore((state) => state.isGenerating)
   const isCompacting = useChatStore((state) => state.isCompacting)
-  const compactMessage = useChatStore((state) => state.compactMessage)
   const addMessage = useChatStore((state) => state.addMessage)
   const addSystemMessage = useChatStore((state) => state.addSystemMessage)
   const setGenerating = useChatStore((state) => state.setGenerating)
@@ -457,12 +456,6 @@ export default function ChatInput() {
             </div>
           )}
           <div className={`input-box ${isCompacting ? 'compacting' : ''}`}>
-            {isCompacting && (
-              <div className="compact-status-row" role="status" aria-live="polite">
-                <LoaderCircle size={14} className="compact-status-spinner" />
-                <span>{compactMessage || 'Compacting context...'}</span>
-              </div>
-            )}
             <textarea
               ref={textareaRef}
               value={text}

--- a/web/src/components/chat/ChatPanel.test.tsx
+++ b/web/src/components/chat/ChatPanel.test.tsx
@@ -56,7 +56,11 @@ describe('ChatPanel', () => {
     useChatStore.setState({
       messages: [],
       isGenerating: false,
+      isCompacting: false,
+      compactMode: '',
+      compactMessage: '',
       permissionRequests: [],
+      pendingUserQuestion: null,
       agentMode: 'build',
       permissionMode: 'default',
     } as any)
@@ -241,5 +245,67 @@ describe('ChatPanel', () => {
 
     fireEvent.click(optionADescriptionBtn)
     expect(screen.getByText('先执行方案 A')).toBeInTheDocument()
+  })
+
+  it('shows compact status panel above the normal chat input', () => {
+    useChatStore.setState({
+      isCompacting: true,
+      compactMode: 'proactive',
+      compactMessage: 'Context is near the limit. Auto-compacting...',
+    } as any)
+
+    render(<ChatPanel />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Context is near the limit. Auto-compacting...')
+    expect(screen.getByTestId('chat-input')).toBeInTheDocument()
+  })
+
+  it('keeps compact status visible while a permission request is shown', () => {
+    useChatStore.setState({
+      isCompacting: true,
+      compactMode: 'reactive',
+      compactMessage: 'Model reported context too long. Compacting and retrying...',
+      permissionRequests: [{
+        request_id: 'req-compact-permission',
+        tool_call_id: 'tool-compact',
+        tool_name: 'filesystem_edit',
+        tool_category: 'filesystem',
+        action_type: 'write',
+        operation: 'edit',
+        target_type: 'file',
+        target: 'foo.txt',
+        decision: '',
+        reason: 'needs approval',
+      }],
+    } as any)
+
+    render(<ChatPanel />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Model reported context too long. Compacting and retrying...')
+    expect(screen.getByText('权限请求')).toBeInTheDocument()
+    expect(screen.queryByTestId('chat-input')).not.toBeInTheDocument()
+  })
+
+  it('keeps compact status visible while a user question is shown', () => {
+    useChatStore.setState({
+      isCompacting: true,
+      compactMode: 'manual',
+      compactMessage: 'Compacting context...',
+      pendingUserQuestion: {
+        request_id: 'ask-compact',
+        question_id: 'question-compact',
+        title: 'Need input',
+        description: '',
+        kind: 'text',
+        required: true,
+        allow_skip: false,
+      },
+    } as any)
+
+    render(<ChatPanel />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Compacting context...')
+    expect(screen.getByText('Need input')).toBeInTheDocument()
+    expect(screen.queryByTestId('chat-input')).not.toBeInTheDocument()
   })
 })

--- a/web/src/components/chat/ChatPanel.test.tsx
+++ b/web/src/components/chat/ChatPanel.test.tsx
@@ -55,7 +55,11 @@ describe('ChatPanel', () => {
     useChatStore.setState({
       messages: [],
       isGenerating: false,
+      isCompacting: false,
+      compactMode: '',
+      compactMessage: '',
       permissionRequests: [],
+      pendingUserQuestion: null,
       agentMode: 'build',
       permissionMode: 'default',
     } as any)
@@ -154,5 +158,67 @@ describe('ChatPanel', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 20))
     expect(mockGatewayAPI.resolvePermission).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows compact status panel above the normal chat input', () => {
+    useChatStore.setState({
+      isCompacting: true,
+      compactMode: 'proactive',
+      compactMessage: 'Context is near the limit. Auto-compacting...',
+    } as any)
+
+    render(<ChatPanel />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Context is near the limit. Auto-compacting...')
+    expect(screen.getByTestId('chat-input')).toBeInTheDocument()
+  })
+
+  it('keeps compact status visible while a permission request is shown', () => {
+    useChatStore.setState({
+      isCompacting: true,
+      compactMode: 'reactive',
+      compactMessage: 'Model reported context too long. Compacting and retrying...',
+      permissionRequests: [{
+        request_id: 'req-compact-permission',
+        tool_call_id: 'tool-compact',
+        tool_name: 'filesystem_edit',
+        tool_category: 'filesystem',
+        action_type: 'write',
+        operation: 'edit',
+        target_type: 'file',
+        target: 'foo.txt',
+        decision: '',
+        reason: 'needs approval',
+      }],
+    } as any)
+
+    render(<ChatPanel />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Model reported context too long. Compacting and retrying...')
+    expect(screen.getByText('权限请求')).toBeInTheDocument()
+    expect(screen.queryByTestId('chat-input')).not.toBeInTheDocument()
+  })
+
+  it('keeps compact status visible while a user question is shown', () => {
+    useChatStore.setState({
+      isCompacting: true,
+      compactMode: 'manual',
+      compactMessage: 'Compacting context...',
+      pendingUserQuestion: {
+        request_id: 'ask-compact',
+        question_id: 'question-compact',
+        title: 'Need input',
+        description: '',
+        kind: 'text',
+        required: true,
+        allow_skip: false,
+      },
+    } as any)
+
+    render(<ChatPanel />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Compacting context...')
+    expect(screen.getByText('Need input')).toBeInTheDocument()
+    expect(screen.queryByTestId('chat-input')).not.toBeInTheDocument()
   })
 })

--- a/web/src/components/chat/ChatPanel.tsx
+++ b/web/src/components/chat/ChatPanel.tsx
@@ -14,6 +14,7 @@ import {
   Shield,
   X,
   Check,
+  LoaderCircle,
 } from 'lucide-react'
 
 export default function ChatPanel() {
@@ -32,6 +33,8 @@ export default function ChatPanel() {
   const currentPermission = permissionRequests[0]
   const pendingUserQuestion = useChatStore((s) => s.pendingUserQuestion)
   const clearPendingUserQuestion = useChatStore((s) => s.clearPendingUserQuestion)
+  const isCompacting = useChatStore((s) => s.isCompacting)
+  const compactMessage = useChatStore((s) => s.compactMessage)
 
   const [editingTitle, setEditingTitle] = useState(false)
   const [isResolvingPermission, setIsResolvingPermission] = useState(false)
@@ -262,6 +265,13 @@ export default function ChatPanel() {
       </div>
 
       <TodoStrip />
+
+      {isCompacting && (
+        <div className="compact-status-panel" role="status" aria-live="polite">
+          <LoaderCircle size={14} className="compact-status-spinner" />
+          <span>{compactMessage || 'Compacting context...'}</span>
+        </div>
+      )}
 
       {currentPermission && !(agentMode === 'build' && permissionMode === 'bypass') ? (
         <div className="permission-area">

--- a/web/src/components/chat/ChatPanel.tsx
+++ b/web/src/components/chat/ChatPanel.tsx
@@ -15,6 +15,7 @@ import {
   X,
   Check,
   Info,
+  LoaderCircle,
 } from 'lucide-react'
 
 export default function ChatPanel() {
@@ -33,6 +34,8 @@ export default function ChatPanel() {
   const currentPermission = permissionRequests[0]
   const pendingUserQuestion = useChatStore((s) => s.pendingUserQuestion)
   const clearPendingUserQuestion = useChatStore((s) => s.clearPendingUserQuestion)
+  const isCompacting = useChatStore((s) => s.isCompacting)
+  const compactMessage = useChatStore((s) => s.compactMessage)
 
   const [editingTitle, setEditingTitle] = useState(false)
   const [isResolvingPermission, setIsResolvingPermission] = useState(false)
@@ -280,6 +283,13 @@ export default function ChatPanel() {
       </div>
 
       <TodoStrip />
+
+      {isCompacting && (
+        <div className="compact-status-panel" role="status" aria-live="polite">
+          <LoaderCircle size={14} className="compact-status-spinner" />
+          <span>{compactMessage || 'Compacting context...'}</span>
+        </div>
+      )}
 
       {currentPermission && !(agentMode === 'build' && permissionMode === 'bypass') ? (
         <div className="permission-area">

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1156,11 +1156,18 @@ html, body, #root {
 .input-box.compacting {
   border-color: var(--warning-muted);
 }
-.compact-status-row {
+.compact-status-panel {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 12px 0;
+  flex-shrink: 0;
+  max-width: 740px;
+  width: calc(100% - var(--space-12));
+  margin: 0 auto var(--space-2);
+  padding: 8px 12px;
+  border: 1px solid var(--warning-muted);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
   color: var(--warning);
   font-size: 12px;
   font-weight: 500;

--- a/web/src/utils/eventBridge.test.ts
+++ b/web/src/utils/eventBridge.test.ts
@@ -566,6 +566,31 @@ describe("eventBridge", () => {
     expect(useUIStore.getState().toasts).toHaveLength(0);
   });
 
+  it("CompactStart uses proactive mode copy without a toast", () => {
+    const api = createMockGatewayAPI();
+    handleGatewayEvent(
+      {
+        type: EventType.CompactStart,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.CompactStart,
+            payload: { trigger_mode: "proactive" },
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-1",
+      },
+      api,
+    );
+
+    expect(useChatStore.getState().isCompacting).toBe(true);
+    expect(useChatStore.getState().compactMode).toBe("proactive");
+    expect(useChatStore.getState().compactMessage).toBe(
+      "Context is near the limit. Auto-compacting...",
+    );
+    expect(useUIStore.getState().toasts).toHaveLength(0);
+  });
+
   it("CompactApplied clears compact state and shows completion toast", () => {
     const api = createMockGatewayAPI();
     useChatStore
@@ -593,6 +618,31 @@ describe("eventBridge", () => {
     );
   });
 
+  it("CompactApplied for automatic modes clears compact state without completion toast", () => {
+    const api = createMockGatewayAPI();
+    useChatStore
+      .getState()
+      .startCompacting("proactive", "Context is near the limit. Auto-compacting...");
+
+    handleGatewayEvent(
+      {
+        type: EventType.CompactApplied,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.CompactApplied,
+            payload: { TriggerMode: "proactive", Applied: true },
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-1",
+      },
+      api,
+    );
+
+    expect(useChatStore.getState().isCompacting).toBe(false);
+    expect(useUIStore.getState().toasts).toHaveLength(0);
+  });
+
   it("CompactError clears compact state and uses payload message", () => {
     const api = createMockGatewayAPI();
     useChatStore
@@ -617,6 +667,33 @@ describe("eventBridge", () => {
     expect(useChatStore.getState().isCompacting).toBe(false);
     expect(useUIStore.getState().toasts.at(-1)?.message).toBe(
       "compact timed out",
+    );
+  });
+
+  it("CompactError for automatic modes includes automatic compact context", () => {
+    const api = createMockGatewayAPI();
+    useChatStore
+      .getState()
+      .startCompacting("reactive", "Model reported context too long. Compacting and retrying...");
+
+    handleGatewayEvent(
+      {
+        type: EventType.CompactError,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.CompactError,
+            payload: { TriggerMode: "reactive", Message: "context still too long" },
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-1",
+      },
+      api,
+    );
+
+    expect(useChatStore.getState().isCompacting).toBe(false);
+    expect(useUIStore.getState().toasts.at(-1)?.message).toBe(
+      "Auto context compaction failed: context still too long",
     );
   });
 

--- a/web/src/utils/eventBridge.ts
+++ b/web/src/utils/eventBridge.ts
@@ -538,6 +538,34 @@ function strField(payload: unknown, key: string): string {
   return ((payload as PayloadRecord)?.[key] as string) ?? "";
 }
 
+function resolveCompactMode(payload: unknown): string {
+  if (typeof payload === "string") return payload.trim() || "manual";
+  return (
+    strField(payload, "trigger_mode") ||
+    strField(payload, "TriggerMode") ||
+    "manual"
+  );
+}
+
+function compactMessageForMode(mode: string): string {
+  switch (mode) {
+    case "proactive":
+      return "Context is near the limit. Auto-compacting...";
+    case "reactive":
+      return "Model reported context too long. Compacting and retrying...";
+    case "manual":
+    default:
+      return "Compacting context...";
+  }
+}
+
+function compactErrorMessageForMode(mode: string, message: string): string {
+  if (mode === "proactive" || mode === "reactive") {
+    return message ? `Auto context compaction failed: ${message}` : "Auto context compaction failed";
+  }
+  return message || "Compaction failed";
+}
+
 /** 从 tool_result 事件中解析最终工具调用 ID，兼容字段名差异。 */
 function resolveToolResultCallID(eventPayload: unknown): string {
   return (
@@ -851,33 +879,30 @@ export function handleGatewayEvent(
       break;
 
     case EventType.CompactStart: {
-      const mode =
-        typeof eventPayload === "string"
-          ? eventPayload
-          : strField(eventPayload, "trigger_mode") ||
-            strField(eventPayload, "TriggerMode") ||
-            "manual";
+      const mode = resolveCompactMode(eventPayload);
       useChatStore
         .getState()
-        .startCompacting(mode, "Compacting context...");
+        .startCompacting(mode, compactMessageForMode(mode));
       break;
     }
 
     case EventType.CompactApplied: {
+      const mode = resolveCompactMode(eventPayload);
       useChatStore.getState().finishCompacting();
-      uiStore.showToast("Context compacted", "success");
+      if (mode === "manual") {
+        uiStore.showToast("Context compacted", "success");
+      }
       break;
     }
 
     case EventType.CompactError: {
-      useChatStore.getState().finishCompacting();
-      uiStore.showToast(
+      const mode = resolveCompactMode(eventPayload);
+      const message =
         strField(eventPayload, "message") ||
-          strField(eventPayload, "Message") ||
-          (typeof eventPayload === "string" ? eventPayload : "") ||
-          "Compaction failed",
-        "error",
-      );
+        strField(eventPayload, "Message") ||
+        (typeof eventPayload === "string" ? eventPayload : "");
+      useChatStore.getState().finishCompacting();
+      uiStore.showToast(compactErrorMessageForMode(mode, message), "error");
       break;
     }
 


### PR DESCRIPTION
## 背景

现在有两个问题
一是memo提取有think会报错
二是前端compact信息错误

## 当前修改

- 修复 provider 侧 memo 提取时混入 `think` 内容导致解析失败的问题，并补齐回归测试。
- 优化 Web compact 状态 UI 的展示逻辑，避免输入区状态展示职责混入。
- 调整 Web 事件桥接对 compact / ask_user 等运行时事件的处理，并补齐事件桥接与 ChatPanel 测试。

## 验证

- `git diff --check up/main...HEAD` 通过。
- `npm test` 于 `web/` 通过：47 个测试文件，298 个测试。
- `go test ./...` 未全量通过：`internal/repository` 的 `TestRepositoryHelpersAndGitParsing/run_git_command_and_utility_helpers` 与 `internal/runner` 的 `TestCapSignerHelpers` 在当前 Windows 路径环境失败，失败点不属于本 PR 修改范围。