### PR TITLE
fix(web): 优化供应商配置模型展示与减少不必要的 Todo 冲突提示

### DIFF
--- a/web/src/components/layout/Sidebar.test.tsx
+++ b/web/src/components/layout/Sidebar.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
 import Sidebar from './Sidebar'
 import { useChatStore } from '@/stores/useChatStore'
 import { useGatewayStore } from '@/stores/useGatewayStore'
@@ -8,6 +9,7 @@ import { useUIStore } from '@/stores/useUIStore'
 import { useWorkspaceStore } from '@/stores/useWorkspaceStore'
 
 let mockGatewayAPI: any = null
+const appCss = readFileSync('src/index.css', 'utf-8')
 
 vi.mock('@/context/RuntimeProvider', () => ({
   useGatewayAPI: () => mockGatewayAPI,
@@ -232,6 +234,10 @@ describe('Sidebar ProviderModal', () => {
     const arkCard = providerCard('Ark')
     const models = arkCard.querySelector('.config-card-models')
     expect(models).toBeInstanceOf(HTMLElement)
+    const modelRule = appCss.match(/\.config-card-models\s*{(?<body>[^}]*)}/)?.groups?.body ?? ''
+    expect(modelRule).toContain('flex-wrap: nowrap')
+    expect(modelRule).toContain('overflow-x: auto')
+    expect(modelRule).toContain('overflow-y: hidden')
     expect(models?.querySelectorAll('.config-card-model-tag')).toHaveLength(16)
     expect(within(arkCard).getByRole('button', { name: /选择/i })).toBeTruthy()
     expect(within(arkCard).getByRole('button', { name: /删除/i })).toBeTruthy()

--- a/web/src/components/layout/Sidebar.test.tsx
+++ b/web/src/components/layout/Sidebar.test.tsx
@@ -199,6 +199,44 @@ describe('Sidebar ProviderModal', () => {
     expect(screen.getByText('switch failed')).toBeInTheDocument()
   })
 
+  it('keeps provider models in a single scrollable row when there are many models', async () => {
+    mockGatewayAPI.listProviders = vi.fn().mockResolvedValue({
+      payload: {
+        providers: [
+          {
+            id: 'ark',
+            name: 'Ark',
+            source: 'custom',
+            selected: false,
+            models: Array.from({ length: 16 }, (_, index) => ({
+              id: `ark-code-${index + 1}`,
+              name: `ark-code-${index + 1}`,
+            })),
+          },
+        ],
+      },
+    })
+    mockGatewayAPI.getSessionModel = vi.fn().mockResolvedValue({
+      payload: {
+        provider_id: 'openai',
+        model_id: 'gpt-5.4',
+        model_name: 'GPT-5.4',
+        provider: 'openai',
+      },
+    })
+
+    render(<Sidebar />)
+    fireEvent.click(screen.getByRole('button', { name: /供应商/i }))
+    await screen.findByText('Ark')
+
+    const arkCard = providerCard('Ark')
+    const models = arkCard.querySelector('.config-card-models')
+    expect(models).toBeInstanceOf(HTMLElement)
+    expect(models?.querySelectorAll('.config-card-model-tag')).toHaveLength(16)
+    expect(within(arkCard).getByRole('button', { name: /选择/i })).toBeTruthy()
+    expect(within(arkCard).getByRole('button', { name: /删除/i })).toBeTruthy()
+  })
+
   it('only shows the expanded workspace style on the current workspace', async () => {
     const switchWorkspace = vi.fn().mockResolvedValue(undefined)
     useWorkspaceStore.setState({

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1475,13 +1475,29 @@ html, body, #root {
 .config-card-info { flex: 1; min-width: 0; }
 .config-card-name { font-size: 13px; font-weight: 600; color: var(--text-primary); }
 .config-card-meta { font-size: 11px; color: var(--text-tertiary); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.config-card-models { display: flex; gap: 4px; flex-wrap: wrap; margin-top: 4px; }
+.config-card-models {
+  display: flex;
+  gap: 4px;
+  flex-wrap: nowrap;
+  margin-top: 4px;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+}
+.config-card-models::-webkit-scrollbar { height: 4px; }
+.config-card-models::-webkit-scrollbar-thumb {
+  background: var(--bg-active);
+  border-radius: var(--radius-full);
+}
 .config-card-model-tag {
   font-size: 10px; padding: 1px 6px;
   border-radius: var(--radius-sm);
   background: var(--bg-active);
   color: var(--text-secondary);
   font-family: var(--font-mono);
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 
 /* ── Provider Card (in modals) ── */

--- a/web/src/utils/eventBridge.test.ts
+++ b/web/src/utils/eventBridge.test.ts
@@ -925,6 +925,29 @@ describe("eventBridge", () => {
     expect(useUIStore.getState().toasts).toHaveLength(0);
   });
 
+  it("TodoConflict invalid_transition does NOT show toast", () => {
+    const api = createMockGatewayAPI();
+    handleGatewayEvent(
+      {
+        type: EventType.TodoConflict,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.TodoConflict,
+            payload: { action: "update", reason: "invalid_transition" },
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-1",
+      },
+      api,
+    );
+
+    expect(useRuntimeInsightStore.getState().todoConflict?.reason).toBe(
+      "invalid_transition",
+    );
+    expect(useUIStore.getState().toasts).toHaveLength(0);
+  });
+
   it("TodoConflict invalid_arguments shows info toast", () => {
     const api = createMockGatewayAPI();
     handleGatewayEvent(

--- a/web/src/utils/eventBridge.ts
+++ b/web/src/utils/eventBridge.ts
@@ -982,9 +982,13 @@ export function handleGatewayEvent(
       const payload = eventPayload as TodoEventPayload | undefined;
       if (payload) insightStore.setTodoConflict(payload);
       const reason = strField(eventPayload, "reason");
-      // revision_conflict 是可恢复冲突，仅在面板显示，不弹全局 toast;
+      // revision_conflict 与 invalid_transition 是可恢复冲突，仅在面板显示，不弹全局 toast;
       // 其余冲突降级为 info 避免打断聊天体验。
-      if (reason && reason !== "revision_conflict") {
+      if (
+        reason &&
+        reason !== "revision_conflict" &&
+        reason !== "invalid_transition"
+      ) {
         uiStore.showToast(`Todo conflict: ${reason}`, "info");
       }
       break;


### PR DESCRIPTION
## 场景故事
- 场景 1：供应商模型展示优化 用户在配置供应商时，某些供应商（如 Ark）提供了大量模型（例如 16 个）。在旧版本中，这些模型标签会自动换行，导致配置卡片高度过高，占用过多垂直空间，影响用户体验。用户需要频繁滚动才能看到完整的配置项。

- 场景 2：Todo 冲突提示优化 用户在使用过程中，当 Todo 状态发生 invalid_transition 时，系统会弹出全局 toast 提示。这种提示频繁出现，打断用户的聊天体验。实际上，invalid_transition 是可恢复的冲突，只需要在面板中显示即可，不需要中断用户操作。

## 如何修改
- 修改 1：优化模型标签布局（web/src/index.css）

将 .config-card-models 的 flex-wrap 从 wrap 改为 nowrap
添加水平滚动支持：overflow-x: auto 和 overflow-y: hidden
添加自定义滚动条样式（高度 4px，圆角）
为 .config-card-model-tag 添加 flex: 0 0 auto 和 white-space: nowrap 防止标签换行
- 修改 2：调整 Todo 冲突提示逻辑（web/src/utils/eventBridge.ts）

在 TodoConflict 事件处理中，将 invalid_transition 与 revision_conflict 同等对待
这两种原因都视为可恢复冲突，仅在面板显示，不弹出全局 toast
其他冲突原因仍降级为 info 级别 toast
- 修改 3：补充测试用例

在 Sidebar.test.tsx 中添加测试，验证大量模型时保持单行横向滚动
在 eventBridge.test.ts 中添加测试，验证 invalid_transition 不触发 toast
## 修改验收
- 验收 1：供应商模型展示

当供应商有 16 个模型时，模型标签应保持在一行，不换行
模型标签区域应支持水平滚动，滚动条样式符合设计
配置卡片的"选择"和"删除"按钮仍可正常显示和操作
相关测试用例通过：keeps provider models in a single scrollable row when there are many models
- 验收 2：Todo 冲突提示

当 Todo 冲突原因为 invalid_transition 时，不应弹出全局 toast
冲突信息仍应在面板中正确显示（通过 useRuntimeInsightStore）
原因为 revision_conflict 时同样不弹出 toast
其他冲突原因仍显示 info 级别 toast
相关测试用例通过：TodoConflict invalid_transition does NOT show toast
- 验收 3：回归测试

现有功能不受影响，供应商配置正常工作
其他类型的 Todo 冲突处理逻辑保持不变
整体测试通过：npm test 或 go test（根据项目测试命令）