### PR TITLE
feat(cli): 终端诊断用户体验优化 — 补全文档、友好错误提示、更新加载动画

### DIFF
--- a/internal/cli/shell_diag_commands.go
+++ b/internal/cli/shell_diag_commands.go
@@ -26,6 +26,11 @@ const (
 	diagControlSessionPrefix = "diag-cli"
 	diagAskSkillID           = "terminal-diagnosis"
 	diagInputMaxBytes        = 256 * 1024
+
+	// errNoShellSession 提示用户先通过 `neocode shell` 启动代理终端。
+	errNoShellSession = "no neocode shell session found; run `neocode shell` first to start a terminal proxy session, then run this command again"
+	// errTargetRoleUnavailable 是网关返回的原始错误特征串，用于识别需要友好提示的场景。
+	errTargetRoleUnavailable = "target role stream is unavailable"
 )
 
 var (
@@ -289,18 +294,27 @@ func defaultDiagCommandRunner(ctx context.Context, options diagCommandOptions) e
 		return runDiagAsk(ctx, options)
 	}
 	targetSessionID := resolveDiagTargetSessionID(options.SessionID)
+	if targetSessionID == "" {
+		return errors.New(errNoShellSession)
+	}
 	return sendDiagnoseSignalFn(ctx, targetSessionID)
 }
 
 // defaultDiagInteractiveCommandRunner 触发 shell 进入 IDM 模式。
 func defaultDiagInteractiveCommandRunner(ctx context.Context, options diagCommandOptions) error {
 	targetSessionID := resolveDiagTargetSessionID(options.SessionID)
+	if targetSessionID == "" {
+		return errors.New(errNoShellSession)
+	}
 	return sendIDMEnterSignalFn(ctx, targetSessionID)
 }
 
 // defaultDiagAutoCommandRunner 处理 auto on/off/status，并输出状态文案。
 func defaultDiagAutoCommandRunner(ctx context.Context, options diagAutoCommandOptions, stdout io.Writer) error {
 	targetSessionID := resolveDiagTargetSessionID(options.SessionID)
+	if targetSessionID == "" {
+		return errors.New(errNoShellSession)
+	}
 	if options.QueryOnly {
 		enabled, err := queryAutoModeFn(ctx, targetSessionID)
 		if err != nil {
@@ -391,7 +405,7 @@ func triggerDiagAction(ctx context.Context, sessionID string, action string) (ga
 		bindSessionID = generateDiagSessionID(diagControlSessionPrefix)
 	}
 	if err := bindDiagStream(callCtx, client, bindSessionID); err != nil {
-		return gateway.MessageFrame{}, err
+		return gateway.MessageFrame{}, wrapDiagGatewayError(err)
 	}
 
 	var frame gateway.MessageFrame
@@ -407,19 +421,38 @@ func triggerDiagAction(ctx context.Context, sessionID string, action string) (ga
 			Retries: 0,
 		},
 	); err != nil {
-		return gateway.MessageFrame{}, err
+		return gateway.MessageFrame{}, wrapDiagGatewayError(err)
 	}
 	if frame.Type == gateway.FrameTypeError && frame.Error != nil {
-		return gateway.MessageFrame{}, fmt.Errorf(
+		return gateway.MessageFrame{}, wrapDiagGatewayError(fmt.Errorf(
 			"gateway trigger_action failed (%s): %s",
 			strings.TrimSpace(frame.Error.Code),
 			strings.TrimSpace(frame.Error.Message),
-		)
+		))
 	}
 	if frame.Type != gateway.FrameTypeAck {
 		return gateway.MessageFrame{}, fmt.Errorf("unexpected gateway frame type: %s", strings.TrimSpace(string(frame.Type)))
 	}
 	return frame, nil
+}
+
+// isNoShellSessionError 检测网关错误是否指示当前没有活跃的 shell 会话。
+func isNoShellSessionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), errTargetRoleUnavailable)
+}
+
+// wrapDiagGatewayError 对无 shell 会话的网关错误附加友好提示。
+func wrapDiagGatewayError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if isNoShellSessionError(err) {
+		return fmt.Errorf("%s (original: %w)", errNoShellSession, err)
+	}
+	return err
 }
 
 // bindDiagStream 以 CLI 角色绑定事件流，接收后续 RPC 事件和通知。

--- a/internal/cli/shell_diag_commands_test.go
+++ b/internal/cli/shell_diag_commands_test.go
@@ -421,3 +421,89 @@ func mustMarshalDiagPayload(value any) string {
 	}
 	return strings.TrimSpace(string(payload))
 }
+
+func TestDefaultDiagCommandRunnerNoShellSession(t *testing.T) {
+	originalReadEnv := readDiagEnvValue
+	t.Cleanup(func() { readDiagEnvValue = originalReadEnv })
+
+	readDiagEnvValue = func(key string) string { return "" }
+
+	err := defaultDiagCommandRunner(context.Background(), diagCommandOptions{})
+	if err == nil {
+		t.Fatal("expected error when no shell session is available")
+	}
+	if !strings.Contains(err.Error(), errNoShellSession) {
+		t.Fatalf("error = %q, want contains %q", err.Error(), errNoShellSession)
+	}
+}
+
+func TestDefaultDiagInteractiveCommandRunnerNoShellSession(t *testing.T) {
+	originalReadEnv := readDiagEnvValue
+	t.Cleanup(func() { readDiagEnvValue = originalReadEnv })
+
+	readDiagEnvValue = func(key string) string { return "" }
+
+	err := defaultDiagInteractiveCommandRunner(context.Background(), diagCommandOptions{})
+	if err == nil {
+		t.Fatal("expected error when no shell session is available")
+	}
+	if !strings.Contains(err.Error(), errNoShellSession) {
+		t.Fatalf("error = %q, want contains %q", err.Error(), errNoShellSession)
+	}
+}
+
+func TestDefaultDiagAutoCommandRunnerNoShellSession(t *testing.T) {
+	originalReadEnv := readDiagEnvValue
+	t.Cleanup(func() { readDiagEnvValue = originalReadEnv })
+
+	readDiagEnvValue = func(key string) string { return "" }
+
+	err := defaultDiagAutoCommandRunner(context.Background(), diagAutoCommandOptions{QueryOnly: true}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error when no shell session is available")
+	}
+	if !strings.Contains(err.Error(), errNoShellSession) {
+		t.Fatalf("error = %q, want contains %q", err.Error(), errNoShellSession)
+	}
+}
+
+func TestWrapDiagGatewayError(t *testing.T) {
+	t.Run("nil returns nil", func(t *testing.T) {
+		if err := wrapDiagGatewayError(nil); err != nil {
+			t.Fatalf("wrapDiagGatewayError(nil) = %v", err)
+		}
+	})
+
+	t.Run("non-shell error passes through unchanged", func(t *testing.T) {
+		original := errors.New("some other error")
+		if err := wrapDiagGatewayError(original); err != original {
+			t.Fatalf("expected unwrapped original error, got %v", err)
+		}
+	})
+
+	t.Run("shell session error is wrapped", func(t *testing.T) {
+		original := errors.New("gateway trigger_action failed (resource_not_found): target role stream is unavailable")
+		wrapped := wrapDiagGatewayError(original)
+		if wrapped == nil {
+			t.Fatal("expected wrapped error")
+		}
+		if !strings.Contains(wrapped.Error(), errNoShellSession) {
+			t.Fatalf("wrapped error = %q, want contains %q", wrapped.Error(), errNoShellSession)
+		}
+		if !strings.Contains(wrapped.Error(), original.Error()) {
+			t.Fatalf("wrapped error = %q, want contains original %q", wrapped.Error(), original.Error())
+		}
+	})
+}
+
+func TestIsNoShellSessionError(t *testing.T) {
+	if isNoShellSessionError(nil) {
+		t.Fatal("isNoShellSessionError(nil) = true")
+	}
+	if !isNoShellSessionError(errors.New("target role stream is unavailable")) {
+		t.Fatal("isNoShellSessionError should detect 'target role stream is unavailable'")
+	}
+	if isNoShellSessionError(errors.New("some other error")) {
+		t.Fatal("isNoShellSessionError should not match other errors")
+	}
+}

--- a/internal/cli/update_command.go
+++ b/internal/cli/update_command.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -20,6 +21,34 @@ var runUpdateCommand = defaultUpdateCommandRunner
 var doUpdate = updater.DoUpdate
 
 var updateCommandTimeout = 5 * time.Minute
+
+// updateSpinnerFrames 定义更新加载动画的旋转字符帧。
+var updateSpinnerFrames = []string{"-", "\\", "|", "/"}
+
+// startUpdateSpinner 在 os.Stderr 上输出旋转加载动画，返回停止函数。
+func startUpdateSpinner() func() {
+	done := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		i := 0
+		for {
+			select {
+			case <-done:
+				fmt.Fprint(os.Stderr, "\r \r")
+				return
+			case <-ticker.C:
+				frame := updateSpinnerFrames[i%len(updateSpinnerFrames)]
+				fmt.Fprintf(os.Stderr, "\r%s Updating...", frame)
+				i++
+			}
+		}
+	}()
+	return func() {
+		close(done)
+		time.Sleep(150 * time.Millisecond)
+	}
+}
 
 const updateTimeoutErrorTemplate = "\u66f4\u65b0\u8d85\u65f6\uff08%s\uff09\uff0c\u8bf7\u68c0\u67e5\u7f51\u7edc\u540e\u91cd\u8bd5"
 
@@ -60,6 +89,9 @@ func newUpdateCommand() *cobra.Command {
 func defaultUpdateCommandRunner(ctx context.Context, options updateCommandOptions) (updater.UpdateResult, error) {
 	updateCtx, cancel := context.WithTimeout(ctx, updateCommandTimeout)
 	defer cancel()
+
+	stop := startUpdateSpinner()
+	defer stop()
 
 	result, err := doUpdate(updateCtx, updater.UpdateOptions{
 		CurrentVersion:    version.Current(),

--- a/www/.vitepress/config.mts
+++ b/www/.vitepress/config.mts
@@ -99,6 +99,7 @@ export default defineConfig({
                 { text: "HTTP URL 唤醒指南", link: "/guide/http-daemon-wake-user-guide" },
                 { text: "配置指南", link: "/guide/configuration" },
                 { text: "工具与权限", link: "/guide/tools-permissions" },
+                { text: "终端代理与诊断", link: "/guide/shell-diag" },
               ],
             },
             {
@@ -196,6 +197,7 @@ export default defineConfig({
                 { text: "Daily Use", link: "/en/guide/daily-use" },
                 { text: "Configuration", link: "/en/guide/configuration" },
                 { text: "Tools & Permissions", link: "/en/guide/tools-permissions" },
+                { text: "Shell Proxy & Diagnosis", link: "/en/guide/shell-diag" },
               ],
             },
             {

--- a/www/en/guide/shell-diag.md
+++ b/www/en/guide/shell-diag.md
@@ -1,0 +1,159 @@
+---
+title: Shell Proxy & Terminal Diagnosis
+description: Launch a proxy shell with neocode shell and trigger automated or on-demand terminal error diagnosis using neocode diag.
+---
+
+# Shell Proxy & Terminal Diagnosis
+
+NeoCode provides a terminal proxy and diagnosis feature that allows the Agent to observe your terminal activity in real time and trigger automated or manual diagnosis when errors occur.
+
+The workflow is: start a proxy terminal session with `neocode shell`, work normally inside it, and when an error occurs, use `neocode diag` to trigger a diagnosis or enable auto-diagnosis for the Agent to analyze errors proactively.
+
+## Starting a Proxy Shell
+
+Launch a proxy shell session in your terminal:
+
+```bash
+neocode shell
+```
+
+Once started, you enter a NeoCode-proxied terminal environment. The session registers itself with the NeoCode Gateway as a shell role, allowing subsequent diagnosis commands to locate the target session.
+
+> **Note**: All diagnosis commands (`neocode diag` and its subcommands) depend on an active `neocode shell` session. Start `neocode shell` in one terminal window first, then run diagnosis commands in another.
+
+## Shell Integration
+
+If your shell supports integration, use `--init` to print the initialization script:
+
+```bash
+# Print bash init script
+neocode shell --init bash
+
+# Print zsh init script
+neocode shell --init zsh
+```
+
+You can also append the output to your shell config so it loads automatically:
+
+```bash
+neocode shell --init bash >> ~/.bashrc
+```
+
+## Triggering a One-Shot Diagnosis
+
+When an error appears in the terminal, run the diagnosis command in another terminal window:
+
+```bash
+# Trigger a manual diagnosis (both forms are equivalent)
+neocode diag
+neocode diag diagnose
+```
+
+You can pipe error logs directly into the diagnosis:
+
+```bash
+cat error.log | neocode diag --session <session-id>
+```
+
+Or pass error content with the `--error-log` flag:
+
+```bash
+neocode diag --error-log "command not found: xxx"
+```
+
+Diagnosis results are streamed to your terminal.
+
+## Interactive Diagnosis Mode (IDM)
+
+Interactive diagnosis mode provides a sandbox environment for multi-turn conversations with the Agent to troubleshoot issues:
+
+```bash
+neocode diag -i
+```
+
+In IDM, the Agent can read your terminal context and provide diagnostic suggestions in a conversation. To exit IDM:
+
+- Type `exit`
+- Press `Ctrl+C` while idle
+
+## Auto-Diagnosis Toggle
+
+You can control whether the Agent automatically triggers diagnosis when terminal errors occur:
+
+| Command | Effect |
+|---------|--------|
+| `neocode diag auto on` | Enable auto-diagnosis |
+| `neocode diag auto off` | Disable auto-diagnosis |
+| `neocode diag auto status` | Show current auto-diagnosis status |
+
+```bash
+# Enable auto-diagnosis
+neocode diag auto on
+
+# Check status
+neocode diag auto status
+```
+
+To target a specific shell session, use `--session`:
+
+```bash
+neocode diag auto on --session <session-id>
+```
+
+## Common Issues
+
+### `neocode diag` reports "no neocode shell session found"
+
+**Symptom**
+
+- Running `neocode diag` or `neocode diag -i` shows a session-not-found error
+
+**Likely causes**
+
+- You have not started `neocode shell` yet
+- The proxy shell session has exited
+- The `NEOCODE_SHELL_SESSION` environment variable is not visible in the other terminal
+
+**Fix**
+
+1. Start `neocode shell` in one terminal window first.
+2. Run the diagnosis command in another terminal window.
+3. Make sure the proxy shell session is still running.
+
+### `neocode shell` cannot start on this platform
+
+**Symptom**
+
+- Platform not supported or launch failure
+
+**Likely causes**
+
+- The current platform does not support PTY proxying (`neocode shell` currently supports Unix-like systems only)
+
+**Fix**
+
+1. Check your operating system with `uname -s`.
+2. Windows support for `neocode shell` is planned for a future release.
+
+### Diagnosis hangs or times out
+
+**Symptom**
+
+- `neocode diag` produces no output for a long time
+
+**Likely causes**
+
+- Gateway is not running or unreachable
+- Network issue causing RPC timeout
+
+**Fix**
+
+1. Verify the `neocode shell` session is still running.
+2. Check that the Gateway connection is healthy.
+3. Retry the command.
+
+## Next steps
+
+- Daily usage patterns: [Daily Use](./daily-use)
+- Other troubleshooting: [Troubleshooting](./troubleshooting)
+- Configuration options: [Configuration](./configuration)

--- a/www/guide/shell-diag.md
+++ b/www/guide/shell-diag.md
@@ -1,0 +1,159 @@
+---
+title: 终端代理与诊断
+description: 使用 neocode shell 进入代理终端，通过 neocode diag 触发或自动诊断终端错误。
+---
+
+# 终端代理与诊断
+
+NeoCode 提供终端代理与诊断功能，让 Agent 能够实时感知你在终端中的操作，并在出现错误时自动或手动触发诊断。
+
+使用流程为：先通过 `neocode shell` 启动代理终端会话，然后在代理终端中正常工作。当遇到错误时，可以用 `neocode diag` 触发诊断，或开启自动诊断让 Agent 主动分析错误。
+
+## 启动代理 Shell
+
+在终端中启动代理 Shell 会话：
+
+```bash
+neocode shell
+```
+
+启动后，你会进入一个由 NeoCode 代理的终端环境。该会话会向 NeoCode Gateway 注册为 shell 角色，从而使后续的诊断命令能够找到目标会话。
+
+> **注意**：所有诊断命令（`neocode diag` 及其子命令）都依赖当前已有一个活跃的 `neocode shell` 会话。请先在一个终端窗口启动 `neocode shell`，然后在另一个终端窗口执行诊断命令。
+
+## Shell Integration
+
+如果你使用的 Shell 支持 integration，可以通过 `--init` 输出初始化脚本：
+
+```bash
+# 输出 bash 初始化脚本
+neocode shell --init bash
+
+# 输出 zsh 初始化脚本
+neocode shell --init zsh
+```
+
+你也可以将输出直接写入 shell 配置文件，使每次启动代理 Shell 时自动加载：
+
+```bash
+neocode shell --init bash >> ~/.bashrc
+```
+
+## 触发一次诊断
+
+当终端中出现报错时，在另一个终端窗口执行诊断命令：
+
+```bash
+# 触发一次手动诊断（两种写法等价）
+neocode diag
+neocode diag diagnose
+```
+
+你也可以通过管道直接将错误日志传入诊断：
+
+```bash
+cat error.log | neocode diag --session <session-id>
+```
+
+或使用 `--error-log` 参数直接指定错误内容：
+
+```bash
+neocode diag --error-log "command not found: xxx"
+```
+
+诊断结果会以流式输出显示在终端中。
+
+## 交互式诊断沙盒（IDM）
+
+交互式诊断模式提供一个沙盒环境，你可以在其中与 Agent 进行多轮对话来定位问题：
+
+```bash
+neocode diag -i
+```
+
+在 IDM 中，Agent 可以读取你的终端上下文，并在对话中给出诊断建议。退出 IDM 的方式：
+
+- 输入 `exit` 退出
+- 在空闲状态下按 `Ctrl+C` 退出
+
+## 自动诊断开关
+
+你可以设置在终端中出现错误时，Agent 是否自动触发诊断：
+
+| 命令 | 作用 |
+|------|------|
+| `neocode diag auto on` | 开启自动诊断 |
+| `neocode diag auto off` | 关闭自动诊断 |
+| `neocode diag auto status` | 查询当前自动诊断状态 |
+
+```bash
+# 开启自动诊断
+neocode diag auto on
+
+# 查询状态
+neocode diag auto status
+```
+
+如果知道目标 Shell 会话 ID，可以通过 `--session` 参数指定：
+
+```bash
+neocode diag auto on --session <session-id>
+```
+
+## 常见问题
+
+### 运行 `neocode diag` 时报错 "no neocode shell session found"
+
+**现象**
+
+- 执行 `neocode diag` 或 `neocode diag -i` 时提示找不到 shell 会话
+
+**可能原因**
+
+- 尚未启动 `neocode shell`
+- 代理 Shell 会话已退出
+- `NEOCODE_SHELL_SESSION` 环境变量在另一个终端中不可见
+
+**怎么处理**
+
+1. 在一个终端窗口中先执行 `neocode shell`，进入代理终端。
+2. 在另一个终端窗口中执行诊断命令。
+3. 确保代理 Shell 会话仍在运行，没有退出。
+
+### `neocode shell` 无法在当前平台启动
+
+**现象**
+
+- 提示平台不支持或启动失败
+
+**可能原因**
+
+- 当前平台不支持 PTY 代理（`neocode shell` 当前仅支持 Unix-like 系统）
+
+**怎么处理**
+
+1. 确认当前操作系统：`uname -s`。
+2. 如果你在 Windows 上，当前版本暂不支持 `neocode shell`，Windows 支持计划在未来版本中提供。
+
+### 诊断无响应或超时
+
+**现象**
+
+- `neocode diag` 执行后长时间无输出
+
+**可能原因**
+
+- Gateway 未运行或无法连接
+- 网络问题导致 RPC 调用超时
+
+**怎么处理**
+
+1. 确认 `neocode shell` 会话仍在运行。
+2. 检查 Gateway 连接是否正常。
+3. 重试命令。
+
+## 下一步
+
+- 了解 NeoCode 的日常使用方式：[日常使用](./daily-use)
+- 遇到其他问题：[排障与常见问题](./troubleshooting)
+- 查看配置选项：[配置指南](./configuration)


### PR DESCRIPTION
## 概述

  针对终端诊断功能的三个体验短板进行统一优化：

  1. **补全官网使用文档** — 终端诊断功能缺少用户指南页面
  2. **优化无 shell 会话时的错误提示** — 原网关错误信息对用户不友好
  3. **`neocode update` 添加加载动画** — 更新过程无任何反馈，用户无法判断是否卡死

  ## 变更详情

  ### 1. 补全双语文档（`www/`）

  - 新建 `www/guide/shell-diag.md`（中文）和 `www/en/guide/shell-diag.md`（英文）
  - 覆盖 `neocode shell`、`neocode diag`、`neocode diag -i`、`neocode diag auto` 的全部用法
  - 包含常见问题章节（含 "未启动 shell 即执行 diag" 的处理说明）
  - 在 `www/.vitepress/config.mts` 中英文侧边栏同步注册

  ### 2. 友好错误提示（`internal/cli/shell_diag_commands.go`）

  - **预检**：在三个 command runner 中，当 `resolveDiagTargetSessionID()` 返回空时直接返回友好提示，不再发起 RPC 调用
  - **后检**：在 `triggerDiagAction()` 中对网关返回的 `"target role stream is unavailable"` 错误进行包装，附加 "请先执行 `neocode shell`" 的引导信息
  - 新增 7 个测试用例覆盖预检、后检和错误包装逻辑

  ### 3. 更新加载动画（`internal/cli/update_command.go`）

  - 新增 `startUpdateSpinner()`，以 goroutine 方式在 stderr 输出旋转动画（`- \ | /`），100ms 每帧
  - 在 `defaultUpdateCommandRunner()` 中以 `defer stop()` 包裹 `doUpdate()` 调用
  - 动画在更新完成或出错时自动清理，不影响 stdout 的结果输出

  ## 涉及文件

  | 文件 | 变更 |
  |------|------|
  | `www/guide/shell-diag.md` | 新建 |
  | `www/en/guide/shell-diag.md` | 新建 |
  | `www/.vitepress/config.mts` | 侧边栏注册 |
  | `internal/cli/shell_diag_commands.go` | 预检 + 后检 + 辅助函数 |
  | `internal/cli/shell_diag_commands_test.go` | 新增 7 个测试 |
  | `internal/cli/update_command.go` | 加载动画 |

  ## 验证

  - [x] `go test ./internal/cli/...` 全部通过
  - [x] `go test ./internal/updater/...` 全部通过
  - [x] `go build ./internal/cli/` 编译通过
  - [ ] 本地 VitePress 预览（`cd www && pnpm dev`）确认页面可访问
  - [x] 实际终端中验证：无 shell 时直接 `neocode diag` 应看到友好提示
  - [x] 实际终端中验证：`neocode update` 应看到旋转加载动画
---
Closes #613 