### PR TITLE
feat(hooks): publish and version hook payload schema

### DIFF
--- a/docs/reference/hook-payload.v1.json
+++ b/docs/reference/hook-payload.v1.json
@@ -1,0 +1,1301 @@
+{
+  "$id": "https://neocode.dev/schemas/hook-payload.v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Public hook payload contract for command stdin and shared HTTP observe fields.",
+  "oneOf": [
+    {
+      "additionalProperties": false,
+      "properties": {
+        "hook_id": {
+          "description": "触发当前 payload 的 hook 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "kind": {
+          "description": "hook 的 kind；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "metadata": {
+          "additionalProperties": false,
+          "description": "Point-specific hook metadata fields.",
+          "properties": {
+            "assistant_text_empty": {
+              "description": "assistant 文本输出是否为空。",
+              "type": "boolean",
+              "x-stability": "stable"
+            },
+            "recent_tool_summary": {
+              "description": "最近一批工具调用摘要，结构仍可能继续演进。",
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "is_error": {
+                    "description": "该工具结果是否为错误。",
+                    "type": "boolean",
+                    "x-stability": "stable"
+                  },
+                  "name": {
+                    "description": "工具名称。",
+                    "type": "string",
+                    "x-stability": "stable"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array",
+              "x-stability": "experimental"
+            },
+            "run_id": {
+              "description": "当前 run 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "session_id": {
+              "description": "当前 session 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "todo_summary": {
+              "additionalProperties": false,
+              "description": "当前 todo 摘要，字段仍可能继续演进。",
+              "properties": {
+                "required_completed": {
+                  "description": "已完成的 required todo 数量。",
+                  "type": "integer",
+                  "x-stability": "stable"
+                },
+                "required_failed": {
+                  "description": "已失败的 required todo 数量。",
+                  "type": "integer",
+                  "x-stability": "stable"
+                },
+                "required_open": {
+                  "description": "尚未终态的 required todo 数量。",
+                  "type": "integer",
+                  "x-stability": "stable"
+                },
+                "required_total": {
+                  "description": "required todo 总数。",
+                  "type": "integer",
+                  "x-stability": "stable"
+                },
+                "total": {
+                  "description": "todo 总数。",
+                  "type": "integer",
+                  "x-stability": "stable"
+                }
+              },
+              "type": "object",
+              "x-stability": "experimental"
+            },
+            "workdir": {
+              "description": "本次运行的工作目录。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "workspace_changed": {
+              "description": "当前 run 是否已产生 workspace 写入。",
+              "type": "boolean",
+              "x-stability": "stable"
+            }
+          },
+          "type": "object"
+        },
+        "mode": {
+          "description": "hook 的 mode；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "payload_version": {
+          "const": "1",
+          "description": "公开 payload 协议版本号。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "point": {
+          "const": "accept_gate",
+          "description": "当前 payload 对应的 hook 点位。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "run_id": {
+          "description": "本次运行的 run 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "scope": {
+          "description": "hook 的 scope；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "session_id": {
+          "description": "当前会话标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "triggered_at": {
+          "description": "HTTP observe payload 发出时的 UTC 时间戳。",
+          "type": "string",
+          "x-stability": "stable"
+        }
+      },
+      "required": [
+        "payload_version",
+        "hook_id",
+        "point"
+      ],
+      "title": "accept_gate",
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "hook_id": {
+          "description": "触发当前 payload 的 hook 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "kind": {
+          "description": "hook 的 kind；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "metadata": {
+          "additionalProperties": false,
+          "description": "Point-specific hook metadata fields.",
+          "properties": {
+            "error_class": {
+              "description": "工具错误分类。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "execution_error": {
+              "description": "工具执行层错误文本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "is_error": {
+              "description": "工具结果是否为错误。",
+              "type": "boolean",
+              "x-stability": "stable"
+            },
+            "result_content_preview": {
+              "description": "工具结果内容预览。",
+              "type": "string",
+              "x-stability": "experimental"
+            },
+            "run_id": {
+              "description": "当前 run 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "session_id": {
+              "description": "当前 session 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "tool_arguments_preview": {
+              "description": "脱敏并截断后的工具参数预览。",
+              "type": "string",
+              "x-stability": "experimental"
+            },
+            "tool_call_id": {
+              "description": "当前工具调用标识。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "tool_name": {
+              "description": "当前工具名称。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "workdir": {
+              "description": "本次运行的工作目录。",
+              "type": "string",
+              "x-stability": "stable"
+            }
+          },
+          "type": "object"
+        },
+        "mode": {
+          "description": "hook 的 mode；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "payload_version": {
+          "const": "1",
+          "description": "公开 payload 协议版本号。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "point": {
+          "const": "after_tool_failure",
+          "description": "当前 payload 对应的 hook 点位。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "run_id": {
+          "description": "本次运行的 run 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "scope": {
+          "description": "hook 的 scope；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "session_id": {
+          "description": "当前会话标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "triggered_at": {
+          "description": "HTTP observe payload 发出时的 UTC 时间戳。",
+          "type": "string",
+          "x-stability": "stable"
+        }
+      },
+      "required": [
+        "payload_version",
+        "hook_id",
+        "point"
+      ],
+      "title": "after_tool_failure",
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "hook_id": {
+          "description": "触发当前 payload 的 hook 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "kind": {
+          "description": "hook 的 kind；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "metadata": {
+          "additionalProperties": false,
+          "description": "Point-specific hook metadata fields.",
+          "properties": {
+            "error_class": {
+              "description": "工具错误分类。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "execution_error": {
+              "description": "工具执行层错误文本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "is_error": {
+              "description": "工具结果是否为错误。",
+              "type": "boolean",
+              "x-stability": "stable"
+            },
+            "result_content_preview": {
+              "description": "工具结果内容预览。",
+              "type": "string",
+              "x-stability": "experimental"
+            },
+            "result_metadata_present": {
+              "description": "工具结果 metadata 是否非空。",
+              "type": "boolean",
+              "x-stability": "stable"
+            },
+            "run_id": {
+              "description": "当前 run 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "session_id": {
+              "description": "当前 session 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "tool_call_id": {
+              "description": "当前工具调用标识。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "tool_name": {
+              "description": "当前工具名称。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "workdir": {
+              "description": "本次运行的工作目录。",
+              "type": "string",
+              "x-stability": "stable"
+            }
+          },
+          "type": "object"
+        },
+        "mode": {
+          "description": "hook 的 mode；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "payload_version": {
+          "const": "1",
+          "description": "公开 payload 协议版本号。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "point": {
+          "const": "after_tool_result",
+          "description": "当前 payload 对应的 hook 点位。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "run_id": {
+          "description": "本次运行的 run 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "scope": {
+          "description": "hook 的 scope；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "session_id": {
+          "description": "当前会话标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "triggered_at": {
+          "description": "HTTP observe payload 发出时的 UTC 时间戳。",
+          "type": "string",
+          "x-stability": "stable"
+        }
+      },
+      "required": [
+        "payload_version",
+        "hook_id",
+        "point"
+      ],
+      "title": "after_tool_result",
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "hook_id": {
+          "description": "触发当前 payload 的 hook 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "kind": {
+          "description": "hook 的 kind；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "metadata": {
+          "additionalProperties": false,
+          "description": "Point-specific hook metadata fields.",
+          "properties": {
+            "run_id": {
+              "description": "当前 run 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "session_id": {
+              "description": "当前 session 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            }
+          },
+          "type": "object"
+        },
+        "mode": {
+          "description": "hook 的 mode；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "payload_version": {
+          "const": "1",
+          "description": "公开 payload 协议版本号。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "point": {
+          "const": "before_completion_decision",
+          "description": "当前 payload 对应的 hook 点位。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "run_id": {
+          "description": "本次运行的 run 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "scope": {
+          "description": "hook 的 scope；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "session_id": {
+          "description": "当前会话标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "triggered_at": {
+          "description": "HTTP observe payload 发出时的 UTC 时间戳。",
+          "type": "string",
+          "x-stability": "stable"
+        }
+      },
+      "required": [
+        "payload_version",
+        "hook_id",
+        "point"
+      ],
+      "title": "before_completion_decision",
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "hook_id": {
+          "description": "触发当前 payload 的 hook 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "kind": {
+          "description": "hook 的 kind；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "metadata": {
+          "additionalProperties": false,
+          "description": "Point-specific hook metadata fields.",
+          "properties": {
+            "decision": {
+              "description": "权限决策结果。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "reason": {
+              "description": "权限决策原因。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "rule_id": {
+              "description": "命中的权限规则标识。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "run_id": {
+              "description": "当前 run 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "session_id": {
+              "description": "当前 session 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "tool_call_id": {
+              "description": "当前工具调用标识。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "tool_name": {
+              "description": "当前工具名称。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "workdir": {
+              "description": "本次运行的工作目录。",
+              "type": "string",
+              "x-stability": "stable"
+            }
+          },
+          "type": "object"
+        },
+        "mode": {
+          "description": "hook 的 mode；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "payload_version": {
+          "const": "1",
+          "description": "公开 payload 协议版本号。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "point": {
+          "const": "before_permission_decision",
+          "description": "当前 payload 对应的 hook 点位。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "run_id": {
+          "description": "本次运行的 run 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "scope": {
+          "description": "hook 的 scope；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "session_id": {
+          "description": "当前会话标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "triggered_at": {
+          "description": "HTTP observe payload 发出时的 UTC 时间戳。",
+          "type": "string",
+          "x-stability": "stable"
+        }
+      },
+      "required": [
+        "payload_version",
+        "hook_id",
+        "point"
+      ],
+      "title": "before_permission_decision",
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "hook_id": {
+          "description": "触发当前 payload 的 hook 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "kind": {
+          "description": "hook 的 kind；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "metadata": {
+          "additionalProperties": false,
+          "description": "Point-specific hook metadata fields.",
+          "properties": {
+            "run_id": {
+              "description": "当前 run 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "session_id": {
+              "description": "当前 session 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "tool_arguments_preview": {
+              "description": "脱敏并截断后的工具参数预览。",
+              "type": "string",
+              "x-stability": "experimental"
+            },
+            "tool_call_id": {
+              "description": "当前工具调用标识。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "tool_name": {
+              "description": "当前工具名称。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "workdir": {
+              "description": "本次运行的工作目录。",
+              "type": "string",
+              "x-stability": "stable"
+            }
+          },
+          "type": "object"
+        },
+        "mode": {
+          "description": "hook 的 mode；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "payload_version": {
+          "const": "1",
+          "description": "公开 payload 协议版本号。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "point": {
+          "const": "before_tool_call",
+          "description": "当前 payload 对应的 hook 点位。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "run_id": {
+          "description": "本次运行的 run 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "scope": {
+          "description": "hook 的 scope；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "session_id": {
+          "description": "当前会话标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "triggered_at": {
+          "description": "HTTP observe payload 发出时的 UTC 时间戳。",
+          "type": "string",
+          "x-stability": "stable"
+        }
+      },
+      "required": [
+        "payload_version",
+        "hook_id",
+        "point"
+      ],
+      "title": "before_tool_call",
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "hook_id": {
+          "description": "触发当前 payload 的 hook 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "kind": {
+          "description": "hook 的 kind；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "metadata": {
+          "additionalProperties": false,
+          "description": "Point-specific hook metadata fields.",
+          "properties": {
+            "applied": {
+              "description": "compact 结果是否已应用。",
+              "type": "boolean",
+              "x-stability": "stable"
+            },
+            "run_id": {
+              "description": "当前 run 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "session_id": {
+              "description": "当前 session 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "trigger_mode": {
+              "description": "触发 compact 的模式。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "workdir": {
+              "description": "compact 使用的工作目录。",
+              "type": "string",
+              "x-stability": "stable"
+            }
+          },
+          "type": "object"
+        },
+        "mode": {
+          "description": "hook 的 mode；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "payload_version": {
+          "const": "1",
+          "description": "公开 payload 协议版本号。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "point": {
+          "const": "post_compact",
+          "description": "当前 payload 对应的 hook 点位。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "run_id": {
+          "description": "本次运行的 run 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "scope": {
+          "description": "hook 的 scope；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "session_id": {
+          "description": "当前会话标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "triggered_at": {
+          "description": "HTTP observe payload 发出时的 UTC 时间戳。",
+          "type": "string",
+          "x-stability": "stable"
+        }
+      },
+      "required": [
+        "payload_version",
+        "hook_id",
+        "point"
+      ],
+      "title": "post_compact",
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "hook_id": {
+          "description": "触发当前 payload 的 hook 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "kind": {
+          "description": "hook 的 kind；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "metadata": {
+          "additionalProperties": false,
+          "description": "Point-specific hook metadata fields.",
+          "properties": {
+            "run_id": {
+              "description": "当前 run 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "session_id": {
+              "description": "当前 session 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "trigger_mode": {
+              "description": "触发 compact 的模式。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "workdir": {
+              "description": "compact 使用的工作目录。",
+              "type": "string",
+              "x-stability": "stable"
+            }
+          },
+          "type": "object"
+        },
+        "mode": {
+          "description": "hook 的 mode；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "payload_version": {
+          "const": "1",
+          "description": "公开 payload 协议版本号。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "point": {
+          "const": "pre_compact",
+          "description": "当前 payload 对应的 hook 点位。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "run_id": {
+          "description": "本次运行的 run 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "scope": {
+          "description": "hook 的 scope；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "session_id": {
+          "description": "当前会话标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "triggered_at": {
+          "description": "HTTP observe payload 发出时的 UTC 时间戳。",
+          "type": "string",
+          "x-stability": "stable"
+        }
+      },
+      "required": [
+        "payload_version",
+        "hook_id",
+        "point"
+      ],
+      "title": "pre_compact",
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "hook_id": {
+          "description": "触发当前 payload 的 hook 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "kind": {
+          "description": "hook 的 kind；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "metadata": {
+          "additionalProperties": false,
+          "description": "Point-specific hook metadata fields.",
+          "properties": {
+            "detail": {
+              "description": "停止原因的补充说明。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "run_id": {
+              "description": "当前 run 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "session_id": {
+              "description": "当前 session 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "stop_reason": {
+              "description": "当前运行的停止原因。",
+              "type": "string",
+              "x-stability": "stable"
+            }
+          },
+          "type": "object"
+        },
+        "mode": {
+          "description": "hook 的 mode；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "payload_version": {
+          "const": "1",
+          "description": "公开 payload 协议版本号。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "point": {
+          "const": "session_end",
+          "description": "当前 payload 对应的 hook 点位。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "run_id": {
+          "description": "本次运行的 run 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "scope": {
+          "description": "hook 的 scope；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "session_id": {
+          "description": "当前会话标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "triggered_at": {
+          "description": "HTTP observe payload 发出时的 UTC 时间戳。",
+          "type": "string",
+          "x-stability": "stable"
+        }
+      },
+      "required": [
+        "payload_version",
+        "hook_id",
+        "point"
+      ],
+      "title": "session_end",
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "hook_id": {
+          "description": "触发当前 payload 的 hook 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "kind": {
+          "description": "hook 的 kind；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "metadata": {
+          "additionalProperties": false,
+          "description": "Point-specific hook metadata fields.",
+          "properties": {
+            "run_id": {
+              "description": "当前 run 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "session_id": {
+              "description": "当前 session 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "workdir": {
+              "description": "本次运行的工作目录。",
+              "type": "string",
+              "x-stability": "stable"
+            }
+          },
+          "type": "object"
+        },
+        "mode": {
+          "description": "hook 的 mode；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "payload_version": {
+          "const": "1",
+          "description": "公开 payload 协议版本号。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "point": {
+          "const": "session_start",
+          "description": "当前 payload 对应的 hook 点位。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "run_id": {
+          "description": "本次运行的 run 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "scope": {
+          "description": "hook 的 scope；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "session_id": {
+          "description": "当前会话标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "triggered_at": {
+          "description": "HTTP observe payload 发出时的 UTC 时间戳。",
+          "type": "string",
+          "x-stability": "stable"
+        }
+      },
+      "required": [
+        "payload_version",
+        "hook_id",
+        "point"
+      ],
+      "title": "session_start",
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "hook_id": {
+          "description": "触发当前 payload 的 hook 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "kind": {
+          "description": "hook 的 kind；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "metadata": {
+          "additionalProperties": false,
+          "description": "Point-specific hook metadata fields.",
+          "properties": {
+            "role": {
+              "description": "子代理角色。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "run_id": {
+              "description": "当前 run 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "session_id": {
+              "description": "当前 session 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "task_id": {
+              "description": "子代理任务标识。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "tool_name": {
+              "description": "触发子代理的工具名。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "trigger": {
+              "description": "触发子代理的来源。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "workdir": {
+              "description": "子代理运行工作目录。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "workspace": {
+              "description": "子代理工作目录。",
+              "type": "string",
+              "x-stability": "stable"
+            }
+          },
+          "type": "object"
+        },
+        "mode": {
+          "description": "hook 的 mode；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "payload_version": {
+          "const": "1",
+          "description": "公开 payload 协议版本号。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "point": {
+          "const": "subagent_start",
+          "description": "当前 payload 对应的 hook 点位。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "run_id": {
+          "description": "本次运行的 run 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "scope": {
+          "description": "hook 的 scope；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "session_id": {
+          "description": "当前会话标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "triggered_at": {
+          "description": "HTTP observe payload 发出时的 UTC 时间戳。",
+          "type": "string",
+          "x-stability": "stable"
+        }
+      },
+      "required": [
+        "payload_version",
+        "hook_id",
+        "point"
+      ],
+      "title": "subagent_start",
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "hook_id": {
+          "description": "触发当前 payload 的 hook 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "kind": {
+          "description": "hook 的 kind；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "metadata": {
+          "additionalProperties": false,
+          "description": "Point-specific hook metadata fields.",
+          "properties": {
+            "error": {
+              "description": "子代理错误信息。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "role": {
+              "description": "子代理角色。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "run_id": {
+              "description": "当前 run 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "session_id": {
+              "description": "当前 session 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "state": {
+              "description": "子代理结束时状态。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "step_count": {
+              "description": "子代理累计步数。",
+              "type": "integer",
+              "x-stability": "stable"
+            },
+            "stop_reason": {
+              "description": "子代理停止原因。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "task_id": {
+              "description": "子代理任务标识。",
+              "type": "string",
+              "x-stability": "stable"
+            }
+          },
+          "type": "object"
+        },
+        "mode": {
+          "description": "hook 的 mode；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "payload_version": {
+          "const": "1",
+          "description": "公开 payload 协议版本号。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "point": {
+          "const": "subagent_stop",
+          "description": "当前 payload 对应的 hook 点位。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "run_id": {
+          "description": "本次运行的 run 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "scope": {
+          "description": "hook 的 scope；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "session_id": {
+          "description": "当前会话标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "triggered_at": {
+          "description": "HTTP observe payload 发出时的 UTC 时间戳。",
+          "type": "string",
+          "x-stability": "stable"
+        }
+      },
+      "required": [
+        "payload_version",
+        "hook_id",
+        "point"
+      ],
+      "title": "subagent_stop",
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "hook_id": {
+          "description": "触发当前 payload 的 hook 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "kind": {
+          "description": "hook 的 kind；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "metadata": {
+          "additionalProperties": false,
+          "description": "Point-specific hook metadata fields.",
+          "properties": {
+            "run_id": {
+              "description": "当前 run 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "session_id": {
+              "description": "当前 session 标识的 metadata 冗余副本。",
+              "type": "string",
+              "x-stability": "stable"
+            },
+            "workdir": {
+              "description": "本次运行的工作目录。",
+              "type": "string",
+              "x-stability": "stable"
+            }
+          },
+          "type": "object"
+        },
+        "mode": {
+          "description": "hook 的 mode；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "payload_version": {
+          "const": "1",
+          "description": "公开 payload 协议版本号。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "point": {
+          "const": "user_prompt_submit",
+          "description": "当前 payload 对应的 hook 点位。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "run_id": {
+          "description": "本次运行的 run 标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "scope": {
+          "description": "hook 的 scope；HTTP observe 作为传输附加字段透传。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "session_id": {
+          "description": "当前会话标识。",
+          "type": "string",
+          "x-stability": "stable"
+        },
+        "triggered_at": {
+          "description": "HTTP observe payload 发出时的 UTC 时间戳。",
+          "type": "string",
+          "x-stability": "stable"
+        }
+      },
+      "required": [
+        "payload_version",
+        "hook_id",
+        "point"
+      ],
+      "title": "user_prompt_submit",
+      "type": "object"
+    }
+  ],
+  "title": "NeoCode Hook Payload v1",
+  "type": "object"
+}

--- a/docs/runtime-hooks-design.md
+++ b/docs/runtime-hooks-design.md
@@ -55,8 +55,8 @@ repo hooks 文件路径固定为：
 <workspace>/.neocode/hooks.yaml
 ```
 
-仅支持与 P2 相同的 builtin 子集（`kind=builtin`、`mode=sync`、`UserAllowed=true` points、3 个 handlers）。
-repo hooks 暂不支持 `kind=http`，external kinds（`command/http/prompt/agent`）在 repo 侧仍显式拒绝。
+支持与 P2 相同的 builtin 子集（`kind=builtin`、`mode=sync`、`UserAllowed=true` points、3 个 handlers），并开放 `kind=command + mode=sync`。
+repo hooks 仍不支持 `kind=http`；external kinds 中当前仅 `command` 开放，`prompt/agent` 仍显式拒绝。
 
 执行顺序固定为：
 
@@ -73,21 +73,54 @@ internal -> user -> repo
 
 ### 上下文裁剪
 
-user/repo hook 接收的 `HookContext` 经过白名单裁剪，仅保留最小必要字段：
+user/repo hook 接收的 `HookContext` 经过点位感知的 payload schema 裁剪，仅保留最小必要字段：
 
-- `run_id` / `session_id`
-- `point` / `tool_call_id` / `tool_name`
-- `tool_arguments_preview`（脱敏+截断后的参数预览）
-- `is_error` / `error_class`
-- `result_content_preview` / `result_metadata_present`
-- `execution_error`
-- `workdir`
+- 顶层字段：`run_id` / `session_id`
+- metadata 字段：按 `point` 不同暴露对应的最小子集，例如 `tool_call_id`、`tool_name`、`workdir`
+- 预览/摘要类字段：`tool_arguments_preview`、`result_content_preview`、`todo_summary`、`recent_tool_summary`
+- 完整机器可读契约见 `docs/reference/hook-payload.v1.json`
 
 不会暴露：
 
 - API key / capability token
 - service 指针与 provider 客户端对象
 - 原始工具参数明文（`tool_arguments`）
+
+### Payload Schema
+
+Hook payload 已从 runtime 内部白名单提升为公开契约：
+
+- 版本号真源：`internal/runtime/hooks.PayloadVersion`
+- 当前版本：`payload_version: "1"`
+- 生成命令：`go generate ./internal/runtime/hooks`
+- 生成产物：`docs/reference/hook-payload.v1.json`
+- command stdin 与 HTTP observe body 都带 `payload_version`
+- HTTP observe 在共享字段之外，继续保留 `scope`、`kind`、`mode`、`triggered_at` 作为 transport 附加字段
+- `metadata.point`、`completion_passed`、`has_tool_calls`、`assistant_role` 这类未由 runtime 真实生产的字段不再公开
+
+稳定性分级：
+
+- `stable`：身份/控制类字段，默认兼容承诺
+- `experimental`：预览/摘要类字段，当前包括 `tool_arguments_preview`、`result_content_preview`、`todo_summary`、`recent_tool_summary`
+- `deprecated`：保留给后续版本迁移，本版未使用
+
+各点位 metadata 字段：
+
+| point | metadata fields |
+|---|---|
+| `before_tool_call` | `run_id`, `session_id`, `tool_call_id`, `tool_name`, `tool_arguments_preview` (experimental), `workdir` |
+| `after_tool_result` | `run_id`, `session_id`, `tool_call_id`, `tool_name`, `is_error`, `error_class`, `result_content_preview` (experimental), `result_metadata_present`, `execution_error`, `workdir` |
+| `before_completion_decision` | `run_id`, `session_id` |
+| `accept_gate` | `run_id`, `session_id`, `workdir`, `workspace_changed`, `assistant_text_empty`, `todo_summary` (experimental), `recent_tool_summary` (experimental) |
+| `before_permission_decision` | `run_id`, `session_id`, `tool_call_id`, `tool_name`, `decision`, `reason`, `rule_id`, `workdir` |
+| `after_tool_failure` | `run_id`, `session_id`, `tool_call_id`, `tool_name`, `tool_arguments_preview` (experimental), `is_error`, `error_class`, `execution_error`, `result_content_preview` (experimental), `workdir` |
+| `session_start` | `run_id`, `session_id`, `workdir` |
+| `session_end` | `run_id`, `session_id`, `stop_reason`, `detail` |
+| `user_prompt_submit` | `run_id`, `session_id`, `workdir` |
+| `pre_compact` | `run_id`, `session_id`, `workdir`, `trigger_mode` |
+| `post_compact` | `run_id`, `session_id`, `workdir`, `trigger_mode`, `applied` |
+| `subagent_start` | `run_id`, `session_id`, `task_id`, `role`, `workspace`, `tool_name`, `trigger`, `workdir` |
+| `subagent_stop` | `run_id`, `session_id`, `task_id`, `role`, `state`, `stop_reason`, `step_count`, `error` |
 
 ### 点位能力矩阵（P4）
 
@@ -184,6 +217,7 @@ trust store 固定路径：
 - `hook_id`：hook 配置中的 `id`
 - `point`：触发点位名称
 - `metadata`：经白名单裁剪后的上下文字段（与 builtin/http hook 相同的 allowlist）
+- 完整字段表与稳定性分级见 `docs/reference/hook-payload.v1.json`
 
 ### stdout 协议
 

--- a/internal/runtime/hooks/cmd/hookpayloadschema/main.go
+++ b/internal/runtime/hooks/cmd/hookpayloadschema/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	runtimehooks "neo-code/internal/runtime/hooks"
+)
+
+func main() {
+	content, err := runtimehooks.MarshalPayloadJSONSchema()
+	if err != nil {
+		fail(err)
+	}
+	targetPath := filepath.Clean(filepath.Join("..", "..", "..", "docs", "reference", schemaFileName()))
+	if err := os.WriteFile(targetPath, content, 0o644); err != nil {
+		fail(err)
+	}
+}
+
+func schemaFileName() string {
+	return fmt.Sprintf("hook-payload.v%s.json", runtimehooks.PayloadVersion)
+}
+
+func fail(err error) {
+	_, _ = fmt.Fprintf(os.Stderr, "generate hook payload schema: %v\n", err)
+	os.Exit(1)
+}

--- a/internal/runtime/hooks/command_handler.go
+++ b/internal/runtime/hooks/command_handler.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CommandHookPayloadVersion 定义 command hook stdin 协议版本号，变更 stdin 结构时递增。
-const CommandHookPayloadVersion = "1"
+const CommandHookPayloadVersion = PayloadVersion
 
 // maxCommandStdoutBytes 限制外部命令 stdout 最大读取字节数，防止 OOM。
 const maxCommandStdoutBytes = 1 << 20 // 1 MiB
@@ -109,14 +109,14 @@ func ParseCommandParams(params map[string]any) (argv []string, shell bool, err e
 // BuildCommandPayload 构造传给外部命令的 stdin JSON payload。
 func BuildCommandPayload(hookID string, point HookPoint, input HookContext) CommandHookPayload {
 	payload := CommandHookPayload{
-		PayloadVersion: CommandHookPayloadVersion,
+		PayloadVersion: PayloadVersion,
 		HookID:         strings.TrimSpace(hookID),
 		Point:          string(point),
 		RunID:          strings.TrimSpace(input.RunID),
 		SessionID:      strings.TrimSpace(input.SessionID),
 	}
-	if len(input.Metadata) > 0 {
-		payload.Metadata = input.Metadata
+	if metadata := sanitizePayloadMetadata(point, input.Metadata); len(metadata) > 0 {
+		payload.Metadata = metadata
 	}
 	return payload
 }
@@ -256,7 +256,7 @@ func buildCommandEnv(spec CommandHookSpec) []string {
 	env := []string{
 		"NEOCODE_HOOK_HOOK_ID=" + spec.HookID,
 		"NEOCODE_HOOK_POINT=" + string(spec.Point),
-		"NEOCODE_HOOK_PAYLOAD_VERSION=" + CommandHookPayloadVersion,
+		"NEOCODE_HOOK_PAYLOAD_VERSION=" + PayloadVersion,
 	}
 	if runtime.GOOS == "windows" {
 		for _, key := range []string{"SystemRoot", "SystemDrive", "USERPROFILE"} {

--- a/internal/runtime/hooks/command_handler_test.go
+++ b/internal/runtime/hooks/command_handler_test.go
@@ -18,12 +18,14 @@ func TestBuildCommandPayload(t *testing.T) {
 		RunID:     "run-123",
 		SessionID: "sess-456",
 		Metadata: map[string]any{
-			"tool_name": "bash",
-			"workdir":   "/tmp",
+			"tool_name":        "bash",
+			"workdir":          "/tmp",
+			"tool_arguments":   "rm -rf /tmp",
+			"capability_token": "secret",
 		},
 	})
-	if payload.PayloadVersion != CommandHookPayloadVersion {
-		t.Fatalf("payload_version = %q, want %q", payload.PayloadVersion, CommandHookPayloadVersion)
+	if payload.PayloadVersion != PayloadVersion {
+		t.Fatalf("payload_version = %q, want %q", payload.PayloadVersion, PayloadVersion)
 	}
 	if payload.HookID != "my-hook" {
 		t.Fatalf("hook_id = %q, want %q", payload.HookID, "my-hook")
@@ -39,6 +41,12 @@ func TestBuildCommandPayload(t *testing.T) {
 	}
 	if payload.Metadata["tool_name"] != "bash" {
 		t.Fatalf("metadata[tool_name] = %v, want %q", payload.Metadata["tool_name"], "bash")
+	}
+	if _, exists := payload.Metadata["tool_arguments"]; exists {
+		t.Fatal("metadata[tool_arguments] should be stripped by payload schema")
+	}
+	if _, exists := payload.Metadata["capability_token"]; exists {
+		t.Fatal("metadata[capability_token] should be stripped by payload schema")
 	}
 }
 
@@ -723,13 +731,13 @@ func TestRunCommandHookStdinPayloadWithMetadata(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		spec = CommandHookSpec{
 			HookID:  "stdin-meta",
-			Point:   HookPointUserPromptSubmit,
+			Point:   HookPointBeforeToolCall,
 			Command: []string{"powershell", "-Command", "$input"},
 		}
 	} else {
 		spec = CommandHookSpec{
 			HookID:  "stdin-meta",
-			Point:   HookPointUserPromptSubmit,
+			Point:   HookPointBeforeToolCall,
 			Command: []string{"cat"},
 		}
 	}

--- a/internal/runtime/hooks/docgen_generate.go
+++ b/internal/runtime/hooks/docgen_generate.go
@@ -1,0 +1,3 @@
+package hooks
+
+//go:generate go run ./cmd/hookpayloadschema

--- a/internal/runtime/hooks/executor.go
+++ b/internal/runtime/hooks/executor.go
@@ -77,7 +77,7 @@ func (e *Executor) Run(ctx context.Context, point HookPoint, input HookContext) 
 	for _, spec := range specs {
 		hookInput := input.Clone()
 		if spec.Scope == HookScopeUser || spec.Scope == HookScopeRepo {
-			hookInput = sanitizeUserHookContext(hookInput)
+			hookInput = sanitizeUserHookContext(spec.Point, hookInput)
 		}
 		if spec.Matcher != nil && !spec.Matcher.Match(hookInput) {
 			continue
@@ -331,59 +331,12 @@ func (e *Executor) callHandler(
 	}
 }
 
-func sanitizeUserHookContext(input HookContext) HookContext {
+func sanitizeUserHookContext(point HookPoint, input HookContext) HookContext {
 	sanitized := HookContext{
 		RunID:     strings.TrimSpace(input.RunID),
 		SessionID: strings.TrimSpace(input.SessionID),
 	}
-	if len(input.Metadata) == 0 {
-		return sanitized
-	}
-	allowedMetadataKeys := map[string]struct{}{
-		"point":                   {},
-		"tool_call_id":            {},
-		"tool_name":               {},
-		"tool_arguments_preview":  {},
-		"is_error":                {},
-		"error_class":             {},
-		"result_content_preview":  {},
-		"result_metadata_present": {},
-		"execution_error":         {},
-		"workdir":                 {},
-		"session_id":              {},
-		"run_id":                  {},
-		"task_id":                 {},
-		"role":                    {},
-		"workspace":               {},
-		"trigger":                 {},
-		"state":                   {},
-		"stop_reason":             {},
-		"step_count":              {},
-		"error":                   {},
-		"trigger_mode":            {},
-		"applied":                 {},
-		"decision":                {},
-		"reason":                  {},
-		"rule_id":                 {},
-		"completion_passed":       {},
-		"has_tool_calls":          {},
-		"assistant_role":          {},
-		"detail":                  {},
-		"workspace_changed":       {},
-		"assistant_text_empty":    {},
-		"todo_summary":            {},
-		"recent_tool_summary":     {},
-	}
-	for key, value := range input.Metadata {
-		normalizedKey := strings.ToLower(strings.TrimSpace(key))
-		if _, ok := allowedMetadataKeys[normalizedKey]; !ok {
-			continue
-		}
-		if sanitized.Metadata == nil {
-			sanitized.Metadata = make(map[string]any, len(input.Metadata))
-		}
-		sanitized.Metadata[normalizedKey] = cloneMetadataValue(value)
-	}
+	sanitized.Metadata = sanitizePayloadMetadata(point, input.Metadata)
 	return sanitized
 }
 

--- a/internal/runtime/hooks/executor_test.go
+++ b/internal/runtime/hooks/executor_test.go
@@ -959,6 +959,8 @@ func TestExecutorSanitizeUserHookContext(t *testing.T) {
 			"tool_arguments":         "--secret-token=abc",
 			"tool_arguments_preview": "token=***",
 			"capability_token":       "should-not-leak",
+			"completion_passed":      true,
+			"assistant_role":         "assistant",
 			"workdir":                "/tmp/work",
 		},
 	})
@@ -977,6 +979,12 @@ func TestExecutorSanitizeUserHookContext(t *testing.T) {
 	}
 	if _, exists := captured.Metadata["capability_token"]; exists {
 		t.Fatal("capability_token should be stripped for user hook context")
+	}
+	if _, exists := captured.Metadata["completion_passed"]; exists {
+		t.Fatal("completion_passed should be stripped when not produced by runtime")
+	}
+	if _, exists := captured.Metadata["assistant_role"]; exists {
+		t.Fatal("assistant_role should be stripped when not produced by runtime")
 	}
 }
 
@@ -1007,6 +1015,8 @@ func TestExecutorSanitizeRepoHookContext(t *testing.T) {
 			"tool_arguments":         "--secret-token=abc",
 			"tool_arguments_preview": "token=***",
 			"capability_token":       "should-not-leak",
+			"completion_passed":      true,
+			"assistant_role":         "assistant",
 			"workdir":                "/tmp/work",
 		},
 	})
@@ -1022,6 +1032,12 @@ func TestExecutorSanitizeRepoHookContext(t *testing.T) {
 	}
 	if _, exists := captured.Metadata["capability_token"]; exists {
 		t.Fatal("capability_token should be stripped for repo hook context")
+	}
+	if _, exists := captured.Metadata["completion_passed"]; exists {
+		t.Fatal("completion_passed should be stripped for repo hook context")
+	}
+	if _, exists := captured.Metadata["assistant_role"]; exists {
+		t.Fatal("assistant_role should be stripped for repo hook context")
 	}
 }
 
@@ -1052,4 +1068,3 @@ func TestExecutorSkipsHookWhenMatcherMissed(t *testing.T) {
 		t.Fatalf("len(Results) = %d, want 0 when matcher missed", len(output.Results))
 	}
 }
-

--- a/internal/runtime/hooks/payload_schema.go
+++ b/internal/runtime/hooks/payload_schema.go
@@ -1,0 +1,418 @@
+package hooks
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+)
+
+// PayloadVersion 定义对外公开的 hook payload 协议版本号。
+const PayloadVersion = "1"
+
+// PayloadStability 描述字段在对外契约中的稳定性等级。
+type PayloadStability string
+
+const (
+	// PayloadStabilityStable 表示字段已进入稳定契约。
+	PayloadStabilityStable PayloadStability = "stable"
+	// PayloadStabilityExperimental 表示字段仍可能继续演进。
+	PayloadStabilityExperimental PayloadStability = "experimental"
+	// PayloadStabilityDeprecated 表示字段已进入弃用阶段。
+	PayloadStabilityDeprecated PayloadStability = "deprecated"
+)
+
+// PayloadFieldSchema 描述单个 payload 字段的公开契约。
+type PayloadFieldSchema struct {
+	Name           string           `json:"name"`
+	JSONType       string           `json:"json_type"`
+	Stability      PayloadStability `json:"stability"`
+	Description    string           `json:"description,omitempty"`
+	Properties     []PayloadFieldSchema
+	ItemType       string
+	ItemProperties []PayloadFieldSchema
+}
+
+// PointPayloadSchema 描述单个 hook 点位的公开 payload 契约。
+type PointPayloadSchema struct {
+	Point          HookPoint            `json:"point"`
+	PayloadVersion string               `json:"payload_version"`
+	TopLevel       []PayloadFieldSchema `json:"top_level"`
+	Metadata       []PayloadFieldSchema `json:"metadata"`
+}
+
+var payloadTopLevelFields = []PayloadFieldSchema{
+	payloadStringField("payload_version", PayloadStabilityStable, "公开 payload 协议版本号。"),
+	payloadStringField("hook_id", PayloadStabilityStable, "触发当前 payload 的 hook 标识。"),
+	payloadStringField("point", PayloadStabilityStable, "当前 payload 对应的 hook 点位。"),
+	payloadStringField("run_id", PayloadStabilityStable, "本次运行的 run 标识。"),
+	payloadStringField("session_id", PayloadStabilityStable, "当前会话标识。"),
+	payloadStringField("scope", PayloadStabilityStable, "hook 的 scope；HTTP observe 作为传输附加字段透传。"),
+	payloadStringField("kind", PayloadStabilityStable, "hook 的 kind；HTTP observe 作为传输附加字段透传。"),
+	payloadStringField("mode", PayloadStabilityStable, "hook 的 mode；HTTP observe 作为传输附加字段透传。"),
+	payloadStringField("triggered_at", PayloadStabilityStable, "HTTP observe payload 发出时的 UTC 时间戳。"),
+}
+
+var pointPayloadMetadata = map[HookPoint][]PayloadFieldSchema{
+	HookPointAcceptGate: {
+		payloadStringField("run_id", PayloadStabilityStable, "当前 run 标识的 metadata 冗余副本。"),
+		payloadStringField("session_id", PayloadStabilityStable, "当前 session 标识的 metadata 冗余副本。"),
+		payloadStringField("workdir", PayloadStabilityStable, "本次运行的工作目录。"),
+		payloadBoolField("workspace_changed", PayloadStabilityStable, "当前 run 是否已产生 workspace 写入。"),
+		payloadBoolField("assistant_text_empty", PayloadStabilityStable, "assistant 文本输出是否为空。"),
+		payloadObjectField(
+			"todo_summary",
+			PayloadStabilityExperimental,
+			"当前 todo 摘要，字段仍可能继续演进。",
+			payloadIntegerField("total", PayloadStabilityStable, "todo 总数。"),
+			payloadIntegerField("required_total", PayloadStabilityStable, "required todo 总数。"),
+			payloadIntegerField("required_completed", PayloadStabilityStable, "已完成的 required todo 数量。"),
+			payloadIntegerField("required_failed", PayloadStabilityStable, "已失败的 required todo 数量。"),
+			payloadIntegerField("required_open", PayloadStabilityStable, "尚未终态的 required todo 数量。"),
+		),
+		payloadArrayOfObjectsField(
+			"recent_tool_summary",
+			PayloadStabilityExperimental,
+			"最近一批工具调用摘要，结构仍可能继续演进。",
+			payloadStringField("name", PayloadStabilityStable, "工具名称。"),
+			payloadBoolField("is_error", PayloadStabilityStable, "该工具结果是否为错误。"),
+		),
+	},
+	HookPointAfterToolFailure: {
+		payloadStringField("run_id", PayloadStabilityStable, "当前 run 标识的 metadata 冗余副本。"),
+		payloadStringField("session_id", PayloadStabilityStable, "当前 session 标识的 metadata 冗余副本。"),
+		payloadStringField("tool_call_id", PayloadStabilityStable, "当前工具调用标识。"),
+		payloadStringField("tool_name", PayloadStabilityStable, "当前工具名称。"),
+		payloadStringField("tool_arguments_preview", PayloadStabilityExperimental, "脱敏并截断后的工具参数预览。"),
+		payloadBoolField("is_error", PayloadStabilityStable, "工具结果是否为错误。"),
+		payloadStringField("error_class", PayloadStabilityStable, "工具错误分类。"),
+		payloadStringField("execution_error", PayloadStabilityStable, "工具执行层错误文本。"),
+		payloadStringField("result_content_preview", PayloadStabilityExperimental, "工具结果内容预览。"),
+		payloadStringField("workdir", PayloadStabilityStable, "本次运行的工作目录。"),
+	},
+	HookPointAfterToolResult: {
+		payloadStringField("run_id", PayloadStabilityStable, "当前 run 标识的 metadata 冗余副本。"),
+		payloadStringField("session_id", PayloadStabilityStable, "当前 session 标识的 metadata 冗余副本。"),
+		payloadStringField("tool_call_id", PayloadStabilityStable, "当前工具调用标识。"),
+		payloadStringField("tool_name", PayloadStabilityStable, "当前工具名称。"),
+		payloadBoolField("is_error", PayloadStabilityStable, "工具结果是否为错误。"),
+		payloadStringField("error_class", PayloadStabilityStable, "工具错误分类。"),
+		payloadStringField("result_content_preview", PayloadStabilityExperimental, "工具结果内容预览。"),
+		payloadBoolField("result_metadata_present", PayloadStabilityStable, "工具结果 metadata 是否非空。"),
+		payloadStringField("execution_error", PayloadStabilityStable, "工具执行层错误文本。"),
+		payloadStringField("workdir", PayloadStabilityStable, "本次运行的工作目录。"),
+	},
+	HookPointBeforeCompletionDecision: {
+		payloadStringField("run_id", PayloadStabilityStable, "当前 run 标识的 metadata 冗余副本。"),
+		payloadStringField("session_id", PayloadStabilityStable, "当前 session 标识的 metadata 冗余副本。"),
+	},
+	HookPointBeforePermissionDecision: {
+		payloadStringField("run_id", PayloadStabilityStable, "当前 run 标识的 metadata 冗余副本。"),
+		payloadStringField("session_id", PayloadStabilityStable, "当前 session 标识的 metadata 冗余副本。"),
+		payloadStringField("tool_call_id", PayloadStabilityStable, "当前工具调用标识。"),
+		payloadStringField("tool_name", PayloadStabilityStable, "当前工具名称。"),
+		payloadStringField("decision", PayloadStabilityStable, "权限决策结果。"),
+		payloadStringField("reason", PayloadStabilityStable, "权限决策原因。"),
+		payloadStringField("rule_id", PayloadStabilityStable, "命中的权限规则标识。"),
+		payloadStringField("workdir", PayloadStabilityStable, "本次运行的工作目录。"),
+	},
+	HookPointBeforeToolCall: {
+		payloadStringField("run_id", PayloadStabilityStable, "当前 run 标识的 metadata 冗余副本。"),
+		payloadStringField("session_id", PayloadStabilityStable, "当前 session 标识的 metadata 冗余副本。"),
+		payloadStringField("tool_call_id", PayloadStabilityStable, "当前工具调用标识。"),
+		payloadStringField("tool_name", PayloadStabilityStable, "当前工具名称。"),
+		payloadStringField("tool_arguments_preview", PayloadStabilityExperimental, "脱敏并截断后的工具参数预览。"),
+		payloadStringField("workdir", PayloadStabilityStable, "本次运行的工作目录。"),
+	},
+	HookPointPostCompact: {
+		payloadStringField("run_id", PayloadStabilityStable, "当前 run 标识的 metadata 冗余副本。"),
+		payloadStringField("session_id", PayloadStabilityStable, "当前 session 标识的 metadata 冗余副本。"),
+		payloadStringField("workdir", PayloadStabilityStable, "compact 使用的工作目录。"),
+		payloadStringField("trigger_mode", PayloadStabilityStable, "触发 compact 的模式。"),
+		payloadBoolField("applied", PayloadStabilityStable, "compact 结果是否已应用。"),
+	},
+	HookPointPreCompact: {
+		payloadStringField("run_id", PayloadStabilityStable, "当前 run 标识的 metadata 冗余副本。"),
+		payloadStringField("session_id", PayloadStabilityStable, "当前 session 标识的 metadata 冗余副本。"),
+		payloadStringField("workdir", PayloadStabilityStable, "compact 使用的工作目录。"),
+		payloadStringField("trigger_mode", PayloadStabilityStable, "触发 compact 的模式。"),
+	},
+	HookPointSessionEnd: {
+		payloadStringField("run_id", PayloadStabilityStable, "当前 run 标识的 metadata 冗余副本。"),
+		payloadStringField("session_id", PayloadStabilityStable, "当前 session 标识的 metadata 冗余副本。"),
+		payloadStringField("stop_reason", PayloadStabilityStable, "当前运行的停止原因。"),
+		payloadStringField("detail", PayloadStabilityStable, "停止原因的补充说明。"),
+	},
+	HookPointSessionStart: {
+		payloadStringField("run_id", PayloadStabilityStable, "当前 run 标识的 metadata 冗余副本。"),
+		payloadStringField("session_id", PayloadStabilityStable, "当前 session 标识的 metadata 冗余副本。"),
+		payloadStringField("workdir", PayloadStabilityStable, "本次运行的工作目录。"),
+	},
+	HookPointSubAgentStart: {
+		payloadStringField("run_id", PayloadStabilityStable, "当前 run 标识的 metadata 冗余副本。"),
+		payloadStringField("session_id", PayloadStabilityStable, "当前 session 标识的 metadata 冗余副本。"),
+		payloadStringField("task_id", PayloadStabilityStable, "子代理任务标识。"),
+		payloadStringField("role", PayloadStabilityStable, "子代理角色。"),
+		payloadStringField("workspace", PayloadStabilityStable, "子代理工作目录。"),
+		payloadStringField("tool_name", PayloadStabilityStable, "触发子代理的工具名。"),
+		payloadStringField("trigger", PayloadStabilityStable, "触发子代理的来源。"),
+		payloadStringField("workdir", PayloadStabilityStable, "子代理运行工作目录。"),
+	},
+	HookPointSubAgentStop: {
+		payloadStringField("run_id", PayloadStabilityStable, "当前 run 标识的 metadata 冗余副本。"),
+		payloadStringField("session_id", PayloadStabilityStable, "当前 session 标识的 metadata 冗余副本。"),
+		payloadStringField("task_id", PayloadStabilityStable, "子代理任务标识。"),
+		payloadStringField("role", PayloadStabilityStable, "子代理角色。"),
+		payloadStringField("state", PayloadStabilityStable, "子代理结束时状态。"),
+		payloadStringField("stop_reason", PayloadStabilityStable, "子代理停止原因。"),
+		payloadIntegerField("step_count", PayloadStabilityStable, "子代理累计步数。"),
+		payloadStringField("error", PayloadStabilityStable, "子代理错误信息。"),
+	},
+	HookPointUserPromptSubmit: {
+		payloadStringField("run_id", PayloadStabilityStable, "当前 run 标识的 metadata 冗余副本。"),
+		payloadStringField("session_id", PayloadStabilityStable, "当前 session 标识的 metadata 冗余副本。"),
+		payloadStringField("workdir", PayloadStabilityStable, "本次运行的工作目录。"),
+	},
+}
+
+// PayloadSchema 返回指定点位的公开 payload 契约定义。
+func PayloadSchema(point HookPoint) PointPayloadSchema {
+	metadata, ok := pointPayloadMetadata[point]
+	if !ok {
+		return PointPayloadSchema{}
+	}
+	return PointPayloadSchema{
+		Point:          point,
+		PayloadVersion: PayloadVersion,
+		TopLevel:       clonePayloadFieldSchemas(payloadTopLevelFields),
+		Metadata:       clonePayloadFieldSchemas(metadata),
+	}
+}
+
+// ListPayloadSchemas 返回所有已注册点位的 payload 契约，顺序与 ListHookPoints 一致。
+func ListPayloadSchemas() []PointPayloadSchema {
+	points := ListHookPoints()
+	schemas := make([]PointPayloadSchema, 0, len(points))
+	for _, point := range points {
+		schema := PayloadSchema(point)
+		if schema.Point == "" {
+			continue
+		}
+		schemas = append(schemas, schema)
+	}
+	return schemas
+}
+
+// BuildPayloadJSONSchema 构建对外公开的 hook payload JSON Schema。
+func BuildPayloadJSONSchema() map[string]any {
+	oneOf := make([]any, 0, len(pointPayloadMetadata))
+	for _, schema := range ListPayloadSchemas() {
+		oneOf = append(oneOf, buildPointPayloadJSONSchema(schema))
+	}
+	return map[string]any{
+		"$schema":     "https://json-schema.org/draft/2020-12/schema",
+		"$id":         "https://neocode.dev/schemas/hook-payload.v1.json",
+		"title":       "NeoCode Hook Payload v1",
+		"description": "Public hook payload contract for command stdin and shared HTTP observe fields.",
+		"type":        "object",
+		"oneOf":       oneOf,
+	}
+}
+
+// MarshalPayloadJSONSchema 以稳定格式序列化 hook payload JSON Schema。
+func MarshalPayloadJSONSchema() ([]byte, error) {
+	encoded, err := json.MarshalIndent(BuildPayloadJSONSchema(), "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	encoded = append(encoded, '\n')
+	return encoded, nil
+}
+
+// payloadStringField 构造 string 类型的字段契约定义。
+func payloadStringField(name string, stability PayloadStability, description string) PayloadFieldSchema {
+	return PayloadFieldSchema{
+		Name:        name,
+		JSONType:    "string",
+		Stability:   stability,
+		Description: description,
+	}
+}
+
+// payloadBoolField 构造 boolean 类型的字段契约定义。
+func payloadBoolField(name string, stability PayloadStability, description string) PayloadFieldSchema {
+	return PayloadFieldSchema{
+		Name:        name,
+		JSONType:    "boolean",
+		Stability:   stability,
+		Description: description,
+	}
+}
+
+// payloadIntegerField 构造 integer 类型的字段契约定义。
+func payloadIntegerField(name string, stability PayloadStability, description string) PayloadFieldSchema {
+	return PayloadFieldSchema{
+		Name:        name,
+		JSONType:    "integer",
+		Stability:   stability,
+		Description: description,
+	}
+}
+
+// payloadObjectField 构造 object 类型的字段契约定义。
+func payloadObjectField(
+	name string,
+	stability PayloadStability,
+	description string,
+	properties ...PayloadFieldSchema,
+) PayloadFieldSchema {
+	return PayloadFieldSchema{
+		Name:        name,
+		JSONType:    "object",
+		Stability:   stability,
+		Description: description,
+		Properties:  clonePayloadFieldSchemas(properties),
+	}
+}
+
+// payloadArrayOfObjectsField 构造对象数组类型的字段契约定义。
+func payloadArrayOfObjectsField(
+	name string,
+	stability PayloadStability,
+	description string,
+	itemProperties ...PayloadFieldSchema,
+) PayloadFieldSchema {
+	return PayloadFieldSchema{
+		Name:           name,
+		JSONType:       "array",
+		Stability:      stability,
+		Description:    description,
+		ItemType:       "object",
+		ItemProperties: clonePayloadFieldSchemas(itemProperties),
+	}
+}
+
+// clonePayloadFieldSchemas 深拷贝字段定义，避免调用方修改共享 schema。
+func clonePayloadFieldSchemas(fields []PayloadFieldSchema) []PayloadFieldSchema {
+	if len(fields) == 0 {
+		return nil
+	}
+	cloned := make([]PayloadFieldSchema, len(fields))
+	copy(cloned, fields)
+	for index := range cloned {
+		cloned[index].Properties = clonePayloadFieldSchemas(fields[index].Properties)
+		cloned[index].ItemProperties = clonePayloadFieldSchemas(fields[index].ItemProperties)
+	}
+	return cloned
+}
+
+// sanitizePayloadMetadata 按点位 schema 过滤 metadata，并复制允许暴露的值。
+func sanitizePayloadMetadata(point HookPoint, metadata map[string]any) map[string]any {
+	if len(metadata) == 0 {
+		return nil
+	}
+	schema := PayloadSchema(point)
+	if schema.Point == "" || len(schema.Metadata) == 0 {
+		return nil
+	}
+	allowed := make(map[string]struct{}, len(schema.Metadata))
+	for _, field := range schema.Metadata {
+		allowed[strings.ToLower(strings.TrimSpace(field.Name))] = struct{}{}
+	}
+	sanitized := make(map[string]any, len(schema.Metadata))
+	for key, value := range metadata {
+		normalizedKey := strings.ToLower(strings.TrimSpace(key))
+		if _, ok := allowed[normalizedKey]; !ok {
+			continue
+		}
+		sanitized[normalizedKey] = cloneMetadataValue(value)
+	}
+	if len(sanitized) == 0 {
+		return nil
+	}
+	return sanitized
+}
+
+// buildPointPayloadJSONSchema 将单点位契约转换为 JSON Schema 分支。
+func buildPointPayloadJSONSchema(schema PointPayloadSchema) map[string]any {
+	properties := make(map[string]any, len(schema.TopLevel)+1)
+	required := []string{"payload_version", "hook_id", "point"}
+	for _, field := range schema.TopLevel {
+		propertySchema := buildPayloadFieldJSONSchema(field)
+		switch field.Name {
+		case "payload_version":
+			propertySchema["const"] = schema.PayloadVersion
+		case "point":
+			propertySchema["const"] = string(schema.Point)
+		}
+		properties[field.Name] = propertySchema
+	}
+	properties["metadata"] = map[string]any{
+		"type":                 "object",
+		"description":          "Point-specific hook metadata fields.",
+		"additionalProperties": false,
+		"properties":           buildPayloadPropertySchemas(schema.Metadata),
+	}
+	return map[string]any{
+		"title":                string(schema.Point),
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             required,
+		"properties":           properties,
+	}
+}
+
+// buildPayloadFieldJSONSchema 将字段契约转换为 JSON Schema 节点。
+func buildPayloadFieldJSONSchema(field PayloadFieldSchema) map[string]any {
+	schema := map[string]any{
+		"type":        field.JSONType,
+		"x-stability": string(field.Stability),
+	}
+	if description := strings.TrimSpace(field.Description); description != "" {
+		schema["description"] = description
+	}
+	switch field.JSONType {
+	case "array":
+		items := map[string]any{}
+		if field.ItemType != "" {
+			items["type"] = field.ItemType
+		}
+		if len(field.ItemProperties) > 0 {
+			items["properties"] = buildPayloadPropertySchemas(field.ItemProperties)
+			items["additionalProperties"] = false
+		}
+		if len(items) > 0 {
+			schema["items"] = items
+		}
+	case "object":
+		schema["additionalProperties"] = false
+		if len(field.Properties) > 0 {
+			schema["properties"] = buildPayloadPropertySchemas(field.Properties)
+		}
+	}
+	return schema
+}
+
+// buildPayloadPropertySchemas 批量构造字段名到 JSON Schema 的映射。
+func buildPayloadPropertySchemas(fields []PayloadFieldSchema) map[string]any {
+	if len(fields) == 0 {
+		return map[string]any{}
+	}
+	properties := make(map[string]any, len(fields))
+	for _, field := range fields {
+		properties[field.Name] = buildPayloadFieldJSONSchema(field)
+	}
+	return properties
+}
+
+// fieldNamesByStability 收集指定稳定性等级的字段名，供测试回归校验使用。
+func fieldNamesByStability(fields []PayloadFieldSchema, stability PayloadStability) []string {
+	names := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if field.Stability != stability {
+			continue
+		}
+		names = append(names, field.Name)
+	}
+	slices.Sort(names)
+	return names
+}

--- a/internal/runtime/hooks/payload_schema_test.go
+++ b/internal/runtime/hooks/payload_schema_test.go
@@ -1,0 +1,126 @@
+package hooks
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestPayloadSchemaTopLevelStableFields(t *testing.T) {
+	t.Parallel()
+
+	want := []string{
+		"hook_id",
+		"kind",
+		"mode",
+		"payload_version",
+		"point",
+		"run_id",
+		"scope",
+		"session_id",
+		"triggered_at",
+	}
+	for _, point := range ListHookPoints() {
+		point := point
+		t.Run(string(point), func(t *testing.T) {
+			t.Parallel()
+			got := fieldNamesByStability(PayloadSchema(point).TopLevel, PayloadStabilityStable)
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("top-level stable fields = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestPayloadSchemaMetadataStableFields(t *testing.T) {
+	t.Parallel()
+
+	want := map[HookPoint][]string{
+		HookPointAcceptGate:               {"assistant_text_empty", "run_id", "session_id", "workdir", "workspace_changed"},
+		HookPointAfterToolFailure:         {"error_class", "execution_error", "is_error", "run_id", "session_id", "tool_call_id", "tool_name", "workdir"},
+		HookPointAfterToolResult:          {"error_class", "execution_error", "is_error", "result_metadata_present", "run_id", "session_id", "tool_call_id", "tool_name", "workdir"},
+		HookPointBeforeCompletionDecision: {"run_id", "session_id"},
+		HookPointBeforePermissionDecision: {"decision", "reason", "rule_id", "run_id", "session_id", "tool_call_id", "tool_name", "workdir"},
+		HookPointBeforeToolCall:           {"run_id", "session_id", "tool_call_id", "tool_name", "workdir"},
+		HookPointPostCompact:              {"applied", "run_id", "session_id", "trigger_mode", "workdir"},
+		HookPointPreCompact:               {"run_id", "session_id", "trigger_mode", "workdir"},
+		HookPointSessionEnd:               {"detail", "run_id", "session_id", "stop_reason"},
+		HookPointSessionStart:             {"run_id", "session_id", "workdir"},
+		HookPointSubAgentStart:            {"role", "run_id", "session_id", "task_id", "tool_name", "trigger", "workdir", "workspace"},
+		HookPointSubAgentStop:             {"error", "role", "run_id", "session_id", "state", "step_count", "stop_reason", "task_id"},
+		HookPointUserPromptSubmit:         {"run_id", "session_id", "workdir"},
+	}
+	for point, expected := range want {
+		point := point
+		expected := expected
+		t.Run(string(point), func(t *testing.T) {
+			t.Parallel()
+			got := fieldNamesByStability(PayloadSchema(point).Metadata, PayloadStabilityStable)
+			if !reflect.DeepEqual(got, expected) {
+				t.Fatalf("stable metadata fields = %v, want %v", got, expected)
+			}
+		})
+	}
+}
+
+func TestPayloadSchemaDropsUnproducedAllowlistFields(t *testing.T) {
+	t.Parallel()
+
+	blocked := map[string]struct{}{
+		"point":             {},
+		"completion_passed": {},
+		"has_tool_calls":    {},
+		"assistant_role":    {},
+	}
+	for _, schema := range ListPayloadSchemas() {
+		for _, field := range schema.Metadata {
+			if _, exists := blocked[field.Name]; exists {
+				t.Fatalf("payload schema for %q should not expose unproduced field %q", schema.Point, field.Name)
+			}
+		}
+	}
+}
+
+func TestPayloadSchemaNestedTypes(t *testing.T) {
+	t.Parallel()
+
+	schema := PayloadSchema(HookPointAcceptGate)
+	if len(schema.Metadata) == 0 {
+		t.Fatal("accept_gate metadata should not be empty")
+	}
+	var todoSummary PayloadFieldSchema
+	var recentToolSummary PayloadFieldSchema
+	for _, field := range schema.Metadata {
+		switch field.Name {
+		case "todo_summary":
+			todoSummary = field
+		case "recent_tool_summary":
+			recentToolSummary = field
+		}
+	}
+	if todoSummary.JSONType != "object" || len(todoSummary.Properties) == 0 {
+		t.Fatalf("todo_summary schema = %+v, want object with properties", todoSummary)
+	}
+	if recentToolSummary.JSONType != "array" || recentToolSummary.ItemType != "object" || len(recentToolSummary.ItemProperties) == 0 {
+		t.Fatalf("recent_tool_summary schema = %+v, want array of objects", recentToolSummary)
+	}
+}
+
+func TestMarshalPayloadJSONSchemaMatchesGeneratedFile(t *testing.T) {
+	t.Parallel()
+
+	got, err := MarshalPayloadJSONSchema()
+	if err != nil {
+		t.Fatalf("MarshalPayloadJSONSchema() error = %v", err)
+	}
+	targetPath := filepath.Join("..", "..", "..", "docs", "reference", fmt.Sprintf("hook-payload.v%s.json", PayloadVersion))
+	want, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read generated schema file: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("generated schema mismatch with %s; run `go generate ./internal/runtime/hooks`", targetPath)
+	}
+}

--- a/internal/runtime/user_hooks.go
+++ b/internal/runtime/user_hooks.go
@@ -233,17 +233,17 @@ func buildConfiguredHookSpec(
 		return runtimehooks.HookSpec{}, buildErr
 	}
 	return runtimehooks.HookSpec{
-		ID:                      strings.TrimSpace(item.ID),
-		Point:                   point,
-		Scope:                   scope,
-		Source:                  source,
-		Kind:                    specKind,
-		Mode:                    specMode,
-		Priority:                item.Priority,
-		Timeout:                 time.Duration(item.TimeoutSec) * time.Second,
-		FailurePolicy:           mapRuntimeHookFailurePolicy(item.FailurePolicy),
-		Handler:                 handler,
-		Matcher:                 matcher,
+		ID:            strings.TrimSpace(item.ID),
+		Point:         point,
+		Scope:         scope,
+		Source:        source,
+		Kind:          specKind,
+		Mode:          specMode,
+		Priority:      item.Priority,
+		Timeout:       time.Duration(item.TimeoutSec) * time.Second,
+		FailurePolicy: mapRuntimeHookFailurePolicy(item.FailurePolicy),
+		Handler:       handler,
+		Matcher:       matcher,
 	}, nil
 }
 
@@ -262,15 +262,15 @@ func validateConfiguredHookItemForP6Lite(item config.RuntimeHookItemConfig, scop
 		if mode != configuredHookModeSync {
 			return fmt.Errorf("mode %q is not supported", item.Mode)
 		}
-			handler := strings.ToLower(strings.TrimSpace(item.Handler))
-			if handler == "warn_on_tool_call" && !runtimehooks.HasHookMatcherConfig(item.Match) {
-				return fmt.Errorf("handler %q requires match", item.Handler)
+		handler := strings.ToLower(strings.TrimSpace(item.Handler))
+		if handler == "warn_on_tool_call" && !runtimehooks.HasHookMatcherConfig(item.Match) {
+			return fmt.Errorf("handler %q requires match", item.Handler)
+		}
+		if runtimehooks.HasHookMatcherConfig(item.Match) {
+			if err := runtimehooks.ValidateHookMatcher(runtimehooks.HookPoint(strings.TrimSpace(item.Point)), item.Match); err != nil {
+				return fmt.Errorf("match: %w", err)
 			}
-			if runtimehooks.HasHookMatcherConfig(item.Match) {
-				if err := runtimehooks.ValidateHookMatcher(runtimehooks.HookPoint(strings.TrimSpace(item.Point)), item.Match); err != nil {
-					return fmt.Errorf("match: %w", err)
-				}
-			}
+		}
 	case configuredHookKindCommand:
 		if mode != configuredHookModeSync {
 			return fmt.Errorf("mode %q is not supported for kind command (only sync)", item.Mode)
@@ -307,7 +307,6 @@ func validateConfiguredHookItemForP6Lite(item config.RuntimeHookItemConfig, scop
 	}
 	return nil
 }
-
 
 // buildConfiguredHookMatcher 编译 hook matcher。
 func buildConfiguredHookMatcher(item config.RuntimeHookItemConfig, point runtimehooks.HookPoint) (*runtimehooks.HookMatcher, error) {
@@ -376,16 +375,16 @@ func buildUserBuiltinHookHandler(
 			}
 			return runtimehooks.HookResult{Status: runtimehooks.HookResultPass}
 		}, nil
-		case "warn_on_tool_call":
-			defaultMessage := "tool call matched warn_on_tool_call"
-			if customMessage := strings.TrimSpace(readHookParamString(params, "message")); customMessage != "" {
-				defaultMessage = customMessage
-			}
-			return func(ctx context.Context, input runtimehooks.HookContext) runtimehooks.HookResult {
-				_ = ctx
-				_ = input
-				return runtimehooks.HookResult{Status: runtimehooks.HookResultPass, Message: defaultMessage}
-			}, nil
+	case "warn_on_tool_call":
+		defaultMessage := "tool call matched warn_on_tool_call"
+		if customMessage := strings.TrimSpace(readHookParamString(params, "message")); customMessage != "" {
+			defaultMessage = customMessage
+		}
+		return func(ctx context.Context, input runtimehooks.HookContext) runtimehooks.HookResult {
+			_ = ctx
+			_ = input
+			return runtimehooks.HookResult{Status: runtimehooks.HookResultPass, Message: defaultMessage}
+		}, nil
 	case "add_context_note":
 		note := strings.TrimSpace(readHookParamString(params, "note"))
 		if note == "" {
@@ -441,21 +440,23 @@ func buildUserHTTPObserveHookHandler(item config.RuntimeHookItemConfig) (runtime
 	}
 	includeMetadata := readHookParamBool(item.Params, "include_metadata", false)
 	hookID := strings.TrimSpace(item.ID)
-	point := strings.TrimSpace(item.Point)
+	pointName := strings.TrimSpace(item.Point)
+	point := runtimehooks.HookPoint(pointName)
 
 	return func(ctx context.Context, input runtimehooks.HookContext) runtimehooks.HookResult {
 		payload := map[string]any{
-			"hook_id":      hookID,
-			"point":        point,
-			"scope":        "user",
-			"kind":         configuredHookKindHTTP,
-			"mode":         configuredHookModeObserve,
-			"run_id":       strings.TrimSpace(input.RunID),
-			"session_id":   strings.TrimSpace(input.SessionID),
-			"triggered_at": time.Now().UTC().Format(time.RFC3339Nano),
+			"payload_version": runtimehooks.PayloadVersion,
+			"hook_id":         hookID,
+			"point":           pointName,
+			"scope":           "user",
+			"kind":            configuredHookKindHTTP,
+			"mode":            configuredHookModeObserve,
+			"run_id":          strings.TrimSpace(input.RunID),
+			"session_id":      strings.TrimSpace(input.SessionID),
+			"triggered_at":    time.Now().UTC().Format(time.RFC3339Nano),
 		}
 		if includeMetadata && len(input.Metadata) > 0 {
-			payload["metadata"] = sanitizeHTTPObserveMetadata(input.Metadata)
+			payload["metadata"] = sanitizeHTTPObserveMetadata(point, input.Metadata)
 		}
 		body, err := json.Marshal(payload)
 		if err != nil {
@@ -493,17 +494,31 @@ func buildUserHTTPObserveHookHandler(item config.RuntimeHookItemConfig) (runtime
 }
 
 // sanitizeHTTPObserveMetadata 对外发 payload 前剥离敏感预览字段，避免意外外传。
-func sanitizeHTTPObserveMetadata(metadata map[string]any) map[string]any {
+func sanitizeHTTPObserveMetadata(point runtimehooks.HookPoint, metadata map[string]any) map[string]any {
 	if len(metadata) == 0 {
 		return nil
 	}
-	sanitized := make(map[string]any, len(metadata))
+	allowedFields := runtimehooks.PayloadSchema(point).Metadata
+	if len(allowedFields) == 0 {
+		return nil
+	}
+	allowedNames := make(map[string]struct{}, len(allowedFields))
+	for _, field := range allowedFields {
+		allowedNames[strings.ToLower(strings.TrimSpace(field.Name))] = struct{}{}
+	}
+	sanitized := make(map[string]any, len(allowedFields))
 	for key, value := range metadata {
 		normalized := strings.ToLower(strings.TrimSpace(key))
+		if _, allowed := allowedNames[normalized]; !allowed {
+			continue
+		}
 		if _, blocked := httpObserveSensitiveMetadataKeys[normalized]; blocked {
 			continue
 		}
 		sanitized[key] = value
+	}
+	if len(sanitized) == 0 {
+		return nil
 	}
 	return sanitized
 }

--- a/internal/runtime/user_hooks_test.go
+++ b/internal/runtime/user_hooks_test.go
@@ -37,7 +37,7 @@ func TestBuildUserHookSpecMapsFailurePolicyAndScope(t *testing.T) {
 			"tool_name": "bash",
 		},
 		Params: map[string]any{
-			"message":   "tool call warning",
+			"message": "tool call warning",
 		},
 	}
 
@@ -118,6 +118,9 @@ func TestBuildUserHookSpecAllowsHTTPObserve(t *testing.T) {
 	}
 	if mode, _ := captured["mode"].(string); mode != "observe" {
 		t.Fatalf("payload.mode = %v, want observe", captured["mode"])
+	}
+	if payloadVersion, _ := captured["payload_version"].(string); payloadVersion != runtimehooks.PayloadVersion {
+		t.Fatalf("payload.payload_version = %v, want %q", captured["payload_version"], runtimehooks.PayloadVersion)
 	}
 	if hookID, _ := captured["hook_id"].(string); hookID != "http-observe" {
 		t.Fatalf("payload.hook_id = %v, want http-observe", captured["hook_id"])
@@ -243,6 +246,7 @@ func TestBuildUserHookSpecHTTPObserveCanIncludeSanitizedMetadata(t *testing.T) {
 			"tool_name":              "bash",
 			"result_content_preview": "should_not_leak",
 			"execution_error":        "should_not_leak",
+			"phase":                  "plan",
 		},
 	})
 	if result.Status != runtimehooks.HookResultPass {
@@ -260,6 +264,9 @@ func TestBuildUserHookSpecHTTPObserveCanIncludeSanitizedMetadata(t *testing.T) {
 	}
 	if _, exists := rawMeta["execution_error"]; exists {
 		t.Fatal("execution_error should be stripped from http observe payload metadata")
+	}
+	if _, exists := rawMeta["phase"]; exists {
+		t.Fatal("phase should be stripped by payload schema before HTTP observe")
 	}
 }
 
@@ -353,14 +360,13 @@ func TestWarnOnToolCallAndAddContextNoteHandlers(t *testing.T) {
 	t.Parallel()
 
 	warnHandler, err := buildUserBuiltinHookHandler("warn_on_tool_call", map[string]any{
-		"message":   "bash was called",
+		"message": "bash was called",
 	}, t.TempDir())
 	if err != nil {
 		t.Fatalf("build warn handler: %v", err)
 	}
 	warnResult := warnHandler(context.Background(), runtimehooks.HookContext{
-		Metadata: map[string]any{
-		},
+		Metadata: map[string]any{},
 	})
 	if warnResult.Status != runtimehooks.HookResultPass {
 		t.Fatalf("warn status = %q, want pass", warnResult.Status)
@@ -369,14 +375,14 @@ func TestWarnOnToolCallAndAddContextNoteHandlers(t *testing.T) {
 		t.Fatalf("warn message = %q, want %q", warnResult.Message, "bash was called")
 	}
 
-		anyToolResult := warnHandler(context.Background(), runtimehooks.HookContext{
-			Metadata: map[string]any{
-				"tool_name": "filesystem",
-			},
-		})
-		if anyToolResult.Message != "bash was called" {
-			t.Fatalf("warn message = %q, want %q", anyToolResult.Message, "bash was called")
-		}
+	anyToolResult := warnHandler(context.Background(), runtimehooks.HookContext{
+		Metadata: map[string]any{
+			"tool_name": "filesystem",
+		},
+	})
+	if anyToolResult.Message != "bash was called" {
+		t.Fatalf("warn message = %q, want %q", anyToolResult.Message, "bash was called")
+	}
 
 	noteHandler, err := buildUserBuiltinHookHandler("add_context_note", map[string]any{
 		"note": "manual check required",
@@ -407,10 +413,10 @@ func TestConfigureRuntimeHooksFromConfig(t *testing.T) {
 			Scope:   "user",
 			Kind:    "builtin",
 			Mode:    "sync",
-				Handler: "warn_on_tool_call",
-				Match: map[string]any{
-					"tool_name": "bash",
-				},
+			Handler: "warn_on_tool_call",
+			Match: map[string]any{
+				"tool_name": "bash",
+			},
 		},
 	}
 	cfg.Runtime.Hooks.ApplyDefaults(config.StaticDefaults().Runtime.Hooks)
@@ -455,12 +461,12 @@ func TestConfigureRuntimeHooksFromConfigKeepsBaseExecutorAndComposes(t *testing.
 			Scope:   "user",
 			Kind:    "builtin",
 			Mode:    "sync",
-				Match: map[string]any{
-					"tool_name": "bash",
-				},
+			Match: map[string]any{
+				"tool_name": "bash",
+			},
 			Handler: "warn_on_tool_call",
 			Params: map[string]any{
-				"message":   "warn",
+				"message": "warn",
 			},
 		},
 	}
@@ -820,11 +826,11 @@ func TestConfigureRuntimeHooksWithoutItemsKeepsBehaviorUnchanged(t *testing.T) {
 	if service.hookExecutor == nil {
 		t.Fatal("expected runtime hooks chain to remain available for repo discovery")
 	}
-		out := service.hookExecutor.Run(
-			context.Background(),
-			runtimehooks.HookPointBeforeToolCall,
-			runtimehooks.HookContext{Metadata: map[string]any{"workdir": cfg.Workdir}},
-		)
+	out := service.hookExecutor.Run(
+		context.Background(),
+		runtimehooks.HookPointBeforeToolCall,
+		runtimehooks.HookContext{Metadata: map[string]any{"workdir": cfg.Workdir}},
+	)
 	if out.Blocked || len(out.Results) != 0 {
 		t.Fatalf("unexpected hook output without user/repo config: %+v", out)
 	}
@@ -1047,10 +1053,10 @@ func TestHTTPObserveHelperBranches(t *testing.T) {
 		if !readHookParamBool(map[string]any{"x": struct{}{}}, "x", true) {
 			t.Fatal("unsupported type should return default")
 		}
-		if sanitizeHTTPObserveMetadata(nil) != nil {
+		if sanitizeHTTPObserveMetadata(runtimehooks.HookPointBeforeToolCall, nil) != nil {
 			t.Fatal("nil metadata should stay nil")
 		}
-		if sanitizeHTTPObserveMetadata(map[string]any{}) != nil {
+		if sanitizeHTTPObserveMetadata(runtimehooks.HookPointBeforeToolCall, map[string]any{}) != nil {
 			t.Fatal("empty metadata should stay nil")
 		}
 	})
@@ -1146,7 +1152,7 @@ func TestHTTPObserveHelperBranches(t *testing.T) {
 			t.Fatalf("buildUserHTTPObserveHookHandler(marshal) error = %v", err)
 		}
 		result = handler(context.Background(), runtimehooks.HookContext{
-			Metadata: map[string]any{"bad": func() {}},
+			Metadata: map[string]any{"tool_name": func() {}},
 		})
 		if result.Status != runtimehooks.HookResultFailed || !strings.Contains(result.Error, "marshal payload failed") {
 			t.Fatalf("unexpected marshal failure result: %+v", result)
@@ -1355,7 +1361,6 @@ func TestConfigureRuntimeHooksInjectsAsyncResultSinkIntoBaseExecutor(t *testing.
 	t.Fatal("expected async rewake notification to be enqueued via configured async sink")
 }
 
-
 type countingHookExecutor struct {
 	calls  atomic.Int32
 	output runtimehooks.RunOutput
@@ -1545,10 +1550,10 @@ func TestUserHookHandlersAndPathChecks(t *testing.T) {
 	if result.Message == "" {
 		t.Fatalf("expected default warn message for matched tool")
 	}
-		result = warnHandler(context.Background(), runtimehooks.HookContext{})
-		if result.Message == "" {
-			t.Fatalf("expected default warn message, got empty")
-		}
+	result = warnHandler(context.Background(), runtimehooks.HookContext{})
+	if result.Message == "" {
+		t.Fatalf("expected default warn message, got empty")
+	}
 
 	noteHandler, err := buildUserBuiltinHookHandler("add_context_note", map[string]any{"message": "note-via-message"}, workdir)
 	if err != nil {


### PR DESCRIPTION
## Summary

Implements #685 by promoting hook payload metadata filtering into a versioned public schema owned by `internal/runtime/hooks`.

This change makes the payload contract a single source of truth for:
- command hook stdin payloads
- shared HTTP observe payload fields
- generated reference docs / JSON Schema
- runtime-side user/repo hook context sanitization

## What Changed

- add `internal/runtime/hooks.PayloadVersion = "1"` as the shared payload version source
- add exported payload schema types and helpers:
  - `PayloadStability`
  - `PayloadFieldSchema`
  - `PointPayloadSchema`
  - `PayloadSchema(point)`
  - `ListPayloadSchemas()`
- define point-aware metadata schemas from actual runtime-produced fields only
- remove legacy allowlist-only fields from the public contract, including:
  - `metadata.point`
  - `completion_passed`
  - `has_tool_calls`
  - `assistant_role`
- switch user/repo hook sanitization to derive allowed metadata from `PayloadSchema(point)` instead of a hardcoded map
- update command hook payload building to:
  - use the shared `PayloadVersion`
  - sanitize stdin metadata through the schema
- update HTTP observe payload building to:
  - include top-level `payload_version`
  - share the same `point/run_id/session_id/metadata` contract
  - keep transport-only fields `scope/kind/mode/triggered_at`
  - continue applying the stricter outbound sensitive-field stripping on top of schema filtering
- add `go generate ./internal/runtime/hooks` support and generate `docs/reference/hook-payload.v1.json`
- update `docs/runtime-hooks-design.md` with the payload schema section and fix the outdated repo hook `command` support description

## Public Contract Notes

- current public version is `payload_version: "1"`
- preview / summary style fields are marked `experimental`:
  - `tool_arguments_preview`
  - `result_content_preview`
  - `todo_summary`
  - `recent_tool_summary`
- identity / control fields remain `stable`
- no runtime JSON Schema validation library is introduced on the hot path; runtime consumes Go definitions only

## Verification

Ran:

```bash
go generate ./internal/runtime/hooks
go test ./internal/runtime/hooks ./internal/runtime -run "HTTPObserve|ConfigureRuntimeHooks|RepoHook|UserHook|AcceptanceContinue"
go test ./internal/config -run "RuntimeHook|HookPointSingleSourceConsistency"
```

Covered in tests:
- payload schema field-set and stability regressions per hook point
- generated schema file stays in sync with `go generate`
- command stdin `payload_version` and schema-based metadata filtering
- user/repo hook context sanitization remains point-aware and strips non-contract fields
- HTTP observe includes `payload_version` and keeps the stricter outbound metadata filtering

Closes #685
