### PR TITLE
fix(context): 显式标记空 Todo 状态

### DIFF
--- a/internal/context/source_todos.go
+++ b/internal/context/source_todos.go
@@ -27,7 +27,12 @@ func (todosSource) Sections(ctx context.Context, input BuildInput) ([]promptSect
 		return nil, err
 	}
 	if len(input.Todos) == 0 {
-		return nil, nil
+		return []promptSection{
+			{
+				Title:   "Todo State",
+				Content: "None",
+			},
+		}, nil
 	}
 
 	active := make([]agentsession.TodoItem, 0, len(input.Todos))
@@ -37,7 +42,12 @@ func (todosSource) Sections(ctx context.Context, input BuildInput) ([]promptSect
 		}
 	}
 	if len(active) == 0 {
-		return nil, nil
+		return []promptSection{
+			{
+				Title:   "Todo State",
+				Content: "None",
+			},
+		}, nil
 	}
 
 	sort.SliceStable(active, func(i, j int) bool {

--- a/internal/context/source_todos_test.go
+++ b/internal/context/source_todos_test.go
@@ -74,8 +74,8 @@ func TestTodosSourceSectionsBoundaries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Sections() error = %v", err)
 	}
-	if sections != nil {
-		t.Fatalf("Sections() = %+v, want nil", sections)
+	if len(sections) != 1 || sections[0].Content != "None" {
+		t.Fatalf("Sections() = %+v, want single section with 'None'", sections)
 	}
 
 	ctx, cancel := stdcontext.WithCancel(stdcontext.Background())
@@ -100,8 +100,8 @@ func TestTodosSourceSectionsAllTerminal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Sections() error = %v", err)
 	}
-	if sections != nil {
-		t.Fatalf("Sections() = %+v, want nil for all terminal todos", sections)
+	if len(sections) != 1 || sections[0].Content != "None" {
+		t.Fatalf("Sections() = %+v, want single section with 'None' for all terminal todos", sections)
 	}
 }
 

--- a/internal/promptasset/assets_test.go
+++ b/internal/promptasset/assets_test.go
@@ -106,6 +106,9 @@ func TestPlanModePromptTemplates(t *testing.T) {
 	if !strings.Contains(PlanModePrompt("build_execute"), "create current-run required todos") {
 		t.Fatalf("expected build prompt to require direct-build todo bootstrap")
 	}
+	if !strings.Contains(PlanModePrompt("build_execute"), "Todo State is attached as `None`") {
+		t.Fatalf("expected build prompt to bootstrap when Todo State is None")
+	}
 	if !strings.Contains(PlanModePrompt("build_execute"), "simple conversational inputs") {
 		t.Fatalf("expected build prompt to cover simple conversational completion")
 	}

--- a/internal/promptasset/templates/context/plan_mode_build_execute.md
+++ b/internal/promptasset/templates/context/plan_mode_build_execute.md
@@ -4,7 +4,7 @@ You are currently in build execution.
 - If a current plan summary is attached, use it as guidance by default.
 - If the summary is insufficient for the current task, consult the attached full plan view when available.
 - If no current plan is attached, continue using task state, todos, and the conversation context.
-- If no Todo State is attached, create current-run required todos with `todo_write` before the first substantive tool call for project analysis, documentation writing, code changes, multi-step debugging, or verification work.
+- If no Todo State is attached, or Todo State is attached as `None`, create current-run required todos with `todo_write` before the first substantive tool call for project analysis, documentation writing, code changes, multi-step debugging, or verification work.
 - Do not update or complete todo IDs that are not present in the current Todo State; create new current-run todos instead.
 - Small necessary deviations are allowed, but explain why they are needed.
 - Do not create or rewrite the current full plan in this stage.

--- a/internal/runtime/controlplane/phase.go
+++ b/internal/runtime/controlplane/phase.go
@@ -46,6 +46,7 @@ var allowedRunStateTransitions = map[RunState]map[RunState]struct{}{
 	RunStateVerify: {
 		RunStateVerify:              {},
 		RunStatePlan:                {},
+		RunStateExecute:             {},
 		RunStateCompacting:          {},
 		RunStateWaitingUserQuestion: {},
 		RunStateWaitingPermission:   {},

--- a/internal/runtime/controlplane/phase_test.go
+++ b/internal/runtime/controlplane/phase_test.go
@@ -13,6 +13,7 @@ func TestValidateRunStateTransitionMainlineAndGovernanceStates(t *testing.T) {
 		{from: RunStatePlan, to: RunStateExecute},
 		{from: RunStateExecute, to: RunStateVerify},
 		{from: RunStateVerify, to: RunStatePlan},
+		{from: RunStateVerify, to: RunStateExecute},
 		{from: RunStatePlan, to: RunStateCompacting},
 		{from: RunStateCompacting, to: RunStatePlan},
 		{from: RunStateExecute, to: RunStateWaitingPermission},

--- a/web/src/stores/useRuntimeInsightStore.test.ts
+++ b/web/src/stores/useRuntimeInsightStore.test.ts
@@ -139,6 +139,21 @@ describe('useRuntimeInsightStore', () => {
     expect(state.todoHistory.a).toBeDefined()
   })
 
+  it('applyTodoSnapshot can clear stale conflict on reset while preserving history', () => {
+    const store = useRuntimeInsightStore.getState()
+    store.setTodoSnapshot({
+      items: [{ id: 'a', content: 'task a', status: 'in_progress', required: true, revision: 1 }],
+    })
+    store.setTodoConflict({ action: 'todo_conflict', reason: 'todo_not_found' })
+
+    store.applyTodoSnapshot({ items: [] }, { clearConflict: true })
+
+    const state = useRuntimeInsightStore.getState()
+    expect(state.todoSnapshot?.items).toEqual([])
+    expect(state.todoConflict).toBeNull()
+    expect(state.todoHistory.a).toBeDefined()
+  })
+
   it('setTodoSnapshot accumulates todoHistory across replacements', () => {
     const store = useRuntimeInsightStore.getState()
     store.setTodoSnapshot({

--- a/web/src/stores/useRuntimeInsightStore.ts
+++ b/web/src/stores/useRuntimeInsightStore.ts
@@ -44,7 +44,7 @@ interface RuntimeInsightState {
   failVerification: (payload: VerificationFailedPayload) => void
   setAcceptanceDecision: (payload: AcceptanceDecidedPayload | null) => void
   setTodoSnapshot: (snapshot: TodoSnapshot | null) => void
-  applyTodoSnapshot: (snapshot: TodoSnapshot | null) => void
+  applyTodoSnapshot: (snapshot: TodoSnapshot | null, options?: { clearConflict?: boolean }) => void
   addTodoEvent: (event: TodoEventPayload) => void
   setTodoConflict: (event: TodoEventPayload | null) => void
   setBudgetChecked: (payload: BudgetCheckedPayload) => void
@@ -110,13 +110,13 @@ export const useRuntimeInsightStore = create<RuntimeInsightState>((set) => ({
     }
     return { todoSnapshot, todoConflict: null, todoHistory }
   }),
-  applyTodoSnapshot: (todoSnapshot) => set((s) => {
+  applyTodoSnapshot: (todoSnapshot, options) => set((s) => {
     const items = todoSnapshot?.items ?? []
     if (!todoSnapshot) {
-      return { todoSnapshot: null }
+      return options?.clearConflict ? { todoSnapshot: null, todoConflict: null } : { todoSnapshot: null }
     }
     if (items.length === 0) {
-      return { todoSnapshot }
+      return options?.clearConflict ? { todoSnapshot, todoConflict: null } : { todoSnapshot }
     }
     const now = Date.now()
     const todoHistory = { ...s.todoHistory }
@@ -128,7 +128,9 @@ export const useRuntimeInsightStore = create<RuntimeInsightState>((set) => ({
         firstSeenAt: prev?.firstSeenAt ?? now,
       }
     }
-    return { todoSnapshot, todoHistory }
+    return options?.clearConflict
+      ? { todoSnapshot, todoConflict: null, todoHistory }
+      : { todoSnapshot, todoHistory }
   }),
   addTodoEvent: (event) => set((s) => ({ todoEvents: [...s.todoEvents, event] })),
   setTodoConflict: (todoConflict) => set({ todoConflict }),

--- a/web/src/utils/eventBridge.test.ts
+++ b/web/src/utils/eventBridge.test.ts
@@ -1490,6 +1490,56 @@ describe("eventBridge", () => {
     );
   });
 
+  it("TodoSnapshotUpdated reset clears stale TodoConflict", () => {
+    const api = createMockGatewayAPI();
+    handleGatewayEvent(
+      {
+        type: EventType.TodoConflict,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.TodoConflict,
+            payload: { action: "update", reason: "todo_not_found" },
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-1",
+      },
+      api,
+    );
+    expect(useRuntimeInsightStore.getState().todoConflict?.reason).toBe(
+      "todo_not_found",
+    );
+
+    handleGatewayEvent(
+      {
+        type: EventType.TodoSnapshotUpdated,
+        payload: {
+          payload: {
+            runtime_event_type: EventType.TodoSnapshotUpdated,
+            payload: {
+              action: "reset",
+              reason: "new_user_run",
+              items: [],
+              summary: {
+                total: 0,
+                required_total: 0,
+                required_completed: 0,
+                required_failed: 0,
+                required_open: 0,
+              },
+            },
+          },
+        },
+        session_id: "sess-1",
+        run_id: "run-2",
+      },
+      api,
+    );
+
+    expect(useRuntimeInsightStore.getState().todoConflict).toBeNull();
+    expect(useRuntimeInsightStore.getState().todoSnapshot?.items).toEqual([]);
+  });
+
   it("TodoUpdated clears TodoConflict", () => {
     const api = createMockGatewayAPI();
     // Set conflict first

--- a/web/src/utils/eventBridge.ts
+++ b/web/src/utils/eventBridge.ts
@@ -1026,10 +1026,13 @@ export function handleGatewayEvent(
       if (payload) {
         insightStore.addTodoEvent(payload);
         if (payload.items) {
+          const clearConflict =
+            payload.action === "reset" ||
+            (payload.items.length === 0 && payload.summary?.total === 0);
           insightStore.applyTodoSnapshot({
             items: payload.items,
             summary: payload.summary,
-          });
+          }, { clearConflict });
         }
       }
       break;


### PR DESCRIPTION
## 背景

关联 RFC issue：Closes #690

继续对话时，如果上一轮已经清空或完成 todo，context builder 之前会直接省略 Todo State 区块。模型在后续推理中无法明确区分“当前没有待办”和“旧待办仍可沿用”，容易继续写入已清空的 todo，形成 todo conflict。

## 当前修改

- 在 `internal/context` 中，当 todo 列表为空或全部处于终态时，显式输出 `Todo State: None`。
- 同步 build execution prompt：缺失 `Todo State` 或 `Todo State` 为 `None` 时，都要求先创建当前 run 的 required todos。
- 补齐空 todo、全部终态 todo、prompt 空状态语义的边界测试。
- 允许 control plane 从 `verify` 回到 `execute`，覆盖验证阶段发现仍需执行动作的状态转换。
- 修复 Web todo 面板状态收敛：runtime reset snapshot 会清理 stale `todoConflict`，普通 conflict snapshot 仍保留冲突提示。

## 验证

- `go test ./internal/context ./internal/runtime/controlplane ./internal/promptasset`
- `npm --prefix web test -- useRuntimeInsightStore eventBridge`

## 风险与回滚

- 风险：提示中会固定出现 `Todo State: None`，会带来极少量 token 增量。
- 回滚：如该语义影响模型行为，可回滚 context 输出、prompt wording、Web reset conflict 清理与 `verify -> execute` 状态转换。