### PR TITLE
fix(web,gateway): 修复工作会话切换竞态并收敛文件预览工作区边界

### DIFF
--- a/docs/reference/tui-gateway-contract-matrix.md
+++ b/docs/reference/tui-gateway-contract-matrix.md
@@ -64,3 +64,9 @@ Primary gateway codes used for UI mapping:
 - No multi-version payload decoding.
 - No alias method fallback.
 - No legacy field fallback in event payload.
+
+## Workspace Boundary For File Preview
+
+- For `gateway.listFiles`, `gateway.readFile`, `gateway.listGitDiffFiles`, and `gateway.readGitDiffFile`, server-side root resolution is always constrained by the current workspace boundary.
+- Request-level `workdir` is kept for protocol compatibility, but runtime implementation does not trust it as an override root.
+- When a stored session workdir is outside the current workspace root, the request is rejected with a controlled boundary error.

--- a/internal/cli/gateway_runtime_bridge.go
+++ b/internal/cli/gateway_runtime_bridge.go
@@ -1972,34 +1972,82 @@ func isRuntimeNotFoundError(err error) bool {
 	return errors.Is(err, agentsession.ErrSessionNotFound) || errors.Is(err, os.ErrNotExist)
 }
 
-// resolveListFilesRoot 按请求、会话、全局配置的优先级确定文件树根目录。
+// resolveListFilesRoot 解析文件预览根目录并强制收敛在当前工作区边界内。
+// 兼容保留请求中的 workdir 字段，但实现层不会信任该字段，避免客户端绕过边界。
 func (b *gatewayRuntimePortBridge) resolveListFilesRoot(
 	ctx context.Context,
 	input gateway.ListFilesInput,
 ) (string, error) {
-	root := strings.TrimSpace(input.Workdir)
-	if root == "" && strings.TrimSpace(input.SessionID) != "" && b.sessionStore != nil {
+	workspaceRoot, err := b.resolveWorkspaceRootForFileAccess()
+	if err != nil {
+		return "", err
+	}
+
+	root := workspaceRoot
+	if strings.TrimSpace(input.SessionID) != "" && b.sessionStore != nil {
 		session, err := b.loadStoredSession(ctx, strings.TrimSpace(input.SessionID))
 		if err != nil && !isRuntimeNotFoundError(err) {
 			return "", err
 		}
-		root = strings.TrimSpace(session.Workdir)
-	}
-	if root == "" {
-		root = strings.TrimSpace(b.currentConfig().Workdir)
-	}
-	if root == "" {
-		var err error
-		root, err = os.Getwd()
-		if err != nil {
-			return "", err
+		sessionRoot := strings.TrimSpace(session.Workdir)
+		if sessionRoot != "" {
+			if !isPathWithinRoot(sessionRoot, workspaceRoot) {
+				return "", fmt.Errorf("gateway runtime bridge: session workdir escapes current workspace root")
+			}
+			root = sessionRoot
 		}
 	}
-	absolute, err := filepath.Abs(root)
+	absolute, err := filepath.Abs(filepath.Clean(root))
 	if err != nil {
 		return "", err
 	}
 	return filepath.Clean(absolute), nil
+}
+
+// resolveWorkspaceRootForFileAccess 返回当前工作区文件访问根目录。
+// 优先使用 runtime 配置中的 workdir，缺失时回退到当前进程工作目录。
+func (b *gatewayRuntimePortBridge) resolveWorkspaceRootForFileAccess() (string, error) {
+	root := strings.TrimSpace(b.currentConfig().Workdir)
+	if root == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		root = cwd
+	}
+	absolute, err := filepath.Abs(filepath.Clean(root))
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(absolute), nil
+}
+
+// isPathWithinRoot 判断 candidate 是否位于 root 目录内（含自身），同时处理符号链接场景。
+func isPathWithinRoot(candidate string, root string) bool {
+	candidateAbs, err := filepath.Abs(filepath.Clean(candidate))
+	if err != nil {
+		return false
+	}
+	rootAbs, err := filepath.Abs(filepath.Clean(root))
+	if err != nil {
+		return false
+	}
+	candidateForCheck := candidateAbs
+	if resolvedCandidate, resolveErr := filepath.EvalSymlinks(candidateAbs); resolveErr == nil {
+		candidateForCheck = resolvedCandidate
+	}
+	rootForCheck := rootAbs
+	if resolvedRoot, resolveErr := filepath.EvalSymlinks(rootAbs); resolveErr == nil {
+		rootForCheck = resolvedRoot
+	}
+	relative, err := filepath.Rel(rootForCheck, candidateForCheck)
+	if err != nil {
+		return false
+	}
+	if relative == "." {
+		return true
+	}
+	return relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) && !filepath.IsAbs(relative)
 }
 
 // loadStoredSession 通过可选的会话加载接口读取持久会话。

--- a/internal/cli/gateway_runtime_bridge_test.go
+++ b/internal/cli/gateway_runtime_bridge_test.go
@@ -17,6 +17,7 @@ import (
 	configstate "neo-code/internal/config/state"
 	"neo-code/internal/gateway"
 	providertypes "neo-code/internal/provider/types"
+	"neo-code/internal/repository"
 	agentruntime "neo-code/internal/runtime"
 	agentsession "neo-code/internal/session"
 	"neo-code/internal/skills"
@@ -1791,48 +1792,47 @@ func TestResolveListFilesRootPriorities(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 
-	// priority 1: input.Workdir
-	bridge1, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore)
-	defer bridge1.Close()
-	root, err := bridge1.resolveListFilesRoot(context.Background(), gateway.ListFilesInput{Workdir: subDir})
-	if err != nil {
-		t.Fatalf("resolve with workdir: %v", err)
-	}
-	if root != subDir {
-		t.Fatalf("root = %q, want %q", root, subDir)
-	}
-
-	// priority 2: session workdir (store implements bridgeSessionLoader)
+	// priority 1: session workdir (must stay inside current workspace root)
 	loaderStore := &bridgeSessionStoreWithLoader{
 		bridgeSessionStoreStub: bridgeSessionStoreStub{},
 		session:                agentsession.Session{Workdir: subDir},
 	}
-	bridge2, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, loaderStore)
-	defer bridge2.Close()
-	root, err = bridge2.resolveListFilesRoot(context.Background(), gateway.ListFilesInput{SessionID: "s-1"})
+	cfgMgr1 := &configManagerStub{cfg: config.Config{Workdir: tmpDir}}
+	bridge1, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, loaderStore, cfgMgr1, nil)
+	defer bridge1.Close()
+	root, err := bridge1.resolveListFilesRoot(context.Background(), gateway.ListFilesInput{SessionID: "s-1"})
 	if err != nil {
 		t.Fatalf("resolve with session: %v", err)
 	}
-	if root != subDir {
-		t.Fatalf("root = %q, want %q", root, subDir)
+	if root != filepath.Clean(subDir) {
+		t.Fatalf("root = %q, want %q", root, filepath.Clean(subDir))
 	}
 
-	// priority 3: config workdir
-	cfgMgr := &configManagerStub{cfg: config.Config{Workdir: subDir}}
-	bridge3, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore, cfgMgr, nil)
-	defer bridge3.Close()
-	root, err = bridge3.resolveListFilesRoot(context.Background(), gateway.ListFilesInput{})
+	// priority 2: config workdir
+	cfgMgr2 := &configManagerStub{cfg: config.Config{Workdir: subDir}}
+	bridge2, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore, cfgMgr2, nil)
+	defer bridge2.Close()
+	root, err = bridge2.resolveListFilesRoot(context.Background(), gateway.ListFilesInput{})
 	if err != nil {
 		t.Fatalf("resolve with config: %v", err)
 	}
-	if root != subDir {
-		t.Fatalf("root = %q, want %q", root, subDir)
+	if root != filepath.Clean(subDir) {
+		t.Fatalf("root = %q, want %q", root, filepath.Clean(subDir))
 	}
 
-	// priority 4: os.Getwd
-	bridge4, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore)
-	defer bridge4.Close()
-	root, err = bridge4.resolveListFilesRoot(context.Background(), gateway.ListFilesInput{})
+	// input.Workdir should be ignored and not override workspace root
+	root, err = bridge2.resolveListFilesRoot(context.Background(), gateway.ListFilesInput{Workdir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("resolve with ignored workdir: %v", err)
+	}
+	if root != filepath.Clean(subDir) {
+		t.Fatalf("root = %q, want %q", root, filepath.Clean(subDir))
+	}
+
+	// priority 3: os.Getwd fallback
+	bridge3, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore)
+	defer bridge3.Close()
+	root, err = bridge3.resolveListFilesRoot(context.Background(), gateway.ListFilesInput{})
 	if err != nil {
 		t.Fatalf("resolve with getwd: %v", err)
 	}
@@ -1858,27 +1858,45 @@ func TestResolveListFilesRootSessionNotFound(t *testing.T) {
 		bridgeSessionStoreStub: bridgeSessionStoreStub{},
 		loadErr:                agentsession.ErrSessionNotFound,
 	}
-	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, loaderStore)
+	cfgRoot := t.TempDir()
+	cfgMgr := &configManagerStub{cfg: config.Config{Workdir: cfgRoot}}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, loaderStore, cfgMgr, nil)
 	defer bridge.Close()
 
 	root, err := bridge.resolveListFilesRoot(context.Background(), gateway.ListFilesInput{SessionID: "s-1"})
 	if err != nil {
 		t.Fatalf("resolve with not-found session should not error: %v", err)
 	}
-	wd, _ := os.Getwd()
-	absWd, _ := filepath.Abs(wd)
-	if root != filepath.Clean(absWd) {
-		t.Fatalf("root = %q, want %q", root, filepath.Clean(absWd))
+	if root != filepath.Clean(cfgRoot) {
+		t.Fatalf("root = %q, want %q", root, filepath.Clean(cfgRoot))
+	}
+}
+
+func TestResolveListFilesRootRejectsSessionWorkdirEscapingWorkspaceRoot(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	outsideRoot := t.TempDir()
+	loaderStore := &bridgeSessionStoreWithLoader{
+		bridgeSessionStoreStub: bridgeSessionStoreStub{},
+		session:                agentsession.Session{Workdir: outsideRoot},
+	}
+	cfgMgr := &configManagerStub{cfg: config.Config{Workdir: workspaceRoot}}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, loaderStore, cfgMgr, nil)
+	defer bridge.Close()
+
+	_, err := bridge.resolveListFilesRoot(context.Background(), gateway.ListFilesInput{SessionID: "s-1"})
+	if err == nil || !strings.Contains(err.Error(), "escapes current workspace root") {
+		t.Fatalf("expected workspace boundary error, got %v", err)
 	}
 }
 
 func TestGatewayRuntimePortBridgeListFilesReadDirFail(t *testing.T) {
-	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore)
+	cfgRoot := t.TempDir()
+	cfgMgr := &configManagerStub{cfg: config.Config{Workdir: cfgRoot}}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore, cfgMgr, nil)
 	defer bridge.Close()
 
 	_, err := bridge.ListFiles(context.Background(), gateway.ListFilesInput{
 		SubjectID: testBridgeSubjectID,
-		Workdir:   t.TempDir(),
 		Path:      "nonexistent-dir",
 	})
 	if err == nil {
@@ -1894,12 +1912,12 @@ func TestGatewayRuntimePortBridgeListFilesFiltersAndSorts(t *testing.T) {
 	_ = os.MkdirAll(filepath.Join(tmpDir, "Zdir"), 0755)
 	_ = os.MkdirAll(filepath.Join(tmpDir, "adir"), 0755)
 
-	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore)
+	cfgMgr := &configManagerStub{cfg: config.Config{Workdir: tmpDir}}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore, cfgMgr, nil)
 	defer bridge.Close()
 
 	entries, err := bridge.ListFiles(context.Background(), gateway.ListFilesInput{
 		SubjectID: testBridgeSubjectID,
-		Workdir:   tmpDir,
 	})
 	if err != nil {
 		t.Fatalf("list files: %v", err)
@@ -1922,6 +1940,32 @@ func TestGatewayRuntimePortBridgeListFilesFiltersAndSorts(t *testing.T) {
 	}
 }
 
+func TestGatewayRuntimePortBridgeListFilesIgnoresInputWorkdir(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	outsideRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "inside.txt"), []byte("inside"), 0644); err != nil {
+		t.Fatalf("write inside file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outsideRoot, "outside.txt"), []byte("outside"), 0644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+
+	cfgMgr := &configManagerStub{cfg: config.Config{Workdir: workspaceRoot}}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore, cfgMgr, nil)
+	defer bridge.Close()
+
+	entries, err := bridge.ListFiles(context.Background(), gateway.ListFilesInput{
+		SubjectID: testBridgeSubjectID,
+		Workdir:   outsideRoot,
+	})
+	if err != nil {
+		t.Fatalf("ListFiles() error = %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name != "inside.txt" {
+		t.Fatalf("entries = %+v, want only inside.txt from workspace root", entries)
+	}
+}
+
 func TestGatewayRuntimePortBridgeListGitDiffFilesExpandsUntrackedDirectory(t *testing.T) {
 	tmpDir := t.TempDir()
 	runGitTestCommand(t, tmpDir, "init")
@@ -1939,12 +1983,12 @@ func TestGatewayRuntimePortBridgeListGitDiffFilesExpandsUntrackedDirectory(t *te
 		t.Fatalf("write b.txt: %v", err)
 	}
 
-	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore)
+	cfgMgr := &configManagerStub{cfg: config.Config{Workdir: tmpDir}}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore, cfgMgr, nil)
 	defer bridge.Close()
 
 	result, err := bridge.ListGitDiffFiles(context.Background(), gateway.ListGitDiffFilesInput{
 		SubjectID: testBridgeSubjectID,
-		Workdir:   tmpDir,
 	})
 	if err != nil {
 		t.Fatalf("ListGitDiffFiles() error = %v", err)
@@ -1956,6 +2000,64 @@ func TestGatewayRuntimePortBridgeListGitDiffFilesExpandsUntrackedDirectory(t *te
 	wantPaths := []string{"handwrite_res/a.txt", "handwrite_res/nested/b.txt"}
 	if strings.Join(gotPaths, ",") != strings.Join(wantPaths, ",") {
 		t.Fatalf("paths = %#v, want %#v", gotPaths, wantPaths)
+	}
+}
+
+func TestGatewayRuntimePortBridgeListGitDiffFilesIgnoresInputWorkdir(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	runGitTestCommand(t, workspaceRoot, "init")
+	runGitTestCommand(t, workspaceRoot, "config", "user.name", "NeoCode Test")
+	runGitTestCommand(t, workspaceRoot, "config", "user.email", "test@example.com")
+	runGitTestCommand(t, workspaceRoot, "commit", "--allow-empty", "-m", "init")
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "changed.txt"), []byte("x\n"), 0644); err != nil {
+		t.Fatalf("write changed file: %v", err)
+	}
+
+	outsideRoot := t.TempDir()
+	cfgMgr := &configManagerStub{cfg: config.Config{Workdir: workspaceRoot}}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore, cfgMgr, nil)
+	defer bridge.Close()
+
+	result, err := bridge.ListGitDiffFiles(context.Background(), gateway.ListGitDiffFilesInput{
+		SubjectID: testBridgeSubjectID,
+		Workdir:   outsideRoot,
+	})
+	if err != nil {
+		t.Fatalf("ListGitDiffFiles() error = %v", err)
+	}
+	if !result.InGitRepo {
+		t.Fatalf("expected workspace root repo to be used, got non-repo result: %+v", result)
+	}
+	if result.TotalCount != 1 || len(result.Files) != 1 || result.Files[0].Path != "changed.txt" {
+		t.Fatalf("unexpected git diff result: %+v", result)
+	}
+}
+
+func TestGatewayRuntimePortBridgeReadGitDiffFileIgnoresInputWorkdir(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	runGitTestCommand(t, workspaceRoot, "init")
+	runGitTestCommand(t, workspaceRoot, "config", "user.name", "NeoCode Test")
+	runGitTestCommand(t, workspaceRoot, "config", "user.email", "test@example.com")
+	runGitTestCommand(t, workspaceRoot, "commit", "--allow-empty", "-m", "init")
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "changed.txt"), []byte("line-1\n"), 0644); err != nil {
+		t.Fatalf("write changed file: %v", err)
+	}
+
+	outsideRoot := t.TempDir()
+	cfgMgr := &configManagerStub{cfg: config.Config{Workdir: workspaceRoot}}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore, cfgMgr, nil)
+	defer bridge.Close()
+
+	result, err := bridge.ReadGitDiffFile(context.Background(), gateway.ReadGitDiffFileInput{
+		SubjectID: testBridgeSubjectID,
+		Workdir:   outsideRoot,
+		Path:      "changed.txt",
+	})
+	if err != nil {
+		t.Fatalf("ReadGitDiffFile() error = %v", err)
+	}
+	if result.Path != "changed.txt" || result.Status != string(repository.StatusUntracked) {
+		t.Fatalf("unexpected read git diff result: %+v", result)
 	}
 }
 
@@ -1975,12 +2077,12 @@ func TestGatewayRuntimePortBridgeReadFileSuccess(t *testing.T) {
 		t.Fatalf("write file: %v", err)
 	}
 
-	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore)
+	cfgMgr := &configManagerStub{cfg: config.Config{Workdir: tmpDir}}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore, cfgMgr, nil)
 	defer bridge.Close()
 
 	result, err := bridge.ReadFile(context.Background(), gateway.ReadFileInput{
 		SubjectID: testBridgeSubjectID,
-		Workdir:   tmpDir,
 		Path:      "main.go",
 	})
 	if err != nil {
@@ -1997,18 +2099,45 @@ func TestGatewayRuntimePortBridgeReadFileSuccess(t *testing.T) {
 	}
 }
 
+func TestGatewayRuntimePortBridgeReadFileIgnoresInputWorkdir(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	outsideRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "main.go"), []byte("package main\n"), 0644); err != nil {
+		t.Fatalf("write workspace file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outsideRoot, "main.go"), []byte("package outside\n"), 0644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+
+	cfgMgr := &configManagerStub{cfg: config.Config{Workdir: workspaceRoot}}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore, cfgMgr, nil)
+	defer bridge.Close()
+
+	result, err := bridge.ReadFile(context.Background(), gateway.ReadFileInput{
+		SubjectID: testBridgeSubjectID,
+		Workdir:   outsideRoot,
+		Path:      "main.go",
+	})
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if result.Content != "package main\n" {
+		t.Fatalf("content = %q, want workspace file content", result.Content)
+	}
+}
+
 func TestGatewayRuntimePortBridgeReadFileRejectsDirectory(t *testing.T) {
 	tmpDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmpDir, "dir"), 0755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 
-	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore)
+	cfgMgr := &configManagerStub{cfg: config.Config{Workdir: tmpDir}}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore, cfgMgr, nil)
 	defer bridge.Close()
 
 	_, err := bridge.ReadFile(context.Background(), gateway.ReadFileInput{
 		SubjectID: testBridgeSubjectID,
-		Workdir:   tmpDir,
 		Path:      "dir",
 	})
 	if err == nil || !strings.Contains(err.Error(), "is a directory") {
@@ -2019,12 +2148,12 @@ func TestGatewayRuntimePortBridgeReadFileRejectsDirectory(t *testing.T) {
 func TestGatewayRuntimePortBridgeReadFileRejectsEscapedPath(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore)
+	cfgMgr := &configManagerStub{cfg: config.Config{Workdir: tmpDir}}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore, cfgMgr, nil)
 	defer bridge.Close()
 
 	_, err := bridge.ReadFile(context.Background(), gateway.ReadFileInput{
 		SubjectID: testBridgeSubjectID,
-		Workdir:   tmpDir,
 		Path:      "../secret.txt",
 	})
 	if err == nil || !strings.Contains(err.Error(), "escapes workdir") {
@@ -2040,12 +2169,12 @@ func TestGatewayRuntimePortBridgeReadFileTruncatesLargeFile(t *testing.T) {
 		t.Fatalf("write file: %v", err)
 	}
 
-	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore)
+	cfgMgr := &configManagerStub{cfg: config.Config{Workdir: tmpDir}}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore, cfgMgr, nil)
 	defer bridge.Close()
 
 	result, err := bridge.ReadFile(context.Background(), gateway.ReadFileInput{
 		SubjectID: testBridgeSubjectID,
-		Workdir:   tmpDir,
 		Path:      "large.txt",
 	})
 	if err != nil {
@@ -2063,12 +2192,12 @@ func TestGatewayRuntimePortBridgeReadFileMarksBinaryContent(t *testing.T) {
 		t.Fatalf("write file: %v", err)
 	}
 
-	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore)
+	cfgMgr := &configManagerStub{cfg: config.Config{Workdir: tmpDir}}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore, cfgMgr, nil)
 	defer bridge.Close()
 
 	result, err := bridge.ReadFile(context.Background(), gateway.ReadFileInput{
 		SubjectID: testBridgeSubjectID,
-		Workdir:   tmpDir,
 		Path:      "bin.dat",
 	})
 	if err != nil {

--- a/internal/cli/gateway_runtime_bridge_test.go
+++ b/internal/cli/gateway_runtime_bridge_test.go
@@ -1872,6 +1872,41 @@ func TestResolveListFilesRootSessionNotFound(t *testing.T) {
 	}
 }
 
+func TestResolveListFilesRootFallsBackWhenSessionWorkdirEmpty(t *testing.T) {
+	cfgRoot := t.TempDir()
+	loaderStore := &bridgeSessionStoreWithLoader{
+		bridgeSessionStoreStub: bridgeSessionStoreStub{},
+		session:                agentsession.Session{Workdir: " \t "},
+	}
+	cfgMgr := &configManagerStub{cfg: config.Config{Workdir: cfgRoot}}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, loaderStore, cfgMgr, nil)
+	defer bridge.Close()
+
+	root, err := bridge.resolveListFilesRoot(context.Background(), gateway.ListFilesInput{SessionID: "s-1"})
+	if err != nil {
+		t.Fatalf("resolve with empty session workdir should not error: %v", err)
+	}
+	if root != filepath.Clean(cfgRoot) {
+		t.Fatalf("root = %q, want %q", root, filepath.Clean(cfgRoot))
+	}
+}
+
+func TestResolveListFilesRootPropagatesUnexpectedSessionLoadError(t *testing.T) {
+	cfgRoot := t.TempDir()
+	loaderStore := &bridgeSessionStoreWithLoader{
+		bridgeSessionStoreStub: bridgeSessionStoreStub{},
+		loadErr:                errors.New("load failed"),
+	}
+	cfgMgr := &configManagerStub{cfg: config.Config{Workdir: cfgRoot}}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, loaderStore, cfgMgr, nil)
+	defer bridge.Close()
+
+	_, err := bridge.resolveListFilesRoot(context.Background(), gateway.ListFilesInput{SessionID: "s-1"})
+	if err == nil || err.Error() != "load failed" {
+		t.Fatalf("expected load failed error, got %v", err)
+	}
+}
+
 func TestResolveListFilesRootRejectsSessionWorkdirEscapingWorkspaceRoot(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	outsideRoot := t.TempDir()
@@ -1886,6 +1921,92 @@ func TestResolveListFilesRootRejectsSessionWorkdirEscapingWorkspaceRoot(t *testi
 	_, err := bridge.resolveListFilesRoot(context.Background(), gateway.ListFilesInput{SessionID: "s-1"})
 	if err == nil || !strings.Contains(err.Error(), "escapes current workspace root") {
 		t.Fatalf("expected workspace boundary error, got %v", err)
+	}
+}
+
+func TestIsPathWithinRoot(t *testing.T) {
+	root := t.TempDir()
+	insideDir := filepath.Join(root, "inside")
+	if err := os.MkdirAll(insideDir, 0o755); err != nil {
+		t.Fatalf("mkdir inside dir: %v", err)
+	}
+
+	if !isPathWithinRoot(root, root) {
+		t.Fatal("expected workspace root to be accepted as its own boundary")
+	}
+	if !isPathWithinRoot(insideDir, root) {
+		t.Fatal("expected child dir to be accepted")
+	}
+
+	outsideRoot := t.TempDir()
+	if isPathWithinRoot(outsideRoot, root) {
+		t.Fatal("expected unrelated path to be rejected")
+	}
+
+	linkPath := filepath.Join(root, "linked-outside")
+	if err := os.Symlink(outsideRoot, linkPath); err != nil {
+		t.Fatalf("symlink outside: %v", err)
+	}
+	if isPathWithinRoot(linkPath, root) {
+		t.Fatal("expected symlink escaping workspace root to be rejected")
+	}
+}
+
+func TestResolveWorkspaceRootForFileAccess(t *testing.T) {
+	configuredRoot := t.TempDir()
+	cfgMgr := &configManagerStub{cfg: config.Config{Workdir: configuredRoot}}
+	bridge, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, testSessionStore, cfgMgr, nil)
+	defer bridge.Close()
+
+	root, err := bridge.resolveWorkspaceRootForFileAccess()
+	if err != nil {
+		t.Fatalf("resolve configured workspace root: %v", err)
+	}
+	if root != filepath.Clean(configuredRoot) {
+		t.Fatalf("root = %q, want %q", root, filepath.Clean(configuredRoot))
+	}
+
+	bridgeNoConfig, _ := newGatewayRuntimePortBridge(
+		context.Background(),
+		&runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)},
+		testSessionStore,
+		&configManagerStub{cfg: config.Config{Workdir: " \t "}},
+		nil,
+	)
+	defer bridgeNoConfig.Close()
+
+	root, err = bridgeNoConfig.resolveWorkspaceRootForFileAccess()
+	if err != nil {
+		t.Fatalf("resolve cwd fallback workspace root: %v", err)
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	absWd, err := filepath.Abs(wd)
+	if err != nil {
+		t.Fatalf("abs wd: %v", err)
+	}
+	if root != filepath.Clean(absWd) {
+		t.Fatalf("root = %q, want %q", root, filepath.Clean(absWd))
+	}
+}
+
+func TestLoadStoredSessionRejectsUnavailableOrUnsupportedSessionStore(t *testing.T) {
+	bridgeNilStore, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, nil)
+	defer bridgeNilStore.Close()
+
+	_, err := bridgeNilStore.loadStoredSession(context.Background(), "s-1")
+	if err == nil || !strings.Contains(err.Error(), "session store is unavailable") {
+		t.Fatalf("expected unavailable store error, got %v", err)
+	}
+
+	bridgeUnsupported, _ := newGatewayRuntimePortBridge(context.Background(), &runtimeStub{eventsCh: make(chan agentruntime.RuntimeEvent, 1)}, &bridgeSessionStoreStub{})
+	defer bridgeUnsupported.Close()
+
+	_, err = bridgeUnsupported.loadStoredSession(context.Background(), "s-1")
+	if err == nil || !strings.Contains(err.Error(), "does not support load session") {
+		t.Fatalf("expected unsupported loader error, got %v", err)
 	}
 }
 

--- a/internal/cli/web_command_test.go
+++ b/internal/cli/web_command_test.go
@@ -1,15 +1,21 @@
 package cli
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io/fs"
 	"log"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"testing/fstest"
+	"time"
 )
 
 // writeWebCommandTestFile 写入 web 命令测试所需的最小文件内容，避免各测试重复拼装目录。
@@ -284,5 +290,358 @@ func TestRunWebCommandSkipBuildStillUsesEmbeddedAssets(t *testing.T) {
 	}
 	if capturedStaticFS == nil {
 		t.Fatal("startGatewayServer staticFS = nil, want embedded assets FS")
+	}
+}
+
+func TestValidateStaticDirAndResolveOverride(t *testing.T) {
+	tempDir := t.TempDir()
+	staticDir := filepath.Join(tempDir, "dist")
+	if _, err := validateStaticDir(staticDir); err == nil {
+		t.Fatal("validateStaticDir() error = nil, want missing index.html error")
+	}
+
+	writeWebCommandTestFile(t, filepath.Join(staticDir, "index.html"), "<html></html>")
+	got, err := resolveWebStaticDir(staticDir)
+	if err != nil {
+		t.Fatalf("resolveWebStaticDir() error = %v", err)
+	}
+	if got != staticDir {
+		t.Fatalf("resolveWebStaticDir() = %q, want %q", got, staticDir)
+	}
+
+	dirIndex := filepath.Join(tempDir, "bad-dist", "index.html")
+	if err := os.MkdirAll(dirIndex, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dirIndex, err)
+	}
+	if _, err := validateStaticDir(filepath.Dir(dirIndex)); err == nil || !strings.Contains(err.Error(), "is a directory") {
+		t.Fatalf("validateStaticDir() error = %v, want directory error", err)
+	}
+}
+
+func TestIsStaleFrontendBuildBranches(t *testing.T) {
+	tempDir := t.TempDir()
+	webDir := filepath.Join(tempDir, "web")
+	srcDir := filepath.Join(webDir, "src")
+	distIndex := filepath.Join(webDir, "dist", "index.html")
+
+	if !isStaleFrontendBuild(webDir) {
+		t.Fatal("isStaleFrontendBuild() = false, want true when dist is missing")
+	}
+
+	writeWebCommandTestFile(t, distIndex, "<html></html>")
+	writeWebCommandTestFile(t, filepath.Join(webDir, "package.json"), "{}")
+	writeWebCommandTestFile(t, filepath.Join(webDir, "vite.config.ts"), "export default {}")
+	writeWebCommandTestFile(t, filepath.Join(webDir, "tsconfig.json"), "{}")
+	writeWebCommandTestFile(t, filepath.Join(srcDir, "main.ts"), "console.log('ok')")
+
+	distTime := time.Now()
+	if err := os.Chtimes(distIndex, distTime, distTime); err != nil {
+		t.Fatalf("chtimes dist: %v", err)
+	}
+	olderTime := distTime.Add(-time.Minute)
+	for _, path := range []string{
+		filepath.Join(webDir, "package.json"),
+		filepath.Join(webDir, "vite.config.ts"),
+		filepath.Join(webDir, "tsconfig.json"),
+		filepath.Join(srcDir, "main.ts"),
+	} {
+		if err := os.Chtimes(path, olderTime, olderTime); err != nil {
+			t.Fatalf("chtimes %s: %v", path, err)
+		}
+	}
+
+	if isStaleFrontendBuild(webDir) {
+		t.Fatal("isStaleFrontendBuild() = true, want false when dist is newest")
+	}
+
+	newerTime := distTime.Add(time.Minute)
+	packageJSON := filepath.Join(webDir, "package.json")
+	if err := os.Chtimes(packageJSON, newerTime, newerTime); err != nil {
+		t.Fatalf("chtimes package.json: %v", err)
+	}
+	if !isStaleFrontendBuild(webDir) {
+		t.Fatal("isStaleFrontendBuild() = false, want true when package.json is newer")
+	}
+
+	if err := os.Chtimes(packageJSON, olderTime, olderTime); err != nil {
+		t.Fatalf("restore package.json time: %v", err)
+	}
+	srcFile := filepath.Join(srcDir, "main.ts")
+	if err := os.Chtimes(srcFile, newerTime, newerTime); err != nil {
+		t.Fatalf("chtimes src: %v", err)
+	}
+	if !isStaleFrontendBuild(webDir) {
+		t.Fatal("isStaleFrontendBuild() = false, want true when src file is newer")
+	}
+}
+
+func TestBuildFrontendAndReadGatewayToken(t *testing.T) {
+	tempDir := t.TempDir()
+	webDir := filepath.Join(tempDir, "web")
+	if err := os.MkdirAll(webDir, 0o755); err != nil {
+		t.Fatalf("mkdir webdir: %v", err)
+	}
+
+	npmPath := filepath.Join(tempDir, "npm")
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		"set -eu",
+		"if [ \"$1\" = \"install\" ]; then",
+		"  exit 0",
+		"fi",
+		"if [ \"$1\" = \"run\" ] && [ \"$2\" = \"build\" ]; then",
+		"  mkdir -p \"$PWD/dist\"",
+		"  printf '<html></html>' > \"$PWD/dist/index.html\"",
+		"  exit 0",
+		"fi",
+		"exit 1",
+	}, "\n")
+	if err := os.WriteFile(npmPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write npm stub: %v", err)
+	}
+	stubWebCommandHooks(t, nil, nil, func(string) (string, error) {
+		return npmPath, nil
+	})
+
+	logger := log.New(&bytes.Buffer{}, "", 0)
+	if err := buildFrontend(webDir, logger); err != nil {
+		t.Fatalf("buildFrontend() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(webDir, "dist", "index.html")); err != nil {
+		t.Fatalf("built dist/index.html missing: %v", err)
+	}
+
+	homeDir := filepath.Join(tempDir, "home")
+	authDir := filepath.Join(homeDir, ".neocode")
+	if err := os.MkdirAll(authDir, 0o755); err != nil {
+		t.Fatalf("mkdir auth dir: %v", err)
+	}
+	authData, err := json.Marshal(map[string]string{"token": "  secret-token  "})
+	if err != nil {
+		t.Fatalf("marshal auth data: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, "auth.json"), authData, 0o644); err != nil {
+		t.Fatalf("write auth.json: %v", err)
+	}
+	originalHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", homeDir); err != nil {
+		t.Fatalf("set HOME: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", originalHome)
+	})
+	if got := readGatewayToken(); got != "secret-token" {
+		t.Fatalf("readGatewayToken() = %q, want %q", got, "secret-token")
+	}
+}
+
+func TestWaitForGatewayAndOpenBrowserAndResolveListenAddress(t *testing.T) {
+	tempDir := t.TempDir()
+	homeDir := filepath.Join(tempDir, "home")
+	authDir := filepath.Join(homeDir, ".neocode")
+	if err := os.MkdirAll(authDir, 0o755); err != nil {
+		t.Fatalf("mkdir auth dir: %v", err)
+	}
+	authData, err := json.Marshal(map[string]string{"token": "token-123"})
+	if err != nil {
+		t.Fatalf("marshal auth data: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, "auth.json"), authData, 0o644); err != nil {
+		t.Fatalf("write auth.json: %v", err)
+	}
+	originalHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", homeDir); err != nil {
+		t.Fatalf("set HOME: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", originalHome)
+	})
+
+	binDir := filepath.Join(tempDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+	openLog := filepath.Join(tempDir, "opened-url.txt")
+	scriptPath := filepath.Join(binDir, "xdg-open")
+	script := "#!/bin/sh\nprintf '%s' \"$1\" > \"" + openLog + "\"\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write xdg-open stub: %v", err)
+	}
+	originalPath := os.Getenv("PATH")
+	if err := os.Setenv("PATH", binDir+string(os.PathListSeparator)+originalPath); err != nil {
+		t.Fatalf("set PATH: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Setenv("PATH", originalPath)
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	logger := log.New(&bytes.Buffer{}, "", 0)
+	waitForGatewayAndOpenBrowser(context.Background(), strings.TrimPrefix(server.URL, "http://"), logger)
+
+	var data []byte
+	var readErr error
+	for i := 0; i < 20; i++ {
+		data, readErr = os.ReadFile(openLog)
+		if readErr == nil {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if readErr != nil {
+		t.Fatalf("read open log: %v", readErr)
+	}
+	if got := string(data); got != server.URL+"/?token=token-123" {
+		t.Fatalf("opened url = %q, want %q", got, server.URL+"/?token=token-123")
+	}
+
+	if got := resolveWebListenAddress("bad-address"); got != "bad-address" {
+		t.Fatalf("resolveWebListenAddress() = %q, want original invalid address", got)
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+	occupied := listener.Addr().String()
+	resolved := resolveWebListenAddress(occupied)
+	if resolved == occupied {
+		t.Fatalf("resolveWebListenAddress() = %q, want fallback port", resolved)
+	}
+}
+
+func TestResolveWebStaticDirCurrentWorkdirAndReadGatewayTokenInvalid(t *testing.T) {
+	tempDir := t.TempDir()
+	chdirForWebCommandTest(t, tempDir)
+	writeWebCommandTestFile(t, filepath.Join(tempDir, "web", "dist", "index.html"), "<html></html>")
+	stubResolveExecutablePath(t, func() (string, error) {
+		return "", errors.New("skip executable lookup")
+	})
+
+	got, err := resolveWebStaticDir("")
+	if err != nil {
+		t.Fatalf("resolveWebStaticDir() error = %v", err)
+	}
+	if got != filepath.Join(tempDir, "web", "dist") {
+		t.Fatalf("resolveWebStaticDir() = %q, want cwd web/dist", got)
+	}
+
+	homeDir := filepath.Join(tempDir, "home")
+	authDir := filepath.Join(homeDir, ".neocode")
+	if err := os.MkdirAll(authDir, 0o755); err != nil {
+		t.Fatalf("mkdir auth dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, "auth.json"), []byte("{invalid"), 0o644); err != nil {
+		t.Fatalf("write invalid auth.json: %v", err)
+	}
+	originalHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", homeDir); err != nil {
+		t.Fatalf("set HOME: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", originalHome)
+	})
+	if got := readGatewayToken(); got != "" {
+		t.Fatalf("readGatewayToken() = %q, want empty on invalid json", got)
+	}
+}
+
+func TestRunWebCommandFallbackAndSkipBuildErrors(t *testing.T) {
+	tempDir := t.TempDir()
+	chdirForWebCommandTest(t, tempDir)
+	stubResolveExecutablePath(t, func() (string, error) {
+		return "", errors.New("skip executable lookup")
+	})
+	stubWebCommandEmbeddedAssets(t, nil, false)
+
+	err := runWebCommand(context.Background(), webCommandOptions{
+		HTTPAddress: "127.0.0.1:8080",
+		LogLevel:    "info",
+		SkipBuild:   true,
+		OpenBrowser: false,
+		Workdir:     tempDir,
+	})
+	if err == nil || !strings.Contains(err.Error(), "--skip-build is set") {
+		t.Fatalf("runWebCommand() error = %v, want skip-build missing assets error", err)
+	}
+
+	writeWebCommandTestFile(t, filepath.Join(tempDir, "web", "package.json"), "{}")
+	err = runWebCommand(context.Background(), webCommandOptions{
+		HTTPAddress: "127.0.0.1:8080",
+		LogLevel:    "info",
+		OpenBrowser: false,
+		Workdir:     tempDir,
+	})
+	if err == nil || !strings.Contains(err.Error(), "frontend build failed on this machine") {
+		t.Fatalf("runWebCommand() error = %v, want build failure error", err)
+	}
+}
+
+func TestRunWebCommandRebuildsStaleDistAndDefaultsWorkdir(t *testing.T) {
+	tempDir := t.TempDir()
+	chdirForWebCommandTest(t, tempDir)
+	webDir := filepath.Join(tempDir, "web")
+	writeWebCommandTestFile(t, filepath.Join(webDir, "package.json"), "{}")
+	writeWebCommandTestFile(t, filepath.Join(webDir, "vite.config.ts"), "export default {}")
+	writeWebCommandTestFile(t, filepath.Join(webDir, "tsconfig.json"), "{}")
+	writeWebCommandTestFile(t, filepath.Join(webDir, "src", "main.ts"), "console.log('stale')")
+	writeWebCommandTestFile(t, filepath.Join(webDir, "dist", "index.html"), "<html></html>")
+
+	distIndex := filepath.Join(webDir, "dist", "index.html")
+	oldTime := time.Now().Add(-time.Hour)
+	newTime := time.Now()
+	if err := os.Chtimes(distIndex, oldTime, oldTime); err != nil {
+		t.Fatalf("chtimes dist: %v", err)
+	}
+	for _, path := range []string{
+		filepath.Join(webDir, "package.json"),
+		filepath.Join(webDir, "vite.config.ts"),
+		filepath.Join(webDir, "tsconfig.json"),
+		filepath.Join(webDir, "src", "main.ts"),
+	} {
+		if err := os.Chtimes(path, newTime, newTime); err != nil {
+			t.Fatalf("chtimes %s: %v", path, err)
+		}
+	}
+
+	buildCalled := false
+	var captured gatewayCommandOptions
+	sentinelErr := errors.New("stop after start")
+	stubWebCommandHooks(
+		t,
+		func(_ context.Context, options gatewayCommandOptions, _ string, _ fs.FS, _ func(string)) error {
+			captured = options
+			return sentinelErr
+		},
+		func(webDir string, _ *log.Logger) error {
+			buildCalled = true
+			writeWebCommandTestFile(t, filepath.Join(webDir, "dist", "index.html"), "<html></html>")
+			return nil
+		},
+		nil,
+	)
+
+	err := runWebCommand(context.Background(), webCommandOptions{
+		HTTPAddress: "127.0.0.1:8080",
+		LogLevel:    "info",
+		OpenBrowser: false,
+	})
+	if !errors.Is(err, sentinelErr) {
+		t.Fatalf("runWebCommand() error = %v, want sentinel error", err)
+	}
+	if !buildCalled {
+		t.Fatal("runWebCommand() did not rebuild stale frontend dist")
+	}
+	if captured.Workdir != tempDir {
+		t.Fatalf("gateway workdir = %q, want cwd %q", captured.Workdir, tempDir)
 	}
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -144,7 +144,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -560,7 +559,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -609,7 +607,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2426,7 +2423,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2828,7 +2826,6 @@
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -2874,7 +2871,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2886,7 +2882,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2993,7 +2988,6 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -3199,7 +3193,6 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3366,6 +3359,7 @@
       "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.4",
@@ -3385,6 +3379,7 @@
       "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
@@ -3407,6 +3402,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3422,7 +3418,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/archiver-utils/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -3430,6 +3427,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -3685,7 +3683,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4056,7 +4053,6 @@
       "resolved": "https://registry.npmmirror.com/chevrotain/-/chevrotain-12.0.0.tgz",
       "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "12.0.0",
         "@chevrotain/gast": "12.0.0",
@@ -4292,6 +4288,7 @@
       "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -4432,6 +4429,7 @@
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -4445,6 +4443,7 @@
       "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
@@ -4501,7 +4500,6 @@
       "resolved": "https://registry.npmmirror.com/cytoscape/-/cytoscape-3.33.3.tgz",
       "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -4902,7 +4900,6 @@
       "resolved": "https://registry.npmmirror.com/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5268,7 +5265,6 @@
       "integrity": "sha512-NoXo6Liy2heSklTI5OIZbCgXC1RzrDQsZkeEwXhdOro3FT1VBOvbubvscdPnjVuQ4AMwwv61oaH96AbiYg9EnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "builder-util": "25.1.7",
@@ -5351,7 +5347,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.4.2",
@@ -5436,7 +5433,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^20.9.0",
@@ -5481,6 +5477,7 @@
       "integrity": "sha512-2ntkJ+9+0GFP6nAISiMabKt6eqBB0kX1QqHNWFWAXgi0VULKGisM46luRFpIBiU3u/TDmhZMM8tzvo2Abn3ayg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "archiver": "^5.3.1",
@@ -5494,6 +5491,7 @@
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -5509,6 +5507,7 @@
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -5522,6 +5521,7 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -6090,7 +6090,8 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -6421,7 +6422,6 @@
       "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -7088,7 +7088,8 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
@@ -7396,6 +7397,7 @@
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -7409,6 +7411,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -7424,7 +7427,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -7432,6 +7436,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -7454,14 +7459,16 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
@@ -7474,7 +7481,8 @@
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
@@ -7488,14 +7496,16 @@
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -7571,6 +7581,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8097,7 +8108,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -8715,8 +8725,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/mime": {
       "version": "2.6.0",
@@ -8938,8 +8947,7 @@
       "version": "0.52.2",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -9101,6 +9109,7 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9492,6 +9501,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9507,6 +9517,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9519,7 +9530,8 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -9601,7 +9613,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9614,7 +9625,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -9628,7 +9638,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -9706,6 +9717,7 @@
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -9715,7 +9727,8 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
       "version": "2.1.0",
@@ -9723,6 +9736,7 @@
       "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -9733,6 +9747,7 @@
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -10683,6 +10698,7 @@
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -10823,7 +10839,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10996,7 +11011,6 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -11247,7 +11261,6 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -11337,8 +11350,7 @@
       "resolved": "https://registry.npmjs.org/vite-plugin-electron-renderer/-/vite-plugin-electron-renderer-0.14.6.tgz",
       "integrity": "sha512-oqkWFa7kQIkvHXG7+Mnl1RTroA4sP0yesKatmAy0gjZC4VwUqlvF9IvOpHd1fpLWsqYX/eZlVxlhULNtaQ78Jw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
@@ -11364,7 +11376,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11378,7 +11389,6 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -11805,6 +11815,7 @@
       "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^3.0.4",
         "compress-commons": "^4.1.2",
@@ -11820,6 +11831,7 @@
       "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob": "^7.2.3",
         "graceful-fs": "^4.2.0",

--- a/web/src/components/layout/Sidebar.test.tsx
+++ b/web/src/components/layout/Sidebar.test.tsx
@@ -351,6 +351,29 @@ describe('Sidebar ProviderModal', () => {
     expect(addWorkspaceButton as HTMLButtonElement).toBeDisabled()
   })
 
+  it('switches another workspace but does not re-switch the current workspace', async () => {
+    const switchWorkspace = vi.fn().mockResolvedValue(undefined)
+    useWorkspaceStore.setState({
+      workspaces: [
+        { hash: 'w1', path: '/workspace-one', name: 'Workspace One', createdAt: '1', updatedAt: '1' },
+        { hash: 'w2', path: '/workspace-two', name: 'Workspace Two', createdAt: '1', updatedAt: '1' },
+      ],
+      currentWorkspaceHash: 'w1',
+      changing: false,
+      switchWorkspace,
+    } as any)
+
+    render(<Sidebar />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Workspace Two/i }))
+    await waitFor(() => {
+      expect(switchWorkspace).toHaveBeenCalledWith('w2', mockGatewayAPI)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Workspace One/i }))
+    expect(switchWorkspace).toHaveBeenCalledTimes(1)
+  })
+
   it('immediately dispatches collapsed-rail actions', async () => {
     const toggleSidebar = vi.fn()
     const prepareNewChat = vi.fn()

--- a/web/src/components/layout/Sidebar.test.tsx
+++ b/web/src/components/layout/Sidebar.test.tsx
@@ -21,6 +21,7 @@ vi.mock('@/context/RuntimeProvider', () => ({
 
 describe('Sidebar ProviderModal', () => {
   beforeEach(() => {
+    vi.restoreAllMocks()
     cleanup()
     mockGatewayAPI = {
       listMCPServers: vi.fn().mockResolvedValue({
@@ -130,6 +131,7 @@ describe('Sidebar ProviderModal', () => {
     useWorkspaceStore.setState({
       workspaces: [],
       currentWorkspaceHash: '',
+      changing: false,
       switchWorkspace: vi.fn(),
       renameWorkspace: vi.fn(),
       deleteWorkspace: vi.fn(),
@@ -326,6 +328,27 @@ describe('Sidebar ProviderModal', () => {
       expect(chevronFor(workspaceOne)).not.toHaveClass('expanded')
       expect(chevronFor(workspaceTwo)).toHaveClass('expanded')
     })
+  })
+
+  it('disables workspace actions while a workspace change is in flight', () => {
+    useWorkspaceStore.setState({
+      workspaces: [
+        { hash: 'w1', path: '/workspace-one', name: 'Workspace One', createdAt: '1', updatedAt: '1' },
+        { hash: 'w2', path: '/workspace-two', name: 'Workspace Two', createdAt: '1', updatedAt: '1' },
+      ],
+      currentWorkspaceHash: 'w1',
+      changing: true,
+      switchWorkspace: vi.fn(),
+    } as any)
+
+    const { container } = render(<Sidebar />)
+
+    expect(screen.getByRole('button', { name: /Workspace One/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Workspace Two/i })).toBeDisabled()
+
+    const addWorkspaceButton = container.querySelector('.sidebar-section-header .btn')
+    expect(addWorkspaceButton).toBeInstanceOf(HTMLButtonElement)
+    expect(addWorkspaceButton as HTMLButtonElement).toBeDisabled()
   })
 
   it('immediately dispatches collapsed-rail actions', async () => {

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -47,6 +47,7 @@ export default function Sidebar({ collapsed }: SidebarProps) {
 
   const workspaces = useWorkspaceStore((s) => s.workspaces)
   const currentWorkspaceHash = useWorkspaceStore((s) => s.currentWorkspaceHash)
+  const workspaceChanging = useWorkspaceStore((s) => s.changing)
   const switchWorkspace = useWorkspaceStore((s) => s.switchWorkspace)
   const renameWorkspace = useWorkspaceStore((s) => s.renameWorkspace)
   const deleteWorkspace = useWorkspaceStore((s) => s.deleteWorkspace)
@@ -110,6 +111,7 @@ export default function Sidebar({ collapsed }: SidebarProps) {
 
   async function handleSelectWorkspace(hash: string) {
     if (!gatewayAPI) return
+    if (useWorkspaceStore.getState().changing) return
     if (hash !== currentWorkspaceHash) {
       await switchWorkspace(hash, gatewayAPI)
     }
@@ -139,6 +141,7 @@ export default function Sidebar({ collapsed }: SidebarProps) {
 
   async function handleCreateWorkspace(path: string, name?: string) {
     if (!gatewayAPI || !path.trim()) return
+    if (useWorkspaceStore.getState().changing) return
     await createWorkspace(path.trim(), gatewayAPI, name?.trim() || undefined)
     setCreateWorkspaceOpen(false)
   }
@@ -209,7 +212,13 @@ export default function Sidebar({ collapsed }: SidebarProps) {
       {/* Section header: label + add workspace */}
       <div className="sidebar-section-header">
         <span className="sidebar-section-label">工作区</span>
-        <button className="btn btn-ghost" style={{ width: 24, height: 24, padding: 0 }} title="新建工作区" onClick={() => setCreateWorkspaceOpen(true)}>
+        <button
+          className="btn btn-ghost"
+          style={{ width: 24, height: 24, padding: 0 }}
+          title="新建工作区"
+          onClick={() => setCreateWorkspaceOpen(true)}
+          disabled={workspaceChanging}
+        >
           <FolderPlus size={14} />
         </button>
       </div>
@@ -266,6 +275,7 @@ export default function Sidebar({ collapsed }: SidebarProps) {
                 expanded={rowExpanded}
                 isCurrent={isCurrent}
                 isRenaming={isRenaming}
+                disabled={workspaceChanging}
                 renameValue={workspaceRenameValue}
                 onRenameValueChange={setWorkspaceRenameValue}
                 onCommitRename={() => handleCommitWorkspaceRename(ws.hash)}
@@ -438,11 +448,13 @@ function SessionItem({
 
 function WorkspaceRow({
   workspace, expanded, isCurrent, isRenaming, renameValue,
+  disabled,
   onRenameValueChange, onCommitRename, onCancelRename,
   onClick, onStartRename, onDelete,
 }: {
   workspace: Workspace
   expanded: boolean; isCurrent: boolean; isRenaming: boolean
+  disabled: boolean
   renameValue: string
   onRenameValueChange: (v: string) => void
   onCommitRename: () => void
@@ -459,7 +471,7 @@ function WorkspaceRow({
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
     >
-      <button className="workspace-header-main" onClick={onClick} title={workspace.path}>
+      <button className="workspace-header-main" onClick={onClick} title={workspace.path} disabled={disabled}>
         <span className={`chevron ${expanded ? 'expanded' : ''}`}>
           <ChevronRight size={14} />
         </span>

--- a/web/src/stores/useSessionStore.test.ts
+++ b/web/src/stores/useSessionStore.test.ts
@@ -168,6 +168,25 @@ describe('useSessionStore', () => {
     expect(useChatStore.getState().messages[0].role).toBe('user')
   })
 
+  it('switchSession keeps transitioning true until loadSession finishes', async () => {
+    const mockBindStream = vi.fn().mockResolvedValue({})
+    let resolveLoad!: (value: any) => void
+    const mockLoadSession = vi.fn().mockImplementation(
+      () => new Promise((resolve) => { resolveLoad = resolve }),
+    )
+    const mockAPI = { bindStream: mockBindStream, loadSession: mockLoadSession } as any
+
+    const switchPromise = useSessionStore.getState().switchSession('sess-2', mockAPI)
+    await Promise.resolve()
+
+    expect(useChatStore.getState().isTransitioning).toBe(true)
+
+    resolveLoad({ payload: { messages: [] } })
+    await switchPromise
+
+    expect(useChatStore.getState().isTransitioning).toBe(false)
+  })
+
   it('fetchSessions auto-selects first session and binds stream', async () => {
     const setMessagesSpy = vi.spyOn(useChatStore.getState(), 'setMessages')
     const addMessageSpy = vi.spyOn(useChatStore.getState(), 'addMessage')
@@ -215,6 +234,56 @@ describe('useSessionStore', () => {
 
     expect(useSessionStore.getState().currentSessionId).toBe('sess-b')
     expect(mockBindStream).not.toHaveBeenCalled()
+  })
+
+  it('fetchSessions ignores stale late response from an older request', async () => {
+    let resolveFirst!: (value: any) => void
+    let resolveSecond!: (value: any) => void
+    const mockListSessions = vi
+      .fn()
+      .mockImplementationOnce(
+        () => new Promise((resolve) => { resolveFirst = resolve }),
+      )
+      .mockImplementationOnce(
+        () => new Promise((resolve) => { resolveSecond = resolve }),
+      )
+    const mockAPI = {
+      listSessions: mockListSessions,
+      bindStream: vi.fn().mockResolvedValue({}),
+      loadSession: vi.fn().mockResolvedValue({ payload: { messages: [] } }),
+    } as any
+
+    useSessionStore.setState({ currentSessionId: 'sess-keep' })
+
+    const firstRequest = useSessionStore.getState().fetchSessions(mockAPI, true)
+    const secondRequest = useSessionStore.getState().fetchSessions(mockAPI, true)
+
+    resolveSecond({
+      payload: {
+        sessions: [{
+          id: 'sess-new',
+          title: 'New',
+          created_at: '2026-05-10T01:00:00Z',
+          updated_at: '2026-05-10T01:00:00Z',
+        }],
+      },
+    })
+    await secondRequest
+
+    resolveFirst({
+      payload: {
+        sessions: [{
+          id: 'sess-old',
+          title: 'Old',
+          created_at: '2026-05-09T01:00:00Z',
+          updated_at: '2026-05-09T01:00:00Z',
+        }],
+      },
+    })
+    await firstRequest
+
+    const sessions = useSessionStore.getState().projects.flatMap((project) => project.sessions)
+    expect(sessions.map((session) => session.id)).toEqual(['sess-new'])
   })
 
   it('fetchSessions uses the newer of created_at/updated_at as display time', async () => {

--- a/web/src/stores/useSessionStore.test.ts
+++ b/web/src/stores/useSessionStore.test.ts
@@ -3,6 +3,7 @@ import { mapHistoryMessages, useSessionStore } from './useSessionStore'
 import { useChatStore } from './useChatStore'
 import { useGatewayStore } from './useGatewayStore'
 import { useRuntimeInsightStore } from './useRuntimeInsightStore'
+import { useUIStore } from './useUIStore'
 
 beforeEach(() => {
   useSessionStore.setState((useSessionStore.getInitialState?.() ?? { projects: [], currentSessionId: '', currentProjectId: '', loading: false }) as any)
@@ -115,6 +116,19 @@ describe('useSessionStore', () => {
     expect(useSessionStore.getState().currentSessionId).toBe('')
   })
 
+  it('createSession is blocked while generating', () => {
+    const showToast = vi.fn()
+    useChatStore.setState({ isGenerating: true } as any)
+    useUIStore.setState({ showToast } as any)
+    useSessionStore.setState({ currentSessionId: 'sess-1', currentProjectId: 'group-1' })
+
+    useSessionStore.getState().createSession()
+
+    expect(useSessionStore.getState().currentSessionId).toBe('sess-1')
+    expect(useSessionStore.getState().currentProjectId).toBe('group-1')
+    expect(showToast).toHaveBeenCalledWith('Cannot start a new session while generating; stop the current run first.', 'info')
+  })
+
   it('prepareNewChat also clears state and does not set temp id', () => {
     useSessionStore.setState({ currentSessionId: 'sess-1' })
     useChatStore.getState().addMessage({ id: '1', role: 'user', content: 'hello', type: 'text', timestamp: 1 })
@@ -124,6 +138,19 @@ describe('useSessionStore', () => {
     expect(useChatStore.getState().messages).toHaveLength(0)
     expect(useSessionStore.getState().currentSessionId).toBe('')
     expect(useSessionStore.getState().currentProjectId).toBe('')
+  })
+
+  it('prepareNewChat is blocked while generating', () => {
+    const showToast = vi.fn()
+    useChatStore.setState({ isGenerating: true } as any)
+    useUIStore.setState({ showToast } as any)
+    useSessionStore.setState({ currentSessionId: 'sess-1', currentProjectId: 'group-1' })
+
+    useSessionStore.getState().prepareNewChat()
+
+    expect(useSessionStore.getState().currentSessionId).toBe('sess-1')
+    expect(useSessionStore.getState().currentProjectId).toBe('group-1')
+    expect(showToast).toHaveBeenCalledWith('Cannot start a new session while generating; stop the current run first.', 'info')
   })
 
   it('initializeActiveSession binds stream for valid session id', async () => {
@@ -144,6 +171,20 @@ describe('useSessionStore', () => {
     await useSessionStore.getState().initializeActiveSession(mockAPI)
 
     expect(mockBindStream).not.toHaveBeenCalled()
+  })
+
+  it('initializeActiveSession shows toast when bindStream fails', async () => {
+    const showToast = vi.fn()
+    const mockBindStream = vi.fn().mockRejectedValue(new Error('bind failed'))
+    const mockAPI = { bindStream: mockBindStream } as any
+    useUIStore.setState({ showToast } as any)
+
+    useSessionStore.setState({ currentSessionId: 'sess-1', _initialBindDone: false } as any)
+    await useSessionStore.getState().initializeActiveSession(mockAPI)
+
+    expect(mockBindStream).toHaveBeenCalledWith({ session_id: 'sess-1', channel: 'all' })
+    expect(useSessionStore.getState()._initialBindDone).toBe(false)
+    expect(showToast).toHaveBeenCalledWith('Failed to bind event stream; real-time messages may not arrive.', 'error')
   })
 
   it('switchSession binds stream and loads session data', async () => {
@@ -348,6 +389,42 @@ describe('useSessionStore', () => {
     expect(sessions.map((session) => session.id)).toEqual(['sess-new'])
   })
 
+  it('fetchSessions shows toast when auto bind or load fails', async () => {
+    const showToast = vi.fn()
+    useUIStore.setState({ showToast } as any)
+    const mockListSessions = vi.fn().mockResolvedValue({
+      payload: {
+        sessions: [{
+          id: 'sess-a',
+          title: 'Alpha',
+          created_at: '2026-05-09T01:00:00Z',
+          updated_at: '2026-05-09T02:00:00Z',
+        }],
+      },
+    })
+    const mockBindStream = vi.fn().mockRejectedValue(new Error('bind failed'))
+    const mockAPI = { listSessions: mockListSessions, bindStream: mockBindStream } as any
+
+    await useSessionStore.getState().fetchSessions(mockAPI)
+
+    expect(useSessionStore.getState().currentSessionId).toBe('sess-a')
+    expect(showToast).toHaveBeenCalledWith('Failed to load session', 'error')
+  })
+
+  it('fetchSessions clears projects when listSessions fails', async () => {
+    useSessionStore.setState({
+      projects: [{ id: 'group', name: 'Group', sessions: [{ id: 'sess-1', title: 'A', time: '2026-05-10T00:00:00.000Z' }] }],
+    } as any)
+    const mockAPI = {
+      listSessions: vi.fn().mockRejectedValue(new Error('list failed')),
+    } as any
+
+    await useSessionStore.getState().fetchSessions(mockAPI, true)
+
+    expect(useSessionStore.getState().projects).toEqual([])
+    expect(useSessionStore.getState().loading).toBe(false)
+  })
+
   it('fetchSessions uses the newer of created_at/updated_at as display time', async () => {
     const mockListSessions = vi.fn().mockResolvedValue({
       payload: {
@@ -417,5 +494,40 @@ describe('useSessionStore', () => {
 
     const insightStore = useRuntimeInsightStore.getState()
     expect(insightStore.todoSnapshot?.items?.[0].id).toBe('t1')
+  })
+
+  it('removeSessionLocally prunes empty groups', () => {
+    useSessionStore.setState({
+      projects: [
+        {
+          id: 'group-a',
+          name: 'A',
+          sessions: [
+            { id: 'sess-1', title: 'One', time: '2026-05-10T00:00:00.000Z' },
+          ],
+        },
+        {
+          id: 'group-b',
+          name: 'B',
+          sessions: [
+            { id: 'sess-2', title: 'Two', time: '2026-05-10T00:00:00.000Z' },
+            { id: 'sess-3', title: 'Three', time: '2026-05-10T00:00:00.000Z' },
+          ],
+        },
+      ],
+    } as any)
+
+    useSessionStore.getState().removeSessionLocally('sess-1')
+    useSessionStore.getState().removeSessionLocally('sess-2')
+
+    expect(useSessionStore.getState().projects).toEqual([
+      {
+        id: 'group-b',
+        name: 'B',
+        sessions: [
+          { id: 'sess-3', title: 'Three', time: '2026-05-10T00:00:00.000Z' },
+        ],
+      },
+    ])
   })
 })

--- a/web/src/stores/useSessionStore.test.ts
+++ b/web/src/stores/useSessionStore.test.ts
@@ -187,6 +187,68 @@ describe('useSessionStore', () => {
     expect(useChatStore.getState().isTransitioning).toBe(false)
   })
 
+  it('resetForWorkspaceSwitch aborts in-flight switchSession and blocks stale writeback', async () => {
+    const mockBindStream = vi.fn().mockResolvedValue({})
+    let resolveLoad!: (value: any) => void
+    const mockLoadSession = vi.fn().mockImplementation(
+      () => new Promise((resolve) => { resolveLoad = resolve }),
+    )
+    const mockAPI = { bindStream: mockBindStream, loadSession: mockLoadSession } as any
+
+    const switchPromise = useSessionStore.getState().switchSession('sess-old', mockAPI)
+    await Promise.resolve()
+
+    useSessionStore.getState().resetForWorkspaceSwitch()
+
+    resolveLoad({
+      payload: {
+        messages: [{ role: 'assistant', content: 'stale payload', tool_calls: [] }],
+        agent_mode: 'plan',
+      },
+    })
+    await switchPromise
+
+    expect(useChatStore.getState().messages).toHaveLength(0)
+    expect(useChatStore.getState().agentMode).toBe('build')
+  })
+
+  it('switchSession applies only latest request when older request resolves later', async () => {
+    const mockBindStream = vi.fn().mockResolvedValue({})
+    let resolveLoadA!: (value: any) => void
+    let resolveLoadB!: (value: any) => void
+    const mockLoadSession = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveLoadA = resolve }))
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveLoadB = resolve }))
+    const mockAPI = { bindStream: mockBindStream, loadSession: mockLoadSession } as any
+
+    const switchA = useSessionStore.getState().switchSession('sess-a', mockAPI)
+    await Promise.resolve()
+    const switchB = useSessionStore.getState().switchSession('sess-b', mockAPI)
+    await Promise.resolve()
+
+    resolveLoadB({
+      payload: {
+        messages: [{ role: 'assistant', content: 'new payload', tool_calls: [] }],
+        agent_mode: 'plan',
+      },
+    })
+    await switchB
+
+    resolveLoadA({
+      payload: {
+        messages: [{ role: 'assistant', content: 'old payload', tool_calls: [] }],
+        agent_mode: 'build',
+      },
+    })
+    await switchA
+
+    expect(useSessionStore.getState().currentSessionId).toBe('sess-b')
+    expect(useChatStore.getState().messages).toHaveLength(1)
+    expect(useChatStore.getState().messages[0].content).toBe('new payload')
+    expect(useChatStore.getState().agentMode).toBe('plan')
+  })
+
   it('fetchSessions auto-selects first session and binds stream', async () => {
     const setMessagesSpy = vi.spyOn(useChatStore.getState(), 'setMessages')
     const addMessageSpy = vi.spyOn(useChatStore.getState(), 'addMessage')

--- a/web/src/stores/useSessionStore.ts
+++ b/web/src/stores/useSessionStore.ts
@@ -261,6 +261,7 @@ export async function reloadSessionAfterCheckpointRestore(
 }
 
 let _fetchSessionsPromise: Promise<void> | null = null
+let _fetchSessionsSeq = 0
 
 export const useSessionStore = create<SessionState>((set, get) => ({
   projects: [],
@@ -295,10 +296,10 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     const prevSessionId = get().currentSessionId
 
     try {
-      // 1. Set transitioning flag and clear messages FIRST (before bindStream)
+      // 1. Clear messages first, then enter transitioning state to keep event drop window effective
       const chatStore = useChatStore.getState()
-      chatStore.setTransitioning(true)
       chatStore.clearMessages()
+      chatStore.setTransitioning(true)
       useRuntimeInsightStore.getState().reset()
       useUIStore.getState().clearCheckpointRollbackUndo()
 
@@ -379,6 +380,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
 
   resetForWorkspaceSwitch: () => {
     _fetchSessionsPromise = null
+    _fetchSessionsSeq += 1
     set({ _initialBindDone: false, loading: false })
   },
 
@@ -393,24 +395,29 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     // 去重：若已有 fetch 在进行中，复用同一 promise（force 跳过去重）
     if (!force && _fetchSessionsPromise) return _fetchSessionsPromise
 
-    _fetchSessionsPromise = (async () => {
+    const requestSeq = ++_fetchSessionsSeq
+    const fetchPromise = (async () => {
       set({ loading: true })
       try {
         const result = await gatewayAPI.listSessions()
+        if (requestSeq !== _fetchSessionsSeq) return
         const sessions = result.payload.sessions
         const projects = mapSessionsToProjects(sessions)
         set({ projects, loading: false })
 
         const state = get()
+        if (requestSeq !== _fetchSessionsSeq) return
         if (!isValidSessionId(state.currentSessionId) && sessions.length > 0) {
           const firstSession = sessions[0]
           set({ currentSessionId: firstSession.id })
           try {
             await gatewayAPI.bindStream({ session_id: firstSession.id, channel: 'all' })
+            if (requestSeq !== _fetchSessionsSeq) return
             set({ _initialBindDone: true })
 
             // Load historical messages for the auto-selected session (concurrently fetch todos + runtime snapshot)
             const sessionFrame = await loadSessionWithInsights(gatewayAPI, firstSession.id)
+            if (requestSeq !== _fetchSessionsSeq) return
             const sessionData = sessionFrame.payload as { messages?: BackendMessage[]; agent_mode?: string }
             if (sessionData.messages && sessionData.messages.length > 0) {
               const mapped = mapHistoryMessages(sessionData.messages)
@@ -419,18 +426,23 @@ export const useSessionStore = create<SessionState>((set, get) => ({
             const restoredMode = sessionData.agent_mode === 'plan' ? 'plan' : 'build'
             useChatStore.getState().setAgentMode(restoredMode)
           } catch (err) {
+            if (requestSeq !== _fetchSessionsSeq) return
             console.error('Auto bindStream or loadSession failed:', err)
             useUIStore.getState().showToast('Failed to load session', 'error')
           }
         }
       } catch (err) {
+        if (requestSeq !== _fetchSessionsSeq) return
         console.error('fetchSessions failed:', err)
         set({ projects: [], loading: false })
       } finally {
-        _fetchSessionsPromise = null
+        if (requestSeq === _fetchSessionsSeq) {
+          _fetchSessionsPromise = null
+        }
       }
     })()
 
-    return _fetchSessionsPromise
+    _fetchSessionsPromise = fetchPromise
+    return fetchPromise
   },
 }))

--- a/web/src/stores/useSessionStore.ts
+++ b/web/src/stores/useSessionStore.ts
@@ -262,6 +262,7 @@ export async function reloadSessionAfterCheckpointRestore(
 
 let _fetchSessionsPromise: Promise<void> | null = null
 let _fetchSessionsSeq = 0
+let _switchSessionSeq = 0
 
 export const useSessionStore = create<SessionState>((set, get) => ({
   projects: [],
@@ -290,6 +291,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     if (prevAbort) {
       prevAbort.abort()
     }
+    const switchSeq = ++_switchSessionSeq
     const abortCtrl = new AbortController()
     set({ _switchAbort: abortCtrl, loading: true })
 
@@ -308,13 +310,15 @@ export const useSessionStore = create<SessionState>((set, get) => ({
 
       // 3. Bind stream (events will be discarded due to isTransitioning)
       await gatewayAPI.bindStream({ session_id: sessionId, channel: 'all' })
+      if (abortCtrl.signal.aborted || switchSeq !== _switchSessionSeq || get()._switchAbort !== abortCtrl) return
 
       // 4. Load historical messages (concurrently fetch todos + runtime snapshot)
       const sessionFrame = await loadSessionWithInsights(gatewayAPI, sessionId)
+      if (abortCtrl.signal.aborted || switchSeq !== _switchSessionSeq || get()._switchAbort !== abortCtrl) return
       const sessionData = sessionFrame.payload as { messages?: BackendMessage[]; agent_mode?: string }
 
       // Check if this request was superseded
-      if (abortCtrl.signal.aborted) return
+      if (abortCtrl.signal.aborted || switchSeq !== _switchSessionSeq || get()._switchAbort !== abortCtrl) return
 
       // 5. Load messages and stop transitioning
       if (sessionData.messages && sessionData.messages.length > 0) {
@@ -326,7 +330,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       useChatStore.getState().setAgentMode(restoredMode)
       chatStore.setTransitioning(false)
     } catch (err) {
-      if (abortCtrl.signal.aborted) return
+      if (abortCtrl.signal.aborted || switchSeq !== _switchSessionSeq || get()._switchAbort !== abortCtrl) return
       console.error('switchSession failed:', err)
       // Revert to previous session and re-bind its stream
       set({ currentSessionId: prevSessionId })
@@ -335,7 +339,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       }
       useChatStore.getState().setTransitioning(false)
     } finally {
-      if (get()._switchAbort === abortCtrl) {
+      if (switchSeq === _switchSessionSeq && get()._switchAbort === abortCtrl) {
         set({ loading: false, _switchAbort: null })
       }
     }
@@ -379,9 +383,14 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   },
 
   resetForWorkspaceSwitch: () => {
+    const currentAbort = get()._switchAbort
+    if (currentAbort) {
+      currentAbort.abort()
+    }
     _fetchSessionsPromise = null
     _fetchSessionsSeq += 1
-    set({ _initialBindDone: false, loading: false })
+    _switchSessionSeq += 1
+    set({ _initialBindDone: false, loading: false, _switchAbort: null })
   },
 
   removeSessionLocally: (sessionId) => {

--- a/web/src/stores/useWorkspaceStore.test.ts
+++ b/web/src/stores/useWorkspaceStore.test.ts
@@ -222,6 +222,47 @@ describe('useWorkspaceStore', () => {
 		expect(showToast).toHaveBeenCalledWith('Failed to create workspace', 'error')
 	})
 
+	it('renameWorkspace updates the matching workspace name', async () => {
+		const gatewayAPI = {
+			renameWorkspace: vi.fn().mockResolvedValue(undefined),
+		} as any
+		useWorkspaceStore.setState({
+			workspaces: [
+				{ hash: 'w1', path: '/1', name: 'Old', createdAt: '1', updatedAt: '1' },
+				{ hash: 'w2', path: '/2', name: 'Keep', createdAt: '1', updatedAt: '1' },
+			],
+		} as any)
+
+		await useWorkspaceStore.getState().renameWorkspace('w1', 'New', gatewayAPI)
+
+		expect(gatewayAPI.renameWorkspace).toHaveBeenCalledWith('w1', 'New')
+		expect(useWorkspaceStore.getState().workspaces.map((w) => w.name)).toEqual(['New', 'Keep'])
+	})
+
+	it('renameWorkspace failure reports toast', async () => {
+		const showToast = vi.fn()
+		useUIStore.setState({ showToast } as any)
+		const gatewayAPI = {
+			renameWorkspace: vi.fn().mockRejectedValue(new Error('boom')),
+		} as any
+
+		await useWorkspaceStore.getState().renameWorkspace('w1', 'New', gatewayAPI)
+
+		expect(showToast).toHaveBeenCalledWith('Failed to rename workspace', 'error')
+	})
+
+	it('deleteWorkspace failure reports toast', async () => {
+		const showToast = vi.fn()
+		useUIStore.setState({ showToast } as any)
+		const gatewayAPI = {
+			deleteWorkspace: vi.fn().mockRejectedValue(new Error('boom')),
+		} as any
+
+		await useWorkspaceStore.getState().deleteWorkspace('w1', gatewayAPI)
+
+		expect(showToast).toHaveBeenCalledWith('Failed to delete workspace', 'error')
+	})
+
 	it('deleteWorkspace switches to remaining first workspace when current is removed', async () => {
 		const switchWorkspace = vi.spyOn(useWorkspaceStore.getState(), 'switchWorkspace')
 		useWorkspaceStore.setState({

--- a/web/src/stores/useWorkspaceStore.test.ts
+++ b/web/src/stores/useWorkspaceStore.test.ts
@@ -88,6 +88,31 @@ describe('useWorkspaceStore', () => {
 		expect(useWorkspaceStore.getState().currentWorkspaceHash).toBe('w2')
 	})
 
+	it('switchWorkspace ignores stale late response from an older switch request', async () => {
+		let resolveA!: () => void
+		let resolveB!: () => void
+		const gatewayAPI = {
+			switchWorkspace: vi
+				.fn()
+				.mockImplementationOnce(() => new Promise<void>((resolve) => { resolveA = resolve }))
+				.mockImplementationOnce(() => new Promise<void>((resolve) => { resolveB = resolve })),
+		} as any
+		const fetchSessions = useSessionStore.getState().fetchSessions as any
+
+		const switchA = useWorkspaceStore.getState().switchWorkspace('wA', gatewayAPI)
+		const switchB = useWorkspaceStore.getState().switchWorkspace('wB', gatewayAPI)
+
+		resolveB()
+		await switchB
+		expect(useWorkspaceStore.getState().currentWorkspaceHash).toBe('wB')
+
+		resolveA()
+		await switchA
+		expect(useWorkspaceStore.getState().currentWorkspaceHash).toBe('wB')
+		expect(fetchSessions).toHaveBeenCalledTimes(1)
+		expect(fetchSessions).toHaveBeenCalledWith(gatewayAPI, true)
+	})
+
 	it('createWorkspace failure reports toast', async () => {
 		const showToast = vi.fn()
 		useUIStore.setState({ showToast } as any)

--- a/web/src/stores/useWorkspaceStore.test.ts
+++ b/web/src/stores/useWorkspaceStore.test.ts
@@ -12,10 +12,12 @@ function flushPromises() {
 
 describe('useWorkspaceStore', () => {
 	beforeEach(() => {
+		vi.restoreAllMocks()
 		useWorkspaceStore.setState({
 			workspaces: [],
 			currentWorkspaceHash: '',
 			loading: false,
+			changing: false,
 		} as any)
 
 		useChatStore.setState({
@@ -95,27 +97,23 @@ describe('useWorkspaceStore', () => {
 		expect(useWorkspaceStore.getState().currentWorkspaceHash).toBe('w2')
 	})
 
-	it('switchWorkspace ignores stale late response from an older switch request', async () => {
-		let resolveA!: () => void
-		let resolveB!: () => void
+	it('switchWorkspace allows only one in-flight request', async () => {
+		let resolveSwitch!: () => void
 		const gatewayAPI = {
 			switchWorkspace: vi
 				.fn()
-				.mockImplementationOnce(() => new Promise<void>((resolve) => { resolveA = resolve }))
-				.mockImplementationOnce(() => new Promise<void>((resolve) => { resolveB = resolve })),
+				.mockImplementationOnce(() => new Promise<void>((resolve) => { resolveSwitch = resolve })),
 		} as any
 		const fetchSessions = useSessionStore.getState().fetchSessions as any
 
 		const switchA = useWorkspaceStore.getState().switchWorkspace('wA', gatewayAPI)
 		const switchB = useWorkspaceStore.getState().switchWorkspace('wB', gatewayAPI)
 
-		resolveB()
-		await switchB
-		expect(useWorkspaceStore.getState().currentWorkspaceHash).toBe('wB')
+		expect(gatewayAPI.switchWorkspace).toHaveBeenCalledTimes(1)
 
-		resolveA()
-		await switchA
-		expect(useWorkspaceStore.getState().currentWorkspaceHash).toBe('wB')
+		resolveSwitch()
+		await Promise.all([switchA, switchB])
+		expect(useWorkspaceStore.getState().currentWorkspaceHash).toBe('wA')
 		expect(fetchSessions).toHaveBeenCalledTimes(1)
 		expect(fetchSessions).toHaveBeenCalledWith(gatewayAPI, true)
 	})
@@ -129,6 +127,23 @@ describe('useWorkspaceStore', () => {
 
 		await useWorkspaceStore.getState().createWorkspace('/x', gatewayAPI)
 		expect(showToast).toHaveBeenCalledWith('Failed to create workspace', 'error')
+	})
+
+	it('switchWorkspace failure restores loading flags and keeps previous workspace hash', async () => {
+		const showToast = vi.fn()
+		useUIStore.setState({ showToast } as any)
+		useWorkspaceStore.setState({ currentWorkspaceHash: 'w1' } as any)
+		const gatewayAPI = {
+			switchWorkspace: vi.fn().mockRejectedValue(new Error('boom')),
+		} as any
+
+		await useWorkspaceStore.getState().switchWorkspace('w2', gatewayAPI)
+
+		expect(useWorkspaceStore.getState().currentWorkspaceHash).toBe('w1')
+		expect(useWorkspaceStore.getState().loading).toBe(false)
+		expect(useWorkspaceStore.getState().changing).toBe(false)
+		expect(useChatStore.getState().setTransitioning).toHaveBeenLastCalledWith(false)
+		expect(showToast).toHaveBeenCalledWith('Failed to switch workspace', 'error')
 	})
 
 	it('createWorkspace clears runtime insight and rollback undo before switching', async () => {
@@ -154,6 +169,57 @@ describe('useWorkspaceStore', () => {
 		expect(useUIStore.getState().clearCheckpointRollbackUndo).toHaveBeenCalled()
 		expect(gatewayAPI.switchWorkspace).toHaveBeenCalledWith('w-new')
 		expect(fetchSessions).toHaveBeenCalledWith(gatewayAPI, true)
+	})
+
+	it('createWorkspace allows only one in-flight request', async () => {
+		let resolveCreate!: (value: any) => void
+		const gatewayAPI = {
+			createWorkspace: vi.fn().mockImplementationOnce(
+				() => new Promise((resolve) => { resolveCreate = resolve }),
+			),
+			switchWorkspace: vi.fn().mockResolvedValue(undefined),
+		} as any
+		const fetchSessions = useSessionStore.getState().fetchSessions as any
+
+		const createA = useWorkspaceStore.getState().createWorkspace('/first', gatewayAPI, 'First')
+		const createB = useWorkspaceStore.getState().createWorkspace('/second', gatewayAPI, 'Second')
+
+		expect(gatewayAPI.createWorkspace).toHaveBeenCalledTimes(1)
+
+		resolveCreate({
+			payload: {
+				workspace: {
+					hash: 'w-first',
+					path: '/first',
+					name: 'First',
+					created_at: '1',
+					updated_at: '1',
+				},
+			},
+		})
+		await Promise.all([createA, createB])
+
+		expect(gatewayAPI.switchWorkspace).toHaveBeenCalledTimes(1)
+		expect(gatewayAPI.switchWorkspace).toHaveBeenCalledWith('w-first')
+		expect(useWorkspaceStore.getState().currentWorkspaceHash).toBe('w-first')
+		expect(fetchSessions).toHaveBeenCalledTimes(1)
+	})
+
+	it('createWorkspace failure restores loading flags and keeps previous workspace hash', async () => {
+		const showToast = vi.fn()
+		useUIStore.setState({ showToast } as any)
+		useWorkspaceStore.setState({ currentWorkspaceHash: 'w1' } as any)
+		const gatewayAPI = {
+			createWorkspace: vi.fn().mockRejectedValue(new Error('boom')),
+		} as any
+
+		await useWorkspaceStore.getState().createWorkspace('/x', gatewayAPI, 'X')
+
+		expect(useWorkspaceStore.getState().currentWorkspaceHash).toBe('w1')
+		expect(useWorkspaceStore.getState().loading).toBe(false)
+		expect(useWorkspaceStore.getState().changing).toBe(false)
+		expect(useChatStore.getState().setTransitioning).toHaveBeenLastCalledWith(false)
+		expect(showToast).toHaveBeenCalledWith('Failed to create workspace', 'error')
 	})
 
 	it('deleteWorkspace switches to remaining first workspace when current is removed', async () => {

--- a/web/src/stores/useWorkspaceStore.test.ts
+++ b/web/src/stores/useWorkspaceStore.test.ts
@@ -4,6 +4,7 @@ import { useChatStore } from './useChatStore'
 import { useSessionStore } from './useSessionStore'
 import { useUIStore } from './useUIStore'
 import { useGatewayStore } from './useGatewayStore'
+import { useRuntimeInsightStore } from './useRuntimeInsightStore'
 
 function flushPromises() {
 	return new Promise((resolve) => setTimeout(resolve, 0))
@@ -32,12 +33,16 @@ describe('useWorkspaceStore', () => {
 		useUIStore.setState({
 			showToast: vi.fn(),
 			clearFileChanges: vi.fn(),
+			clearCheckpointRollbackUndo: vi.fn(),
 			resetPreviewTabs: vi.fn(),
 			setSearchQuery: vi.fn(),
 		} as any)
 		useGatewayStore.setState({
 			setCurrentRunId: vi.fn(),
 			notifyProviderChanged: vi.fn(),
+		} as any)
+		useRuntimeInsightStore.setState({
+			reset: vi.fn(),
 		} as any)
 	})
 
@@ -80,7 +85,9 @@ describe('useWorkspaceStore', () => {
 
 		expect(useChatStore.getState().clearMessages).toHaveBeenCalled()
 		expect(useSessionStore.getState().resetForWorkspaceSwitch).toHaveBeenCalled()
+		expect(useRuntimeInsightStore.getState().reset).toHaveBeenCalled()
 		expect(useUIStore.getState().clearFileChanges).toHaveBeenCalled()
+		expect(useUIStore.getState().clearCheckpointRollbackUndo).toHaveBeenCalled()
 		expect(useUIStore.getState().resetPreviewTabs).toHaveBeenCalled()
 		expect(gatewayAPI.switchWorkspace).toHaveBeenCalledWith('w2')
 		expect(useGatewayStore.getState().notifyProviderChanged).toHaveBeenCalled()
@@ -122,6 +129,31 @@ describe('useWorkspaceStore', () => {
 
 		await useWorkspaceStore.getState().createWorkspace('/x', gatewayAPI)
 		expect(showToast).toHaveBeenCalledWith('Failed to create workspace', 'error')
+	})
+
+	it('createWorkspace clears runtime insight and rollback undo before switching', async () => {
+		const gatewayAPI = {
+			createWorkspace: vi.fn().mockResolvedValue({
+				payload: {
+					workspace: {
+						hash: 'w-new',
+						path: '/new',
+						name: 'New',
+						created_at: '1',
+						updated_at: '1',
+					},
+				},
+			}),
+			switchWorkspace: vi.fn().mockResolvedValue(undefined),
+		} as any
+		const fetchSessions = useSessionStore.getState().fetchSessions as any
+
+		await useWorkspaceStore.getState().createWorkspace('/new', gatewayAPI, 'New')
+
+		expect(useRuntimeInsightStore.getState().reset).toHaveBeenCalled()
+		expect(useUIStore.getState().clearCheckpointRollbackUndo).toHaveBeenCalled()
+		expect(gatewayAPI.switchWorkspace).toHaveBeenCalledWith('w-new')
+		expect(fetchSessions).toHaveBeenCalledWith(gatewayAPI, true)
 	})
 
 	it('deleteWorkspace switches to remaining first workspace when current is removed', async () => {

--- a/web/src/stores/useWorkspaceStore.ts
+++ b/web/src/stores/useWorkspaceStore.ts
@@ -42,6 +42,7 @@ function mapAPIWorkspace(w: APIWorkspace): Workspace {
 }
 
 let _fetchWorkspacesPromise: Promise<void> | null = null
+let _workspaceSwitchSeq = 0
 
 export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   workspaces: [],
@@ -88,6 +89,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
 
     set({ loading: true })
+    const switchSeq = ++_workspaceSwitchSeq
 
     // 先清空所有前端状态（防止重连 handler 读到旧 sessionId 竞态）
     useChatStore.getState().clearMessages()
@@ -105,17 +107,21 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
 
     try {
       await gatewayAPI.switchWorkspace(hash)
+      if (switchSeq !== _workspaceSwitchSeq) return
       set({ currentWorkspaceHash: hash })
       useGatewayStore.getState().notifyProviderChanged()
 
       // 加载新工作区的会话列表
       await useSessionStore.getState().fetchSessions(gatewayAPI, true)
     } catch (err) {
+      if (switchSeq !== _workspaceSwitchSeq) return
       console.error('switchWorkspace failed:', err)
       useUIStore.getState().showToast('Failed to switch workspace', 'error')
     } finally {
-      useChatStore.getState().setTransitioning(false)
-      set({ loading: false })
+      if (switchSeq === _workspaceSwitchSeq) {
+        useChatStore.getState().setTransitioning(false)
+        set({ loading: false })
+      }
     }
   },
 
@@ -126,6 +132,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
 
     set({ loading: true })
+    const switchSeq = ++_workspaceSwitchSeq
 
     // 先清空所有前端状态（与 switchWorkspace 保持一致）
     useChatStore.getState().clearMessages()
@@ -143,6 +150,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
 
     try {
       const result = await gatewayAPI.createWorkspace(path, name)
+      if (switchSeq !== _workspaceSwitchSeq) return
       const w = mapAPIWorkspace(result.payload.workspace)
       set((state) => ({
         workspaces: [w, ...state.workspaces.filter((x) => x.hash !== w.hash)],
@@ -150,19 +158,24 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
 
       // 通知后端切换到新工作区
       await gatewayAPI.switchWorkspace(w.hash)
+      if (switchSeq !== _workspaceSwitchSeq) return
       set({ currentWorkspaceHash: w.hash })
       useGatewayStore.getState().notifyProviderChanged()
 
       // 加载新工作区的会话列表
       await useSessionStore.getState().fetchSessions(gatewayAPI, true)
+      if (switchSeq !== _workspaceSwitchSeq) return
       useUIStore.getState().showToast('Workspace created', 'success')
     } catch (err) {
+      if (switchSeq !== _workspaceSwitchSeq) return
       console.error('createWorkspace failed:', err)
       set({ loading: false })
       useUIStore.getState().showToast('Failed to create workspace', 'error')
     } finally {
-      useChatStore.getState().setTransitioning(false)
-      set({ loading: false })
+      if (switchSeq === _workspaceSwitchSeq) {
+        useChatStore.getState().setTransitioning(false)
+        set({ loading: false })
+      }
     }
   },
 

--- a/web/src/stores/useWorkspaceStore.ts
+++ b/web/src/stores/useWorkspaceStore.ts
@@ -5,6 +5,7 @@ import { useSessionStore } from '@/stores/useSessionStore'
 import { useChatStore } from '@/stores/useChatStore'
 import { useUIStore } from '@/stores/useUIStore'
 import { useGatewayStore } from '@/stores/useGatewayStore'
+import { useRuntimeInsightStore } from '@/stores/useRuntimeInsightStore'
 
 /** 工作区记录 */
 export interface Workspace {
@@ -101,7 +102,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     })
     useSessionStore.getState().resetForWorkspaceSwitch()
     useGatewayStore.getState().setCurrentRunId('')
+    useRuntimeInsightStore.getState().reset()
     useUIStore.getState().clearFileChanges()
+    useUIStore.getState().clearCheckpointRollbackUndo()
     useUIStore.getState().resetPreviewTabs()
     useUIStore.getState().setSearchQuery('')
 
@@ -144,7 +147,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     })
     useSessionStore.getState().resetForWorkspaceSwitch()
     useGatewayStore.getState().setCurrentRunId('')
+    useRuntimeInsightStore.getState().reset()
     useUIStore.getState().clearFileChanges()
+    useUIStore.getState().clearCheckpointRollbackUndo()
     useUIStore.getState().resetPreviewTabs()
     useUIStore.getState().setSearchQuery('')
 

--- a/web/src/stores/useWorkspaceStore.ts
+++ b/web/src/stores/useWorkspaceStore.ts
@@ -21,6 +21,7 @@ interface WorkspaceState {
   workspaces: Workspace[]
   currentWorkspaceHash: string
   loading: boolean
+  changing: boolean
 
   setWorkspaces: (workspaces: Workspace[]) => void
   setCurrentWorkspaceHash: (hash: string) => void
@@ -43,12 +44,13 @@ function mapAPIWorkspace(w: APIWorkspace): Workspace {
 }
 
 let _fetchWorkspacesPromise: Promise<void> | null = null
-let _workspaceSwitchSeq = 0
+let _workspaceChangePromise: Promise<void> | null = null
 
 export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   workspaces: [],
   currentWorkspaceHash: '',
   loading: false,
+  changing: false,
 
   setWorkspaces: (workspaces) => set({ workspaces }),
   setCurrentWorkspaceHash: (currentWorkspaceHash) => set({ currentWorkspaceHash }),
@@ -88,44 +90,45 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       useUIStore.getState().showToast('Cannot switch workspace while generating; stop the current run first.', 'info')
       return
     }
+    if (_workspaceChangePromise) return _workspaceChangePromise
 
-    set({ loading: true })
-    const switchSeq = ++_workspaceSwitchSeq
+    _workspaceChangePromise = (async () => {
+      set({ loading: true, changing: true })
 
-    // 先清空所有前端状态（防止重连 handler 读到旧 sessionId 竞态）
-    useChatStore.getState().clearMessages()
-    useChatStore.getState().setTransitioning(true)
-    useSessionStore.setState({
-      currentSessionId: '',
-      currentProjectId: '',
-      projects: [],
-    })
-    useSessionStore.getState().resetForWorkspaceSwitch()
-    useGatewayStore.getState().setCurrentRunId('')
-    useRuntimeInsightStore.getState().reset()
-    useUIStore.getState().clearFileChanges()
-    useUIStore.getState().clearCheckpointRollbackUndo()
-    useUIStore.getState().resetPreviewTabs()
-    useUIStore.getState().setSearchQuery('')
+      // 先清空所有前端状态（防止重连 handler 读到旧 sessionId 竞态）
+      useChatStore.getState().clearMessages()
+      useChatStore.getState().setTransitioning(true)
+      useSessionStore.setState({
+        currentSessionId: '',
+        currentProjectId: '',
+        projects: [],
+      })
+      useSessionStore.getState().resetForWorkspaceSwitch()
+      useGatewayStore.getState().setCurrentRunId('')
+      useRuntimeInsightStore.getState().reset()
+      useUIStore.getState().clearFileChanges()
+      useUIStore.getState().clearCheckpointRollbackUndo()
+      useUIStore.getState().resetPreviewTabs()
+      useUIStore.getState().setSearchQuery('')
 
-    try {
-      await gatewayAPI.switchWorkspace(hash)
-      if (switchSeq !== _workspaceSwitchSeq) return
-      set({ currentWorkspaceHash: hash })
-      useGatewayStore.getState().notifyProviderChanged()
+      try {
+        await gatewayAPI.switchWorkspace(hash)
+        set({ currentWorkspaceHash: hash })
+        useGatewayStore.getState().notifyProviderChanged()
 
-      // 加载新工作区的会话列表
-      await useSessionStore.getState().fetchSessions(gatewayAPI, true)
-    } catch (err) {
-      if (switchSeq !== _workspaceSwitchSeq) return
-      console.error('switchWorkspace failed:', err)
-      useUIStore.getState().showToast('Failed to switch workspace', 'error')
-    } finally {
-      if (switchSeq === _workspaceSwitchSeq) {
+        // 加载新工作区的会话列表
+        await useSessionStore.getState().fetchSessions(gatewayAPI, true)
+      } catch (err) {
+        console.error('switchWorkspace failed:', err)
+        useUIStore.getState().showToast('Failed to switch workspace', 'error')
+      } finally {
         useChatStore.getState().setTransitioning(false)
-        set({ loading: false })
+        set({ loading: false, changing: false })
+        _workspaceChangePromise = null
       }
-    }
+    })()
+
+    return _workspaceChangePromise
   },
 
   createWorkspace: async (path, gatewayAPI, name) => {
@@ -133,55 +136,53 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       useUIStore.getState().showToast('Cannot switch workspace while generating; stop the current run first.', 'info')
       return
     }
+    if (_workspaceChangePromise) return _workspaceChangePromise
 
-    set({ loading: true })
-    const switchSeq = ++_workspaceSwitchSeq
+    _workspaceChangePromise = (async () => {
+      set({ loading: true, changing: true })
 
-    // 先清空所有前端状态（与 switchWorkspace 保持一致）
-    useChatStore.getState().clearMessages()
-    useChatStore.getState().setTransitioning(true)
-    useSessionStore.setState({
-      currentSessionId: '',
-      currentProjectId: '',
-      projects: [],
-    })
-    useSessionStore.getState().resetForWorkspaceSwitch()
-    useGatewayStore.getState().setCurrentRunId('')
-    useRuntimeInsightStore.getState().reset()
-    useUIStore.getState().clearFileChanges()
-    useUIStore.getState().clearCheckpointRollbackUndo()
-    useUIStore.getState().resetPreviewTabs()
-    useUIStore.getState().setSearchQuery('')
+      // 先清空所有前端状态（与 switchWorkspace 保持一致）
+      useChatStore.getState().clearMessages()
+      useChatStore.getState().setTransitioning(true)
+      useSessionStore.setState({
+        currentSessionId: '',
+        currentProjectId: '',
+        projects: [],
+      })
+      useSessionStore.getState().resetForWorkspaceSwitch()
+      useGatewayStore.getState().setCurrentRunId('')
+      useRuntimeInsightStore.getState().reset()
+      useUIStore.getState().clearFileChanges()
+      useUIStore.getState().clearCheckpointRollbackUndo()
+      useUIStore.getState().resetPreviewTabs()
+      useUIStore.getState().setSearchQuery('')
 
-    try {
-      const result = await gatewayAPI.createWorkspace(path, name)
-      if (switchSeq !== _workspaceSwitchSeq) return
-      const w = mapAPIWorkspace(result.payload.workspace)
-      set((state) => ({
-        workspaces: [w, ...state.workspaces.filter((x) => x.hash !== w.hash)],
-      }))
+      try {
+        const result = await gatewayAPI.createWorkspace(path, name)
+        const w = mapAPIWorkspace(result.payload.workspace)
+        set((state) => ({
+          workspaces: [w, ...state.workspaces.filter((x) => x.hash !== w.hash)],
+        }))
 
-      // 通知后端切换到新工作区
-      await gatewayAPI.switchWorkspace(w.hash)
-      if (switchSeq !== _workspaceSwitchSeq) return
-      set({ currentWorkspaceHash: w.hash })
-      useGatewayStore.getState().notifyProviderChanged()
+        // 通知后端切换到新工作区
+        await gatewayAPI.switchWorkspace(w.hash)
+        set({ currentWorkspaceHash: w.hash })
+        useGatewayStore.getState().notifyProviderChanged()
 
-      // 加载新工作区的会话列表
-      await useSessionStore.getState().fetchSessions(gatewayAPI, true)
-      if (switchSeq !== _workspaceSwitchSeq) return
-      useUIStore.getState().showToast('Workspace created', 'success')
-    } catch (err) {
-      if (switchSeq !== _workspaceSwitchSeq) return
-      console.error('createWorkspace failed:', err)
-      set({ loading: false })
-      useUIStore.getState().showToast('Failed to create workspace', 'error')
-    } finally {
-      if (switchSeq === _workspaceSwitchSeq) {
+        // 加载新工作区的会话列表
+        await useSessionStore.getState().fetchSessions(gatewayAPI, true)
+        useUIStore.getState().showToast('Workspace created', 'success')
+      } catch (err) {
+        console.error('createWorkspace failed:', err)
+        useUIStore.getState().showToast('Failed to create workspace', 'error')
+      } finally {
         useChatStore.getState().setTransitioning(false)
-        set({ loading: false })
+        set({ loading: false, changing: false })
+        _workspaceChangePromise = null
       }
-    }
+    })()
+
+    return _workspaceChangePromise
   },
 
   renameWorkspace: async (hash, name, gatewayAPI) => {

--- a/web/src/utils/eventBridge.test.ts
+++ b/web/src/utils/eventBridge.test.ts
@@ -102,6 +102,65 @@ describe("eventBridge", () => {
     expect(useChatStore.getState().messages[0].content).toBe("Hello");
   });
 
+  it("drops stale session events after session switch for tool and chunk updates", () => {
+    const api = createMockGatewayAPI();
+    useSessionStore.setState({ currentSessionId: "sess-new" } as any);
+
+    handleGatewayEvent(
+      {
+        type: EventType.ToolStart,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.ToolStart,
+            payload: {
+              name: "filesystem_write_file",
+              id: "tc-old",
+              arguments: '{"path":"stale.txt"}',
+            },
+          },
+        },
+        session_id: "sess-old",
+        run_id: "run-old",
+      },
+      api,
+    );
+
+    handleGatewayEvent(
+      {
+        type: EventType.ToolDiff,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.ToolDiff,
+            payload: {
+              tool_name: "filesystem_write_file",
+              file_path: "stale.txt",
+              diff: "--- a/stale.txt\n+++ b/stale.txt\n@@ -0,0 +1 @@\n+old\n",
+              was_new: true,
+            },
+          },
+        },
+        session_id: "sess-old",
+        run_id: "run-old",
+      },
+      api,
+    );
+
+    handleGatewayEvent(
+      {
+        type: EventType.AgentChunk,
+        payload: {
+          payload: { runtime_event_type: EventType.AgentChunk, payload: "stale chunk" },
+        },
+        session_id: "sess-old",
+        run_id: "run-old",
+      },
+      api,
+    );
+
+    expect(useChatStore.getState().messages).toHaveLength(0);
+    expect(useUIStore.getState().fileChanges).toHaveLength(0);
+  });
+
   it("AgentDone finalizes message from parts array", () => {
     const api = createMockGatewayAPI();
     const store = useChatStore.getState();

--- a/web/src/utils/eventBridge.test.ts
+++ b/web/src/utils/eventBridge.test.ts
@@ -388,6 +388,49 @@ describe("eventBridge", () => {
     expect(useChatStore.getState().pendingUserQuestion).toBeNull();
   });
 
+  it("PermissionRequested and PermissionResolved update permission requests", () => {
+    const api = createMockGatewayAPI();
+    handleGatewayEvent(
+      {
+        type: EventType.PermissionRequested,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.PermissionRequested,
+            payload: {
+              request_id: "perm-1",
+              tool_call_id: "tc-1",
+              tool_name: "bash",
+              action_type: "run",
+            },
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-1",
+      },
+      api,
+    );
+
+    expect(useChatStore.getState().permissionRequests).toHaveLength(1);
+    expect(useChatStore.getState().permissionRequests[0].request_id).toBe("perm-1");
+
+    handleGatewayEvent(
+      {
+        type: EventType.PermissionResolved,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.PermissionResolved,
+            payload: { request_id: "perm-1" },
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-1",
+      },
+      api,
+    );
+
+    expect(useChatStore.getState().permissionRequests).toHaveLength(0);
+  });
+
   it("ToolStart adds a tool call message", () => {
     const api = createMockGatewayAPI();
     handleGatewayEvent(
@@ -689,6 +732,40 @@ describe("eventBridge", () => {
     expect(useChatStore.getState().messages[0].toolStatus).toBe("running");
   });
 
+  it("Error shows toast, resets generation, and marks running tool calls as error", () => {
+    const api = createMockGatewayAPI();
+    useChatStore.getState().addMessage({
+      id: "tool-running-error",
+      role: "tool",
+      type: "tool_call",
+      content: "",
+      toolName: "bash",
+      toolCallId: "tc-error",
+      toolStatus: "running",
+      timestamp: Date.now(),
+    });
+    useChatStore.getState().setGenerating(true);
+
+    handleGatewayEvent(
+      {
+        type: EventType.Error,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.Error,
+            payload: "boom",
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-1",
+      },
+      api,
+    );
+
+    expect(useChatStore.getState().isGenerating).toBe(false);
+    expect(useChatStore.getState().messages[0].toolStatus).toBe("error");
+    expect(useUIStore.getState().toasts.at(-1)?.message).toBe("boom");
+  });
+
   it("BudgetChecked updates runtime insight budget state", () => {
     const api = createMockGatewayAPI();
     handleGatewayEvent(
@@ -716,6 +793,62 @@ describe("eventBridge", () => {
       "allow",
     );
     expect(useRuntimeInsightStore.getState().budgetUsageRatio).toBe(0.8);
+  });
+
+  it("TokenUsage, BudgetEstimateFailed, and LedgerReconciled update store snapshots", () => {
+    const api = createMockGatewayAPI();
+
+    handleGatewayEvent(
+      {
+        type: EventType.TokenUsage,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.TokenUsage,
+            payload: { input_tokens: 3, output_tokens: 5, total_tokens: 8 },
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-1",
+      },
+      api,
+    );
+    expect(useChatStore.getState().tokenUsage?.total_tokens).toBe(8);
+
+    handleGatewayEvent(
+      {
+        type: EventType.BudgetEstimateFailed,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.BudgetEstimateFailed,
+            payload: { reason: "missing_price", detail: "no price rule" },
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-1",
+      },
+      api,
+    );
+    expect(useRuntimeInsightStore.getState().budgetEstimateFailed?.reason).toBe(
+      "missing_price",
+    );
+
+    handleGatewayEvent(
+      {
+        type: EventType.LedgerReconciled,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.LedgerReconciled,
+            payload: { estimated_cost_usd: 1, actual_cost_usd: 0.8, delta_usd: -0.2 },
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-1",
+      },
+      api,
+    );
+    expect(useRuntimeInsightStore.getState().ledgerReconciled?.actual_cost_usd).toBe(
+      0.8,
+    );
   });
 
   it("CompactStart sets persistent compact state without a toast", () => {
@@ -1123,6 +1256,31 @@ describe("eventBridge", () => {
       "invalid_transition",
     );
     expect(useUIStore.getState().toasts).toHaveLength(0);
+  });
+
+  it("TodoConflict surfaces a toast for non-recoverable reasons", () => {
+    const api = createMockGatewayAPI();
+    handleGatewayEvent(
+      {
+        type: EventType.TodoConflict,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.TodoConflict,
+            payload: { action: "update", reason: "server_desync" },
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-1",
+      },
+      api,
+    );
+
+    expect(useRuntimeInsightStore.getState().todoConflict?.reason).toBe(
+      "server_desync",
+    );
+    expect(useUIStore.getState().toasts.at(-1)?.message).toBe(
+      "Todo conflict: server_desync",
+    );
   });
 
   it("TodoConflict invalid_arguments shows info toast", () => {
@@ -1832,6 +1990,39 @@ describe("eventBridge", () => {
     expect(useRuntimeInsightStore.getState().acceptanceDecision?.status).toBe(
       "accepted",
     );
+  });
+
+  it("Skill and asset events surface user-facing toasts", () => {
+    const api = createMockGatewayAPI();
+    for (const [eventType, payload] of [
+      [EventType.SkillActivated, { skill_id: "skill-a" }],
+      [EventType.SkillDeactivated, { skill_id: "skill-a" }],
+      [EventType.SkillMissing, { skill_id: "skill-b" }],
+      [EventType.AssetSaved, { path: "/tmp/result.txt" }],
+      [EventType.AssetSaveFailed, { path: "/tmp/result.txt" }],
+    ] as const) {
+      handleGatewayEvent(
+        {
+          type: eventType,
+          payload: {
+            payload: {
+              runtime_event_type: eventType,
+              payload,
+            },
+          },
+          session_id: "sess-1",
+          run_id: "run-1",
+        },
+        api,
+      );
+    }
+
+    const toastMessages = useUIStore.getState().toasts.map((toast) => toast.message);
+    expect(toastMessages).toContain("Skill activated: skill-a");
+    expect(toastMessages).toContain("Skill deactivated: skill-a");
+    expect(toastMessages).toContain("Skill unavailable: skill-b");
+    expect(toastMessages).toContain("File saved: /tmp/result.txt");
+    expect(toastMessages).toContain("Failed to save file: /tmp/result.txt");
   });
 
   it("CheckpointCreated only records runtime insight and does not decorate completed tool calls", () => {

--- a/web/src/utils/eventBridge.test.ts
+++ b/web/src/utils/eventBridge.test.ts
@@ -21,6 +21,7 @@ function createMockGatewayAPI(overrides: Record<string, unknown> = {}) {
 }
 
 beforeEach(() => {
+  vi.restoreAllMocks();
   resetEventBridgeCursors();
   useChatStore.setState({
     messages: [],
@@ -159,6 +160,83 @@ describe("eventBridge", () => {
 
     expect(useChatStore.getState().messages).toHaveLength(0);
     expect(useUIStore.getState().fileChanges).toHaveLength(0);
+  });
+
+  it("drops stale InputNormalized events after session switch", () => {
+    const clearFileChangesSpy = vi.spyOn(
+      useUIStore.getState(),
+      "clearFileChanges",
+    );
+    const setCurrentRunIdSpy = vi.spyOn(
+      useGatewayStore.getState(),
+      "setCurrentRunId",
+    );
+    const listSessions = vi.fn().mockResolvedValue({ payload: { sessions: [] } });
+    const api = createMockGatewayAPI({ listSessions });
+    useSessionStore.setState({ currentSessionId: "sess-new" } as any);
+    useGatewayStore.setState({ currentRunId: "run-current" } as any);
+
+    handleGatewayEvent(
+      {
+        type: EventType.InputNormalized,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.InputNormalized,
+            payload: {
+              session_id: "sess-old",
+              run_id: "run-old",
+            },
+          },
+        },
+        session_id: "sess-old",
+        run_id: "run-old",
+      },
+      api,
+    );
+
+    expect(useSessionStore.getState().currentSessionId).toBe("sess-new");
+    expect(useGatewayStore.getState().currentRunId).toBe("run-current");
+    expect(setCurrentRunIdSpy).not.toHaveBeenCalled();
+    expect(clearFileChangesSpy).not.toHaveBeenCalled();
+    expect(listSessions).not.toHaveBeenCalled();
+  });
+
+  it("accepts InputNormalized when there is no current session yet", async () => {
+    const clearFileChangesSpy = vi.spyOn(
+      useUIStore.getState(),
+      "clearFileChanges",
+    );
+    const setCurrentRunIdSpy = vi.spyOn(
+      useGatewayStore.getState(),
+      "setCurrentRunId",
+    );
+    const listSessions = vi.fn().mockResolvedValue({ payload: { sessions: [] } });
+    const api = createMockGatewayAPI({ listSessions });
+
+    handleGatewayEvent(
+      {
+        type: EventType.InputNormalized,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.InputNormalized,
+            payload: {
+              session_id: "sess-first",
+              run_id: "run-first",
+            },
+          },
+        },
+        session_id: "sess-first",
+        run_id: "run-first",
+      },
+      api,
+    );
+
+    expect(useSessionStore.getState().currentSessionId).toBe("sess-first");
+    expect(setCurrentRunIdSpy).toHaveBeenCalledWith("run-first");
+    expect(clearFileChangesSpy).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(listSessions).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("AgentDone finalizes message from parts array", () => {

--- a/web/src/utils/eventBridge.ts
+++ b/web/src/utils/eventBridge.ts
@@ -538,6 +538,10 @@ function normalizeUserQuestionRequestedPayload(
 }
 
 const CRITICAL_EVENTS = new Set<string>([EventType.Error]);
+const SESSION_AGNOSTIC_EVENTS = new Set<string>([
+  EventType.Error,
+  EventType.InputNormalized,
+]);
 
 function strField(payload: unknown, key: string): string {
   return ((payload as PayloadRecord)?.[key] as string) ?? "";
@@ -632,6 +636,8 @@ export function handleGatewayEvent(
     (innerEnvelope?.runtime_event_type as string | undefined) ??
     (payload.event_type as string | undefined);
   if (!eventType) return;
+  const frameSessionId = (frame.session_id || "").trim();
+  const frameRunId = frame.run_id;
 
   // Discard non-critical events during workspace transition to avoid stale data
   // Only Error events are allowed through during transition
@@ -642,15 +648,22 @@ export function handleGatewayEvent(
     return;
   }
 
+  const currentSessionId = useSessionStore.getState().currentSessionId.trim();
+  if (
+    frameSessionId &&
+    currentSessionId &&
+    frameSessionId !== currentSessionId &&
+    !SESSION_AGNOSTIC_EVENTS.has(eventType)
+  ) {
+    return;
+  }
+
   const eventPayload = innerEnvelope?.payload;
 
   const chatStore = useChatStore.getState();
   const uiStore = useUIStore.getState();
   const gwStore = useGatewayStore.getState();
   const insightStore = useRuntimeInsightStore.getState();
-
-  const frameSessionId = frame.session_id;
-  const frameRunId = frame.run_id;
 
   /** 更新最新 verification 消息的 data 为 insightStore 当前最后一条 record */
   function syncLatestVerificationToChat() {

--- a/web/src/utils/eventBridge.ts
+++ b/web/src/utils/eventBridge.ts
@@ -540,7 +540,6 @@ function normalizeUserQuestionRequestedPayload(
 const CRITICAL_EVENTS = new Set<string>([EventType.Error]);
 const SESSION_AGNOSTIC_EVENTS = new Set<string>([
   EventType.Error,
-  EventType.InputNormalized,
 ]);
 
 function strField(payload: unknown, key: string): string {


### PR DESCRIPTION
## 背景
本 PR 解决 Web 工作会话/工作区切换中的竞态覆盖问题，以及网关文件预览接口可能受客户端 `workdir` 影响导致的边界风险。

## 改动概览

### 1) 前端切换一致性修复
- `web/src/stores/useSessionStore.ts`
  - 调整 `switchSession` 顺序：先 `clearMessages()`，再 `setTransitioning(true)`，确保切换窗口期事件过滤有效。
  - 为 `fetchSessions` 增加请求代际序号，晚到旧响应不再覆盖新状态。
  - `resetForWorkspaceSwitch` 会使旧请求失效。

- `web/src/stores/useWorkspaceStore.ts`
  - 为 `switchWorkspace` / `createWorkspace` 增加 `switchSeq`，仅最新切换可落状态。
  - 旧切换晚到响应直接丢弃，避免状态回跳。

- `web/src/utils/eventBridge.ts`
  - 增加统一会话过滤：非全局关键事件需匹配 `currentSessionId`，否则丢弃。
  - 保留全局关键事件通路（如 `Error`，以及会话对齐所需事件）。

### 2) 网关工作区边界收敛
- `internal/cli/gateway_runtime_bridge.go`
  - `resolveListFilesRoot` 不再信任客户端 `input.Workdir`。
  - 根目录解析统一为：当前工作区根 + 合法会话 workdir（需在 workspace root 内）。
  - 会话 workdir 越界时返回受控错误。
  - `ListFiles / ReadFile / ListGitDiffFiles / ReadGitDiffFile` 统一复用该策略。

### 3) 文档更新
- `docs/reference/tui-gateway-contract-matrix.md`
  - 明确文件预览相关接口受当前工作区边界约束，`workdir` 字段保留兼容但不作为越界覆盖入口。

## 测试

### 已新增/更新测试
- 后端：
  - `internal/cli/gateway_runtime_bridge_test.go`
  - 覆盖：
    - 忽略外部 `workdir`
    - 会话 workdir 越界拒绝
    - git diff 预览接口同策略
- 前端：
  - `web/src/stores/useSessionStore.test.ts`
  - `web/src/stores/useWorkspaceStore.test.ts`
  - `web/src/utils/eventBridge.test.ts`
  - 覆盖：
    - 切换窗口 `isTransitioning` 保持
    - 并发切换晚到响应不回写
    - 旧会话事件被过滤

### 本地验证
- `go test ./internal/cli -run "ResolveListFilesRoot|ListFiles|ReadFile|GitDiff"` ✅
- `npm test -- --run src/stores/useSessionStore.test.ts src/stores/useWorkspaceStore.test.ts src/utils/eventBridge.test.ts` ✅

## 兼容性说明
- JSON-RPC 字段兼容保持不变；
- 语义调整为“当前工作区边界优先”，客户端 `workdir` 不再作为文件预览根目录覆盖来源。

## 风险与回滚
- 风险：依赖旧行为（请求级 `workdir` 覆盖）的调用方将感知更严格边界。
- 回滚：可先回滚前端代际逻辑；边界收敛建议保持（安全基线）。

close #652 