### PR TITLE
fix(session): 串行化 SQLite 会话写入

### DIFF
--- a/internal/cli/gateway_runtime_bridge.go
+++ b/internal/cli/gateway_runtime_bridge.go
@@ -44,6 +44,26 @@ type runtimeSessionCreator interface {
 	CreateSession(ctx context.Context, id string) (agentsession.Session, error)
 }
 
+type runtimeSessionDeleter interface {
+	SupportsSessionMutationBoundary() bool
+	DeleteSession(ctx context.Context, sessionID string) error
+}
+
+type runtimeSessionRenamer interface {
+	SupportsSessionMutationBoundary() bool
+	RenameSession(ctx context.Context, sessionID string, title string) error
+}
+
+type runtimeSessionModelUpdater interface {
+	SupportsSessionMutationBoundary() bool
+	UpdateSessionModel(ctx context.Context, sessionID string, providerID string, modelID string) error
+}
+
+type runtimeSessionsProviderModelSyncer interface {
+	SupportsSessionMutationBoundary() bool
+	SyncSessionsProviderModel(ctx context.Context, providerID string, modelID string) error
+}
+
 type runtimeTodoLister interface {
 	ListTodos(ctx context.Context, sessionID string) (agentruntime.TodoSnapshot, error)
 }
@@ -648,6 +668,12 @@ func (b *gatewayRuntimePortBridge) DeleteSession(ctx context.Context, input gate
 	if sessionID == "" {
 		return false, gateway.ErrRuntimeResourceNotFound
 	}
+	if deleter, ok := b.runtime.(runtimeSessionDeleter); ok {
+		if err := deleter.DeleteSession(ctx, sessionID); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
 	if b.sessionStore == nil {
 		return false, fmt.Errorf("gateway runtime bridge: session store is unavailable")
 	}
@@ -669,6 +695,9 @@ func (b *gatewayRuntimePortBridge) RenameSession(ctx context.Context, input gate
 	}
 	if title == "" {
 		return fmt.Errorf("gateway runtime bridge: title is required for rename")
+	}
+	if renamer, ok := b.runtime.(runtimeSessionRenamer); ok {
+		return renamer.RenameSession(ctx, sessionID, title)
 	}
 	if b.sessionStore == nil {
 		return fmt.Errorf("gateway runtime bridge: session store is unavailable")
@@ -918,6 +947,9 @@ func (b *gatewayRuntimePortBridge) SetSessionModel(ctx context.Context, input ga
 	providerID, modelID, err := b.resolveProviderModelForSession(ctx, session, input.ProviderID, input.ModelID)
 	if err != nil {
 		return err
+	}
+	if updater, ok := b.runtime.(runtimeSessionModelUpdater); ok {
+		return updater.UpdateSessionModel(ctx, session.ID, providerID, modelID)
 	}
 	head := session.HeadSnapshot()
 	head.Provider = providerID
@@ -1998,6 +2030,9 @@ func (b *gatewayRuntimePortBridge) SyncSessionsProviderModel(
 	modelID = strings.TrimSpace(modelID)
 	if providerID == "" || modelID == "" {
 		return nil
+	}
+	if syncer, ok := b.runtime.(runtimeSessionsProviderModelSyncer); ok {
+		return syncer.SyncSessionsProviderModel(ctx, providerID, modelID)
 	}
 
 	summaries, err := b.runtime.ListSessions(ctx)

--- a/internal/cli/gateway_runtime_bridge_test.go
+++ b/internal/cli/gateway_runtime_bridge_test.go
@@ -367,6 +367,46 @@ func (s *bridgeSessionStoreStub) UpdateSessionState(ctx context.Context, input a
 	return nil
 }
 
+type boundaryRuntimeStub struct {
+	*runtimeStub
+	deletedSessionID string
+	renamedSessionID string
+	renamedTitle     string
+	modelSessionID   string
+	modelProviderID  string
+	modelID          string
+	syncProviderID   string
+	syncModelID      string
+}
+
+func (s *boundaryRuntimeStub) SupportsSessionMutationBoundary() bool {
+	return true
+}
+
+func (s *boundaryRuntimeStub) DeleteSession(_ context.Context, sessionID string) error {
+	s.deletedSessionID = sessionID
+	return nil
+}
+
+func (s *boundaryRuntimeStub) RenameSession(_ context.Context, sessionID string, title string) error {
+	s.renamedSessionID = sessionID
+	s.renamedTitle = title
+	return nil
+}
+
+func (s *boundaryRuntimeStub) UpdateSessionModel(_ context.Context, sessionID string, providerID string, modelID string) error {
+	s.modelSessionID = sessionID
+	s.modelProviderID = providerID
+	s.modelID = modelID
+	return nil
+}
+
+func (s *boundaryRuntimeStub) SyncSessionsProviderModel(_ context.Context, providerID string, modelID string) error {
+	s.syncProviderID = providerID
+	s.syncModelID = modelID
+	return nil
+}
+
 func TestGatewayRuntimePortBridgeCheckpointOperations(t *testing.T) {
 	stub := &runtimeStub{
 		listCheckpointsResult: []agentsession.CheckpointRecord{
@@ -1496,6 +1536,32 @@ func TestGatewayRuntimePortBridgeDeleteSession(t *testing.T) {
 	})
 }
 
+func TestGatewayRuntimePortBridgeDeleteSessionUsesRuntimeBoundary(t *testing.T) {
+	store := &bridgeSessionStoreStub{
+		deleteFn: func(_ context.Context, _ string) error {
+			t.Fatalf("DeleteSession should use runtime boundary instead of direct store write")
+			return nil
+		},
+	}
+	stub := &boundaryRuntimeStub{runtimeStub: &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}}
+	bridge, err := newGatewayRuntimePortBridge(context.Background(), stub, store)
+	if err != nil {
+		t.Fatalf("new bridge: %v", err)
+	}
+	defer bridge.Close()
+
+	deleted, err := bridge.DeleteSession(context.Background(), gateway.DeleteSessionInput{
+		SubjectID: testBridgeSubjectID,
+		SessionID: " session-1 ",
+	})
+	if err != nil {
+		t.Fatalf("DeleteSession() error = %v", err)
+	}
+	if !deleted || stub.deletedSessionID != "session-1" {
+		t.Fatalf("deleted=%v runtimeID=%q", deleted, stub.deletedSessionID)
+	}
+}
+
 func TestGatewayRuntimePortBridgeRenameSession(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		store := &bridgeSessionStoreStub{
@@ -1562,6 +1628,32 @@ func TestGatewayRuntimePortBridgeRenameSession(t *testing.T) {
 			t.Fatal("expected error for empty session_id")
 		}
 	})
+}
+
+func TestGatewayRuntimePortBridgeRenameSessionUsesRuntimeBoundary(t *testing.T) {
+	store := &bridgeSessionStoreStub{
+		updateFn: func(_ context.Context, _ agentsession.UpdateSessionStateInput) error {
+			t.Fatalf("RenameSession should use runtime boundary instead of direct store write")
+			return nil
+		},
+	}
+	stub := &boundaryRuntimeStub{runtimeStub: &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}}
+	bridge, err := newGatewayRuntimePortBridge(context.Background(), stub, store)
+	if err != nil {
+		t.Fatalf("new bridge: %v", err)
+	}
+	defer bridge.Close()
+
+	if err := bridge.RenameSession(context.Background(), gateway.RenameSessionInput{
+		SubjectID: testBridgeSubjectID,
+		SessionID: " session-1 ",
+		Title:     " New Title ",
+	}); err != nil {
+		t.Fatalf("RenameSession() error = %v", err)
+	}
+	if stub.renamedSessionID != "session-1" || stub.renamedTitle != "New Title" {
+		t.Fatalf("runtime rename = (%q, %q)", stub.renamedSessionID, stub.renamedTitle)
+	}
 }
 
 // ---- providerSelection stub ----
@@ -2096,6 +2188,58 @@ func TestGatewayRuntimePortBridgeSetSessionModelProviderInference(t *testing.T) 
 	})
 	if err != nil {
 		t.Fatalf("set session model: %v", err)
+	}
+}
+
+func TestGatewayRuntimePortBridgeSetSessionModelUsesRuntimeBoundary(t *testing.T) {
+	store := &bridgeSessionStoreWithLoader{
+		bridgeSessionStoreStub: bridgeSessionStoreStub{
+			updateFn: func(_ context.Context, _ agentsession.UpdateSessionStateInput) error {
+				t.Fatalf("SetSessionModel should use runtime boundary instead of direct store write")
+				return nil
+			},
+		},
+		session: agentsession.Session{ID: "s-1", Provider: "", Model: ""},
+	}
+	ps := &providerSelectionStub{
+		listOptions: []configstate.ProviderOption{
+			{ID: "openai", Models: []providertypes.ModelDescriptor{{ID: "gpt-4", Name: "GPT-4"}}},
+		},
+	}
+	stub := &boundaryRuntimeStub{runtimeStub: &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), stub, store, nil, ps)
+	defer bridge.Close()
+
+	if err := bridge.SetSessionModel(context.Background(), gateway.SetSessionModelInput{
+		SubjectID: testBridgeSubjectID,
+		SessionID: "s-1",
+		ModelID:   "gpt-4",
+	}); err != nil {
+		t.Fatalf("SetSessionModel() error = %v", err)
+	}
+	if stub.modelSessionID != "s-1" || stub.modelProviderID != "openai" || stub.modelID != "gpt-4" {
+		t.Fatalf("runtime model update = (%q, %q, %q)", stub.modelSessionID, stub.modelProviderID, stub.modelID)
+	}
+}
+
+func TestGatewayRuntimePortBridgeSyncSessionsProviderModelUsesRuntimeBoundary(t *testing.T) {
+	store := &bridgeSessionStoreWithLoader{
+		bridgeSessionStoreStub: bridgeSessionStoreStub{
+			updateFn: func(_ context.Context, _ agentsession.UpdateSessionStateInput) error {
+				t.Fatalf("SyncSessionsProviderModel should use runtime boundary instead of direct store write")
+				return nil
+			},
+		},
+	}
+	stub := &boundaryRuntimeStub{runtimeStub: &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), stub, store)
+	defer bridge.Close()
+
+	if err := bridge.SyncSessionsProviderModel(context.Background(), " openai ", " gpt-4 "); err != nil {
+		t.Fatalf("SyncSessionsProviderModel() error = %v", err)
+	}
+	if stub.syncProviderID != "openai" || stub.syncModelID != "gpt-4" {
+		t.Fatalf("runtime sync = (%q, %q)", stub.syncProviderID, stub.syncModelID)
 	}
 }
 

--- a/internal/repository/git.go
+++ b/internal/repository/git.go
@@ -441,13 +441,13 @@ func isAmbiguousGitStatusOutsideRepo(workdir string, output string, err error) b
 func hasGitMetadataAncestor(workdir string) bool {
 	current := filepath.Clean(workdir)
 	for {
-		gitPath := filepath.Join(current, ".git")
-		if _, err := os.Stat(gitPath); err == nil {
-			return true
-		}
 		parent := filepath.Dir(current)
 		if parent == current {
 			return false
+		}
+		gitPath := filepath.Join(current, ".git")
+		if _, err := os.Stat(gitPath); err == nil {
+			return true
 		}
 		current = parent
 	}

--- a/internal/runner/capability.go
+++ b/internal/runner/capability.go
@@ -97,7 +97,7 @@ func resolvePath(target string, workdir string) string {
 	if trimmed == "" {
 		return ""
 	}
-	if filepath.IsAbs(trimmed) {
+	if filepath.IsAbs(trimmed) || strings.HasPrefix(filepath.ToSlash(trimmed), "/") {
 		return trimmed
 	}
 	base := strings.TrimSpace(workdir)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -171,6 +171,10 @@ type runtimeSessionTitleUpdater interface {
 	UpdateSessionTitle(ctx context.Context, input agentsession.UpdateSessionTitleInput) error
 }
 
+type runtimeSessionDeleter interface {
+	DeleteSession(ctx context.Context, sessionID string) error
+}
+
 type Service struct {
 	configManager     *config.Manager
 	sessionStore      agentsession.Store
@@ -469,6 +473,136 @@ func (s *Service) CreateSession(ctx context.Context, id string) (agentsession.Se
 		return s.LoadSession(ctx, sessionID)
 	}
 	return agentsession.Session{}, createErr
+}
+
+// SupportsSessionMutationBoundary 标记 runtime 已为会话管理写入口提供统一锁边界。
+func (s *Service) SupportsSessionMutationBoundary() bool {
+	return true
+}
+
+// DeleteSession 在 runtime 会话锁内删除指定会话，避免运行中管理操作绕过主链路写保护。
+func (s *Service) DeleteSession(ctx context.Context, sessionID string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	normalizedSessionID := strings.TrimSpace(sessionID)
+	if normalizedSessionID == "" {
+		return agentsession.ErrSessionNotFound
+	}
+	deleter, ok := s.sessionStore.(runtimeSessionDeleter)
+	if !ok {
+		return errors.New("runtime: session store does not support delete")
+	}
+
+	sessionMu, releaseLockRef := s.acquireSessionLock(normalizedSessionID)
+	sessionMu.Lock()
+	defer func() {
+		sessionMu.Unlock()
+		releaseLockRef()
+	}()
+	if err := deleter.DeleteSession(ctx, normalizedSessionID); err != nil {
+		return err
+	}
+	s.runtimeSnapshotMu.Lock()
+	delete(s.runtimeSnapshots, normalizedSessionID)
+	s.runtimeSnapshotMu.Unlock()
+	return nil
+}
+
+// RenameSession 在 runtime 会话锁内更新标题，避免 UI 管理写入与运行态持久化竞争。
+func (s *Service) RenameSession(ctx context.Context, sessionID string, title string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	normalizedSessionID := strings.TrimSpace(sessionID)
+	normalizedTitle := strings.TrimSpace(title)
+	if normalizedSessionID == "" {
+		return agentsession.ErrSessionNotFound
+	}
+	if normalizedTitle == "" {
+		return errors.New("runtime: session title is empty")
+	}
+
+	sessionMu, releaseLockRef := s.acquireSessionLock(normalizedSessionID)
+	sessionMu.Lock()
+	defer func() {
+		sessionMu.Unlock()
+		releaseLockRef()
+	}()
+	if titleUpdater, ok := s.sessionStore.(runtimeSessionTitleUpdater); ok {
+		return titleUpdater.UpdateSessionTitle(ctx, agentsession.UpdateSessionTitleInput{
+			SessionID: normalizedSessionID,
+			UpdatedAt: time.Now().UTC(),
+			Title:     normalizedTitle,
+		})
+	}
+	session, err := s.sessionStore.LoadSession(ctx, normalizedSessionID)
+	if err != nil {
+		return err
+	}
+	session.Title = normalizedTitle
+	session.UpdatedAt = time.Now().UTC()
+	return s.sessionStore.UpdateSessionState(ctx, sessionStateInputFromSession(session))
+}
+
+// UpdateSessionModel 在 runtime 会话锁内切换会话 provider/model 元数据。
+func (s *Service) UpdateSessionModel(ctx context.Context, sessionID string, providerID string, modelID string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	normalizedSessionID := strings.TrimSpace(sessionID)
+	providerID = strings.TrimSpace(providerID)
+	modelID = strings.TrimSpace(modelID)
+	if normalizedSessionID == "" {
+		return agentsession.ErrSessionNotFound
+	}
+	if providerID == "" || modelID == "" {
+		return errors.New("runtime: session provider/model is empty")
+	}
+
+	sessionMu, releaseLockRef := s.acquireSessionLock(normalizedSessionID)
+	sessionMu.Lock()
+	defer func() {
+		sessionMu.Unlock()
+		releaseLockRef()
+	}()
+	session, err := s.sessionStore.LoadSession(ctx, normalizedSessionID)
+	if err != nil {
+		return err
+	}
+	session.Provider = providerID
+	session.Model = modelID
+	session.UpdatedAt = time.Now().UTC()
+	return s.sessionStore.UpdateSessionState(ctx, sessionStateInputFromSession(session))
+}
+
+// SyncSessionsProviderModel 在 runtime 会话锁内批量同步当前工作区会话的 provider/model。
+func (s *Service) SyncSessionsProviderModel(ctx context.Context, providerID string, modelID string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	providerID = strings.TrimSpace(providerID)
+	modelID = strings.TrimSpace(modelID)
+	if providerID == "" || modelID == "" {
+		return nil
+	}
+	summaries, err := s.sessionStore.ListSummaries(ctx)
+	if err != nil {
+		return err
+	}
+	for _, summary := range summaries {
+		sessionID := strings.TrimSpace(summary.ID)
+		if sessionID == "" {
+			continue
+		}
+		if err := s.UpdateSessionModel(ctx, sessionID, providerID, modelID); err != nil {
+			if errors.Is(err, agentsession.ErrSessionNotFound) {
+				continue
+			}
+			return err
+		}
+	}
+	return nil
 }
 
 // isRuntimeSessionNotFoundError 判断错误是否代表会话文件/记录不存在。

--- a/internal/runtime/runtime_internal_helpers_test.go
+++ b/internal/runtime/runtime_internal_helpers_test.go
@@ -767,6 +767,69 @@ func TestExecuteAssistantToolCallsCanceledSaveStillEmitsResultWhenExecErr(t *tes
 	assertEventSequence(t, events, []EventType{EventToolStart, EventToolResult})
 }
 
+func TestExecuteAssistantToolCallsPersistsResultsInCallOrder(t *testing.T) {
+	t.Parallel()
+
+	store := newMemoryStore()
+	session := newRuntimeSession("session-exec-tool-order")
+	store.sessions[session.ID] = cloneSession(session)
+
+	var mu sync.Mutex
+	active := 0
+	maxActive := 0
+	manager := &stubToolManager{
+		executeFn: func(ctx context.Context, input tools.ToolCallInput) (tools.ToolResult, error) {
+			mu.Lock()
+			active++
+			if active > maxActive {
+				maxActive = active
+			}
+			mu.Unlock()
+			if input.Name == "tool_slow" {
+				time.Sleep(50 * time.Millisecond)
+			} else {
+				time.Sleep(10 * time.Millisecond)
+			}
+			mu.Lock()
+			active--
+			mu.Unlock()
+			return tools.ToolResult{Name: input.Name, Content: input.Name + " done"}, nil
+		},
+	}
+	service := &Service{
+		sessionStore:   store,
+		toolManager:    manager,
+		approvalBroker: approval.NewBroker(),
+		events:         make(chan RuntimeEvent, 32),
+	}
+	state := newRunState("run-exec-tool-order", session)
+	assistant := providertypes.Message{
+		Role: providertypes.RoleAssistant,
+		ToolCalls: []providertypes.ToolCall{
+			{ID: "call-slow", Name: "tool_slow", Arguments: `{}`},
+			{ID: "call-fast", Name: "tool_fast", Arguments: `{}`},
+		},
+	}
+
+	if _, err := service.executeAssistantToolCalls(context.Background(), &state, TurnBudgetSnapshot{}, assistant); err != nil {
+		t.Fatalf("executeAssistantToolCalls() error = %v", err)
+	}
+	if maxActive < 2 {
+		t.Fatalf("expected tools to execute concurrently, maxActive=%d", maxActive)
+	}
+	if len(state.session.Messages) != 2 {
+		t.Fatalf("message count = %d, want 2", len(state.session.Messages))
+	}
+	got := []string{
+		renderPartsForTest(state.session.Messages[0].Parts),
+		renderPartsForTest(state.session.Messages[1].Parts),
+	}
+	want := []string{"tool_slow done", "tool_fast done"}
+	if got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("persisted tool messages = %#v, want %#v", got, want)
+	}
+}
+
 func TestSetMemoExtractorAndRunTriggersExtraction(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/toolexec.go
+++ b/internal/runtime/toolexec.go
@@ -42,6 +42,8 @@ func (s *Service) executeAssistantToolCalls(
 	toolLocks := buildToolExecutionLocks(assistant.ToolCalls)
 	taskCh := make(chan indexedToolCall)
 	results := make([]tools.ToolResult, len(assistant.ToolCalls))
+	execErrs := make([]error, len(assistant.ToolCalls))
+	workerErrs := make([]error, len(assistant.ToolCalls))
 	completed := make([]bool, len(assistant.ToolCalls))
 	writes := make([]bool, len(assistant.ToolCalls))
 	var mu sync.Mutex
@@ -57,7 +59,7 @@ func (s *Service) executeAssistantToolCalls(
 		go func() {
 			defer workerWG.Done()
 			for task := range taskCh {
-				result, wrote, err := s.executeOneToolCall(
+				result, wrote, execErr, err := s.executeOneToolCallWithoutPersistence(
 					execCtx,
 					state,
 					snapshot,
@@ -67,6 +69,8 @@ func (s *Service) executeAssistantToolCalls(
 				)
 				mu.Lock()
 				results[task.index] = result
+				execErrs[task.index] = execErr
+				workerErrs[task.index] = err
 				completed[task.index] = true
 				writes[task.index] = wrote
 				mu.Unlock()
@@ -94,6 +98,14 @@ func (s *Service) executeAssistantToolCalls(
 		if !ok {
 			continue
 		}
+		if workerErrs[index] == nil {
+			call := assistant.ToolCalls[index]
+			if persistErr := s.persistCompletedToolCallResult(ctx, state, call, results[index], execErrs[index]); persistErr != nil {
+				recordAndCancelOnFirstError(&mu, &firstErr, persistErr, cancelExec)
+			} else if ctxErr := execCtx.Err(); ctxErr != nil {
+				recordAndCancelOnFirstError(&mu, &firstErr, ctxErr, cancelExec)
+			}
+		}
 		summary.Results = append(summary.Results, results[index])
 		if writes[index] {
 			summary.HasSuccessfulWorkspaceWrite = true
@@ -112,8 +124,31 @@ func (s *Service) executeOneToolCall(
 	toolLock *sync.Mutex,
 	checkContext func() bool,
 ) (tools.ToolResult, bool, error) {
+	result, wrote, execErr, err := s.executeOneToolCallWithoutPersistence(ctx, state, snapshot, call, toolLock, checkContext)
+	if err != nil {
+		return result, wrote, err
+	}
+	if persistErr := s.persistCompletedToolCallResult(ctx, state, call, result, execErr); persistErr != nil {
+		return result, false, persistErr
+	}
+	return result, wrote, nil
+}
+
+// executeOneToolCallWithoutPersistence 执行单个工具调用并返回待回灌结果，调用方负责按稳定顺序持久化。
+func (s *Service) executeOneToolCallWithoutPersistence(
+	ctx context.Context,
+	state *runState,
+	snapshot TurnBudgetSnapshot,
+	call providertypes.ToolCall,
+	toolLock *sync.Mutex,
+	checkContext func() bool,
+) (tools.ToolResult, bool, error, error) {
 	if checkContext() {
-		return tools.ToolResult{}, false, ctx.Err()
+		err := ctx.Err()
+		if err == nil {
+			err = context.Canceled
+		}
+		return tools.ToolResult{}, false, err, err
 	}
 
 	toolLock.Lock()
@@ -146,11 +181,7 @@ func (s *Service) executeOneToolCall(
 			Reason:     reason,
 			Enforced:   true,
 		})
-		if err := s.appendToolMessageAndSave(ctx, state, call, result); err != nil {
-			return result, false, err
-		}
-		s.emitRunScoped(ctx, EventToolResult, state, result)
-		return result, false, nil
+		return result, false, nil, nil
 	}
 
 	s.emitRunScoped(ctx, EventToolStart, state, call)
@@ -298,7 +329,7 @@ func (s *Service) executeOneToolCall(
 	if errors.Is(execErr, context.Canceled) {
 		s.emitAfterToolResultHook(ctx, state, call, result, execErr, snapshot.Workdir)
 		s.emitAfterToolFailureHook(ctx, state, call, result, execErr, snapshot.Workdir)
-		return result, false, execErr
+		return result, false, execErr, execErr
 	}
 	if execErr != nil && strings.TrimSpace(result.Content) == "" {
 		result.Content = execErr.Error()
@@ -308,11 +339,25 @@ func (s *Service) executeOneToolCall(
 		s.emitAfterToolFailureHook(ctx, state, call, result, execErr, snapshot.Workdir)
 	}
 
+	if execErr != nil {
+		return result, false, execErr, nil
+	}
+	return result, hasSuccessfulWorkspaceWriteFact(result, execErr), nil, nil
+}
+
+// persistCompletedToolCallResult 按调度顺序回灌工具结果，避免并发 worker 同时写入同一会话 transcript。
+func (s *Service) persistCompletedToolCallResult(
+	ctx context.Context,
+	state *runState,
+	call providertypes.ToolCall,
+	result tools.ToolResult,
+	execErr error,
+) error {
 	if err := s.appendToolMessageAndSave(ctx, state, call, result); err != nil {
 		if execErr != nil && errors.Is(err, context.Canceled) {
 			s.emitRunScoped(ctx, EventToolResult, state, result)
 		}
-		return result, false, err
+		return err
 	}
 
 	s.emitRunScoped(ctx, EventToolResult, state, result)
@@ -336,14 +381,7 @@ func (s *Service) executeOneToolCall(
 		state.rememberedThisRun = true
 		state.mu.Unlock()
 	}
-
-	if checkContext() {
-		return result, hasSuccessfulWorkspaceWriteFact(result, execErr), ctx.Err()
-	}
-	if execErr != nil {
-		return result, false, nil
-	}
-	return result, hasSuccessfulWorkspaceWriteFact(result, execErr), nil
+	return nil
 }
 
 // resolveToolParallelism 计算本轮工具执行的并发上限，避免无界 goroutine 扩散。

--- a/internal/session/sqlite_store.go
+++ b/internal/session/sqlite_store.go
@@ -61,6 +61,7 @@ type SQLiteStore struct {
 	dbPath     string
 
 	initMu      sync.Mutex
+	writeMu     sync.Mutex
 	db          *sql.DB
 	limitsMu    sync.RWMutex
 	assetPolicy AssetPolicy
@@ -117,6 +118,9 @@ func (s *SQLiteStore) CleanupExpiredSessions(ctx context.Context, maxAge time.Du
 	if maxAge <= 0 {
 		return 0, nil
 	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	db, err := s.ensureDB(ctx)
 	if err != nil {
 		return 0, err
@@ -163,6 +167,9 @@ func (s *SQLiteStore) CreateSession(ctx context.Context, input CreateSessionInpu
 	if err := s.ensureStorageDirs(); err != nil {
 		return Session{}, err
 	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	db, err := s.ensureDB(ctx)
 	if err != nil {
 		return Session{}, err
@@ -308,6 +315,9 @@ func (s *SQLiteStore) AppendMessages(ctx context.Context, input AppendMessagesIn
 	if len(input.Messages) == 0 {
 		return errors.New("session: append messages input is empty")
 	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	db, err := s.ensureDB(ctx)
 	if err != nil {
 		return err
@@ -387,6 +397,9 @@ func (s *SQLiteStore) UpdateSessionWorkdir(ctx context.Context, input UpdateSess
 	if err := validateStorageID("session id", input.SessionID); err != nil {
 		return fmt.Errorf("session: %w", err)
 	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	db, err := s.ensureDB(ctx)
 	if err != nil {
 		return err
@@ -416,6 +429,9 @@ func (s *SQLiteStore) UpdateSessionTitle(ctx context.Context, input UpdateSessio
 	if err := validateStorageID("session id", input.SessionID); err != nil {
 		return fmt.Errorf("session: %w", err)
 	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	db, err := s.ensureDB(ctx)
 	if err != nil {
 		return err
@@ -446,6 +462,9 @@ func (s *SQLiteStore) UpdateSessionState(ctx context.Context, input UpdateSessio
 	if err != nil {
 		return err
 	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	db, err := s.ensureDB(ctx)
 	if err != nil {
 		return err
@@ -508,6 +527,9 @@ func (s *SQLiteStore) ReplaceTranscript(ctx context.Context, input ReplaceTransc
 	if err != nil {
 		return err
 	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	db, err := s.ensureDB(ctx)
 	if err != nil {
 		return err
@@ -601,6 +623,9 @@ func (s *SQLiteStore) SaveAsset(ctx context.Context, sessionID string, r io.Read
 	if err := validateStorageID("session id", sessionID); err != nil {
 		return AssetMeta{}, fmt.Errorf("session: %w", err)
 	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	db, err := s.ensureDB(ctx)
 	if err != nil {
 		return AssetMeta{}, err
@@ -723,6 +748,9 @@ func (s *SQLiteStore) DeleteAsset(ctx context.Context, sessionID string, assetID
 	if err := validateStorageID("asset id", assetID); err != nil {
 		return fmt.Errorf("session: %w", err)
 	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	db, err := s.ensureDB(ctx)
 	if err != nil {
 		return err
@@ -758,6 +786,9 @@ func (s *SQLiteStore) DeleteSession(ctx context.Context, sessionID string) error
 	if err := validateStorageID("session id", sessionID); err != nil {
 		return fmt.Errorf("session: %w", err)
 	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	db, err := s.ensureDB(ctx)
 	if err != nil {
 		return err
@@ -798,8 +829,8 @@ func (s *SQLiteStore) initialize(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("session: open sqlite db: %w", err)
 	}
-	db.SetMaxOpenConns(4)
-	db.SetMaxIdleConns(4)
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
 
 	if err := applySQLitePragmas(ctx, db); err != nil {
 		_ = db.Close()

--- a/internal/session/sqlite_store_additional_test.go
+++ b/internal/session/sqlite_store_additional_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -99,6 +100,212 @@ func TestSQLiteStoreUpdateSessionTitlePersistsSanitizedTitle(t *testing.T) {
 	}
 	if loaded.Title != "line1 line2" {
 		t.Fatalf("expected sanitized single-line title, got %q", loaded.Title)
+	}
+}
+
+func TestSQLiteStoreConcurrentAppendMessagesSerializesWrites(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newTestStore(t)
+	created, err := store.CreateSession(ctx, CreateSessionInput{
+		ID:    "concurrent_append",
+		Title: "Concurrent Append",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+
+	const workers = 32
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- store.AppendMessages(ctx, AppendMessagesInput{
+				SessionID: created.ID,
+				Messages: []providertypes.Message{{
+					Role:  providertypes.RoleUser,
+					Parts: []providertypes.ContentPart{providertypes.NewTextPart("message " + buildIndexedSuffix(i))},
+				}},
+				UpdatedAt: created.UpdatedAt.Add(time.Duration(i) * time.Millisecond),
+				Provider:  "provider",
+				Model:     "model",
+				Workdir:   created.Workdir,
+			})
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("AppendMessages() concurrent error = %v", err)
+		}
+	}
+
+	loaded, err := store.LoadSession(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("LoadSession() error = %v", err)
+	}
+	if len(loaded.Messages) != workers {
+		t.Fatalf("message count = %d, want %d", len(loaded.Messages), workers)
+	}
+	db := store.DB()
+	var lastSeq, messageCount, distinctSeq int
+	if err := db.QueryRowContext(ctx, `SELECT last_seq, message_count FROM sessions WHERE id = ?`, created.ID).
+		Scan(&lastSeq, &messageCount); err != nil {
+		t.Fatalf("query session counters: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(DISTINCT seq) FROM messages WHERE session_id = ?`, created.ID).
+		Scan(&distinctSeq); err != nil {
+		t.Fatalf("query distinct seq: %v", err)
+	}
+	if lastSeq != workers || messageCount != workers || distinctSeq != workers {
+		t.Fatalf("counters = lastSeq:%d messageCount:%d distinctSeq:%d, want %d", lastSeq, messageCount, distinctSeq, workers)
+	}
+}
+
+func TestSQLiteStoreConcurrentMixedWritesRemainLoadable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newTestStore(t)
+	created, err := store.CreateSession(ctx, CreateSessionInput{
+		ID:    "concurrent_mixed",
+		Title: "Concurrent Mixed",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+
+	const workers = 24
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			switch i % 3 {
+			case 0:
+				errs <- store.AppendMessages(ctx, AppendMessagesInput{
+					SessionID: created.ID,
+					Messages: []providertypes.Message{{
+						Role:  providertypes.RoleAssistant,
+						Parts: []providertypes.ContentPart{providertypes.NewTextPart("assistant " + buildIndexedSuffix(i))},
+					}},
+					UpdatedAt: created.UpdatedAt.Add(time.Duration(i) * time.Millisecond),
+				})
+			case 1:
+				errs <- store.UpdateSessionTitle(ctx, UpdateSessionTitleInput{
+					SessionID: created.ID,
+					UpdatedAt: created.UpdatedAt.Add(time.Duration(i) * time.Millisecond),
+					Title:     "title " + buildIndexedSuffix(i),
+				})
+			default:
+				head := created.HeadSnapshot()
+				head.Provider = "provider"
+				head.Model = "model-" + buildIndexedSuffix(i)
+				errs <- store.UpdateSessionState(ctx, UpdateSessionStateInput{
+					SessionID: created.ID,
+					Title:     created.Title,
+					UpdatedAt: created.UpdatedAt.Add(time.Duration(i) * time.Millisecond),
+					Head:      head,
+				})
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("mixed write error = %v", err)
+		}
+	}
+
+	loaded, err := store.LoadSession(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("LoadSession() after mixed writes error = %v", err)
+	}
+	if len(loaded.Messages) != workers/3 {
+		t.Fatalf("message count = %d, want %d", len(loaded.Messages), workers/3)
+	}
+}
+
+func TestSQLiteStoreConcurrentAssetAndTranscriptWrites(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newTestStore(t)
+	created, err := store.CreateSession(ctx, CreateSessionInput{
+		ID:    "concurrent_assets",
+		Title: "Concurrent Assets",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+
+	const assetWrites = 8
+	const messageWrites = 8
+	errs := make(chan error, assetWrites+messageWrites)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < assetWrites; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := store.SaveAsset(ctx, created.ID, strings.NewReader("asset "+buildIndexedSuffix(i)), "image/png")
+			errs <- err
+		}()
+	}
+	for i := 0; i < messageWrites; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- store.AppendMessages(ctx, AppendMessagesInput{
+				SessionID: created.ID,
+				Messages: []providertypes.Message{{
+					Role:  providertypes.RoleUser,
+					Parts: []providertypes.ContentPart{providertypes.NewTextPart("message " + buildIndexedSuffix(i))},
+				}},
+			})
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("asset/transcript concurrent write error = %v", err)
+		}
+	}
+
+	loaded, err := store.LoadSession(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("LoadSession() error = %v", err)
+	}
+	if len(loaded.Messages) != messageWrites {
+		t.Fatalf("message count = %d, want %d", len(loaded.Messages), messageWrites)
+	}
+	var assetCount int
+	if err := store.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM session_assets WHERE session_id = ?`, created.ID).
+		Scan(&assetCount); err != nil {
+		t.Fatalf("query asset count: %v", err)
+	}
+	if assetCount != assetWrites {
+		t.Fatalf("asset count = %d, want %d", assetCount, assetWrites)
 	}
 }
 


### PR DESCRIPTION
## 背景

运行中同一会话可能因为多个工具结果并发回灌、Gateway 管理写入口绕过 Runtime 会话锁等路径，同时竞争 SQLite 写事务，偶发触发 `database is locked` 并中断当前会话。

## 当前修改

- 在 `SQLiteStore` 内增加单 writer 写锁，并将 SQLite 连接池收敛为单连接，避免同一工作区数据库多 writer 抢锁。
- 保留工具执行并发，但将 tool result 的 transcript 持久化改为按原始 tool call 顺序串行回灌。
- 增加 Runtime 会话 mutation 边界，Gateway 的删除、重命名、模型切换、provider/model 同步优先走 Runtime 会话锁。
- 修复两个 Windows 环境敏感测试点：卷根 `.git` 误判、slash-rooted 路径解析。
- 补充 SQLite 并发写、工具结果顺序回灌、Gateway mutation 边界路由相关测试。

## 验证

- `git diff --check`
- `go test ./...`
- `CGO_ENABLED=1 go test -race ./internal/session ./internal/runtime`