### PR TITLE
fix(runtime/tui): gate stale resume checkpoint and complete verification lifecycle event contract

### DIFF
--- a/internal/runtime/checkpoint_flow_test.go
+++ b/internal/runtime/checkpoint_flow_test.go
@@ -347,6 +347,7 @@ func TestApplyResumeCheckpointReplayPlanStrategy(t *testing.T) {
 	state := newRunState("run-resume-plan", fixture.session)
 	currentWorkspaceKey := resolveResumeWorkspaceKey(state.session.Workdir, state.effectiveWorkdir)
 	currentTranscriptRevision := sessionTranscriptRevision(state.session)
+	currentLegacyTranscriptRevision := sessionLegacyTranscriptRevision(state.session)
 	spy := &checkpointStoreSpy{
 		latestResume: &agentsession.ResumeCheckpoint{
 			RunID:              "run-old",
@@ -358,7 +359,7 @@ func TestApplyResumeCheckpointReplayPlanStrategy(t *testing.T) {
 			TranscriptRevision: currentTranscriptRevision,
 		},
 	}
-	if !resumeCheckpointMatchesState(*spy.latestResume, currentWorkspaceKey, currentTranscriptRevision) {
+	if !resumeCheckpointMatchesState(*spy.latestResume, currentWorkspaceKey, currentTranscriptRevision, currentLegacyTranscriptRevision) {
 		t.Fatalf("resume checkpoint should match current state in replay-plan strategy case")
 	}
 	service := &Service{
@@ -384,6 +385,7 @@ func TestApplyResumeCheckpointVerifyClosureStrategy(t *testing.T) {
 	state := newRunState("run-resume-verify", fixture.session)
 	currentWorkspaceKey := resolveResumeWorkspaceKey(state.session.Workdir, state.effectiveWorkdir)
 	currentTranscriptRevision := sessionTranscriptRevision(state.session)
+	currentLegacyTranscriptRevision := sessionLegacyTranscriptRevision(state.session)
 	spy := &checkpointStoreSpy{
 		latestResume: &agentsession.ResumeCheckpoint{
 			RunID:              "run-old-verify",
@@ -395,7 +397,7 @@ func TestApplyResumeCheckpointVerifyClosureStrategy(t *testing.T) {
 			TranscriptRevision: currentTranscriptRevision,
 		},
 	}
-	if !resumeCheckpointMatchesState(*spy.latestResume, currentWorkspaceKey, currentTranscriptRevision) {
+	if !resumeCheckpointMatchesState(*spy.latestResume, currentWorkspaceKey, currentTranscriptRevision, currentLegacyTranscriptRevision) {
 		t.Fatalf("resume checkpoint should match current state in verify-closure strategy case")
 	}
 	service := &Service{
@@ -512,6 +514,64 @@ func TestSessionTranscriptRevisionChangesWithoutMessageCountChange(t *testing.T)
 	}
 	if sessionTranscriptRevision(base) == sessionTranscriptRevision(next) {
 		t.Fatalf("expected transcript revision token to change when task/todo state changes without message-count change")
+	}
+}
+
+func TestSessionTranscriptRevisionIgnoresMetadataOnlyUpdatedAt(t *testing.T) {
+	t.Parallel()
+
+	base := agentsession.NewWithWorkdir("resume-token-metadata", t.TempDir())
+	base.Messages = []providertypes.Message{
+		{
+			Role: providertypes.RoleUser,
+			Parts: []providertypes.ContentPart{
+				providertypes.NewTextPart("same"),
+			},
+		},
+	}
+	base.TaskState = agentsession.TaskState{
+		Goal:          "same-goal",
+		LastUpdatedAt: time.Unix(1700001000, 0).UTC(),
+	}
+	base.UpdatedAt = time.Unix(1700002000, 0).UTC()
+
+	next := base
+	next.UpdatedAt = time.Unix(1700009000, 0).UTC()
+
+	if sessionTranscriptRevision(base) != sessionTranscriptRevision(next) {
+		t.Fatalf("expected transcript revision token to ignore metadata-only UpdatedAt changes")
+	}
+}
+
+func TestResumeCheckpointMatchesStateSupportsLegacyMessageCountFallback(t *testing.T) {
+	t.Parallel()
+
+	session := agentsession.NewWithWorkdir("legacy-resume", t.TempDir())
+	session.Messages = []providertypes.Message{
+		{
+			Role: providertypes.RoleUser,
+			Parts: []providertypes.ContentPart{
+				providertypes.NewTextPart("a"),
+			},
+		},
+	}
+	session.TaskState = agentsession.TaskState{
+		Goal:          "legacy fallback",
+		LastUpdatedAt: time.Unix(1700010000, 0).UTC(),
+	}
+	workspaceKey := agentsession.WorkspacePathKey(session.Workdir)
+	currentRevision := sessionTranscriptRevision(session)
+	legacyRevision := sessionLegacyTranscriptRevision(session)
+	if legacyRevision <= 0 {
+		t.Fatalf("legacy transcript revision should be positive, got %d", legacyRevision)
+	}
+
+	resume := agentsession.ResumeCheckpoint{
+		WorkspaceKey:       workspaceKey,
+		TranscriptRevision: legacyRevision,
+	}
+	if !resumeCheckpointMatchesState(resume, workspaceKey, currentRevision, legacyRevision) {
+		t.Fatalf("expected legacy len(messages) checkpoint to match during compatibility fallback")
 	}
 }
 

--- a/internal/runtime/checkpoint_flow_test.go
+++ b/internal/runtime/checkpoint_flow_test.go
@@ -345,16 +345,21 @@ func TestUpdateResumeCheckpoint(t *testing.T) {
 func TestApplyResumeCheckpointReplayPlanStrategy(t *testing.T) {
 	fixture := newRuntimeCheckpointFixture(t)
 	state := newRunState("run-resume-plan", fixture.session)
+	currentWorkspaceKey := resolveResumeWorkspaceKey(state.session.Workdir, state.effectiveWorkdir)
+	currentTranscriptRevision := sessionTranscriptRevision(state.session)
 	spy := &checkpointStoreSpy{
 		latestResume: &agentsession.ResumeCheckpoint{
 			RunID:              "run-old",
-			WorkspaceKey:       agentsession.WorkspacePathKey(fixture.session.Workdir),
+			WorkspaceKey:       currentWorkspaceKey,
 			SessionID:          fixture.session.ID,
 			Turn:               4,
 			Phase:              "execute",
 			CompletionState:    "",
-			TranscriptRevision: int64(len(fixture.session.Messages)),
+			TranscriptRevision: currentTranscriptRevision,
 		},
+	}
+	if !resumeCheckpointMatchesState(*spy.latestResume, currentWorkspaceKey, currentTranscriptRevision) {
+		t.Fatalf("resume checkpoint should match current state in replay-plan strategy case")
 	}
 	service := &Service{
 		checkpointStore:  spy,
@@ -377,16 +382,21 @@ func TestApplyResumeCheckpointReplayPlanStrategy(t *testing.T) {
 func TestApplyResumeCheckpointVerifyClosureStrategy(t *testing.T) {
 	fixture := newRuntimeCheckpointFixture(t)
 	state := newRunState("run-resume-verify", fixture.session)
+	currentWorkspaceKey := resolveResumeWorkspaceKey(state.session.Workdir, state.effectiveWorkdir)
+	currentTranscriptRevision := sessionTranscriptRevision(state.session)
 	spy := &checkpointStoreSpy{
 		latestResume: &agentsession.ResumeCheckpoint{
 			RunID:              "run-old-verify",
-			WorkspaceKey:       agentsession.WorkspacePathKey(fixture.session.Workdir),
+			WorkspaceKey:       currentWorkspaceKey,
 			SessionID:          fixture.session.ID,
 			Turn:               2,
 			Phase:              "verify",
 			CompletionState:    "completed",
-			TranscriptRevision: int64(len(fixture.session.Messages)),
+			TranscriptRevision: currentTranscriptRevision,
 		},
+	}
+	if !resumeCheckpointMatchesState(*spy.latestResume, currentWorkspaceKey, currentTranscriptRevision) {
+		t.Fatalf("resume checkpoint should match current state in verify-closure strategy case")
 	}
 	service := &Service{
 		checkpointStore:  spy,
@@ -428,7 +438,7 @@ func TestApplyResumeCheckpointSkipsUnsupportedInputs(t *testing.T) {
 			Turn:               1,
 			Phase:              "stopped",
 			CompletionState:    "completed",
-			TranscriptRevision: int64(len(fixture.session.Messages)),
+			TranscriptRevision: sessionTranscriptRevision(fixture.session),
 		},
 	}
 	service.applyResumeCheckpoint(context.Background(), &unsupportedState)
@@ -472,6 +482,39 @@ func TestDeriveResumeBaseLifecycle(t *testing.T) {
 	}
 }
 
+func TestSessionTranscriptRevisionChangesWithoutMessageCountChange(t *testing.T) {
+	t.Parallel()
+
+	base := agentsession.NewWithWorkdir("resume-token", t.TempDir())
+	base.Messages = []providertypes.Message{
+		{
+			Role: providertypes.RoleUser,
+			Parts: []providertypes.ContentPart{
+				providertypes.NewTextPart("same-message-count"),
+			},
+		},
+	}
+	base.UpdatedAt = time.Unix(1700000000, 0).UTC()
+	base.TaskState = agentsession.TaskState{
+		Goal:          "implement flow",
+		LastUpdatedAt: time.Unix(1700000001, 0).UTC(),
+	}
+	base.TodoVersion = 1
+
+	next := base
+	next.TaskState.NextStep = "run verification"
+	next.TaskState.LastUpdatedAt = time.Unix(1700000002, 0).UTC()
+	next.UpdatedAt = time.Unix(1700000003, 0).UTC()
+	next.TodoVersion = 2
+
+	if len(base.Messages) != len(next.Messages) {
+		t.Fatalf("message count changed unexpectedly: %d -> %d", len(base.Messages), len(next.Messages))
+	}
+	if sessionTranscriptRevision(base) == sessionTranscriptRevision(next) {
+		t.Fatalf("expected transcript revision token to change when task/todo state changes without message-count change")
+	}
+}
+
 func TestApplyResumeCheckpointSkipsWorkspaceMismatch(t *testing.T) {
 	fixture := newRuntimeCheckpointFixture(t)
 	state := newRunState("run-resume-workspace-mismatch", fixture.session)
@@ -482,7 +525,7 @@ func TestApplyResumeCheckpointSkipsWorkspaceMismatch(t *testing.T) {
 			SessionID:          fixture.session.ID,
 			Turn:               1,
 			Phase:              "execute",
-			TranscriptRevision: int64(len(fixture.session.Messages)),
+			TranscriptRevision: sessionTranscriptRevision(fixture.session),
 			CompletionState:    "",
 		},
 	}
@@ -515,7 +558,7 @@ func TestApplyResumeCheckpointSkipsTranscriptRevisionMismatch(t *testing.T) {
 			SessionID:          fixture.session.ID,
 			Turn:               1,
 			Phase:              "execute",
-			TranscriptRevision: int64(len(fixture.session.Messages) + 3),
+			TranscriptRevision: sessionTranscriptRevision(fixture.session) + 1,
 			CompletionState:    "",
 		},
 	}
@@ -579,7 +622,7 @@ func TestServiceRunResumeVerifyClosureBootstrapsFirstTurn(t *testing.T) {
 			Turn:               2,
 			Phase:              "verify",
 			CompletionState:    "completed",
-			TranscriptRevision: int64(len(seed.Messages)),
+			TranscriptRevision: sessionTranscriptRevision(seed),
 		},
 	}
 	service := NewWithFactory(

--- a/internal/runtime/checkpoint_flow_test.go
+++ b/internal/runtime/checkpoint_flow_test.go
@@ -347,11 +347,13 @@ func TestApplyResumeCheckpointReplayPlanStrategy(t *testing.T) {
 	state := newRunState("run-resume-plan", fixture.session)
 	spy := &checkpointStoreSpy{
 		latestResume: &agentsession.ResumeCheckpoint{
-			RunID:           "run-old",
-			SessionID:       fixture.session.ID,
-			Turn:            4,
-			Phase:           "execute",
-			CompletionState: "",
+			RunID:              "run-old",
+			WorkspaceKey:       agentsession.WorkspacePathKey(fixture.session.Workdir),
+			SessionID:          fixture.session.ID,
+			Turn:               4,
+			Phase:              "execute",
+			CompletionState:    "",
+			TranscriptRevision: int64(len(fixture.session.Messages)),
 		},
 	}
 	service := &Service{
@@ -377,11 +379,13 @@ func TestApplyResumeCheckpointVerifyClosureStrategy(t *testing.T) {
 	state := newRunState("run-resume-verify", fixture.session)
 	spy := &checkpointStoreSpy{
 		latestResume: &agentsession.ResumeCheckpoint{
-			RunID:           "run-old-verify",
-			SessionID:       fixture.session.ID,
-			Turn:            2,
-			Phase:           "verify",
-			CompletionState: "completed",
+			RunID:              "run-old-verify",
+			WorkspaceKey:       agentsession.WorkspacePathKey(fixture.session.Workdir),
+			SessionID:          fixture.session.ID,
+			Turn:               2,
+			Phase:              "verify",
+			CompletionState:    "completed",
+			TranscriptRevision: int64(len(fixture.session.Messages)),
 		},
 	}
 	service := &Service{
@@ -418,11 +422,13 @@ func TestApplyResumeCheckpointSkipsUnsupportedInputs(t *testing.T) {
 	unsupportedState := newRunState("run-unsupported-resume", fixture.session)
 	service.checkpointStore = &checkpointStoreSpy{
 		latestResume: &agentsession.ResumeCheckpoint{
-			RunID:           "run-unknown",
-			SessionID:       fixture.session.ID,
-			Turn:            1,
-			Phase:           "stopped",
-			CompletionState: "completed",
+			RunID:              "run-unknown",
+			WorkspaceKey:       agentsession.WorkspacePathKey(fixture.session.Workdir),
+			SessionID:          fixture.session.ID,
+			Turn:               1,
+			Phase:              "stopped",
+			CompletionState:    "completed",
+			TranscriptRevision: int64(len(fixture.session.Messages)),
 		},
 	}
 	service.applyResumeCheckpoint(context.Background(), &unsupportedState)
@@ -466,11 +472,92 @@ func TestDeriveResumeBaseLifecycle(t *testing.T) {
 	}
 }
 
+func TestApplyResumeCheckpointSkipsWorkspaceMismatch(t *testing.T) {
+	fixture := newRuntimeCheckpointFixture(t)
+	state := newRunState("run-resume-workspace-mismatch", fixture.session)
+	spy := &checkpointStoreSpy{
+		latestResume: &agentsession.ResumeCheckpoint{
+			RunID:              "run-old",
+			WorkspaceKey:       "workspace://stale",
+			SessionID:          fixture.session.ID,
+			Turn:               1,
+			Phase:              "execute",
+			TranscriptRevision: int64(len(fixture.session.Messages)),
+			CompletionState:    "",
+		},
+	}
+	service := &Service{
+		checkpointStore:  spy,
+		events:           make(chan RuntimeEvent, 16),
+		runtimeSnapshots: make(map[string]RuntimeSnapshot),
+	}
+
+	service.applyResumeCheckpoint(context.Background(), &state)
+
+	if state.resumeNextBaseLifecycle != "" {
+		t.Fatalf("resumeNextBaseLifecycle = %q, want empty", state.resumeNextBaseLifecycle)
+	}
+	if strings.TrimSpace(state.pendingSystemReminder) != "" {
+		t.Fatalf("pendingSystemReminder = %q, want empty", state.pendingSystemReminder)
+	}
+	if len(collectRuntimeEvents(service.Events())) != 0 {
+		t.Fatal("expected no runtime events when workspace key mismatches")
+	}
+}
+
+func TestApplyResumeCheckpointSkipsTranscriptRevisionMismatch(t *testing.T) {
+	fixture := newRuntimeCheckpointFixture(t)
+	state := newRunState("run-resume-transcript-mismatch", fixture.session)
+	spy := &checkpointStoreSpy{
+		latestResume: &agentsession.ResumeCheckpoint{
+			RunID:              "run-old",
+			WorkspaceKey:       agentsession.WorkspacePathKey(fixture.session.Workdir),
+			SessionID:          fixture.session.ID,
+			Turn:               1,
+			Phase:              "execute",
+			TranscriptRevision: int64(len(fixture.session.Messages) + 3),
+			CompletionState:    "",
+		},
+	}
+	service := &Service{
+		checkpointStore:  spy,
+		events:           make(chan RuntimeEvent, 16),
+		runtimeSnapshots: make(map[string]RuntimeSnapshot),
+	}
+
+	service.applyResumeCheckpoint(context.Background(), &state)
+
+	if state.resumeNextBaseLifecycle != "" {
+		t.Fatalf("resumeNextBaseLifecycle = %q, want empty", state.resumeNextBaseLifecycle)
+	}
+	if strings.TrimSpace(state.pendingSystemReminder) != "" {
+		t.Fatalf("pendingSystemReminder = %q, want empty", state.pendingSystemReminder)
+	}
+	if len(collectRuntimeEvents(service.Events())) != 0 {
+		t.Fatal("expected no runtime events when transcript revision mismatches")
+	}
+}
+
 func TestServiceRunResumeVerifyClosureBootstrapsFirstTurn(t *testing.T) {
 	t.Parallel()
 
 	manager := newRuntimeConfigManager(t)
 	store := newMemoryStore()
+	seed, err := store.CreateSession(context.Background(), agentsession.CreateSessionInput{
+		ID:    "session-resume-verify",
+		Title: "resume verify seed",
+		Head: agentsession.SessionHead{
+			Provider: "openai",
+			Model:    manager.Get().CurrentModel,
+			Workdir:  manager.Get().Workdir,
+			TaskState: agentsession.TaskState{
+				VerificationProfile: agentsession.VerificationProfileTaskOnly,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
 	providerImpl := &scriptedProvider{
 		responses: []scriptedResponse{
 			{
@@ -486,11 +573,13 @@ func TestServiceRunResumeVerifyClosureBootstrapsFirstTurn(t *testing.T) {
 	}
 	resumeStore := &checkpointStoreSpy{
 		latestResume: &agentsession.ResumeCheckpoint{
-			RunID:           "run-old-verify",
-			SessionID:       "ignored-by-spy",
-			Turn:            2,
-			Phase:           "verify",
-			CompletionState: "completed",
+			RunID:              "run-old-verify",
+			WorkspaceKey:       agentsession.WorkspacePathKey(seed.Workdir),
+			SessionID:          seed.ID,
+			Turn:               2,
+			Phase:              "verify",
+			CompletionState:    "completed",
+			TranscriptRevision: int64(len(seed.Messages)),
 		},
 	}
 	service := NewWithFactory(
@@ -505,8 +594,9 @@ func TestServiceRunResumeVerifyClosureBootstrapsFirstTurn(t *testing.T) {
 	service.runtimeSnapshots = make(map[string]RuntimeSnapshot)
 
 	if err := service.Run(context.Background(), UserInput{
-		RunID: "run-resume-verify-first-turn",
-		Parts: []providertypes.ContentPart{providertypes.NewTextPart("continue")},
+		RunID:     "run-resume-verify-first-turn",
+		SessionID: seed.ID,
+		Parts:     []providertypes.ContentPart{providertypes.NewTextPart("continue")},
 	}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}

--- a/internal/runtime/checkpoint_flow_test.go
+++ b/internal/runtime/checkpoint_flow_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,6 +18,7 @@ import (
 
 type checkpointStoreSpy struct {
 	lastResume      agentsession.ResumeCheckpoint
+	setResumeErr    error
 	latestResume    *agentsession.ResumeCheckpoint
 	latestResumeErr error
 	listRecords     []agentsession.CheckpointRecord
@@ -56,7 +58,7 @@ func (s *checkpointStoreSpy) RestoreCheckpoint(context.Context, checkpoint.Resto
 
 func (s *checkpointStoreSpy) SetResumeCheckpoint(_ context.Context, rc agentsession.ResumeCheckpoint) error {
 	s.lastResume = rc
-	return nil
+	return s.setResumeErr
 }
 
 func (s *checkpointStoreSpy) PruneExpiredCheckpoints(context.Context, string, int) (int, error) {
@@ -342,6 +344,32 @@ func TestUpdateResumeCheckpoint(t *testing.T) {
 	}
 }
 
+func TestUpdateResumeCheckpointSkipsWhenStoreUnavailable(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRuntimeCheckpointFixture(t)
+	state := newRunState("run-no-store", fixture.session)
+	service := &Service{}
+	service.updateResumeCheckpoint(context.Background(), &state, "plan", "")
+}
+
+func TestUpdateResumeCheckpointSwallowsStoreErrorAndUsesEffectiveWorkdir(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRuntimeCheckpointFixture(t)
+	state := newRunState("run-resume-workdir-fallback", fixture.session)
+	state.session.Workdir = "   "
+	state.effectiveWorkdir = fixture.workdir
+	spy := &checkpointStoreSpy{setResumeErr: errors.New("write failed")}
+	service := &Service{checkpointStore: spy}
+
+	service.updateResumeCheckpoint(context.Background(), &state, "verify", "running")
+
+	if spy.lastResume.WorkspaceKey != agentsession.WorkspacePathKey(fixture.workdir) {
+		t.Fatalf("WorkspaceKey = %q, want %q", spy.lastResume.WorkspaceKey, agentsession.WorkspacePathKey(fixture.workdir))
+	}
+}
+
 func TestApplyResumeCheckpointReplayPlanStrategy(t *testing.T) {
 	fixture := newRuntimeCheckpointFixture(t)
 	state := newRunState("run-resume-plan", fixture.session)
@@ -572,6 +600,124 @@ func TestResumeCheckpointMatchesStateSupportsLegacyMessageCountFallback(t *testi
 	}
 	if !resumeCheckpointMatchesState(resume, workspaceKey, currentRevision, legacyRevision) {
 		t.Fatalf("expected legacy len(messages) checkpoint to match during compatibility fallback")
+	}
+}
+
+func TestResolveResumeWorkspaceKey(t *testing.T) {
+	t.Parallel()
+
+	sessionWorkdir := t.TempDir()
+	effectiveWorkdir := t.TempDir()
+	got := resolveResumeWorkspaceKey(sessionWorkdir, effectiveWorkdir)
+	if got != agentsession.WorkspacePathKey(sessionWorkdir) {
+		t.Fatalf("resolveResumeWorkspaceKey(session, effective) = %q, want %q", got, agentsession.WorkspacePathKey(sessionWorkdir))
+	}
+
+	gotFallback := resolveResumeWorkspaceKey("   ", effectiveWorkdir)
+	if gotFallback != agentsession.WorkspacePathKey(effectiveWorkdir) {
+		t.Fatalf("resolveResumeWorkspaceKey(empty, effective) = %q, want %q", gotFallback, agentsession.WorkspacePathKey(effectiveWorkdir))
+	}
+}
+
+func TestResumeCheckpointMatchesStateBranches(t *testing.T) {
+	t.Parallel()
+
+	workspace := agentsession.WorkspacePathKey(t.TempDir())
+	if resumeCheckpointMatchesState(agentsession.ResumeCheckpoint{}, workspace, 1, 1) {
+		t.Fatal("expected empty checkpoint workspace to fail")
+	}
+	if resumeCheckpointMatchesState(agentsession.ResumeCheckpoint{WorkspaceKey: workspace}, "", 1, 1) {
+		t.Fatal("expected empty current workspace to fail")
+	}
+	if resumeCheckpointMatchesState(agentsession.ResumeCheckpoint{WorkspaceKey: workspace + "-other", TranscriptRevision: 1}, workspace, 1, 1) {
+		t.Fatal("expected workspace mismatch to fail")
+	}
+	if resumeCheckpointMatchesState(agentsession.ResumeCheckpoint{WorkspaceKey: workspace, TranscriptRevision: -1}, workspace, 1, 1) {
+		t.Fatal("expected negative checkpoint revision to fail")
+	}
+	if resumeCheckpointMatchesState(agentsession.ResumeCheckpoint{WorkspaceKey: workspace, TranscriptRevision: 1}, workspace, -1, 1) {
+		t.Fatal("expected negative current revision to fail")
+	}
+	if !resumeCheckpointMatchesState(agentsession.ResumeCheckpoint{WorkspaceKey: workspace, TranscriptRevision: 9}, workspace, 9, 3) {
+		t.Fatal("expected exact current revision match to pass")
+	}
+	if resumeCheckpointMatchesState(agentsession.ResumeCheckpoint{WorkspaceKey: workspace, TranscriptRevision: 8}, workspace, 9, -1) {
+		t.Fatal("expected legacy fallback disabled on negative legacy revision")
+	}
+	if resumeCheckpointMatchesState(agentsession.ResumeCheckpoint{WorkspaceKey: workspace, TranscriptRevision: 8}, workspace, 9, 7) {
+		t.Fatal("expected mismatch across current/legacy revisions to fail")
+	}
+}
+
+func TestSessionTranscriptRevisionIncludesTodoAndPlanState(t *testing.T) {
+	t.Parallel()
+
+	required := true
+	base := agentsession.NewWithWorkdir("resume-rich", t.TempDir())
+	base.Messages = []providertypes.Message{
+		{
+			Role: providertypes.RoleUser,
+			Parts: []providertypes.ContentPart{
+				providertypes.NewTextPart("same-count"),
+			},
+		},
+	}
+	base.TodoVersion = 2
+	base.Todos = []agentsession.TodoItem{
+		{
+			ID:            "todo-1",
+			Content:       "prepare report",
+			Status:        agentsession.TodoStatusInProgress,
+			Required:      &required,
+			OwnerType:     agentsession.TodoOwnerTypeAgent,
+			OwnerID:       "agent-1",
+			FailureReason: "",
+			BlockedReason: agentsession.TodoBlockedReasonPermissionWait,
+			Revision:      3,
+			UpdatedAt:     time.Unix(1700020000, 0).UTC(),
+		},
+	}
+	base.TaskState = agentsession.TaskState{
+		VerificationProfile: agentsession.VerificationProfileFixBug,
+		Goal:                "fix bug",
+		Progress:            []string{"  inspect logs  ", "write test"},
+		OpenItems:           []string{"   verify patch"},
+		NextStep:            "  run tests  ",
+		Blockers:            []string{" permission "},
+		KeyArtifacts:        []string{" report.md "},
+		Decisions:           []string{" keep legacy fallback "},
+		UserConstraints:     []string{" no destructive ops "},
+		LastUpdatedAt:       time.Unix(1700020001, 0).UTC(),
+	}
+	base.CurrentPlan = &agentsession.PlanArtifact{
+		ID:       "plan-1",
+		Revision: 2,
+	}
+	base.LastFullPlanRevision = 2
+	base.PlanApprovalPendingFullAlign = true
+
+	cloned := base
+	cloned.TaskState.Progress = append([]string(nil), base.TaskState.Progress...)
+	cloned.TaskState.OpenItems = append([]string(nil), base.TaskState.OpenItems...)
+	cloned.TaskState.Blockers = append([]string(nil), base.TaskState.Blockers...)
+	cloned.TaskState.KeyArtifacts = append([]string(nil), base.TaskState.KeyArtifacts...)
+	cloned.TaskState.Decisions = append([]string(nil), base.TaskState.Decisions...)
+	cloned.TaskState.UserConstraints = append([]string(nil), base.TaskState.UserConstraints...)
+	cloned.Todos = append([]agentsession.TodoItem(nil), base.Todos...)
+	if len(cloned.Todos) > 0 {
+		requiredCopy := *cloned.Todos[0].Required
+		cloned.Todos[0].Required = &requiredCopy
+	}
+
+	before := sessionTranscriptRevision(base)
+	after := sessionTranscriptRevision(cloned)
+	if before != after {
+		t.Fatalf("expected equal revisions for equivalent rich state, got %d vs %d", before, after)
+	}
+
+	cloned.Todos[0].Status = agentsession.TodoStatusCompleted
+	if sessionTranscriptRevision(base) == sessionTranscriptRevision(cloned) {
+		t.Fatal("expected todo status change to affect transcript revision")
 	}
 }
 

--- a/internal/runtime/checkpoint_resume.go
+++ b/internal/runtime/checkpoint_resume.go
@@ -59,6 +59,7 @@ func (s *Service) applyResumeCheckpoint(ctx context.Context, state *runState) {
 	sessionID := strings.TrimSpace(state.session.ID)
 	workspaceKey := resolveResumeWorkspaceKey(state.session.Workdir, state.effectiveWorkdir)
 	transcriptRevision := sessionTranscriptRevision(state.session)
+	legacyTranscriptRevision := sessionLegacyTranscriptRevision(state.session)
 	state.mu.Unlock()
 	if sessionID == "" {
 		return
@@ -68,7 +69,7 @@ func (s *Service) applyResumeCheckpoint(ctx context.Context, state *runState) {
 	if err != nil || resume == nil {
 		return
 	}
-	if !resumeCheckpointMatchesState(*resume, workspaceKey, transcriptRevision) {
+	if !resumeCheckpointMatchesState(*resume, workspaceKey, transcriptRevision, legacyTranscriptRevision) {
 		return
 	}
 
@@ -114,7 +115,6 @@ func sessionTranscriptRevision(session agentsession.Session) int64 {
 
 	snapshot := resumeConsistencySnapshot{
 		MessageCount:                    len(session.Messages),
-		SessionUpdatedAtUnixMilli:       session.UpdatedAt.UnixMilli(),
 		TodoVersion:                     session.TodoVersion,
 		Todos:                           buildResumeTodoFingerprints(session.Todos),
 		TaskState:                       buildResumeTaskStateFingerprint(session.TaskState),
@@ -138,6 +138,11 @@ func sessionTranscriptRevision(session agentsession.Session) int64 {
 	return int64(hasher.Sum64() & positiveInt64Mask)
 }
 
+// sessionLegacyTranscriptRevision 返回升级前使用的 transcript 版本语义：消息条数。
+func sessionLegacyTranscriptRevision(session agentsession.Session) int64 {
+	return int64(len(session.Messages))
+}
+
 // resolveResumeWorkspaceKey 统一计算 resume checkpoint 的工作区比较键，优先会话 workdir，缺失时回退运行时生效目录。
 func resolveResumeWorkspaceKey(sessionWorkdir string, effectiveWorkdir string) string {
 	workdir := strings.TrimSpace(sessionWorkdir)
@@ -152,6 +157,7 @@ func resumeCheckpointMatchesState(
 	resume agentsession.ResumeCheckpoint,
 	currentWorkspaceKey string,
 	currentTranscriptRevision int64,
+	legacyTranscriptRevision int64,
 ) bool {
 	resumeWorkspaceKey := strings.TrimSpace(resume.WorkspaceKey)
 	workspaceKey := strings.TrimSpace(currentWorkspaceKey)
@@ -165,13 +171,19 @@ func resumeCheckpointMatchesState(
 	if resume.TranscriptRevision < 0 || currentTranscriptRevision < 0 {
 		return false
 	}
-	return resume.TranscriptRevision == currentTranscriptRevision
+	if resume.TranscriptRevision == currentTranscriptRevision {
+		return true
+	}
+	// 兼容升级前 checkpoint：旧语义使用 len(messages)。
+	if legacyTranscriptRevision < 0 {
+		return false
+	}
+	return resume.TranscriptRevision == legacyTranscriptRevision
 }
 
 // resumeConsistencySnapshot 用于构建 resume 一致性指纹，避免仅靠消息数导致的误命中。
 type resumeConsistencySnapshot struct {
 	MessageCount                    int                        `json:"message_count"`
-	SessionUpdatedAtUnixMilli       int64                      `json:"session_updated_at_unix_milli"`
 	TodoVersion                     int                        `json:"todo_version"`
 	Todos                           []resumeTodoFingerprint    `json:"todos,omitempty"`
 	TaskState                       resumeTaskStateFingerprint `json:"task_state"`

--- a/internal/runtime/checkpoint_resume.go
+++ b/internal/runtime/checkpoint_resume.go
@@ -26,17 +26,19 @@ func (s *Service) updateResumeCheckpoint(ctx context.Context, state *runState, p
 	session := state.session
 	runID := state.runID
 	turn := state.turn
+	effectiveWorkdir := strings.TrimSpace(state.effectiveWorkdir)
 	state.mu.Unlock()
 
 	rc := agentsession.ResumeCheckpoint{
-		ID:              agentsession.NewID("rc"),
-		WorkspaceKey:    agentsession.WorkspacePathKey(session.Workdir),
-		RunID:           runID,
-		SessionID:       session.ID,
-		Turn:            turn,
-		Phase:           phase,
-		CompletionState: completionState,
-		UpdatedAt:       time.Now(),
+		ID:                 agentsession.NewID("rc"),
+		WorkspaceKey:       resolveResumeWorkspaceKey(session.Workdir, effectiveWorkdir),
+		RunID:              runID,
+		SessionID:          session.ID,
+		Turn:               turn,
+		Phase:              phase,
+		CompletionState:    completionState,
+		TranscriptRevision: sessionTranscriptRevision(session),
+		UpdatedAt:          time.Now(),
 	}
 
 	if err := s.checkpointStore.SetResumeCheckpoint(ctx, rc); err != nil {
@@ -52,6 +54,8 @@ func (s *Service) applyResumeCheckpoint(ctx context.Context, state *runState) {
 
 	state.mu.Lock()
 	sessionID := strings.TrimSpace(state.session.ID)
+	workspaceKey := resolveResumeWorkspaceKey(state.session.Workdir, state.effectiveWorkdir)
+	transcriptRevision := sessionTranscriptRevision(state.session)
 	state.mu.Unlock()
 	if sessionID == "" {
 		return
@@ -59,6 +63,9 @@ func (s *Service) applyResumeCheckpoint(ctx context.Context, state *runState) {
 
 	resume, err := s.checkpointStore.GetLatestResumeCheckpoint(ctx, sessionID)
 	if err != nil || resume == nil {
+		return
+	}
+	if !resumeCheckpointMatchesState(*resume, workspaceKey, transcriptRevision) {
 		return
 	}
 
@@ -91,6 +98,41 @@ func (s *Service) applyResumeCheckpoint(ctx context.Context, state *runState) {
 		Strategy:        strategy,
 	})
 	s.emitRuntimeSnapshotUpdated(ctx, state, "resume_applied")
+}
+
+// sessionTranscriptRevision 返回当前会话 transcript 的逻辑版本号，供 resume checkpoint 一致性校验使用。
+func sessionTranscriptRevision(session agentsession.Session) int64 {
+	return int64(len(session.Messages))
+}
+
+// resolveResumeWorkspaceKey 统一计算 resume checkpoint 的工作区比较键，优先会话 workdir，缺失时回退运行时生效目录。
+func resolveResumeWorkspaceKey(sessionWorkdir string, effectiveWorkdir string) string {
+	workdir := strings.TrimSpace(sessionWorkdir)
+	if workdir == "" {
+		workdir = strings.TrimSpace(effectiveWorkdir)
+	}
+	return agentsession.WorkspacePathKey(workdir)
+}
+
+// resumeCheckpointMatchesState 校验 resume checkpoint 是否仍与当前会话工作区/转录版本一致。
+func resumeCheckpointMatchesState(
+	resume agentsession.ResumeCheckpoint,
+	currentWorkspaceKey string,
+	currentTranscriptRevision int64,
+) bool {
+	resumeWorkspaceKey := strings.TrimSpace(resume.WorkspaceKey)
+	workspaceKey := strings.TrimSpace(currentWorkspaceKey)
+	if resumeWorkspaceKey == "" || workspaceKey == "" {
+		return false
+	}
+	if !strings.EqualFold(resumeWorkspaceKey, workspaceKey) {
+		return false
+	}
+
+	if resume.TranscriptRevision < 0 || currentTranscriptRevision < 0 {
+		return false
+	}
+	return resume.TranscriptRevision == currentTranscriptRevision
 }
 
 // deriveResumeBaseLifecycle 将 checkpoint phase/completion_state 映射为恢复时首轮运行态。

--- a/internal/runtime/checkpoint_resume.go
+++ b/internal/runtime/checkpoint_resume.go
@@ -15,7 +15,6 @@ import (
 const (
 	resumeStrategyReplayPlan         = "replay_plan"
 	resumeStrategyVerifyClosureFirst = "resume_verify_closure"
-	resumeTranscriptRevisionInvalid  = int64(-1)
 )
 
 // updateResumeCheckpoint 在 phase 转换时写入或更新 ResumeCheckpoint。
@@ -126,14 +125,11 @@ func sessionTranscriptRevision(session agentsession.Session) int64 {
 		PlanContextDirty:                session.PlanContextDirty,
 		PlanRestorePendingAlign:         session.PlanRestorePendingAlign,
 	}
-	raw, err := json.Marshal(snapshot)
-	if err != nil {
-		return resumeTranscriptRevisionInvalid
-	}
+	// snapshot 字段仅由基础可序列化类型组成，Marshal 对该结构是稳定可达的。
+	raw, _ := json.Marshal(snapshot)
 	hasher := fnv.New64a()
-	if _, err := hasher.Write(raw); err != nil {
-		return resumeTranscriptRevisionInvalid
-	}
+	// fnv.Hash Write 对内存写入不会返回错误，这里忽略 error 以保持实现简洁。
+	_, _ = hasher.Write(raw)
 	const positiveInt64Mask = uint64(1<<63 - 1)
 	return int64(hasher.Sum64() & positiveInt64Mask)
 }

--- a/internal/runtime/checkpoint_resume.go
+++ b/internal/runtime/checkpoint_resume.go
@@ -2,6 +2,8 @@ package runtime
 
 import (
 	"context"
+	"encoding/json"
+	"hash/fnv"
 	"log"
 	"strings"
 	"time"
@@ -13,6 +15,7 @@ import (
 const (
 	resumeStrategyReplayPlan         = "replay_plan"
 	resumeStrategyVerifyClosureFirst = "resume_verify_closure"
+	resumeTranscriptRevisionInvalid  = int64(-1)
 )
 
 // updateResumeCheckpoint 在 phase 转换时写入或更新 ResumeCheckpoint。
@@ -102,7 +105,37 @@ func (s *Service) applyResumeCheckpoint(ctx context.Context, state *runState) {
 
 // sessionTranscriptRevision 返回当前会话 transcript 的逻辑版本号，供 resume checkpoint 一致性校验使用。
 func sessionTranscriptRevision(session agentsession.Session) int64 {
-	return int64(len(session.Messages))
+	currentPlanID := ""
+	currentPlanRevision := 0
+	if session.CurrentPlan != nil {
+		currentPlanID = strings.TrimSpace(session.CurrentPlan.ID)
+		currentPlanRevision = session.CurrentPlan.Revision
+	}
+
+	snapshot := resumeConsistencySnapshot{
+		MessageCount:                    len(session.Messages),
+		SessionUpdatedAtUnixMilli:       session.UpdatedAt.UnixMilli(),
+		TodoVersion:                     session.TodoVersion,
+		Todos:                           buildResumeTodoFingerprints(session.Todos),
+		TaskState:                       buildResumeTaskStateFingerprint(session.TaskState),
+		CurrentPlanID:                   currentPlanID,
+		CurrentPlanRevision:             currentPlanRevision,
+		LastFullPlanRevision:            session.LastFullPlanRevision,
+		PlanApprovalPendingFullAlign:    session.PlanApprovalPendingFullAlign,
+		PlanCompletionPendingFullReview: session.PlanCompletionPendingFullReview,
+		PlanContextDirty:                session.PlanContextDirty,
+		PlanRestorePendingAlign:         session.PlanRestorePendingAlign,
+	}
+	raw, err := json.Marshal(snapshot)
+	if err != nil {
+		return resumeTranscriptRevisionInvalid
+	}
+	hasher := fnv.New64a()
+	if _, err := hasher.Write(raw); err != nil {
+		return resumeTranscriptRevisionInvalid
+	}
+	const positiveInt64Mask = uint64(1<<63 - 1)
+	return int64(hasher.Sum64() & positiveInt64Mask)
 }
 
 // resolveResumeWorkspaceKey 统一计算 resume checkpoint 的工作区比较键，优先会话 workdir，缺失时回退运行时生效目录。
@@ -133,6 +166,99 @@ func resumeCheckpointMatchesState(
 		return false
 	}
 	return resume.TranscriptRevision == currentTranscriptRevision
+}
+
+// resumeConsistencySnapshot 用于构建 resume 一致性指纹，避免仅靠消息数导致的误命中。
+type resumeConsistencySnapshot struct {
+	MessageCount                    int                        `json:"message_count"`
+	SessionUpdatedAtUnixMilli       int64                      `json:"session_updated_at_unix_milli"`
+	TodoVersion                     int                        `json:"todo_version"`
+	Todos                           []resumeTodoFingerprint    `json:"todos,omitempty"`
+	TaskState                       resumeTaskStateFingerprint `json:"task_state"`
+	CurrentPlanID                   string                     `json:"current_plan_id,omitempty"`
+	CurrentPlanRevision             int                        `json:"current_plan_revision,omitempty"`
+	LastFullPlanRevision            int                        `json:"last_full_plan_revision,omitempty"`
+	PlanApprovalPendingFullAlign    bool                       `json:"plan_approval_pending_full_align,omitempty"`
+	PlanCompletionPendingFullReview bool                       `json:"plan_completion_pending_full_review,omitempty"`
+	PlanContextDirty                bool                       `json:"plan_context_dirty,omitempty"`
+	PlanRestorePendingAlign         bool                       `json:"plan_restore_pending_align,omitempty"`
+}
+
+// resumeTodoFingerprint 收敛 resume 判定所需的最小 todo 状态。
+type resumeTodoFingerprint struct {
+	ID            string `json:"id"`
+	Status        string `json:"status"`
+	Required      bool   `json:"required"`
+	OwnerType     string `json:"owner_type,omitempty"`
+	OwnerID       string `json:"owner_id,omitempty"`
+	FailureReason string `json:"failure_reason,omitempty"`
+	BlockedReason string `json:"blocked_reason,omitempty"`
+	Revision      int64  `json:"revision"`
+	UpdatedAtMS   int64  `json:"updated_at_ms"`
+}
+
+// resumeTaskStateFingerprint 收敛 resume 判定所需的最小 task_state 摘要。
+type resumeTaskStateFingerprint struct {
+	VerificationProfile string   `json:"verification_profile,omitempty"`
+	Goal                string   `json:"goal,omitempty"`
+	Progress            []string `json:"progress,omitempty"`
+	OpenItems           []string `json:"open_items,omitempty"`
+	NextStep            string   `json:"next_step,omitempty"`
+	Blockers            []string `json:"blockers,omitempty"`
+	KeyArtifacts        []string `json:"key_artifacts,omitempty"`
+	Decisions           []string `json:"decisions,omitempty"`
+	UserConstraints     []string `json:"user_constraints,omitempty"`
+	LastUpdatedAtMS     int64    `json:"last_updated_at_ms"`
+}
+
+// buildResumeTodoFingerprints 生成 resume 一致性计算所需的 todo 指纹切片。
+func buildResumeTodoFingerprints(items []agentsession.TodoItem) []resumeTodoFingerprint {
+	if len(items) == 0 {
+		return nil
+	}
+	result := make([]resumeTodoFingerprint, 0, len(items))
+	for _, item := range items {
+		result = append(result, resumeTodoFingerprint{
+			ID:            strings.TrimSpace(item.ID),
+			Status:        strings.TrimSpace(string(item.Status)),
+			Required:      item.RequiredValue(),
+			OwnerType:     strings.TrimSpace(item.OwnerType),
+			OwnerID:       strings.TrimSpace(item.OwnerID),
+			FailureReason: strings.TrimSpace(item.FailureReason),
+			BlockedReason: strings.TrimSpace(string(item.BlockedReason)),
+			Revision:      item.Revision,
+			UpdatedAtMS:   item.UpdatedAt.UnixMilli(),
+		})
+	}
+	return result
+}
+
+// buildResumeTaskStateFingerprint 生成 resume 一致性计算所需的 task_state 指纹。
+func buildResumeTaskStateFingerprint(state agentsession.TaskState) resumeTaskStateFingerprint {
+	return resumeTaskStateFingerprint{
+		VerificationProfile: strings.TrimSpace(string(state.VerificationProfile)),
+		Goal:                strings.TrimSpace(state.Goal),
+		Progress:            cloneTrimmedStringList(state.Progress),
+		OpenItems:           cloneTrimmedStringList(state.OpenItems),
+		NextStep:            strings.TrimSpace(state.NextStep),
+		Blockers:            cloneTrimmedStringList(state.Blockers),
+		KeyArtifacts:        cloneTrimmedStringList(state.KeyArtifacts),
+		Decisions:           cloneTrimmedStringList(state.Decisions),
+		UserConstraints:     cloneTrimmedStringList(state.UserConstraints),
+		LastUpdatedAtMS:     state.LastUpdatedAt.UnixMilli(),
+	}
+}
+
+// cloneTrimmedStringList 复制并清洗字符串切片，保证指纹输入稳定。
+func cloneTrimmedStringList(items []string) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		result = append(result, strings.TrimSpace(item))
+	}
+	return result
 }
 
 // deriveResumeBaseLifecycle 将 checkpoint phase/completion_state 映射为恢复时首轮运行态。

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -3030,6 +3030,9 @@ var runtimeEventHandlerRegistry = map[tuiservices.EventType]func(*App, tuiservic
 	tuiservices.EventCompactError:                             runtimeEventCompactErrorHandler,
 	tuiservices.EventTokenUsage:                               runtimeEventTokenUsageHandler,
 	tuiservices.EventPhaseChanged:                             runtimeEventPhaseChangedHandler,
+	tuiservices.EventVerificationStarted:                      runtimeEventVerificationStartedHandler,
+	tuiservices.EventVerificationStageFinished:                runtimeEventVerificationStageFinishedHandler,
+	tuiservices.EventVerificationFinished:                     runtimeEventVerificationFinishedHandler,
 	tuiservices.EventVerificationCompleted:                    runtimeEventVerificationCompletedHandler,
 	tuiservices.EventVerificationFailed:                       runtimeEventVerificationFailedHandler,
 	tuiservices.EventAcceptanceDecided:                        runtimeEventAcceptanceDecidedHandler,
@@ -3522,6 +3525,75 @@ func runtimeEventPhaseChangedHandler(a *App, event tuiservices.RuntimeEvent) boo
 	case "verify":
 		a.setRunProgress(0.82, "Verifying")
 	}
+	return false
+}
+
+// runtimeEventVerificationStartedHandler 处理验证流程开始事件并记录 completion gate 结果。
+func runtimeEventVerificationStartedHandler(a *App, event tuiservices.RuntimeEvent) bool {
+	payload, ok := event.Payload.(tuiservices.VerificationStartedPayload)
+	if !ok {
+		return false
+	}
+	detail := "completion_gate=pass"
+	if !payload.CompletionPassed {
+		detail = "completion_gate=blocked"
+	}
+	if reason := strings.TrimSpace(payload.CompletionBlockedReason); reason != "" {
+		detail = detail + " (" + reason + ")"
+	}
+	a.appendActivity("verify", "Verification started", detail, false)
+	return false
+}
+
+// runtimeEventVerificationStageFinishedHandler 处理单个验证阶段完成事件并展示结果摘要。
+func runtimeEventVerificationStageFinishedHandler(a *App, event tuiservices.RuntimeEvent) bool {
+	payload, ok := event.Payload.(tuiservices.VerificationStageFinishedPayload)
+	if !ok {
+		return false
+	}
+	stageName := strings.TrimSpace(payload.Name)
+	if stageName == "" {
+		stageName = "unknown_stage"
+	}
+	status := strings.ToLower(strings.TrimSpace(payload.Status))
+	title := "Verification stage passed"
+	isError := false
+	if status != "pass" {
+		title = "Verification stage failed"
+		isError = true
+	}
+	detail := stageName
+	if summary := strings.TrimSpace(payload.Summary); summary != "" {
+		detail = detail + " | " + summary
+	} else if reason := strings.TrimSpace(payload.Reason); reason != "" {
+		detail = detail + " | " + reason
+	}
+	if class := strings.TrimSpace(payload.ErrorClass); class != "" {
+		detail = detail + " | class=" + class
+	}
+	a.appendActivity("verify", title, detail, isError)
+	return false
+}
+
+// runtimeEventVerificationFinishedHandler 处理验证流程结束事件并输出最终 acceptance 状态。
+func runtimeEventVerificationFinishedHandler(a *App, event tuiservices.RuntimeEvent) bool {
+	payload, ok := event.Payload.(tuiservices.VerificationFinishedPayload)
+	if !ok {
+		return false
+	}
+	acceptanceStatus := strings.TrimSpace(payload.AcceptanceStatus)
+	if acceptanceStatus == "" {
+		acceptanceStatus = "unknown"
+	}
+	detail := "acceptance_status=" + acceptanceStatus
+	if reason := strings.TrimSpace(string(payload.StopReason)); reason != "" {
+		detail = detail + " | stop=" + reason
+	}
+	if class := strings.TrimSpace(payload.ErrorClass); class != "" {
+		detail = detail + " | class=" + class
+	}
+	isError := !strings.EqualFold(acceptanceStatus, "accepted")
+	a.appendActivity("verify", "Verification finished", detail, isError)
 	return false
 }
 

--- a/internal/tui/core/app/update.go
+++ b/internal/tui/core/app/update.go
@@ -3592,7 +3592,7 @@ func runtimeEventVerificationFinishedHandler(a *App, event tuiservices.RuntimeEv
 	if class := strings.TrimSpace(payload.ErrorClass); class != "" {
 		detail = detail + " | class=" + class
 	}
-	isError := !strings.EqualFold(acceptanceStatus, "accepted")
+	isError := strings.EqualFold(acceptanceStatus, "failed")
 	a.appendActivity("verify", "Verification finished", detail, isError)
 	return false
 }

--- a/internal/tui/core/app/update_runtime_events_test.go
+++ b/internal/tui/core/app/update_runtime_events_test.go
@@ -181,6 +181,15 @@ func TestRuntimeEventHandlerRegistryContainsRenamedEvents(t *testing.T) {
 	if _, ok := runtimeEventHandlerRegistry[agentruntime.EventVerificationCompleted]; !ok {
 		t.Fatalf("expected verification_completed handler to be registered")
 	}
+	if _, ok := runtimeEventHandlerRegistry[agentruntime.EventVerificationStarted]; !ok {
+		t.Fatalf("expected verification_started handler to be registered")
+	}
+	if _, ok := runtimeEventHandlerRegistry[agentruntime.EventVerificationStageFinished]; !ok {
+		t.Fatalf("expected verification_stage_finished handler to be registered")
+	}
+	if _, ok := runtimeEventHandlerRegistry[agentruntime.EventVerificationFinished]; !ok {
+		t.Fatalf("expected verification_finished handler to be registered")
+	}
 	if _, ok := runtimeEventHandlerRegistry[agentruntime.EventVerificationFailed]; !ok {
 		t.Fatalf("expected verification_failed handler to be registered")
 	}
@@ -708,6 +717,51 @@ func TestRuntimeEventMultimodalHandlers(t *testing.T) {
 
 func TestRuntimeEventVerificationAndAcceptanceHandlers(t *testing.T) {
 	app, _ := newTestApp(t)
+
+	if handled := runtimeEventVerificationStartedHandler(&app, agentruntime.RuntimeEvent{Payload: 1}); handled {
+		t.Fatalf("expected invalid verification_started payload to return false")
+	}
+	runtimeEventVerificationStartedHandler(&app, agentruntime.RuntimeEvent{
+		Payload: agentruntime.VerificationStartedPayload{
+			CompletionPassed:        false,
+			CompletionBlockedReason: "pending_todo",
+		},
+	})
+	started := app.activities[len(app.activities)-1]
+	if started.Title != "Verification started" || !strings.Contains(started.Detail, "completion_gate=blocked") || started.IsError {
+		t.Fatalf("unexpected started activity: %+v", started)
+	}
+
+	if handled := runtimeEventVerificationStageFinishedHandler(&app, agentruntime.RuntimeEvent{Payload: 1}); handled {
+		t.Fatalf("expected invalid verification_stage_finished payload to return false")
+	}
+	runtimeEventVerificationStageFinishedHandler(&app, agentruntime.RuntimeEvent{
+		Payload: agentruntime.VerificationStageFinishedPayload{
+			Name:       "required_todo",
+			Status:     "fail",
+			Reason:     "todo remains open",
+			ErrorClass: "unknown",
+		},
+	})
+	stage := app.activities[len(app.activities)-1]
+	if stage.Title != "Verification stage failed" || !strings.Contains(stage.Detail, "required_todo") || !stage.IsError {
+		t.Fatalf("unexpected stage activity: %+v", stage)
+	}
+
+	if handled := runtimeEventVerificationFinishedHandler(&app, agentruntime.RuntimeEvent{Payload: 1}); handled {
+		t.Fatalf("expected invalid verification_finished payload to return false")
+	}
+	runtimeEventVerificationFinishedHandler(&app, agentruntime.RuntimeEvent{
+		Payload: agentruntime.VerificationFinishedPayload{
+			AcceptanceStatus: "failed",
+			StopReason:       agentruntime.StopReasonVerificationFailed,
+			ErrorClass:       "unknown",
+		},
+	})
+	finished := app.activities[len(app.activities)-1]
+	if finished.Title != "Verification finished" || !strings.Contains(finished.Detail, "acceptance_status=failed") || !finished.IsError {
+		t.Fatalf("unexpected finished activity: %+v", finished)
+	}
 
 	if handled := runtimeEventVerificationCompletedHandler(&app, agentruntime.RuntimeEvent{Payload: 1}); handled {
 		t.Fatalf("expected invalid verification_completed payload to return false")

--- a/internal/tui/core/app/update_runtime_events_test.go
+++ b/internal/tui/core/app/update_runtime_events_test.go
@@ -762,6 +762,16 @@ func TestRuntimeEventVerificationAndAcceptanceHandlers(t *testing.T) {
 	if finished.Title != "Verification finished" || !strings.Contains(finished.Detail, "acceptance_status=failed") || !finished.IsError {
 		t.Fatalf("unexpected finished activity: %+v", finished)
 	}
+	runtimeEventVerificationFinishedHandler(&app, agentruntime.RuntimeEvent{
+		Payload: agentruntime.VerificationFinishedPayload{
+			AcceptanceStatus: "continued",
+			StopReason:       agentruntime.StopReasonAcceptContinue,
+		},
+	})
+	continued := app.activities[len(app.activities)-1]
+	if continued.Title != "Verification finished" || !strings.Contains(continued.Detail, "acceptance_status=continued") || continued.IsError {
+		t.Fatalf("unexpected continued activity: %+v", continued)
+	}
 
 	if handled := runtimeEventVerificationCompletedHandler(&app, agentruntime.RuntimeEvent{Payload: 1}); handled {
 		t.Fatalf("expected invalid verification_completed payload to return false")

--- a/internal/tui/services/gateway_stream_client.go
+++ b/internal/tui/services/gateway_stream_client.go
@@ -205,6 +205,12 @@ func restoreRuntimePayload(eventType EventType, payload any) (any, error) {
 		return decodeRuntimePayload[PhaseChangedPayload](payload)
 	case EventStopReasonDecided:
 		return decodeStopReasonPayload(payload)
+	case EventVerificationStarted:
+		return decodeRuntimePayload[VerificationStartedPayload](payload)
+	case EventVerificationStageFinished:
+		return decodeRuntimePayload[VerificationStageFinishedPayload](payload)
+	case EventVerificationFinished:
+		return decodeRuntimePayload[VerificationFinishedPayload](payload)
 	case EventVerificationCompleted:
 		return decodeRuntimePayload[VerificationCompletedPayload](payload)
 	case EventVerificationFailed:

--- a/internal/tui/services/gateway_stream_client_additional_test.go
+++ b/internal/tui/services/gateway_stream_client_additional_test.go
@@ -170,6 +170,63 @@ func TestRestoreRuntimePayloadCoversSpecializedTypes(t *testing.T) {
 			},
 		},
 		{
+			name:      "verification started",
+			eventType: EventVerificationStarted,
+			payload: map[string]any{
+				"completion_passed":         false,
+				"completion_blocked_reason": "pending_todo",
+			},
+			assertFn: func(t *testing.T, got any) {
+				t.Helper()
+				value, ok := got.(VerificationStartedPayload)
+				if !ok {
+					t.Fatalf("payload type = %T", got)
+				}
+				if value.CompletionPassed || value.CompletionBlockedReason != "pending_todo" {
+					t.Fatalf("payload = %#v", value)
+				}
+			},
+		},
+		{
+			name:      "verification stage finished",
+			eventType: EventVerificationStageFinished,
+			payload: map[string]any{
+				"name":        "required_todo",
+				"status":      "fail",
+				"reason":      "open todo remains",
+				"error_class": "unknown",
+			},
+			assertFn: func(t *testing.T, got any) {
+				t.Helper()
+				value, ok := got.(VerificationStageFinishedPayload)
+				if !ok {
+					t.Fatalf("payload type = %T", got)
+				}
+				if value.Name != "required_todo" || value.Status != "fail" || value.ErrorClass != "unknown" {
+					t.Fatalf("payload = %#v", value)
+				}
+			},
+		},
+		{
+			name:      "verification finished",
+			eventType: EventVerificationFinished,
+			payload: map[string]any{
+				"acceptance_status": "failed",
+				"stop_reason":       "verification_failed",
+				"error_class":       "unknown",
+			},
+			assertFn: func(t *testing.T, got any) {
+				t.Helper()
+				value, ok := got.(VerificationFinishedPayload)
+				if !ok {
+					t.Fatalf("payload type = %T", got)
+				}
+				if value.AcceptanceStatus != "failed" || value.StopReason != StopReasonVerificationFailed || value.ErrorClass != "unknown" {
+					t.Fatalf("payload = %#v", value)
+				}
+			},
+		},
+		{
 			name:      "runtime usage payload",
 			eventType: EventType(RuntimeEventUsage),
 			payload:   map[string]any{"delta": map[string]any{"inputtokens": 1}},

--- a/internal/tui/services/runtime_contract.go
+++ b/internal/tui/services/runtime_contract.go
@@ -338,6 +338,12 @@ type StopReasonDecidedPayload struct {
 	Detail string     `json:"detail,omitempty"`
 }
 
+// VerificationStartedPayload 描述验证流程启动事件。
+type VerificationStartedPayload struct {
+	CompletionPassed        bool   `json:"completion_passed"`
+	CompletionBlockedReason string `json:"completion_blocked_reason,omitempty"`
+}
+
 // VerificationStageFinishedPayload 描述单个 verifier 阶段结果。
 type VerificationStageFinishedPayload struct {
 	Name       string `json:"name"`


### PR DESCRIPTION
## 背景
本 PR 针对本轮 review 的两个中等问题做收敛修复：

1. `applyResumeCheckpoint` 仅按 `session_id` 取最新记录，未校验 `workspace_key/transcript_revision`，存在“旧 checkpoint 误导新 run 进入 plan/verify”的风险。
2. runtime 已发出 `verification_started / verification_stage_finished / verification_finished`，但 TUI 侧未形成完整强类型消费闭环，部分事件会以原始 map 形态被忽略。

## 变更概览
### 1) Runtime：恢复 checkpoint 增加一致性闸门
文件：`internal/runtime/checkpoint_resume.go`

- `updateResumeCheckpoint` 现在会持久化当前 transcript 逻辑版本（按消息数计算）。
- 新增工作区键解析逻辑：优先会话 `workdir`，缺失时回退运行时生效目录，统一生成 `workspace_key`。
- `applyResumeCheckpoint` 在应用策略前新增匹配校验：
  - `workspace_key` 必须匹配当前 run；
  - `transcript_revision` 必须匹配当前会话 transcript 版本。
- 不匹配时直接跳过应用，避免 stale checkpoint 污染新一轮执行策略。

### 2) TUI 契约闭环：verification lifecycle 事件端到端消费
文件：
- `internal/tui/services/runtime_contract.go`
- `internal/tui/services/gateway_stream_client.go`
- `internal/tui/core/app/update.go`

- 增加 `VerificationStartedPayload` 契约类型。
- `gateway_stream_client` 补充三类 lifecycle 事件的强类型解码：
  - `verification_started`
  - `verification_stage_finished`
  - `verification_finished`
- `update` 侧注册并实现对应 handler，将事件转为可见 activity（不再静默透传）。

## 测试
新增/更新测试覆盖：

- `internal/runtime/checkpoint_flow_test.go`
  - 校验 workspace mismatch 跳过 resume；
  - 校验 transcript revision mismatch 跳过 resume；
  - 调整 resume verify closure 启动用例，确保在匹配条件下可正常触发恢复策略。
- `internal/tui/services/gateway_stream_client_additional_test.go`
  - 覆盖 verification lifecycle 三类 payload 的强类型恢复。
- `internal/tui/core/app/update_runtime_events_test.go`
  - 覆盖 handler 注册完整性；
  - 覆盖三类 verification lifecycle handler 的有效/无效 payload 分支。

本地执行：
- `go test ./internal/runtime -run "Resume|Verification"`
- `go test ./internal/tui/services ./internal/tui/core/app`

## 改动价值
- 将 resume 策略应用从“仅按 session 最新记录”升级为“按工作区+转录版本双重一致性判定”，显著降低误恢复概率。
- 补齐 verification lifecycle 的 runtime→gateway→tui 事件契约闭环，增强可观测性与调试确定性。
- 变更保持最小侵入：不改主循环语义，只加守卫与消费链补全。

## 风险与兼容性
- 风险可控：仅在 checkpoint 不匹配时跳过恢复策略，默认回退既有 run 路径（plan 起步）。
- 向后兼容：新增字段/事件消费均为增量，不破坏现有事件类型与调用方。